### PR TITLE
Handle incomplete events for event sourced aggregates

### DIFF
--- a/core/src/main/java/org/axonframework/domain/AbstractAggregateRoot.java
+++ b/core/src/main/java/org/axonframework/domain/AbstractAggregateRoot.java
@@ -63,6 +63,17 @@ public abstract class AbstractAggregateRoot<I> implements AggregateRoot<I>, Seri
     /**
      * Registers an event to be published when the aggregate is saved.
      *
+     * @param event the event to register
+     * @param <T>     The type of payload
+     * @return The Event
+     */
+    protected <T> DomainEventMessage<T> registerEvent(DomainEventMessage<T> event) {
+        return getEventContainer().addEvent(event);
+    }
+
+    /**
+     * Registers an event to be published when the aggregate is saved.
+     *
      * @param metaData The meta data of the event to register
      * @param payload  the payload of the event to register
      * @param <T>      The type of payload

--- a/core/src/main/java/org/axonframework/domain/EventContainer.java
+++ b/core/src/main/java/org/axonframework/domain/EventContainer.java
@@ -88,9 +88,13 @@ public class EventContainer implements Serializable {
      * @return the DomainEventMessage added to the container
      */
     public <T> DomainEventMessage<T> addEvent(final DomainEventMessage<T> event) {
-        DomainEventMessage<T> newEvent = new GenericDomainEventMessage<T>(event.getIdentifier(), event.getTimestamp(),
-                aggregateIdentifier, newSequenceNumber(), event.getPayload(), event.getMetaData());
-        return actuallyAddEvent(newEvent);
+        if(event.getAggregateIdentifier() != null){
+            return actuallyAddEvent(event);
+        }else {
+            DomainEventMessage<T> newEvent = new GenericDomainEventMessage<T>(event.getIdentifier(), event.getTimestamp(),
+                    aggregateIdentifier, newSequenceNumber(), event.getPayload(), event.getMetaData());
+            return actuallyAddEvent(newEvent);
+        }
     }
 
 
@@ -98,19 +102,19 @@ public class EventContainer implements Serializable {
      * Helper method for addEvent. Handles the actual adding of the event and calling of all registered
      * EventRegistrationCallback callbacks.
      *
-     * @param newEvent the event to add to this container
+     * @param event the event to add to this container
      * @param <T>      the type of payload contained in the event
      * @return the DomainEventMessage added to the container (possibly altered by callbacks)
      */
-    private <T> DomainEventMessage<T> actuallyAddEvent(DomainEventMessage<T> newEvent) {
+    private <T> DomainEventMessage<T> actuallyAddEvent(DomainEventMessage<T> event) {
         if (registrationCallbacks != null) {
             for (EventRegistrationCallback callback : registrationCallbacks) {
-                newEvent = callback.onRegisteredEvent(newEvent);
+                event = callback.onRegisteredEvent(event);
             }
         }
-        lastSequenceNumber = newEvent.getSequenceNumber();
-        events.add(newEvent);
-        return newEvent;
+        lastSequenceNumber = event.getSequenceNumber();
+        events.add(event);
+        return event;
     }
 
     /**

--- a/core/src/main/java/org/axonframework/eventsourcing/AbstractEventSourcedAggregateRoot.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/AbstractEventSourcedAggregateRoot.java
@@ -110,8 +110,9 @@ public abstract class AbstractEventSourcedAggregateRoot<I> extends AbstractAggre
                                                                      + "It must be initialized at the latest when the "
                                                                      + "first event is applied.");
                 }
-                handleRecursively(new GenericDomainEventMessage<Object>(null, 0, eventPayload, metaData));
-                registerEvent(metaData, eventPayload);
+                final GenericDomainEventMessage<Object> event = new GenericDomainEventMessage<Object>(null, 0, eventPayload, metaData);
+                handleRecursively(event);
+                registerEvent(event);
             } else {
                 // eventsToApply may heb been set to null by serialization
                 if (eventsToApply == null) {


### PR DESCRIPTION
(See https://groups.google.com/forum/#!topic/axonframework/CVW48ZdM8LU for more context)

In event sourced aggregates it is not uncommon that its constructor is a command handler which has to apply an event in order to set up its state. As the aggregate identifier can not be set prior to handling the event, there is a need for a work around which first applies the event and registers it afterwards.

This workaround resulted in slightly different events being applied and saved. If, for example, the timestamp of the event was used in the aggregate creation, this results in different state of the aggregate.

In this pull request I have extended the work around such that it now tries to save the originally applied event. As this event is incomplete, it provides the additional information (i.e. the aggregate identifier).