### PR TITLE
Attribute prefix missing from BSONNode

### DIFF
--- a/mongo/src/main/java/org/axonframework/serializer/bson/BSONNode.java
+++ b/mongo/src/main/java/org/axonframework/serializer/bson/BSONNode.java
@@ -136,9 +136,7 @@ public class BSONNode {
      * @param attributeValue The value of the attribute
      */
     public void setAttribute(String attributeName, String attributeValue) {
-        BSONNode childNode = new BSONNode(attributeName);
-        childNode.setValue(attributeValue);
-        this.childNodes.add(childNode);
+    	addChild(ATTRIBUTE_PREFIX + attributeName, attributeValue);
     }
 
     /**
@@ -154,7 +152,12 @@ public class BSONNode {
         Assert.notNull(name, "Node name must not be null");
         Assert.isFalse(name.startsWith(ATTRIBUTE_PREFIX), "Node names may not start with '" + ATTRIBUTE_PREFIX + "'");
 
+        return addChild(name, null);
+    }
+    
+    private BSONNode addChild(String name, String value) {
         BSONNode childNode = new BSONNode(name);
+        childNode.setValue(value);
         this.childNodes.add(childNode);
         return childNode;
     }
@@ -199,8 +202,12 @@ public class BSONNode {
      */
     public String getAttribute(String name) {
         String attr = ATTRIBUTE_PREFIX + name;
+        return getChildValue(attr);
+    }
+    
+    private String getChildValue(String name) {
         for (BSONNode node : childNodes) {
-            if (attr.equals(node.encodedName)) {
+            if (name.equals(node.encodedName)) {
                 return node.value;
             }
         }

--- a/mongo/src/test/java/org/axonframework/serializer/bson/BSONNodeTest.java
+++ b/mongo/src/test/java/org/axonframework/serializer/bson/BSONNodeTest.java
@@ -16,9 +16,14 @@
 
 package org.axonframework.serializer.bson;
 
-import org.junit.*;
-
 import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 
 /**
  * @author Allard Buijze
@@ -39,4 +44,24 @@ public class BSONNodeTest {
         assertEquals(node.asDBObject().toString(), parsedNode.asDBObject().toString());
     }
 
+    @SuppressWarnings("rawtypes")
+	@Test
+    public void prefixesAttributesWithCorrectPrefix() {
+        BSONNode node = new BSONNode("root");
+        node.setAttribute("test", "attribute");
+        
+        assertEquals("attribute", ((Map)node.asDBObject().get("root")).get("attr_test"));
+    }
+    
+    @Test
+    public void parsesPrefixedAttributesCorrectly() {
+    	DBObject attribute = new BasicDBObject();
+    	attribute.put("attr_test", "attribute");
+    	DBObject root = new BasicDBObject();
+    	root.put("root", attribute);
+    	
+    	BSONNode parsedNode = BSONNode.fromDBObject(root);
+    	
+    	assertEquals("attribute", parsedNode.getAttribute("test"));
+    }
 }


### PR DESCRIPTION
I was having trouble using the BSON serialiser to create snapshots, the assertion was failing in BSONNode.setValue().  This was due to the attr_ prefix not being applied so attributes were being returned by the children() method.  This change adds the prefix in setAttribute()
