### PR TITLE
Fix custom command names with JGroupsConnector

### DIFF
--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
@@ -55,7 +55,7 @@ public abstract class AbstractRoutingStrategy implements RoutingStrategy {
             switch (unresolvedRoutingKeyPolicy) {
                 case ERROR:
                     throw new CommandDispatchException(format("The command [%s] does not contain a routing key.",
-                                                              command.getPayloadType().getName()));
+                                                              command.getCommandName()));
                 case RANDOM_KEY:
                     return Long.toHexString(counter.getAndIncrement());
                 case STATIC_KEY:

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnector.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnector.java
@@ -190,9 +190,9 @@ public class JGroupsConnector implements CommandBusConnector {
     public <R> void send(String routingKey, CommandMessage<?> commandMessage, CommandCallback<R> callback)
             throws Exception {
         Assert.isTrue(awaitJoined(5, TimeUnit.SECONDS), "This Connector did not properly join the Cluster yet.");
-        String destination = consistentHash.getMember(routingKey, commandMessage.getPayloadType().getName());
+        String destination = consistentHash.getMember(routingKey, commandMessage.getCommandName());
         if (destination == null) {
-            throw new CommandDispatchException("No node known to accept " + commandMessage.getPayloadType().getName());
+            throw new CommandDispatchException("No node known to accept " + commandMessage.getCommandName());
         }
         Address dest = getAddress(destination);
         callbacks.put(commandMessage.getIdentifier(), new MemberAwareCommandCallback<R>(dest, callback));
@@ -202,9 +202,9 @@ public class JGroupsConnector implements CommandBusConnector {
     @Override
     public void send(String routingKey, CommandMessage<?> commandMessage) throws Exception {
         Assert.isTrue(awaitJoined(5, TimeUnit.SECONDS), "This Connector did not properly join the Cluster yet.");
-        String destination = consistentHash.getMember(routingKey, commandMessage.getPayloadType().getName());
+        String destination = consistentHash.getMember(routingKey, commandMessage.getCommandName());
         if (destination == null) {
-            throw new CommandDispatchException("No node known to accept " + commandMessage.getPayloadType().getName());
+            throw new CommandDispatchException("No node known to accept " + commandMessage.getCommandName());
         }
         Address dest = getAddress(destination);
         channel.send(dest, new DispatchMessage(commandMessage, serializer, false));


### PR DESCRIPTION
Command name ≠ class name, necessarily.
- JGroupsConnector fix
- Test case
- Updated error message in AbstractRoutingStrategy for consistency (take it or leave it)
