### PR TITLE
Update core/src/main/java/org/axonframework/eventstore/fs/SimpleEventFil...

### DIFF
--- a/core/src/main/java/org/axonframework/eventstore/fs/SimpleEventFileResolver.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/SimpleEventFileResolver.java
@@ -25,6 +25,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * Very straightforward implementation of the EventFileResolver that stores files in a directory structure underneath a
@@ -93,8 +95,16 @@ public class SimpleEventFileResolver implements EventFileResolver {
     }
 
     private File getEventsFile(String type, Object identifier, String extension) throws IOException {
-        return new File(getBaseDirForType(type), identifier + "." + extension);
+        return new File(getBaseDirForType(type), fsSafeIdentifier(identifier) + "." + extension);
     }
+
+    private static String fsSafeIdentifier(Object id) {
+        try {
+            return URLEncoder.encode(id.toString(), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("System doesnt support UTF-8?", e);
+		}
+	}
 
     private File getBaseDirForType(String type) throws IOException {
 


### PR DESCRIPTION
Windows cannot handle some special characters in file names. This was an issue on our mixed-OS-team when we used URIs as Aggregate Identifiers.

This patch URL percent-encodes the Aggregate ID before it is used as part of the file name.
