### PR TITLE
Indexes for mongo snapshot collections

### DIFF
--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
@@ -120,6 +120,11 @@ public class DocumentPerCommitStorageStrategy implements StorageStrategy {
                                              .append(CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),
                                      "uniqueAggregateIndex",
                                      true);
+        snapshotsCollection.ensureIndex(new BasicDBObject(CommitEntry.AGGREGATE_IDENTIFIER_PROPERTY, 1)
+                                             .append(CommitEntry.AGGREGATE_TYPE_PROPERTY, 1)
+                                             .append(CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),
+                                     "uniqueAggregateIndex",
+                                     true);
     }
 
     @Override

--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerEventStorageStrategy.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerEventStorageStrategy.java
@@ -101,6 +101,11 @@ public class DocumentPerEventStorageStrategy implements StorageStrategy {
                                              .append(EventEntry.SEQUENCE_NUMBER_PROPERTY, 1),
                                      "uniqueAggregateIndex",
                                      true);
+        snapshotsCollection.ensureIndex(new BasicDBObject(EventEntry.AGGREGATE_IDENTIFIER_PROPERTY, 1)
+                                             .append(EventEntry.AGGREGATE_TYPE_PROPERTY, 1)
+                                             .append(EventEntry.SEQUENCE_NUMBER_PROPERTY, 1),
+                                     "uniqueAggregateIndex",
+                                     true);
     }
 
     @Override


### PR DESCRIPTION
Snapshot collections have no indexes - if the snapshotter threshold is set to low values this slows down the system considerably when under load.
