### PR TITLE
AXON-231 MongoDB: support login via different (e.g. admin) authentication database.

### DIFF
--- a/mongo/src/main/java/org/axonframework/common/mongo/AuthenticatingMongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/common/mongo/AuthenticatingMongoTemplate.java
@@ -37,6 +37,7 @@ public abstract class AuthenticatingMongoTemplate {
     private final String userName;
     private final char[] password;
     private final DB database;
+    private final DB authenticationDatabase;
 
     /**
      * Initializes the MongoTemplate to connect using the given <code>mongo</code> instance and a database with default
@@ -63,7 +64,23 @@ public abstract class AuthenticatingMongoTemplate {
      */
     protected AuthenticatingMongoTemplate(Mongo mongo, String databaseName, String userName,
                                           char[] password) { // NOSONAR
+        this(mongo, databaseName, databaseName, userName, password);
+    }
+
+    /**
+     * Initializes the MongoTemplate to connect using the given <code>mongo</code> instance and the database with given
+     * <code>databaseName</code>. The given <code>userName</code> and <code>password</code>, when not
+     * <code>null</code>, are used to authenticate against the database.
+     *
+     * @param mongo        The Mongo instance configured to connect to the Mongo Server
+     * @param databaseName The name of the database containing the data
+     * @param userName     The username to authenticate with. Use <code>null</code> to skip authentication
+     * @param password     The password to authenticate with. Use <code>null</code> to skip authentication
+     */
+    protected AuthenticatingMongoTemplate(Mongo mongo, String databaseName, String authenticationDatabaseName, String userName,
+            char[] password) { // NOSONAR
         this.database = mongo.getDB(databaseName);
+        this.authenticationDatabase = databaseName.equals(authenticationDatabaseName) ? database : mongo.getDB(authenticationDatabaseName);
         this.userName = userName;
         this.password = password;
     }
@@ -81,10 +98,10 @@ public abstract class AuthenticatingMongoTemplate {
      * @see DB#authenticate(String, char[])
      */
     protected DB database() {
-        if (!database.isAuthenticated()
+        if (!authenticationDatabase.isAuthenticated()
                 && (userName != null || password != null)
-                && !database.authenticate(userName, password)) {
-            logger.warn("Failed to authenticate user '{}' against database. Incorrect credentials.", userName);
+                && !authenticationDatabase.authenticate(userName, password)) {
+            logger.warn("Failed to authenticate user '{}' against database '{}'. Incorrect credentials.", userName, authenticationDatabase.getName());
         }
         return database;
     }

--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/DefaultMongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/DefaultMongoTemplate.java
@@ -79,6 +79,29 @@ public class DefaultMongoTemplate extends AuthenticatingMongoTemplate implements
     }
 
     /**
+     * Creates a template connecting to given <code>mongo</code> instance, and loads events in the collection with
+     * given <code>domainEventsCollectionName</code> and snapshot events from <code>snapshotEventsCollectionName</code>,
+     * in a database with given <code>databaseName</code>. When not <code>null</code>, the given <code>userName</code>
+     * and <code>password</code> are used to authenticate against the database.
+     *
+     * @param mongo                        The Mongo instance configured to connect to the Mongo Server
+     * @param databaseName                 The name of the database containing the data
+     * @param domainEventsCollectionName   The name of the collection containing domain events
+     * @param snapshotEventsCollectionName The name of the collection containing snapshot events
+     * @param authenticationDatabase       The name of the database to authenticate to
+     * @param userName                     The username to authenticate with. Use <code>null</code> to skip
+     *                                     authentication
+     * @param password                     The password to authenticate with. Use <code>null</code> to skip
+     *                                     authentication
+     */
+    public DefaultMongoTemplate(Mongo mongo, String databaseName, String domainEventsCollectionName,
+            String snapshotEventsCollectionName, String authenticationDatabase, String userName, char[] password) {
+        super(mongo, databaseName, authenticationDatabase, userName, password);
+        this.domainEventsCollectionName = domainEventsCollectionName;
+        this.snapshotEventsCollectionName = snapshotEventsCollectionName;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override


### PR DESCRIPTION
See http://issues.axonframework.org/youtrack/issue/AXON-231 MongoDB: support login via different (e.g. admin) authentication database.

The contributed fix is inspired by a similar fix in Spring-data-mongodb: https://jira.spring.io/browse/DATAMONGO-789
