### PR TITLE
Fix for AXON-335: CommandGateway hangup with JGroupsConnector on non serializable command handler reponses / exceptions

### DIFF
--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/CommandResponseProcessingFailedException.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/CommandResponseProcessingFailedException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.commandhandling.distributed.jgroups;
+
+import org.axonframework.common.AxonException;
+
+/**
+ * Exception indicating that a failure occured during processing of a command response. Typically this would imply an unserializable command response / exception message
+ *
+ * @author Srideep Prasad
+ */
+
+public class CommandResponseProcessingFailedException extends AxonException{
+
+    /**
+     * Initializes the exception using the given <code>message</code>.
+     *
+     * @param message The message describing the exception
+     */
+    public CommandResponseProcessingFailedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Initializes the exception using the given <code>message</code> and <code>cause</code>.
+     *
+     * @param message The message describing the exception
+     * @param cause   The underlying cause of the exception
+     */
+    public CommandResponseProcessingFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/MemberAwareCommandCallback.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/MemberAwareCommandCallback.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling.distributed.jgroups.support.callbacks;
+
+
+import org.axonframework.commandhandling.CommandCallback;
+import org.jgroups.Address;
+import org.jgroups.View;
+
+/**
+ * Internal class used used by JGroupsConnector. For internal use only. Pulled outside to allow for seamless unit testing
+ *
+ * @author Allard Buijze
+ * @since 2.0
+ */
+public class MemberAwareCommandCallback<R> implements CommandCallback<R> {
+
+    private final Address dest;
+    private final CommandCallback<R> callback;
+
+    public MemberAwareCommandCallback(Address dest, CommandCallback<R> callback) {
+        this.dest = dest;
+        this.callback = callback;
+    }
+
+    public boolean isMemberLive(View currentView) {
+        return currentView.containsMember(dest);
+    }
+
+    @Override
+    public void onSuccess(R result) {
+        callback.onSuccess(result);
+    }
+
+    @Override
+    public void onFailure(Throwable cause) {
+        callback.onFailure(cause);
+    }
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling.distributed.jgroups.support.callbacks;
+
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.distributed.jgroups.CommandResponseProcessingFailedException;
+import org.axonframework.commandhandling.distributed.jgroups.ReplyMessage;
+import org.axonframework.serializer.Serializer;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Internal class used used by JGroupsConnector. For internal use only. Pulled outside to allow for seamless unit testing
+ *
+ * @author Allard Buijze
+ * @since 2.0
+ */
+public class ReplyingCallback implements CommandCallback<Object> {
+
+    private final Message msg;
+    private final CommandMessage commandMessage;
+    private final JChannel channel;
+    private Serializer serializer;
+
+    private static final Logger logger = LoggerFactory.getLogger(ReplyingCallback.class);
+
+    public ReplyingCallback(JChannel channel, Message msg, CommandMessage commandMessage, Serializer serializer) {
+        this.msg = msg;
+        this.commandMessage = commandMessage;
+        this.channel = channel;
+        this.serializer = serializer;
+    }
+
+    @Override
+    public void onSuccess(Object result) {
+        try {
+            channel.send(msg.getSrc(), new ReplyMessage(commandMessage.getIdentifier(),
+                    result,
+                    null, serializer));
+        } catch (Exception e) {
+            logger.error("Unable to send reply to command [name: {}, id: {}]. ",
+                    new Object[]{commandMessage.getCommandName(),
+                            commandMessage.getIdentifier(),
+                            e});
+            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command response of type : %s", result.getClass().getName()),e);
+        }
+    }
+
+    @Override
+    public void onFailure(Throwable cause) {
+        try {
+            channel.send(msg.getSrc(), new ReplyMessage(commandMessage.getIdentifier(),
+                    null,
+                    cause, serializer));
+        } catch (Exception e) {
+            logger.error("Unable to send reply:", e);
+            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command exception response of type : %s", e.getClass().getName()),e);
+        }
+    }
+}

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
@@ -59,7 +59,7 @@ public class ReplyingCallback implements CommandCallback<Object> {
                     new Object[]{commandMessage.getCommandName(),
                             commandMessage.getIdentifier(),
                             e});
-            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command response of type : %s", result.getClass().getName()),e);
+            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command response of type : %s, Exception Message: %s", result.getClass().getName(), e.getMessage()),e);
         }
     }
 
@@ -71,7 +71,8 @@ public class ReplyingCallback implements CommandCallback<Object> {
                     cause, serializer));
         } catch (Exception e) {
             logger.error("Unable to send reply:", e);
-            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command exception response of type : %s", e.getClass().getName()),e);
+            //Not capturing the causative exception while throwing - the causative exception may not be serializable and this may cause the commandbus to hangup.
+            throw new CommandResponseProcessingFailedException(String.format("An error occurred while attempting to process command exception response of type : %s, Exception Message:: %s", e.getClass().getName(), e.getMessage()));
         }
     }
 }

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallback.java
@@ -37,7 +37,7 @@ public class ReplyingCallback implements CommandCallback<Object> {
     private final Message msg;
     private final CommandMessage commandMessage;
     private final JChannel channel;
-    private Serializer serializer;
+    private final Serializer serializer;
 
     private static final Logger logger = LoggerFactory.getLogger(ReplyingCallback.class);
 

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/MemberAwareCommandCallbackTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/MemberAwareCommandCallbackTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling.distributed.jgroups.support.callbacks;
+
+import org.axonframework.commandhandling.CommandCallback;
+import org.jgroups.Address;
+import org.jgroups.View;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Srideep Prasad
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MemberAwareCommandCallbackTest {
+
+    private MemberAwareCommandCallback<Object> memberAwareCommandCallback;
+    @Mock
+    private Address mockDest;
+    @Mock
+    private CommandCallback<Object> mockCallback;
+
+    @Before
+    public void setup(){
+        memberAwareCommandCallback = new MemberAwareCommandCallback<Object>(mockDest, mockCallback);
+    }
+
+
+    @Test
+    public void testIsMemberAliveTrue(){
+        View mockView = mock(View.class);
+        when(mockView.containsMember(mockDest)).thenReturn(true);
+
+        assertTrue(memberAwareCommandCallback.isMemberLive(mockView));
+        verify(mockView).containsMember(mockDest);
+    }
+
+    @Test
+    public void testIsMemberAliveFalse(){
+        View mockView = mock(View.class);
+        when(mockView.containsMember(mockDest)).thenReturn(false);
+
+        assertFalse(memberAwareCommandCallback.isMemberLive(mockView));
+        verify(mockView).containsMember(mockDest);
+    }
+
+    @Test
+    public void testOnSuccess(){
+        Object dummyVal = new Object();
+
+        memberAwareCommandCallback.onSuccess(dummyVal);
+
+        verify(mockCallback).onSuccess(dummyVal);
+    }
+
+    @Test
+    public void testOnFailure(){
+        Exception dummyException = new Exception();
+
+        memberAwareCommandCallback.onFailure(dummyException);
+
+        verify(mockCallback).onFailure(dummyException);
+    }
+
+
+
+}

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallbackTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallbackTest.java
@@ -32,11 +32,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.refEq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.isNotNull;
 
 /**
  * @author Srideep Prasad
@@ -109,7 +109,7 @@ public class ReplyingCallbackTest {
 
         doThrow(new Exception("Serialization Exception!")).when(mockChannel).send(same(mockAddr), refEq(expectedReplyMsg));
         expectedException.expect(CommandResponseProcessingFailedException.class);
-        expectedException.expectCause(is(isNotNull(Exception.class)));
+        expectedException.expectCause(nullValue(Exception.class));
 
         replyingCallback.onFailure(exception);
     }

--- a/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallbackTest.java
+++ b/distributed-commandbus/src/test/java/org/axonframework/commandhandling/distributed/jgroups/support/callbacks/ReplyingCallbackTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2015. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling.distributed.jgroups.support.callbacks;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.distributed.jgroups.CommandResponseProcessingFailedException;
+import org.axonframework.commandhandling.distributed.jgroups.ReplyMessage;
+import org.axonframework.serializer.Serializer;
+import org.jgroups.Address;
+import org.jgroups.JChannel;
+import org.jgroups.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Srideep Prasad
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReplyingCallbackTest {
+
+    private ReplyingCallback replyingCallback;
+    @Mock
+    private JChannel mockChannel;
+    @Mock
+    private Message mockMsg;
+    @Mock
+    private CommandMessage mockCommandMsg;
+    @Mock
+    private Serializer mockSerializer;
+    @Mock
+    private Address mockAddr;
+
+    private static final String IDENTIFIER = "identifier";
+
+    @Before
+    public void setup(){
+        replyingCallback = new ReplyingCallback(mockChannel,mockMsg,mockCommandMsg,mockSerializer);
+        when(mockCommandMsg.getIdentifier()).thenReturn(IDENTIFIER);
+        when(mockMsg.getSrc()).thenReturn(mockAddr);
+
+    }
+
+    @Test
+    public void testOnSuccessWithSerializableMsg() throws Exception {
+        Object dummyData = new Object();
+        ReplyMessage expectedReplyMsg = new ReplyMessage(IDENTIFIER, dummyData, null, mockSerializer);
+
+        replyingCallback.onSuccess(dummyData);
+
+        verify(mockChannel).send(eq(mockAddr),refEq(expectedReplyMsg));
+    }
+
+    @Test(expected = CommandResponseProcessingFailedException.class)
+    public void testOnSuccessWithExceptionDuringChannelSend() throws Exception {
+        Object dummyData = new Object();
+        ReplyMessage expectedReplyMsg = new ReplyMessage(IDENTIFIER, dummyData, null, mockSerializer);
+
+        doThrow(new Exception("Serialization Exception!")).when(mockChannel).send(same(mockAddr),refEq(expectedReplyMsg));
+
+        replyingCallback.onSuccess(dummyData);
+    }
+
+    @Test
+    public void testOnFailureWithSerializableException() throws Exception {
+        Exception exception = new Exception();
+        ReplyMessage expectedReplyMsg = new ReplyMessage(IDENTIFIER, null, exception, mockSerializer);
+
+        replyingCallback.onFailure(exception);
+
+        verify(mockChannel).send(eq(mockAddr),refEq(expectedReplyMsg));
+    }
+
+    @Test(expected = CommandResponseProcessingFailedException.class)
+    public void testOnFailureWithExceptionDuringChannelSend() throws Exception {
+        Exception exception = new Exception();
+        ReplyMessage expectedReplyMsg = new ReplyMessage(IDENTIFIER, null, exception, mockSerializer);
+
+        doThrow(new Exception("Serialization Exception!")).when(mockChannel).send(same(mockAddr), refEq(expectedReplyMsg));
+        replyingCallback.onFailure(exception);
+    }
+}


### PR DESCRIPTION
Am sending over a patch to fix the issue detailed in http://issues.axonframework.org/youtrack/issue/AXON-335
In addition to the fix, I've extensively unit tested ReplyingCallback and MemberAwareCallback classes. For the same i've pulled out these classes and unit tested all specific cases. In addition, in JGroupsConnectorTest, have asserted that the ReplyingCallback is getting associated / setup correctly. The exact tests are at a unit level in ReplyingCallbackTest. MemberAwareCallback has no changes as such - but has been pulled out for consistency and unit testability.