### PR TITLE
fix AXON-121: detect usage of duplicate aggregateId

### DIFF
--- a/core/src/main/java/org/axonframework/eventstore/fs/FileSystemEventStore.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/FileSystemEventStore.java
@@ -97,6 +97,9 @@ public class FileSystemEventStore implements EventStore, SnapshotEventStore, Upc
         OutputStream out = null;
         try {
             DomainEventMessage next = eventsToStore.next();
+            if (next.getSequenceNumber() == 0 && eventFileResolver.eventFileExists(type, next.getAggregateIdentifier())) {
+                throw new EventStoreException("Duplicate aggregateIdentifier, type=" + type + ", id=" + next.getAggregateIdentifier());
+            }
             out = eventFileResolver.openEventFileForWriting(type, next.getAggregateIdentifier());
             FileSystemEventMessageWriter eventMessageWriter =
                     new FileSystemEventMessageWriter(new DataOutputStream(out), eventSerializer);


### PR DESCRIPTION
Fix for issue AXON-121. Throws EventStoreExdeption if first event.sequenceNumber == 0 and eventFile already exists.
Maybe a generic DuplicateAggregateIdentifierException would be better, but that requires adjustments to all EventStores.
