### PR TITLE
Event handlers of sagas under test are not called if a GenericEventMessages is used as parameter to whenPubishinA

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
@@ -181,7 +181,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     public FixtureExecutionResult whenPublishingA(Object event) {
         try {
             fixtureExecutionResult.startRecording();
-            sagaManager.handle(new GenericEventMessage<Object>(event));
+            sagaManager.handle(GenericEventMessage.asEventMessage(event));
         } finally {
             FixtureResourceParameterResolverFactory.clear();
         }


### PR DESCRIPTION
The event handlers of sagas under test by `AnnotatedSagaTestFixture` are not called properly if the event is wrapped in a `GenericEventMessage` or other subclasses of `EventMessage`. However, this is sometimes necessary as code in sagas might depend on meta data etc. which can only be passed by wrapping the event in tests.

Related issue: http://issues.axonframework.org/youtrack/issue/AXON-285
