### PR TITLE
Close FileInputStream after event stream read

### DIFF
--- a/core/src/main/java/org/axonframework/common/io/CloseableUtils.java
+++ b/core/src/main/java/org/axonframework/common/io/CloseableUtils.java
@@ -1,0 +1,11 @@
+package org.axonframework.common.io;
+
+import java.io.Closeable;
+
+public class CloseableUtils {
+    public static void closeIfCloseable(Object candidate) {
+        if (candidate instanceof Closeable) {
+            IOUtils.closeQuietly((Closeable) candidate);
+        }
+    }
+}

--- a/core/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing;
 
 import org.axonframework.common.DirectExecutor;
+import org.axonframework.common.io.CloseableUtils;
 import org.axonframework.domain.DomainEventMessage;
 import org.axonframework.domain.DomainEventStream;
 import org.axonframework.eventstore.SnapshotEventStore;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
+
 import javax.annotation.Resource;
 
 /**
@@ -91,6 +93,7 @@ public abstract class AbstractSnapshotter implements Snapshotter {
             if (snapshotEvent != null && snapshotEvent.getSequenceNumber() > firstEventSequenceNumber) {
                 eventStore.appendSnapshotEvent(typeIdentifier, snapshotEvent);
             }
+            CloseableUtils.closeIfCloseable(eventStream);
         }
     }
 

--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.io.CloseableUtils;
 import org.axonframework.domain.AggregateRoot;
 import org.axonframework.domain.DomainEventMessage;
 import org.axonframework.domain.DomainEventStream;
@@ -182,6 +183,7 @@ public class EventSourcingRepository<T extends EventSourcedAggregateRoot> extend
             eventStream = iterator.next().decorateForAppend(getTypeIdentifier(), aggregate, eventStream);
         }
         eventStore.appendEvents(getTypeIdentifier(), eventStream);
+        CloseableUtils.closeIfCloseable(eventStream);
     }
 
     /**
@@ -223,6 +225,7 @@ public class EventSourcingRepository<T extends EventSourcedAggregateRoot> extend
         final T aggregate = aggregateFactory.createAggregate(aggregateIdentifier, events.peek());
         List<DomainEventMessage> unseenEvents = new ArrayList<DomainEventMessage>();
         aggregate.initializeState(new CapturingEventStream(events, unseenEvents, expectedVersion));
+        CloseableUtils.closeIfCloseable(events);
         if (aggregate.isDeleted()) {
             throw new AggregateDeletedException(aggregateIdentifier);
         }

--- a/core/src/main/java/org/axonframework/eventstore/fs/FileSystemBufferedReaderDomainEventStream.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/FileSystemBufferedReaderDomainEventStream.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventstore.fs;
 
+import org.axonframework.common.io.IOUtils;
 import org.axonframework.domain.DomainEventMessage;
 import org.axonframework.domain.DomainEventStream;
 import org.axonframework.eventstore.EventStoreException;
@@ -28,6 +29,7 @@ import org.axonframework.upcasting.UpcastSerializedDomainEventData;
 import org.axonframework.upcasting.UpcasterChain;
 
 import java.io.BufferedInputStream;
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -46,12 +48,13 @@ import java.util.Queue;
  * @author Frank Versnel
  * @since 0.5
  */
-public class FileSystemBufferedReaderDomainEventStream implements DomainEventStream {
+public class FileSystemBufferedReaderDomainEventStream implements DomainEventStream, Closeable {
 
     private Queue<DomainEventMessage> next;
     private final FileSystemEventMessageReader eventMessageReader;
     private final UpcasterChain upcasterChain;
     private final Serializer serializer;
+    private final InputStream inputStream;
 
     /**
      * Initialize a BufferedReaderDomainEventStream using the given <code>inputStream</code> and
@@ -72,6 +75,7 @@ public class FileSystemBufferedReaderDomainEventStream implements DomainEventStr
     public FileSystemBufferedReaderDomainEventStream(InputStream inputStream,
                                                      Serializer serializer,
                                                      UpcasterChain upcasterChain) {
+        this.inputStream = inputStream;
         this.eventMessageReader = new FileSystemEventMessageReader(
                 new DataInputStream(new BufferedInputStream(inputStream)));
         this.upcasterChain = upcasterChain;
@@ -138,5 +142,10 @@ public class FileSystemBufferedReaderDomainEventStream implements DomainEventStr
             events.add(message);
         }
         return events;
+    }
+    
+    @Override
+    public void close() throws IOException {
+    	IOUtils.closeQuietly(inputStream);
     }
 }


### PR DESCRIPTION
FIX: AXON-184 FileInputStream passed into FileSystemBufferedReaderDomainEventStream is not closed after reading

FileSystemEventStore.readEvents(..) returns a FileSystemBufferedReaderDomainEventStream which is backed by a FileInputStream. This FileInputStream is never closed.

This becomes a problem when running integration tests on Windows (yes, some developers actually prefer this), where we want to delete the event store on disk after tests are finished running.

A possible solution will be to make FileSystemBufferedReaderDomainEventStream Closeable and to close it after the DomainEventStream is read.

I have made a patch that alters 3 Java files and adds a new utility class. I changed FileSystemBufferedReaderDomainEventStream to implement Closeable, and added functions to call close on DomainEventStream instances that also implements the Closeable interface. Since there are many DomainEventStream implementations out there (possibly also custom ones, not just in the axonframework libraries), I landed on this runtime detection of Closeable capability.
