### PR TITLE
Make it possible to directly inject an EntityManager into GenericJpaR…

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/HybridJpaRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/HybridJpaRepository.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing;
 
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.domain.AggregateRoot;
 import org.axonframework.eventstore.EventStore;
 import org.axonframework.repository.GenericJpaRepository;
@@ -89,14 +90,9 @@ public class HybridJpaRepository<T extends AggregateRoot> extends GenericJpaRepo
      * @param aggregateType         The type of aggregate stored in this repository.
      * @param lockManager       The locking strategy to use when loading and storing aggregates
      */
-    public HybridJpaRepository(final EntityManager entityManager,
+    public HybridJpaRepository(EntityManager entityManager,
                                Class<T> aggregateType, LockManager lockManager) {
-        this(new EntityManagerProvider() {
-            @Override
-            public EntityManager getEntityManager() {
-                return entityManager;
-            }
-        }, aggregateType, aggregateType.getSimpleName(), lockManager);
+        this(new SimpleEntityManagerProvider(entityManager), aggregateType, aggregateType.getSimpleName(), lockManager);
     }
 
     /**
@@ -126,15 +122,10 @@ public class HybridJpaRepository<T extends AggregateRoot> extends GenericJpaRepo
      * @param aggregateTypeIdentifier The type identifier to store events with
      * @param lockManager         The locking strategy to use when loading and storing aggregates
      */
-    public HybridJpaRepository(final EntityManager entityManager,
+    public HybridJpaRepository(EntityManager entityManager,
                                Class<T> aggregateType, String aggregateTypeIdentifier,
                                LockManager lockManager) {
-        super(new EntityManagerProvider() {
-            @Override
-            public EntityManager getEntityManager() {
-                return entityManager;
-            }
-        }, aggregateType, lockManager);
+        super(new SimpleEntityManagerProvider(entityManager), aggregateType, lockManager);
         this.aggregateTypeIdentifier = aggregateTypeIdentifier;
     }
 

--- a/core/src/main/java/org/axonframework/eventsourcing/HybridJpaRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/HybridJpaRepository.java
@@ -23,6 +23,8 @@ import org.axonframework.repository.GenericJpaRepository;
 import org.axonframework.repository.LockManager;
 import org.axonframework.repository.NullLockManager;
 
+import javax.persistence.EntityManager;
+
 /**
  * Repository that stores both a (JPA based) relational model of the current state of an aggregate and the events
  * produced by that aggregate. When an aggregate is loaded, only the relational model is used to reconstruct the
@@ -83,6 +85,24 @@ public class HybridJpaRepository<T extends AggregateRoot> extends GenericJpaRepo
      * Initializes a Hybrid Repository that stored entities of the given <code>aggregateType</code> and a locking
      * mechanism based on the given <code>lockManager</code>.
      *
+     * @param entityManager The EntityManager instance for this repository
+     * @param aggregateType         The type of aggregate stored in this repository.
+     * @param lockManager       The locking strategy to use when loading and storing aggregates
+     */
+    public HybridJpaRepository(final EntityManager entityManager,
+                               Class<T> aggregateType, LockManager lockManager) {
+        this(new EntityManagerProvider() {
+            @Override
+            public EntityManager getEntityManager() {
+                return entityManager;
+            }
+        }, aggregateType, aggregateType.getSimpleName(), lockManager);
+    }
+
+    /**
+     * Initializes a Hybrid Repository that stored entities of the given <code>aggregateType</code> and a locking
+     * mechanism based on the given <code>lockManager</code>.
+     *
      * @param entityManagerProvider   The EntityManagerProvider providing the EntityManager instance for this
      *                                repository
      * @param aggregateType           The type of aggregate stored in this repository.
@@ -93,6 +113,28 @@ public class HybridJpaRepository<T extends AggregateRoot> extends GenericJpaRepo
                                Class<T> aggregateType, String aggregateTypeIdentifier,
                                LockManager lockManager) {
         super(entityManagerProvider, aggregateType, lockManager);
+        this.aggregateTypeIdentifier = aggregateTypeIdentifier;
+    }
+
+
+    /**
+     * Initializes a Hybrid Repository that stored entities of the given <code>aggregateType</code> and a locking
+     * mechanism based on the given <code>lockManager</code>.
+     *
+     * @param entityManager   The EntityManager instance for this repository
+     * @param aggregateType           The type of aggregate stored in this repository.
+     * @param aggregateTypeIdentifier The type identifier to store events with
+     * @param lockManager         The locking strategy to use when loading and storing aggregates
+     */
+    public HybridJpaRepository(final EntityManager entityManager,
+                               Class<T> aggregateType, String aggregateTypeIdentifier,
+                               LockManager lockManager) {
+        super(new EntityManagerProvider() {
+            @Override
+            public EntityManager getEntityManager() {
+                return entityManager;
+            }
+        }, aggregateType, lockManager);
         this.aggregateTypeIdentifier = aggregateTypeIdentifier;
     }
 

--- a/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
+++ b/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
@@ -48,11 +48,28 @@ public class GenericJpaRepository<T extends AggregateRoot> extends LockingReposi
      * Initialize a repository for storing aggregates of the given <code>aggregateType</code>. No additional locking
      * will be used.
      *
-     * @param entityManagerProvider The EntityManagerProvider providing the EntityManager instance for this EventStore
+     * @param entityManagerProvider The EntityManagerProvider providing the EntityManager instance for this repository
      * @param aggregateType         the aggregate type this repository manages
      */
     public GenericJpaRepository(EntityManagerProvider entityManagerProvider, Class<T> aggregateType) {
         this(entityManagerProvider, aggregateType, new NullLockManager());
+    }
+
+
+    /**
+     * Initialize a repository for storing aggregates of the given <code>aggregateType</code>. No additional locking
+     * will be used.
+     *
+     * @param entityManager The EntityManager instance for this repository
+     * @param aggregateType         the aggregate type this repository manages
+     */
+    public GenericJpaRepository(final EntityManager entityManager, Class<T> aggregateType) {
+        this(new EntityManagerProvider() {
+            @Override
+            public EntityManager getEntityManager() {
+                return entityManager;
+            }
+        }, aggregateType, new NullLockManager());
     }
 
     /**
@@ -66,6 +83,29 @@ public class GenericJpaRepository<T extends AggregateRoot> extends LockingReposi
     public GenericJpaRepository(EntityManagerProvider entityManagerProvider, Class<T> aggregateType,
                                 LockManager lockManager) {
         super(aggregateType, lockManager);
+        Assert.notNull(entityManagerProvider, "entityManagerProvider may not be null");
+        this.entityManagerProvider = entityManagerProvider;
+    }
+
+    /**
+     * Initialize a repository  for storing aggregates of the given <code>aggregateType</code> with an additional
+     * <code> lockManager</code>.
+     *
+     * @param entityManager The EntityManager instance for this repository
+     * @param aggregateType         the aggregate type this repository manages
+     * @param lockManager           the additional locking strategy for this repository
+     */
+    public GenericJpaRepository(final EntityManager entityManager, Class<T> aggregateType,
+                                LockManager lockManager) {
+        super(aggregateType, lockManager);
+
+        EntityManagerProvider entityManagerProvider = new EntityManagerProvider() {
+            @Override
+            public EntityManager getEntityManager() {
+                return entityManager;
+            }
+        };
+
         Assert.notNull(entityManagerProvider, "entityManagerProvider may not be null");
         this.entityManagerProvider = entityManagerProvider;
     }

--- a/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
+++ b/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
@@ -18,6 +18,7 @@ package org.axonframework.repository;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.domain.AggregateRoot;
 
 import javax.persistence.EntityManager;
@@ -63,13 +64,8 @@ public class GenericJpaRepository<T extends AggregateRoot> extends LockingReposi
      * @param entityManager The EntityManager instance for this repository
      * @param aggregateType         the aggregate type this repository manages
      */
-    public GenericJpaRepository(final EntityManager entityManager, Class<T> aggregateType) {
-        this(new EntityManagerProvider() {
-            @Override
-            public EntityManager getEntityManager() {
-                return entityManager;
-            }
-        }, aggregateType, new NullLockManager());
+    public GenericJpaRepository(EntityManager entityManager, Class<T> aggregateType) {
+        this(new SimpleEntityManagerProvider(entityManager), aggregateType, new NullLockManager());
     }
 
     /**
@@ -95,19 +91,10 @@ public class GenericJpaRepository<T extends AggregateRoot> extends LockingReposi
      * @param aggregateType         the aggregate type this repository manages
      * @param lockManager           the additional locking strategy for this repository
      */
-    public GenericJpaRepository(final EntityManager entityManager, Class<T> aggregateType,
+    public GenericJpaRepository(EntityManager entityManager, Class<T> aggregateType,
                                 LockManager lockManager) {
         super(aggregateType, lockManager);
-
-        EntityManagerProvider entityManagerProvider = new EntityManagerProvider() {
-            @Override
-            public EntityManager getEntityManager() {
-                return entityManager;
-            }
-        };
-
-        Assert.notNull(entityManagerProvider, "entityManagerProvider may not be null");
-        this.entityManagerProvider = entityManagerProvider;
+        this.entityManagerProvider = new SimpleEntityManagerProvider(entityManager);
     }
 
     @Override


### PR DESCRIPTION
…epository and HybridJpaRepository. This makes the API friendlier as it removes having to provide an implementation of EntityManagerProvider before the EntityManager needed by these repository can be made available.