### PR TITLE
AXON-174: Allow specification of user defined Annotation types in AnnotationRoutingResolver

### DIFF
--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingResolver.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingResolver.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.axonframework.common.ReflectionUtils.*;
 
@@ -41,6 +43,7 @@ public class AnnotationRoutingResolver {
     /**
      * Examines the payload type to check whether any of the methods or fields declare one of the
      * candidate annotation types. Each candidate type against all methods and fields before the next.
+     * If performance is a concern consider using the {@link AnnotationRoutingResolver#withCacheing} method.
      *
      * @param payloadType the payload type
      * @return the first instance of a matching annotated field or method if found, or null when no match is found
@@ -60,6 +63,39 @@ public class AnnotationRoutingResolver {
             }
         }
         return null;
+    }
+
+    /**
+     * Decorates the basic AnnotationRoutingResolver with a simple HashMap backed cache.
+     *
+     * @param candidateAnnotationTypes annotation types that will be considered
+     * @return a cacheing AnnotationRoutingResolver
+     */
+    public static AnnotationRoutingResolver withCacheing(Class<? extends Annotation>... candidateAnnotationTypes) {
+        return withCacheing(new AnnotationRoutingResolver(candidateAnnotationTypes));
+    }
+
+    /**
+     * Decorates the provided resolver with a simple HashMap backed cache.
+     *
+     * @param resolver the resolver that will be decorated
+     * @return a cacheing AnnotationRoutingResolver
+     */
+    public static AnnotationRoutingResolver withCacheing(final AnnotationRoutingResolver resolver) {
+        return new AnnotationRoutingResolver() {
+            private Map<Class<?>, RoutingStrategy> cache = new HashMap<Class<?>, RoutingStrategy>();
+
+            @Override
+            public RoutingStrategy getRoutingStrategy(Class<?> payloadType) {
+                if (cache.containsKey(payloadType)) {
+                    return cache.get(payloadType);
+                } else {
+                    RoutingStrategy strategy = resolver.getRoutingStrategy(payloadType);
+                    cache.put(payloadType, strategy);
+                    return strategy;
+                }
+            }
+        };
     }
 
     private static class FieldValueRoutingStrategy implements RoutingStrategy {

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -88,6 +88,18 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
     public AnnotationRoutingStrategy(AnnotationRoutingResolver annotationRoutingResolver,
                                      UnresolvedRoutingKeyPolicy unresolvedRoutingKeyPolicy) {
         super(unresolvedRoutingKeyPolicy);
+        this.annotationRoutingResolver = annotationRoutingResolver;
+    }
+
+    /**
+     * Returns a Routing Strategy that checks for one of the candidate annotation types.
+     * The result for each Command type is cached.
+     *
+     * @param candidateAnnotationTypes annotation types that will be considered
+     * @return a AnnotationRoutingStrategy that caches the result for each Command type
+     */
+    public static AnnotationRoutingStrategy withCacheing(Class<? extends Annotation>... candidateAnnotationTypes) {
+        return new AnnotationRoutingStrategy(AnnotationRoutingResolver.withCacheing(candidateAnnotationTypes), UnresolvedRoutingKeyPolicy.ERROR);
     }
 
     @Override

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
@@ -87,6 +87,18 @@ public class AnnotationRoutingStrategyTest {
         actual = testSubject.getRoutingKey(new GenericCommandMessage<Object>(new StubCommand2("SomeOtherIdentifier")));
         assertEquals("SomeOtherIdentifier", actual);
     }
+
+    @Test
+    public void testCachingRoutingStrategy() {
+        testSubject = AnnotationRoutingStrategy.withCacheing(SomeOtherAnnotation.class);
+
+        String actual = testSubject.getRoutingKey(new GenericCommandMessage<Object>(new StubCommand2("SomeIdentifier")));
+        assertEquals("SomeIdentifier", actual);
+
+        actual = testSubject.getRoutingKey(new GenericCommandMessage<Object>(new StubCommand2("SomeIdentifier")));
+        assertEquals("SomeIdentifier", actual);
+    }
+
     public static class StubCommand {
 
         @TargetAggregateIdentifier


### PR DESCRIPTION
Extend AnnotationRoutingStrategy to allow specifying the  type(s) of Annotation that will be checked for, rather than hard wiring to TargetAggregateIdentifier. The use case is to support Command payload classes in POJO API JARs that otherwise have no need to reference Axon code. With this change they can declare their own Annotation types and remain isolated.

-- ended up a bit more than I anticipated here. 

(This request includes a 2nd commit which also adds a couple of static 'withCacheing' methods that show how the design allows extension through decoration ... not sure if you will actually want to include this in Axon itself, I am more than happy if this is left outside of the framework)
