### PR TITLE
Fix for Axon-263 (Saga managers don't accept multiple base packages)

### DIFF
--- a/core/src/main/java/org/axonframework/contextsupport/spring/AbstractSagaManagerBeanDefinitionParser.java
+++ b/core/src/main/java/org/axonframework/contextsupport/spring/AbstractSagaManagerBeanDefinitionParser.java
@@ -181,11 +181,13 @@ public abstract class AbstractSagaManagerBeanDefinitionParser {
             ClassPathScanningCandidateComponentProvider scanner =
                     new ClassPathScanningCandidateComponentProvider(false);
             scanner.addIncludeFilter(new AssignableTypeFilter(AbstractAnnotatedSaga.class));
-            String basePackage = element.getAttribute("base-package");
-            if (StringUtils.hasText(basePackage)) {
-                Set<BeanDefinition> candidates = scanner.findCandidateComponents(basePackage.trim());
-                for (BeanDefinition bd : candidates) {
-                    filteredTypes.add(bd.getBeanClassName());
+            for (String basePackage : element.getAttribute("base-package").split(",")) {
+                basePackage = basePackage.trim();
+                if (StringUtils.hasText(basePackage)) {
+                    Set<BeanDefinition> candidates = scanner.findCandidateComponents(basePackage);
+                    for (BeanDefinition bd : candidates) {
+                        filteredTypes.add(bd.getBeanClassName());
+                    }
                 }
             }
         }


### PR DESCRIPTION
The base-package value is now split on comma before processing.
