### PR TITLE
Simple Javadoc correction to JdbcEventStore

### DIFF
--- a/core/src/main/java/org/axonframework/eventstore/jdbc/JdbcEventStore.java
+++ b/core/src/main/java/org/axonframework/eventstore/jdbc/JdbcEventStore.java
@@ -47,20 +47,19 @@ import org.axonframework.upcasting.UpcasterChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.sql.DataSource;
 
 import static org.axonframework.common.IdentifierValidator.validateIdentifier;
 import static org.axonframework.upcasting.UpcastUtils.upcastAndDeserialize;
 
 /**
- * An EventStore implementation that uses JPA to store DomainEvents in a database. The actual DomainEvent is stored as
- * a
+ * An EventStore implementation that uses JDBC to store DomainEvents in a database. The actual DomainEvent is stored as a
  * serialized blob of bytes. Other columns are used to store meta-data that allow quick finding of DomainEvents for a
  * specific aggregate in the correct order.
  * <p/>

--- a/pom.xml
+++ b/pom.xml
@@ -387,12 +387,6 @@
             <uniqueVersion>false</uniqueVersion>
         </repository>
     </distributionManagement>
-    <scm>
-        <connection>scm:git:git://github.com/AxonFramework/AxonFramework.git</connection>
-        <developerConnection>scm:git:git@github.com:AxonFramework/AxonFramework.git</developerConnection>
-        <url>https://github.com/AxonFramework/AxonFramework</url>
-        <tag>HEAD</tag>
-    </scm>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,12 @@
             <uniqueVersion>false</uniqueVersion>
         </repository>
     </distributionManagement>
+    <scm>
+        <connection>scm:git:git://github.com/AxonFramework/AxonFramework.git</connection>
+        <developerConnection>scm:git:git@github.com:AxonFramework/AxonFramework.git</developerConnection>
+        <url>https://github.com/AxonFramework/AxonFramework</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>


### PR DESCRIPTION
I made a correction to the javadoc for JdbcEventStore, removing the reference to JPA in the class javadoc. I had removed something from the pom.xml as well (for my own purposes) but forgot and left that in for my previous pull request.