### PR TITLE
MongoEventStore sorting

### DIFF
--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/MongoEventStore.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/MongoEventStore.java
@@ -56,8 +56,8 @@ import javax.annotation.PostConstruct;
 public class MongoEventStore implements SnapshotEventStore, EventStoreManagement, UpcasterAware {
 
     private static final Logger logger = LoggerFactory.getLogger(MongoEventStore.class);
-    private static final String ORDER_ASC = "1";
-    private static final String ORDER_DESC = "-1";
+    private static final int ORDER_ASC = 1;
+    private static final int ORDER_DESC = -1;
 
     private final MongoTemplate mongoTemplate;
 

--- a/mongo/src/test/java/org/axonframework/eventstore/mongo/MongoEventStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/eventstore/mongo/MongoEventStoreTest.java
@@ -186,6 +186,28 @@ public class MongoEventStoreTest {
 
         assertEquals(2, domainEvents.size());
     }
+    
+    @Test
+    public void testLoadWithMultipleSnapshotEvents() {
+        testSubject.appendEvents("test", aggregate1.getUncommittedEvents());
+        aggregate1.commitEvents();
+        testSubject.appendSnapshotEvent("test", aggregate1.createSnapshotEvent());
+        aggregate1.changeState();
+        testSubject.appendEvents("test", aggregate1.getUncommittedEvents());
+        aggregate1.commitEvents();
+        testSubject.appendSnapshotEvent("test", aggregate1.createSnapshotEvent());
+        aggregate1.changeState();
+        testSubject.appendEvents("test", aggregate1.getUncommittedEvents());
+        aggregate1.commitEvents();
+
+        DomainEventStream actualEventStream = testSubject.readEvents("test", aggregate1.getIdentifier());
+        List<DomainEventMessage> domainEvents = new ArrayList<DomainEventMessage>();
+        while (actualEventStream.hasNext()) {
+            domainEvents.add(actualEventStream.next());
+        }
+
+        assertEquals(2, domainEvents.size());
+    }
 
     @Test(expected = EventStreamNotFoundException.class)
     public void testLoadNonExistent() {


### PR DESCRIPTION
I've been having gradual slowdown problems when using the MongoEventStore that I think are related to sorting in the Mongo queries.

The sort parameters in MongoEventStore are declared as Strings when MongoDB is expecting a numeric value.  The consequence of this that I was coming up against was that snapshot events are not correctly reverse-sorted, so only the first snapshot is ever returned.  I have some aggregates with hundreds of thousands of events, leading to lengthy loads.

In this change, I've simply changed the sort parameters to ints and added a test for multiple snapshot events.  This also fixes multiple `warning: can't find plugin [-1]` log entries in MongoDB.
