### PR TITLE
Jgroups configuration enhancements

### DIFF
--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/HashChangeListener.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/HashChangeListener.java
@@ -1,0 +1,17 @@
+package org.axonframework.commandhandling.distributed.jgroups;
+
+import org.axonframework.commandhandling.distributed.ConsistentHash;
+import org.jgroups.Address;
+
+import java.util.List;
+
+/**
+ * Receive updates from the JGroupsConnector when the consistent hash changes.
+ * This is useful e.g. to clear domain caches that may contain stale versions of aggregates.
+ *
+ * @author Patrick Haas
+ */
+public interface HashChangeListener {
+
+    void hashChanged(ConsistentHash newHash);
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
@@ -1,0 +1,14 @@
+package org.axonframework.commandhandling.distributed.jgroups;
+
+import org.jgroups.JChannel;
+
+/**
+ * JChannel factory used by the {@link JGroupsConnectorFactoryBean} to create the actual {@link JChannel}.
+ *
+ *
+ * @author Patrick Haas
+ */
+public interface JChannelFactory {
+
+    JChannel createChannel() throws Exception;
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.commandhandling.distributed.jgroups;
 
 import org.jgroups.JChannel;

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JChannelFactory.java
@@ -21,7 +21,6 @@ import org.jgroups.JChannel;
 /**
  * JChannel factory used by the {@link JGroupsConnectorFactoryBean} to create the actual {@link JChannel}.
  *
- *
  * @author Patrick Haas
  */
 public interface JChannelFactory {

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
@@ -57,6 +57,7 @@ public class JGroupsConnectorFactoryBean implements FactoryBean, InitializingBea
     private List<CommandHandlerInterceptor> interceptors;
     private long joinTimeout = -1;
     private boolean registerMBean = false;
+    private HashChangeListener hashChangeListener;
 
     @Override
     public Object getObject() throws Exception {
@@ -92,7 +93,7 @@ public class JGroupsConnectorFactoryBean implements FactoryBean, InitializingBea
         if (channelName != null) {
             channel.setName(channelName);
         }
-        connector = new JGroupsConnector(channel, clusterName, localSegment, serializer);
+        connector = new JGroupsConnector(channel, clusterName, localSegment, serializer, hashChangeListener);
     }
 
     /**
@@ -199,6 +200,17 @@ public class JGroupsConnectorFactoryBean implements FactoryBean, InitializingBea
      */
     public void setRegisterMBean(boolean registerMBean) {
         this.registerMBean = registerMBean;
+    }
+
+    /**
+     * Register a {@link HashChangeListener} with the {@link JGroupsConnector}. The listener
+     * will be notified when the consistent hash changes due to members joining or leaving the
+     * JGroup.
+     *
+     * @param hashChangeListener
+     */
+    public void setHashChangeListener(HashChangeListener hashChangeListener) {
+        this.hashChangeListener = hashChangeListener;
     }
 
     @Override

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
@@ -120,6 +120,7 @@ public class JGroupsConnectorFactoryBean implements FactoryBean, InitializingBea
 
     /**
      * Sets the JChannelFactory that allows programmatic definition of the JChannel.
+     *
      * @param channelFactory
      */
     public void setChannelFactory(JChannelFactory channelFactory) {

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
@@ -1,0 +1,19 @@
+package org.axonframework.commandhandling.distributed.jgroups;
+
+import org.jgroups.JChannel;
+
+/**
+ * @author Patrick Haas
+ */
+public class JGroupsXmlConfigurationChannelFactory implements JChannelFactory {
+    private final String configuration;
+
+    public JGroupsXmlConfigurationChannelFactory(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public JChannel createChannel() throws Exception {
+        return new JChannel(configuration);
+    }
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
@@ -22,6 +22,7 @@ import org.jgroups.JChannel;
  * @author Patrick Haas
  */
 public class JGroupsXmlConfigurationChannelFactory implements JChannelFactory {
+
     private final String configuration;
 
     public JGroupsXmlConfigurationChannelFactory(String configuration) {

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsXmlConfigurationChannelFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.commandhandling.distributed.jgroups;
 
 import org.jgroups.JChannel;

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
@@ -124,7 +124,6 @@ public class JGroupsConnectorFactoryBeanTest {
         verify(mockChannel).close();
     }
 
-
     @Test
     public void testCreateWithCustomChannel() throws Exception {
         JChannelFactory mockFactory = mock(JChannelFactory.class);
@@ -174,8 +173,6 @@ public class JGroupsConnectorFactoryBeanTest {
 
         verify(mockChannel).close();
     }
-
-
 
     @Test
     public void testSimpleProperties() {

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
@@ -43,7 +43,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JGroupsConnectorFactoryBean.class, JChannel.class, JGroupsConnector.class,
-        JGroupsXmlConfigurationChannelFactory.class, Util.class})
+                        JGroupsXmlConfigurationChannelFactory.class, Util.class})
 public class JGroupsConnectorFactoryBeanTest {
 
     private JGroupsConnectorFactoryBean testSubject;
@@ -109,7 +109,7 @@ public class JGroupsConnectorFactoryBeanTest {
 
         verifyNew(JChannel.class).withArguments("custom.xml");
         verifyNew(JGroupsConnector.class).withArguments(eq(mockChannel), eq("ClusterName"),
-                same(localSegment), same(serializer));
+                                                        same(localSegment), same(serializer));
         verify(mockApplicationContext, never()).getBean(Serializer.class);
         verify(mockChannel).setName("localname");
         verify(mockConnector).connect(200);

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBeanTest.java
@@ -21,6 +21,7 @@ import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.serializer.Serializer;
 import org.axonframework.serializer.xml.XStreamSerializer;
 import org.jgroups.JChannel;
+import org.jgroups.util.Util;
 import org.junit.*;
 import org.junit.runner.*;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -33,13 +34,16 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.same;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
  * @author Allard Buijze
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JGroupsConnectorFactoryBean.class, JChannel.class, JGroupsConnector.class})
+@PrepareForTest({JGroupsConnectorFactoryBean.class, JChannel.class, JGroupsConnector.class,
+        JGroupsXmlConfigurationChannelFactory.class, Util.class})
 public class JGroupsConnectorFactoryBeanTest {
 
     private JGroupsConnectorFactoryBean testSubject;
@@ -49,6 +53,7 @@ public class JGroupsConnectorFactoryBeanTest {
 
     @Before
     public void setUp() throws Exception {
+        mockStatic(Util.class);
         mockApplicationContext = mock(ApplicationContext.class);
         mockChannel = mock(JChannel.class);
         mockConnector = mock(JGroupsConnector.class);
@@ -76,6 +81,9 @@ public class JGroupsConnectorFactoryBeanTest {
         verify(mockConnector).connect(100);
         verify(mockChannel, never()).close();
 
+        verifyStatic(never());
+        Util.registerChannel(any(JChannel.class), anyString());
+
         testSubject.stop(new Runnable() {
             @Override
             public void run() {
@@ -101,7 +109,7 @@ public class JGroupsConnectorFactoryBeanTest {
 
         verifyNew(JChannel.class).withArguments("custom.xml");
         verifyNew(JGroupsConnector.class).withArguments(eq(mockChannel), eq("ClusterName"),
-                                                        same(localSegment), same(serializer));
+                same(localSegment), same(serializer));
         verify(mockApplicationContext, never()).getBean(Serializer.class);
         verify(mockChannel).setName("localname");
         verify(mockConnector).connect(200);
@@ -115,6 +123,59 @@ public class JGroupsConnectorFactoryBeanTest {
 
         verify(mockChannel).close();
     }
+
+
+    @Test
+    public void testCreateWithCustomChannel() throws Exception {
+        JChannelFactory mockFactory = mock(JChannelFactory.class);
+        when(mockFactory.createChannel()).thenReturn(mockChannel);
+
+        testSubject.setChannelFactory(mockFactory);
+        testSubject.afterPropertiesSet();
+        testSubject.start();
+        testSubject.getObject();
+
+        verify(mockFactory).createChannel();
+        verifyNew(JGroupsConnector.class).withArguments(eq(mockChannel), eq("beanName"), isA(
+                SimpleCommandBus.class), isA(Serializer.class));
+        verify(mockConnector).connect(100);
+        verify(mockChannel, never()).close();
+
+        testSubject.stop(new Runnable() {
+            @Override
+            public void run() {
+            }
+        });
+
+        verify(mockChannel).close();
+    }
+
+    @Test
+    public void testRegisterMBean() throws Exception {
+
+        testSubject.setRegisterMBean(true);
+        testSubject.afterPropertiesSet();
+        testSubject.start();
+        testSubject.getObject();
+
+        verifyStatic(times(1));
+        Util.registerChannel(eq(mockChannel), isNull(String.class));
+
+        verifyNew(JGroupsConnector.class).withArguments(eq(mockChannel), eq("beanName"), isA(
+                SimpleCommandBus.class), isA(Serializer.class));
+        verify(mockConnector).connect(100);
+        verify(mockChannel, never()).close();
+
+        testSubject.stop(new Runnable() {
+            @Override
+            public void run() {
+            }
+        });
+
+        verify(mockChannel).close();
+    }
+
+
 
     @Test
     public void testSimpleProperties() {

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorTest.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.commandhandling.distributed.jgroups;
 
-import static java.util.Collections.*;
-
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandHandler;
@@ -37,6 +35,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,6 +56,7 @@ public class JGroupsConnectorTest {
     private JGroupsConnector connector2;
     private CommandBus mockCommandBus2;
     private String clusterName;
+    private RecordingHashChangeListener hashChangeListener;
 
     @Before
     public void setUp() throws Exception {
@@ -63,7 +65,9 @@ public class JGroupsConnectorTest {
         mockCommandBus1 = spy(new SimpleCommandBus());
         mockCommandBus2 = spy(new SimpleCommandBus());
         clusterName = "test-" + new Random().nextInt(Integer.MAX_VALUE);
-        connector1 = new JGroupsConnector(channel1, clusterName, mockCommandBus1, new XStreamSerializer());
+        hashChangeListener = new RecordingHashChangeListener();
+        connector1 = new JGroupsConnector(channel1, clusterName, mockCommandBus1, new XStreamSerializer(),
+                                          hashChangeListener);
         connector2 = new JGroupsConnector(channel2, clusterName, mockCommandBus2, new XStreamSerializer());
     }
 
@@ -180,7 +184,7 @@ public class JGroupsConnectorTest {
         ConsistentHash hashBefore = connector1.getConsistentHash();
         // secretly insert an illegal message
         channel1.getReceiver().receive(new Message(channel1.getAddress(), new IpAddress(12345),
-                                  new JoinMessage(10, Collections.<String>emptySet())));
+                                                   new JoinMessage(10, Collections.<String>emptySet())));
         ConsistentHash hash2After = connector1.getConsistentHash();
         assertEquals("That message should not have changed the ring", hashBefore, hash2After);
     }
@@ -261,11 +265,15 @@ public class JGroupsConnectorTest {
             FutureCallback<Object> callback = new FutureCallback<Object>();
             String message = "message" + t;
             if ((t % 3) == 0) {
-                connector1.send(message, new GenericCommandMessage<Object>("myCommand1", message,
-                            Collections.<String,Object>emptyMap()), callback);
+                connector1.send(message,
+                                new GenericCommandMessage<Object>("myCommand1", message,
+                                                                  Collections.<String, Object>emptyMap()),
+                                callback);
             } else {
-                connector2.send(message, new GenericCommandMessage<Object>("myCommand2", message,
-                            Collections.<String,Object>emptyMap()), callback);
+                connector2.send(message,
+                                new GenericCommandMessage<Object>("myCommand2", message,
+                                                                  Collections.<String, Object>emptyMap()),
+                                callback);
             }
             callbacks.add(callback);
         }
@@ -277,6 +285,27 @@ public class JGroupsConnectorTest {
         System.out.println("Node 2 got " + counter2.get());
         verify(mockCommandBus1, times(34)).dispatch(any(CommandMessage.class), isA(CommandCallback.class));
         verify(mockCommandBus2, times(66)).dispatch(any(CommandMessage.class), isA(CommandCallback.class));
+    }
+
+    @Test(timeout = 300000)
+    public void testHashChangeNotification() throws Exception {
+        connector1.connect(10);
+        connector2.connect(10);
+
+        // wait for both connectors to have the same view
+        waitForConnectorSync();
+
+        ConsistentHash notify1 = hashChangeListener.notifications.poll(5, TimeUnit.SECONDS);
+        ConsistentHash notify2 = hashChangeListener.notifications.poll(5, TimeUnit.SECONDS);
+        ConsistentHash notify3 = hashChangeListener.notifications.poll(5, TimeUnit.SECONDS);
+        // Self and other node have joined
+        assertEquals(connector1.getConsistentHash(), notify3);
+
+        channel2.close();
+
+        // Other node has left
+        ConsistentHash notify4 = hashChangeListener.notifications.poll(5, TimeUnit.SECONDS);
+        assertEquals(connector1.getConsistentHash(), notify4);
     }
 
 
@@ -304,6 +333,16 @@ public class JGroupsConnectorTest {
         public Object handle(CommandMessage<T> stringCommandMessage, UnitOfWork unitOfWork) throws Throwable {
             counter.incrementAndGet();
             return "The Reply!";
+        }
+    }
+
+    private static class RecordingHashChangeListener implements HashChangeListener {
+
+        public final BlockingQueue<ConsistentHash> notifications = new LinkedBlockingQueue<ConsistentHash>();
+
+        @Override
+        public void hashChanged(ConsistentHash newHash) {
+            notifications.add(newHash);
         }
     }
 }

--- a/documentation/src/main/docbook/en-US/reference-guide/3-command-handling.xml
+++ b/documentation/src/main/docbook/en-US/reference-guide/3-command-handling.xml
@@ -187,22 +187,22 @@
                 </listitem>
             </itemizedlist>
             <programlisting language="java">public interface MyGateway {
-    
+
     // fire and forget
     void sendCommand(MyPayloadType command);
 
     // method that attaches meta data and will wait for a result for 10 seconds
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    ReturnValue sendCommandAndWaitForAResult(MyPayloadType command, 
+    ReturnValue sendCommandAndWaitForAResult(MyPayloadType command,
                                              @MetaData("userId") String userId);
 
     // alternative that throws exceptions on timeout
     @Timeout(value = 20, unit = TimeUnit.SECONDS)
-    ReturnValue sendCommandAndWaitForAResult(MyPayloadType command) 
+    ReturnValue sendCommandAndWaitForAResult(MyPayloadType command)
                          throws TimeoutException, InterruptedException;
 
     // this method will also wait, caller decides how long
-    void sendCommandAndWait(MyPayloadType command, long timeout, TimeUnit unit) 
+    void sendCommandAndWait(MyPayloadType command, long timeout, TimeUnit unit)
                          throws TimeoutException, InterruptedException;
 }
 
@@ -665,7 +665,7 @@ for (String supportedCommand : handler.supportedCommands()) {
                     </note>
                 </para>
                 <programlisting language="java">public class MyAggregate extends AbstractAnnotatedAggregateRoot {
-   
+
     @AggregateIdentifier
     private String id;
 
@@ -727,7 +727,7 @@ for (String supportedCommand : handler.supportedCommands()) {
                         <code>@CommandHandlingMember</code>. Note that only the declared type of the
                     annotated field is inspected for Command Handlers. If a field value is null at
                     the time an incoming command arrives for that entity, an exception is thrown.<programlisting>public class MyAggregate extends AbstractAnnotatedAggregateRoot {
-   
+
     @AggregateIdentifier
     private String id;
 
@@ -1150,7 +1150,14 @@ try {
                         <para>Finally, the Serializer is used to serialize command messages before
                             they are sent over the wire.</para>
                     </listitem>
-                </itemizedlist></para>
+                </itemizedlist>
+                Optionally, a <code>HashChangeListener</code> may be configured. This listener will be notified
+                when the <code>ConsistentHash</code> used to route messages changes.
+                <note><para>When using a Cache, it
+                should be cleared out when the <code>ConsistentHash</code> changes to avoid potential data corruption
+                (e.g. when commands don't specify a <code>@TargetAggregateVersion</code> and an new member quickly
+                joins and leaves the JGroup, modifying the aggregate while it's still cached elsewhere.)</para></note>
+            </para>
             <para>Ultimately, the JGroupsConnector needs to actually connect, in order to dispatch
                 Messages to other segments. To do so, call the <code>connect()</code> method. It
                 takes a single parameter: the load factor. The load factor defines how much load,


### PR DESCRIPTION
- Optionally register JChannel MBean after connecting
- Delegate creation of JChannel to Factory to allow alternative (programmatic) instantiation of the JChannel, e.g. to apply configuration settings from spring placeholder properties.