### PR TITLE
AXON-349: SagaManager reliability improvements

### DIFF
--- a/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
+++ b/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -373,6 +373,6 @@ public abstract class AbstractSagaManager implements SagaManager, Subscribable {
      */
     @SuppressWarnings("unchecked")
     public Set<Class<? extends Saga>> getManagedSagaTypes() {
-        return new HashSet<Class<? extends Saga>>(Arrays.asList(sagaTypes));
+        return new LinkedHashSet<Class<? extends Saga>>(Arrays.asList(sagaTypes));
     }
 }

--- a/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
+++ b/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
@@ -25,6 +25,7 @@ import org.axonframework.correlation.MultiCorrelationDataProvider;
 import org.axonframework.correlation.SimpleCorrelationDataProvider;
 import org.axonframework.domain.EventMessage;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.replay.ReplayAware;
 import org.axonframework.unitofwork.CurrentUnitOfWork;
 import org.axonframework.unitofwork.UnitOfWork;
 import org.axonframework.unitofwork.UnitOfWorkListenerAdapter;
@@ -51,7 +52,7 @@ import static java.lang.String.format;
  * @author Allard Buijze
  * @since 0.7
  */
-public abstract class AbstractSagaManager implements SagaManager, Subscribable {
+public abstract class AbstractSagaManager implements SagaManager, Subscribable, ReplayAware {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractSagaManager.class);
 
@@ -374,5 +375,20 @@ public abstract class AbstractSagaManager implements SagaManager, Subscribable {
     @SuppressWarnings("unchecked")
     public Set<Class<? extends Saga>> getManagedSagaTypes() {
         return new LinkedHashSet<Class<? extends Saga>>(Arrays.asList(sagaTypes));
+    }
+
+    @Override
+    public void beforeReplay() {
+        throw new IllegalStateException(
+                "SagaManager does not support replay. Attempting to replay cluster containing Saga "
+                        + "event handlers will cause data corruption!");
+    }
+
+    @Override
+    public void afterReplay() {
+    }
+
+    @Override
+    public void onReplayFailed(Throwable cause) {
     }
 }


### PR DESCRIPTION
AXON-349: SagaManager reliability improvements
 - Always fail replay when SagaManager is in cluster.
 - SagaManager will always used the first tracked Saga for cluster selection purposes.