### PR TITLE
Create MongoDB index on the event sequenceNumber

### DIFF
--- a/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
+++ b/mongo/src/main/java/org/axonframework/eventstore/mongo/DocumentPerCommitStorageStrategy.java
@@ -114,11 +114,17 @@ public class DocumentPerCommitStorageStrategy implements StorageStrategy {
                                              .append(CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),
                                      "uniqueAggregateIndex",
                                      true);
+        eventsCollection.ensureIndex(new BasicDBObject(CommitEntry.AGGREGATE_IDENTIFIER_PROPERTY, 1)
+                                             .append(CommitEntry.AGGREGATE_TYPE_PROPERTY, 1)
+                                             .append(CommitEntry.EVENTS_PROPERTY + "." + CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),
+                                     "uniqueAggregateEventIndex",
+                                     true);
 
         eventsCollection.ensureIndex(new BasicDBObject(CommitEntry.TIME_STAMP_PROPERTY, 1)
                                              .append(CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),
                                      "orderedEventStreamIndex",
                                      false);
+
         snapshotsCollection.ensureIndex(new BasicDBObject(CommitEntry.AGGREGATE_IDENTIFIER_PROPERTY, 1)
                                              .append(CommitEntry.AGGREGATE_TYPE_PROPERTY, 1)
                                              .append(CommitEntry.SEQUENCE_NUMBER_PROPERTY, 1),


### PR DESCRIPTION
Currently only the commit sequence number is used, which isn't really a
thing, allowing multiple events with identical aggregate id's and
sequence numbers and ruining my weekend.

The test I added fails consistently on my machine as the indices aren't
actually in mongo at the time the test is run. Not sure if it is due to some
local issue or not, someone with more experience with your test harness
should look at it.