### PR TITLE
Mongo docpercommit strategy

### DIFF
--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
@@ -79,14 +79,17 @@ import static org.axonframework.serializer.MessageSerializer.serializePayload;
  * @author Allard Buijze
  * @since 2.0
  */
-public class DocumentPerCommitStorageStrategy implements StorageStrategy {
+    public class DocumentPerCommitStorageStrategy implements StorageStrategy {
 
     private static final int ORDER_ASC = 1;
     private static final int ORDER_DESC = -1;
 
     @Override
     public DBObject[] createDocuments(String type, Serializer eventSerializer, List<DomainEventMessage> messages) {
-        return new DBObject[]{new CommitEntry(type, eventSerializer, messages).asDBObject()};
+        if(messages != null && messages.size() > 0){
+            return new DBObject[]{new CommitEntry(type, eventSerializer, messages).asDBObject()};
+        }
+        return new DBObject[]{};
     }
 
     @Override

--- a/mongo/src/test/java/org/axonframework/eventstore/mongo/MongoEventStoreTest_DocPerCommit.java
+++ b/mongo/src/test/java/org/axonframework/eventstore/mongo/MongoEventStoreTest_DocPerCommit.java
@@ -106,6 +106,17 @@ public class MongoEventStoreTest_DocPerCommit {
     }
 
     @Test
+    public void testStoreEmptyUncommittedEventList(){
+        assertNotNull(testSubject);
+        StubAggregateRoot aggregate = new StubAggregateRoot();
+        // no events
+        assertEquals(0, aggregate.getUncommittedEventCount());
+        testSubject.appendEvents("test", aggregate.getUncommittedEvents());
+
+        assertEquals(0, mongoTemplate.domainEventCollection().count());
+    }
+
+    @Test
     public void testStoreAndLoadEvents() {
         assertNotNull(testSubject);
         testSubject.appendEvents("test", aggregate1.getUncommittedEvents());


### PR DESCRIPTION
DocumentPerCommit strategy throws exception when dealing with empty lists of event messages.

``` java
   java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.RangeCheck(ArrayList.java:547)
        at java.util.ArrayList.get(ArrayList.java:322)
        at org.axonframework.eventstore.mongo.DocumentPerCommitStorageStrategy$CommitEntry.<init>(DocumentPerCommitStorage
        at org.axonframework.eventstore.mongo.DocumentPerCommitStorageStrategy$CommitEntry.<init>(DocumentPerCommitStorage
        at org.axonframework.eventstore.mongo.DocumentPerCommitStorageStrategy.createDocuments(DocumentPerCommitStorageStr
```
