### PR TITLE
EventValidator.assertPublishedEvents correct for empty arguments list

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -72,6 +72,13 @@ public class EventValidator implements EventListener {
      * @param expected the events that must have been published.
      */
     public void assertPublishedEvents(Object... expected) {
+        if (publishedEvents.size() != expected.length) {
+            throw new AxonAssertionError(format(
+                    "Got wrong number of events published. Expected <%s>, got <%s>",
+                    expected.length,
+                    publishedEvents.size()));
+        }
+
         assertPublishedEventsMatching(payloadsMatching(exactSequenceOf(createEqualToMatchers(expected))));
     }
 

--- a/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
@@ -1,0 +1,51 @@
+package org.axonframework.test.saga;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.test.utils.RecordingCommandBus;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CommandValidatorTest {
+
+    private CommandValidator testSubject;
+
+    private RecordingCommandBus commandBus;
+
+    @Before
+    public void setUp(){
+        commandBus = mock(RecordingCommandBus.class);
+        testSubject = new CommandValidator(commandBus);
+    }
+
+    @Test
+    public void testAssertEmptyDispatchedEqualTo() throws Exception {
+        when(commandBus.getDispatchedCommands()).thenReturn(emptyCommandMessageList());
+
+        testSubject.assertDispatchedEqualTo();
+    }
+
+    @Test
+    public void testAssertNonEmptyDispatchedEqualTo() throws Exception {
+        when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage("command"));
+
+        testSubject.assertDispatchedEqualTo("command");
+    }
+
+    private List<CommandMessage<?>> emptyCommandMessageList() {
+        return Collections.<CommandMessage<?>>emptyList();
+    }
+
+    private List<CommandMessage<?>> listOfOneCommandMessage(String msg) {
+        return Arrays.<CommandMessage<?>>asList(GenericCommandMessage.asCommandMessage(msg));
+    }
+
+
+}

--- a/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -1,0 +1,47 @@
+package org.axonframework.test.saga;
+
+import org.axonframework.domain.GenericEventMessage;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.test.AxonAssertionError;
+import org.axonframework.test.MyOtherEvent;
+import org.axonframework.test.matchers.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EventValidatorTest {
+
+    private EventValidator testSubject;
+
+    @Before
+    public void setUp(){
+        EventBus eventBusShouldNotBeUsed = null;
+        testSubject = new EventValidator(eventBusShouldNotBeUsed);
+    }
+
+    @Test
+    public void testAssertPublishedEventsWithNoEventsMatcherIfNoEventWasPublished() throws Exception {
+        testSubject.assertPublishedEventsMatching(Matchers.noEvents());
+    }
+
+    @Test(expected = AxonAssertionError.class)
+    public void testAssertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() throws Exception {
+        testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
+
+        testSubject.assertPublishedEventsMatching(Matchers.noEvents());
+    }
+
+    @Test
+    public void testAssertPublishedEventsIfNoEventWasPublished() throws Exception {
+        testSubject.assertPublishedEvents();
+    }
+
+    @Test(expected = AxonAssertionError.class)
+    public void testAssertPublishedEventsThrowsAssertionErrorIfEventWasPublished() throws Exception {
+        testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
+
+        testSubject.assertPublishedEvents();
+    }
+
+
+
+}


### PR DESCRIPTION
EventValidator.assertPublishedEvent will now throw an AxonAssertionException when an empty arguments list is passed while there were events published.

More info, see http://issues.axonframework.org/youtrack/issue/AXON-255
