### PR TITLE
ExtendedFileSystemEventStore that can be used together with ReplayingCluster

### DIFF
--- a/core/src/main/java/org/axonframework/eventstore/fs/ExtendedFileSystemEventStore.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/ExtendedFileSystemEventStore.java
@@ -42,7 +42,6 @@ public class ExtendedFileSystemEventStore extends FileSystemEventStore implement
                 DomainEventStream eventStream=readEvents(eventType, identifier);
                 while (eventStream.hasNext()) {
                     DomainEventMessage<?> eventMessage=eventStream.next();
-                    System.err.println(eventMessage);
                     visitor.doWithEvent(eventMessage);
                 }
             }

--- a/core/src/main/java/org/axonframework/eventstore/fs/ExtendedFileSystemEventStore.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/ExtendedFileSystemEventStore.java
@@ -1,0 +1,54 @@
+package org.axonframework.eventstore.fs;
+
+import org.axonframework.domain.DomainEventMessage;
+import org.axonframework.domain.DomainEventStream;
+import org.axonframework.eventhandling.replay.ReplayingCluster;
+import org.axonframework.eventstore.EventVisitor;
+import org.axonframework.eventstore.fs.ListableEventFileResolver.EventFileListConsumer;
+import org.axonframework.eventstore.management.Criteria;
+import org.axonframework.eventstore.management.CriteriaBuilder;
+import org.axonframework.eventstore.management.EventStoreManagement;
+
+/**
+ * Extend FileSystemEventStore to implement EventStoreManagement. This is used to allow FileSystemEventStore to be used
+ * with {@link ReplayingCluster}
+ */
+public class ExtendedFileSystemEventStore extends FileSystemEventStore implements EventStoreManagement
+{
+    protected final ListableEventFileResolver eventFileResolver;
+    public ExtendedFileSystemEventStore(ListableEventFileResolver eventFileResolver)
+    {
+        super(eventFileResolver);
+        this.eventFileResolver=eventFileResolver;
+    }
+    
+    @Override
+    public CriteriaBuilder newCriteriaBuilder()
+    {
+        throw new IllegalStateException("Criteria not supported");
+    }
+    @Override
+    public void visitEvents(Criteria criteria, EventVisitor visitor)
+    {
+        if (criteria!=null) throw new IllegalArgumentException("Criteria not supported");
+    }
+    @Override
+    public void visitEvents(final EventVisitor visitor)
+    {
+        eventFileResolver.listEvents(new EventFileListConsumer() {
+            @Override
+            public void consume(String eventType, String identifier)
+            {
+                DomainEventStream eventStream=readEvents(eventType, identifier);
+                while (eventStream.hasNext()) {
+                    DomainEventMessage<?> eventMessage=eventStream.next();
+                    System.err.println(eventMessage);
+                    visitor.doWithEvent(eventMessage);
+                }
+            }
+        });
+    }
+    
+    
+    
+}

--- a/core/src/main/java/org/axonframework/eventstore/fs/ListableEventFileResolver.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/ListableEventFileResolver.java
@@ -1,0 +1,15 @@
+package org.axonframework.eventstore.fs;
+
+
+/**
+ * Extension to EventFileResolver to allow to iterate through all aggregates
+ */
+public interface ListableEventFileResolver extends EventFileResolver
+{
+    public void listEvents(EventFileListConsumer consumer);
+    
+    public static interface EventFileListConsumer
+    {
+        public void consume(String eventType, String identifier);
+    }
+}

--- a/core/src/main/java/org/axonframework/eventstore/fs/SimpleEventFileResolver.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/SimpleEventFileResolver.java
@@ -47,7 +47,7 @@ public class SimpleEventFileResolver implements EventFileResolver {
      */
     public static final String FILE_EXTENSION_SNAPSHOTS = "snapshots";
 
-    private final File baseDir;
+    protected final File baseDir;
 
     /**
      * Initialize the SimpleEventFileResolver with the given <code>baseDir</code>.

--- a/core/src/main/java/org/axonframework/eventstore/fs/SimpleListableEventFileResolver.java
+++ b/core/src/main/java/org/axonframework/eventstore/fs/SimpleListableEventFileResolver.java
@@ -1,0 +1,48 @@
+package org.axonframework.eventstore.fs;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLDecoder;
+
+import org.axonframework.eventstore.fs.SimpleEventFileResolver;
+
+/**
+ * Variant of SimpleEventFileResolver that allows to iterate through all aggregates (to replay events)
+ * @author mwyraz
+ */
+public class SimpleListableEventFileResolver extends SimpleEventFileResolver implements ListableEventFileResolver
+{
+    public SimpleListableEventFileResolver(File baseDir)
+    {
+        super(baseDir);
+    }
+    
+    @Override
+    public void listEvents(EventFileListConsumer consumer)
+    {
+        final String EXT="."+FILE_EXTENSION_EVENTS;
+        File[] typeDirs=baseDir.listFiles();
+        if (typeDirs!=null) for (File typeDir: typeDirs)
+        {
+            if (!typeDir.isDirectory()) continue;
+            File[] eventFiles=typeDir.listFiles();
+            if (eventFiles!=null) for (File eventFile: eventFiles)
+            {
+                if (!eventFile.isFile()) continue;
+                if (!eventFile.getName().endsWith(EXT)) continue;
+                
+                String decodedEventId;
+                try
+                {
+                    decodedEventId=URLDecoder.decode(eventFile.getName().substring(0,eventFile.getName().length()-EXT.length()),"UTF-8");
+                }
+                catch (IOException ex)
+                {
+                    throw new IllegalStateException("UTF-8 not supported by vm?");
+                }
+                consumer.consume(typeDir.getName(), decodedEventId);
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
Hi Allard,

I have added an ExtendedFileSystemEventStore that is able to iterate through events using the EventStoreManagement interface. This allows it to be used togetehr with ReplayingCluster. Criterias are not supported.

Alternativlely FileSystemEventStore could be extended with this code (that means it would only work if the provided EventFileResolver is a ListableEventFileResolver). EventFileResolver also could be extended with teh new list method (probably the best way to do it but it would change this interface - so if someone implemented his own EventFileResolver he'd have to change the implementation with new next axonframework release).

Kind regards,
Michael.