### PR TITLE
Cursors timing out visiting events in sharded collection

### DIFF
--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/MongoEventStore.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/MongoEventStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventstore.mongo;
 
+import com.mongodb.Bytes;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
@@ -172,6 +173,7 @@ public class MongoEventStore implements SnapshotEventStore, EventStoreManagement
     public void visitEvents(Criteria criteria, EventVisitor visitor) {
         DBCursor cursor = storageStrategy.findEvents(mongoTemplate.domainEventCollection(),
                                                                 (MongoCriteria) criteria);
+        cursor.addOption(Bytes.QUERYOPTION_NOTIMEOUT);
         CursorBackedDomainEventStream events = new CursorBackedDomainEventStream(cursor, null, null);
         while (events.hasNext()) {
             visitor.doWithEvent(events.next());


### PR DESCRIPTION
Hi,

I was having NullPointerExceptions when DocumentPerEventStorageStrategy was creating EventEntries after I sharded my domainevent collection.  I tracked this down to cursors expiring in mongodb since my shard key is time-dependent and it was taking more than 10 minutes to get to the events in one of the shards.

In this change I've added the NOTIMEOUT option to the cursor used to visit the events and the problem has gone away.  I haven't added any tests for this since I didn't want to introduce any heavy mocking into the tests.  The Mongo driver is unreasonably hard to mock :)

Thanks,

Andy
