### PR TITLE
Generic return type getAggregateRoot in AbstractEventSourcedEntity

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/AbstractEventSourcedEntity.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/AbstractEventSourcedEntity.java
@@ -30,12 +30,12 @@ import java.util.Collection;
  * @author Allard Buijze
  * @since 0.7
  */
-public abstract class AbstractEventSourcedEntity implements EventSourcedEntity {
+public abstract class AbstractEventSourcedEntity<T extends AbstractEventSourcedAggregateRoot> implements EventSourcedEntity<T> {
 
-    private volatile AbstractEventSourcedAggregateRoot aggregateRoot;
+    private volatile T aggregateRoot;
 
     @Override
-    public void registerAggregateRoot(AbstractEventSourcedAggregateRoot aggregateRootToRegister) {
+    public void registerAggregateRoot(T aggregateRootToRegister) {
         if (this.aggregateRoot != null && this.aggregateRoot != aggregateRootToRegister) {
             throw new IllegalStateException("Cannot register new aggregate. "
                                                     + "This entity is already part of another aggregate");
@@ -107,7 +107,7 @@ public abstract class AbstractEventSourcedEntity implements EventSourcedEntity {
      *
      * @return the reference to the root of the aggregate this entity is a member of
      */
-    protected AbstractEventSourcedAggregateRoot getAggregateRoot() {
+    protected T getAggregateRoot() {
         return aggregateRoot;
     }
 }

--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcedEntity.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcedEntity.java
@@ -28,7 +28,7 @@ import org.axonframework.domain.DomainEventMessage;
  * @see org.axonframework.eventsourcing.AbstractEventSourcedAggregateRoot#getChildEntities()
  * @since 2.0
  */
-public interface EventSourcedEntity {
+public interface EventSourcedEntity<T extends AbstractEventSourcedAggregateRoot>{
 
     /**
      * Register the aggregate root with this entity. The entity must use this aggregate root to apply Domain Events.
@@ -39,7 +39,7 @@ public interface EventSourcedEntity {
      *
      * @param aggregateRootToRegister the root of the aggregate this entity is part of.
      */
-    void registerAggregateRoot(AbstractEventSourcedAggregateRoot aggregateRootToRegister);
+    void registerAggregateRoot(T aggregateRootToRegister);
 
     /**
      * Report the given <code>event</code> for handling in the current instance (<code>this</code>), as well as all the


### PR DESCRIPTION
Changed getAggregateRoot in AbstractEventSourcedEntity to a generic return type. This way there's no need to explicitly cast to your aggregate root.