### PR TITLE
Added support for @CommandHandler on map of entities

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/annotation/CommandHandlingMemberMap.java
+++ b/core/src/main/java/org/axonframework/commandhandling/annotation/CommandHandlingMemberMap.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2014. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling.annotation;
+
+import org.axonframework.eventsourcing.annotation.AbstractAnnotatedEntity;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for fields that contain a {@link java.util.Map} of Entities capable of handling Commands on behalf of the aggregate. When
+ * a field is annotated with <code>@CommandHandlerMemberMap</code>, it is a hint towards Command Handler discovery
+ * mechanisms that the entity should also be inspected for {@link org.axonframework.commandhandling.annotation.CommandHandler} annotated methods.
+ * <p/>
+ * Note that CommandHandler detection is done using static typing. This means that only the declared type of the field
+ * can be inspected. If a subclass of that type is assigned to the field, any handlers declared on that subclass will
+ * be ignored.
+ *
+ * @author Jeroen Bruinink
+ * @since 2.4
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface CommandHandlingMemberMap {
+
+    /**
+     * The name of the property on the incoming command's payload that identifies the intended target of the command.
+     * This identity should correspond to the keys in the annotated map.
+     * <p/>
+     * The name of this method must correspond with the getter method using the JavaBean specification (property 'id'
+     * is accessed using method 'getId()'), or any other specification supported by a configured
+     * {@link org.axonframework.common.property.PropertyAccessStrategy}.
+     */
+    String commandTargetProperty();
+
+    /**
+     * The type of entity contained in the annotated map. By default, Axon attempts to identify the type by the
+     * generic parameters on the field declaration.
+     */
+    Class<? extends AbstractAnnotatedEntity> entityType() default AbstractAnnotatedEntity.class;
+}

--- a/core/src/test/java/org/axonframework/commandhandling/annotation/AggregateAnnotationCommandHandlerTest.java
+++ b/core/src/test/java/org/axonframework/commandhandling/annotation/AggregateAnnotationCommandHandlerTest.java
@@ -39,6 +39,7 @@ import org.junit.*;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,8 @@ public class AggregateAnnotationCommandHandlerTest {
                 // declared in the entities
                 UpdateNestedEntityStateCommand.class.getName(),
                 UpdateEntityStateCommand.class.getName(),
-                UpdateEntityFromCollectionStateCommand.class.getName()));
+                UpdateEntityFromCollectionStateCommand.class.getName(),
+                UpdateEntityFromMapStateCommand.class.getName()));
 
         assertEquals(expected, actual);
     }
@@ -400,7 +402,7 @@ public class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    public void testCommandHandledByEntityFromCollection_NullIdInEvent() {
+    public void testCommandHandledByEntityFromCollection_NullIdInCommand() {
         Object aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate aggregate = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         aggregate.initializeEntity("1");
@@ -451,14 +453,99 @@ public class AggregateAnnotationCommandHandlerTest {
 
     @Test(expected = AxonConfigurationException.class)
     public void testAnnotatedFieldMustBeACollection() throws Exception {
-        new AggregateAnnotationCommandHandler(WrongAnnotatedField.class, mockRepository);
+        new AggregateAnnotationCommandHandler(AnnotatedFieldIsNotCollection.class, mockRepository);
     }
 
     @Test(expected = AxonConfigurationException.class)
-    public void testAnnotatedFieldMustContainGenericParameterWhenTypeIsNotExplicitlyDefined() throws Exception {
-        new AggregateAnnotationCommandHandler(FieldWithoutGenerics.class, mockRepository);
+    public void testAnnotatedCollectionFieldMustContainGenericParameterWhenTypeIsNotExplicitlyDefined() throws Exception {
+        new AggregateAnnotationCommandHandler(CollectionFieldWithoutGenerics.class, mockRepository);
+    }
+    
+    @Test
+    public void testCommandHandledByEntityFromMap() {
+        Object aggregateIdentifier = "abc123";
+        final StubCommandAnnotatedAggregate aggregate = new StubCommandAnnotatedAggregate(aggregateIdentifier);
+        aggregate.initializeEntity("1");
+        aggregate.initializeEntity("2");
+        aggregate.initializeEntity("3");
+        when(mockRepository.load(any(Object.class), anyLong())).thenReturn(aggregate);
+        commandBus.dispatch(GenericCommandMessage.asCommandMessage(
+                                    new UpdateEntityFromMapStateCommand("abc123", "2")),
+                            new CommandCallback<Object>() {
+                                @Override
+                                public void onSuccess(Object result) {
+                                    assertEquals("handled by 2", result);
+                                }
+
+                                @Override
+                                public void onFailure(Throwable cause) {
+                                    cause.printStackTrace();
+                                    fail("Did not expect exception");
+                                }
+                            }
+        );
+
+        verify(mockRepository).load(aggregateIdentifier, null);
     }
 
+    @Test
+    public void testCommandHandledByEntityFromMap_NoEntityAvailable() {
+        Object aggregateIdentifier = "abc123";
+        final StubCommandAnnotatedAggregate aggregate = new StubCommandAnnotatedAggregate(aggregateIdentifier);
+        aggregate.initializeEntity("1");
+        when(mockRepository.load(any(Object.class), anyLong())).thenReturn(aggregate);
+        commandBus.dispatch(GenericCommandMessage.asCommandMessage(
+                                    new UpdateEntityFromMapStateCommand("abc123", "2")),
+                            new CommandCallback<Object>() {
+                                @Override
+                                public void onSuccess(Object result) {
+                                    fail("Expected exception");
+                                }
+
+                                @Override
+                                public void onFailure(Throwable cause) {
+                                    assertTrue(cause instanceof IllegalStateException);
+                                }
+                            }
+        );
+
+        verify(mockRepository).load(aggregateIdentifier, null);
+    }
+
+    @Test
+    public void testCommandHandledByEntityFromMap_NullIdInCommand() {
+        Object aggregateIdentifier = "abc123";
+        final StubCommandAnnotatedAggregate aggregate = new StubCommandAnnotatedAggregate(aggregateIdentifier);
+        aggregate.initializeEntity("1");
+        when(mockRepository.load(any(Object.class), anyLong())).thenReturn(aggregate);
+        commandBus.dispatch(GenericCommandMessage.asCommandMessage(
+                                    new UpdateEntityFromMapStateCommand("abc123", null)),
+                            new CommandCallback<Object>() {
+                                @Override
+                                public void onSuccess(Object result) {
+                                    fail("Expected exception");
+                                }
+
+                                @Override
+                                public void onFailure(Throwable cause) {
+                                    assertTrue(cause instanceof IllegalStateException);
+                                }
+                            }
+        );
+
+        verify(mockRepository).load(aggregateIdentifier, null);
+    }
+
+    @Test(expected = AxonConfigurationException.class)
+    public void testAnnotatedFieldMustBeAMap() throws Exception {
+        new AggregateAnnotationCommandHandler(AnnotatedFieldIsNotMap.class, mockRepository);
+    }
+
+    @Test(expected = AxonConfigurationException.class)
+    public void testAnnotatedMapFieldMustContainGenericParameterWhenTypeIsNotExplicitlyDefined() throws Exception {
+        new AggregateAnnotationCommandHandler(MapFieldWithoutGenerics.class, mockRepository);
+    }
+    
 
     private abstract static class AbstractStubCommandAnnotatedAggregate extends AbstractAnnotatedAggregateRoot {
 
@@ -485,6 +572,9 @@ public class AggregateAnnotationCommandHandlerTest {
         @CommandHandlingMemberCollection(entityId = "id", commandTargetProperty = "entityId")
         private List<StubCommandAnnotatedCollectionEntity> entities;
 
+        @CommandHandlingMemberMap(commandTargetProperty = "entityId")
+        private Map<String, StubCommandAnnotatedMapEntity> entityMap;
+        
         @CommandHandler
         public StubCommandAnnotatedAggregate(CreateCommand createCommand, MetaData metaData, UnitOfWork unitOfWork,
                                              @org.axonframework.common.annotation.MetaData("notExist") String value) {
@@ -548,25 +638,29 @@ public class AggregateAnnotationCommandHandlerTest {
                 this.entities = new ArrayList<StubCommandAnnotatedCollectionEntity>();
             }
             this.entities.add(new StubCommandAnnotatedCollectionEntity(id));
+            if (this.entityMap == null) {
+            	this.entityMap = new HashMap<String, StubCommandAnnotatedMapEntity>();
+            }
+            this.entityMap.put(id, new StubCommandAnnotatedMapEntity(id));
         }
     }
 
-    private static class WrongAnnotatedField extends StubCommandAnnotatedAggregate {
+    private static class AnnotatedFieldIsNotCollection extends StubCommandAnnotatedAggregate {
 
         @CommandHandlingMemberCollection(entityId = "id", commandTargetProperty = "entityId")
         private Map<String, String> wrongField;
 
-        public WrongAnnotatedField(Object aggregateIdentifier) {
+        public AnnotatedFieldIsNotCollection(Object aggregateIdentifier) {
             super(aggregateIdentifier);
         }
     }
 
-    private static class FieldWithoutGenerics extends StubCommandAnnotatedAggregate {
+    private static class CollectionFieldWithoutGenerics extends StubCommandAnnotatedAggregate {
 
         @CommandHandlingMemberCollection(entityId = "id", commandTargetProperty = "entityId")
         private List wrongField;
 
-        public FieldWithoutGenerics(Object aggregateIdentifier) {
+        public CollectionFieldWithoutGenerics(Object aggregateIdentifier) {
             super(aggregateIdentifier);
         }
     }
@@ -611,6 +705,44 @@ public class AggregateAnnotationCommandHandlerTest {
             return "nested entity command handled just fine";
         }
     }
+    
+    private static class StubCommandAnnotatedMapEntity extends AbstractAnnotatedEntity {
+    	
+    	private String id;
+    	
+    	private StubCommandAnnotatedMapEntity(String id) {
+    		this.id = id;
+		}
+    	
+    	@CommandHandler
+    	public String handle(UpdateEntityFromMapStateCommand command) {
+    		return "handled by " + getId();
+    	}
+
+		private String getId() {
+			return id;
+		}
+    }
+
+    private static class AnnotatedFieldIsNotMap extends StubCommandAnnotatedAggregate {
+
+        @CommandHandlingMemberMap(commandTargetProperty = "entityId")
+        private Set<String> wrongField;
+
+        public AnnotatedFieldIsNotMap(Object aggregateIdentifier) {
+            super(aggregateIdentifier);
+        }
+    }
+
+    private static class MapFieldWithoutGenerics extends StubCommandAnnotatedAggregate {
+
+        @CommandHandlingMemberMap(commandTargetProperty = "entityId")
+        private Map wrongField;
+
+        public MapFieldWithoutGenerics(Object aggregateIdentifier) {
+            super(aggregateIdentifier);
+        }
+    }
 
     private static class UpdateNestedEntityStateCommand {
 
@@ -621,7 +753,7 @@ public class AggregateAnnotationCommandHandlerTest {
             this.aggregateId = aggregateId;
         }
     }
-
+    
     private static class CreateCommand {
 
         private final String id;
@@ -772,4 +904,21 @@ public class AggregateAnnotationCommandHandlerTest {
             return entityId;
         }
     }
+
+    private static class UpdateEntityFromMapStateCommand {
+    	@TargetAggregateIdentifier
+    	private final String aggregateId;
+    	
+    	private final String entityKey;
+    	
+    	private UpdateEntityFromMapStateCommand(String aggregateId, String entityId) {
+    		this.aggregateId = aggregateId;
+    		this.entityKey = entityId;
+    	}
+    	
+    	public String getEntityId() {
+    		return entityKey;
+    	}
+    }
+
 }


### PR DESCRIPTION
Added an annotation to mark fields with a map of entities capable of
handling commands. The annotation specifies which field in the command
to use as a key to look up the appropriate entity in the map.