### PR TITLE
XML serializer based on XOM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -131,6 +131,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>xom</groupId>
+            <artifactId>xom</artifactId>
+            <version>1.2.5</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Optional dependencies -->
         <dependency>

--- a/core/src/main/java/org/axonframework/serializer/xml/InputStreamToXomConverter.java
+++ b/core/src/main/java/org/axonframework/serializer/xml/InputStreamToXomConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2012. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serializer.xml;
+
+import nu.xom.Builder;
+import nu.xom.Document;
+import nu.xom.ParsingException;
+import org.axonframework.serializer.AbstractContentTypeConverter;
+import org.axonframework.serializer.CannotConvertBetweenTypesException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * Converter that converts an input stream to a XOM document. It assumes that the input stream provides UTF-8
+ * formatted XML.
+ *
+ * @author Jochen Munz
+ * @since 2.1.2
+ */
+public class InputStreamToXomConverter extends AbstractContentTypeConverter<InputStream, Document> {
+
+    @Override
+    public Class<InputStream> expectedSourceType() {
+        return InputStream.class;
+    }
+
+    @Override
+    public Class<Document> targetType() {
+        return Document.class;
+    }
+
+    @Override
+    public Document convert(InputStream original) {
+        try {
+            return new Builder().build(new InputStreamReader(original));
+        } catch (ParsingException e) {
+            throw new CannotConvertBetweenTypesException("Cannot convert from InputStream to XOM Document.", e);
+        } catch (IOException e) {
+            throw new CannotConvertBetweenTypesException("Cannot convert from InputStream to XOM Document.", e);
+        }
+
+    }
+}

--- a/core/src/main/java/org/axonframework/serializer/xml/XStreamSerializer.java
+++ b/core/src/main/java/org/axonframework/serializer/xml/XStreamSerializer.java
@@ -18,6 +18,7 @@ package org.axonframework.serializer.xml;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.Dom4JReader;
+import com.thoughtworks.xstream.io.xml.XomReader;
 import org.axonframework.serializer.AbstractXStreamSerializer;
 import org.axonframework.serializer.ChainingConverterFactory;
 import org.axonframework.serializer.ConverterFactory;
@@ -135,7 +136,10 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
     @Override
     public Object doDeserialize(SerializedObject serializedObject, XStream xStream) {
         if ("org.dom4j.Document".equals(serializedObject.getContentType().getName())) {
-            return xStream.unmarshal(new Dom4JReader((Document) serializedObject.getData()));
+            return xStream.unmarshal(new Dom4JReader((org.dom4j.Document) serializedObject.getData()));
+        }
+        if("nu.xom.Document".equals(serializedObject.getContentType().getName())) {
+            return xStream.unmarshal(new XomReader((nu.xom.Document) serializedObject.getData()));
         }
         InputStream serializedData = (InputStream) convert(serializedObject.getContentType(), InputStream.class,
                                                            serializedObject.getData());
@@ -146,5 +150,7 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
     protected void registerConverters(ChainingConverterFactory converterFactory) {
         converterFactory.registerConverter(Dom4JToByteArrayConverter.class);
         converterFactory.registerConverter(InputStreamToDom4jConverter.class);
+        converterFactory.registerConverter(XomToByteArrayConverter.class);
+        converterFactory.registerConverter(InputStreamToXomConverter.class);
     }
 }

--- a/core/src/main/java/org/axonframework/serializer/xml/XomToByteArrayConverter.java
+++ b/core/src/main/java/org/axonframework/serializer/xml/XomToByteArrayConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2012. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serializer.xml;
+
+import nu.xom.Document;
+import org.axonframework.common.io.IOUtils;
+import org.axonframework.serializer.AbstractContentTypeConverter;
+
+/**
+ * Converter that converts XOM Document instances to a byte array. The Document is written as XML string, and
+ * converted to bytes using the UTF-8 character set.
+ *
+ * @author Jochen Munz
+ * @since 2.1.2
+ */
+public class XomToByteArrayConverter extends AbstractContentTypeConverter<Document, byte[]> {
+
+    @Override
+    public Class<Document> expectedSourceType() {
+        return Document.class;
+    }
+
+    @Override
+    public Class<byte[]> targetType() {
+        return byte[].class;
+    }
+
+    @Override
+    public byte[] convert(Document original) {
+        return original.toXML().getBytes(IOUtils.UTF8);
+    }
+}

--- a/core/src/test/java/org/axonframework/serializer/xml/InputStreamToXomConverterTest.java
+++ b/core/src/test/java/org/axonframework/serializer/xml/InputStreamToXomConverterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2012. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serializer.xml;
+
+import nu.xom.Document;
+import org.axonframework.serializer.SerializedObject;
+import org.axonframework.serializer.SimpleSerializedObject;
+import org.axonframework.serializer.SimpleSerializedType;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Jochen Munz
+ */
+public class InputStreamToXomConverterTest {
+
+    private InputStreamToXomConverter testSubject;
+    private SimpleSerializedType type;
+
+    @Before
+    public void setUp() throws Exception {
+        type = new SimpleSerializedType("bla", "0");
+        testSubject = new InputStreamToXomConverter();
+    }
+
+    @Test
+    public void testConvert() throws Exception {
+        byte[] bytes = "<parent><child/></parent>".getBytes();
+        InputStream inputStream = new ByteArrayInputStream(bytes);
+        SerializedObject<Document> actual = testSubject
+                .convert(new SimpleSerializedObject<InputStream>(inputStream, InputStream.class, type));
+
+        assertEquals("parent", actual.getData().getRootElement().getLocalName());
+    }
+}

--- a/core/src/test/java/org/axonframework/serializer/xml/XomToByteArrayConverterTest.java
+++ b/core/src/test/java/org/axonframework/serializer/xml/XomToByteArrayConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2012. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serializer.xml;
+
+import nu.xom.Document;
+import nu.xom.Element;
+import org.axonframework.serializer.SerializedObject;
+import org.axonframework.serializer.SimpleSerializedObject;
+import org.axonframework.serializer.SimpleSerializedType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Jochen Munz
+ */
+public class XomToByteArrayConverterTest {
+
+    private XomToByteArrayConverter testSubject;
+    private SimpleSerializedType serializedType;
+
+    @Before
+    public void setUp() throws Exception {
+        testSubject = new XomToByteArrayConverter();
+        serializedType = new SimpleSerializedType("custom", "0");
+    }
+
+    @Test
+    public void testCanConvert() {
+        assertEquals(Document.class, testSubject.expectedSourceType());
+        assertEquals(byte[].class, testSubject.targetType());
+    }
+
+    @Test
+    public void testConvert() throws Exception {
+        Document doc = new Document(new Element("rootElement"));
+
+        SimpleSerializedObject<Document> original = new SimpleSerializedObject<Document>(doc,
+                Document.class,
+                serializedType);
+        SerializedObject<byte[]> actual = testSubject.convert(original);
+
+        assertNotNull(actual);
+        assertNotNull(actual.getData());
+        String actualString = new String(actual.getData());
+
+        assertTrue("Wrong output: " + actualString, actualString.contains("rootElement"));
+    }
+}


### PR DESCRIPTION
This adds support for an alternative XML serializer to dom4j.

XOM is an open source (LGPL), tree-based API for processing XML with Java that strives for
correctness, simplicity, and performance, in that order.
http://www.xom.nu/
