### PR TITLE
Enhance exception message in case of unsupported metadata mutation.

### DIFF
--- a/core/src/main/java/org/axonframework/domain/MetaData.java
+++ b/core/src/main/java/org/axonframework/domain/MetaData.java
@@ -34,7 +34,7 @@ public class MetaData implements Map<String, Object>, Serializable {
 
     private static final long serialVersionUID = -7892913866303912970L;
     private static final MetaData EMPTY_META_DATA = new MetaData();
-    private static final String UNSUPPORTED_MUTATION_MSG = "Event meta-data is immutable.";
+    private static final String UNSUPPORTED_MUTATION_MSG = "Metadata is immutable.";
 
     private final Map<String, Object> values;
 


### PR DESCRIPTION
Enhance exception message in case of unsupported metadata mutation.
Really the metadata can be used in any message, however the unsupported exception message (confusingly) reported event metadata.