### PR TITLE
bugfix: amqp connection factory was not passed to the listener container, which causes issues with spring autowiring when multiple connection factories were defined

### DIFF
--- a/amqp/src/main/java/org/axonframework/contextsupport/spring/amqp/TerminalBeanDefinitionParser.java
+++ b/amqp/src/main/java/org/axonframework/contextsupport/spring/amqp/TerminalBeanDefinitionParser.java
@@ -68,7 +68,6 @@ public class TerminalBeanDefinitionParser extends AbstractBeanDefinitionParser {
         GenericBeanDefinition listenerContainerDefinition = createContainerManager(element, parserContext);
         final String containerBeanName = resolveId(element, terminalDefinition, parserContext)
                 + CONTAINER_MANAGER_SUFFIX;
-        parserContext.getRegistry().registerBeanDefinition(containerBeanName, listenerContainerDefinition);
 
         terminalDefinition.getPropertyValues().add(PROPERTY_CONTAINER_LIFECYCLE_MANAGER,
                                                    new RuntimeBeanReference(containerBeanName));
@@ -85,6 +84,14 @@ public class TerminalBeanDefinitionParser extends AbstractBeanDefinitionParser {
             }
         }
 
+        // Report connectionFactory to listener if defined
+        if (element.hasAttribute("connection-factory")) {
+	        listenerContainerDefinition.getPropertyValues()
+	        	.add(BEAN_REFERENCE_PROPERTIES.get("connection-factory"), 
+	        			new RuntimeBeanReference(element.getAttribute("connection-factory")));
+        }        
+        parserContext.getRegistry().registerBeanDefinition(containerBeanName, listenerContainerDefinition);
+        
         return terminalDefinition;
     }
 

--- a/amqp/src/test/resources/META-INF/spring/amqp-namespace-context.xml
+++ b/amqp/src/test/resources/META-INF/spring/amqp-namespace-context.xml
@@ -17,10 +17,13 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:amqp="http://www.axonframework.org/schema/amqp"
-       xmlns:axon="http://www.axonframework.org/schema/core"
+       xmlns:axon="http://www.axonframework.org/schema/core" xmlns:rabbit="http://www.springframework.org/schema/rabbit"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
             http://www.axonframework.org/schema/amqp http://www.axonframework.org/schema/axon-amqp-2.0.xsd
+            http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
             http://www.axonframework.org/schema/core http://www.axonframework.org/schema/axon-core-2.0.xsd">
+
+	<rabbit:connection-factory id="connectionFactory2"/>
 
     <amqp:terminal id="terminal1" exchange-name="Exchange" durable="true" transactional="false"
                    connection-factory="connectionFactory" message-converter="messageConverter"


### PR DESCRIPTION
Manually defined connectionFactory in terminal is not passed to the listener container, which causes it to be autowired in the container, with error if there are more than one spring amqp connection factory defined in the context..

This patch ensure transmission of the factory from terminal to listener container if required, adapting the test configuration to check this behaviour.
