### PR TITLE
Add EventTemplate to the built-in resources in AnnotateSagaTestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
@@ -22,6 +22,7 @@ import org.axonframework.domain.EventMessage;
 import org.axonframework.domain.GenericDomainEventMessage;
 import org.axonframework.domain.GenericEventMessage;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventTemplate;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.saga.GenericSagaFactory;
 import org.axonframework.saga.annotation.AbstractAnnotatedSaga;
@@ -82,6 +83,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
         sagaManager.setSuppressExceptions(false);
 
         registeredResources.add(eventBus);
+        registeredResources.add(new EventTemplate(eventBus));
         commandBus = new RecordingCommandBus();
         registeredResources.add(commandBus);
         registeredResources.add(eventScheduler);

--- a/test/src/test/java/org/axonframework/test/saga/StubSaga.java
+++ b/test/src/test/java/org/axonframework/test/saga/StubSaga.java
@@ -19,6 +19,7 @@ package org.axonframework.test.saga;
 import org.axonframework.domain.EventMessage;
 import org.axonframework.domain.GenericEventMessage;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventTemplate;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.saga.annotation.AbstractAnnotatedSaga;
@@ -38,6 +39,7 @@ public class StubSaga extends AbstractAnnotatedSaga {
     private static final int TRIGGER_DURATION_MINUTES = 10;
     private transient StubGateway stubGateway;
     private transient EventBus eventBus;
+    private transient EventTemplate eventTemplate;
     private transient EventScheduler scheduler;
     private List<Object> handledEvents = new ArrayList<Object>();
     private ScheduleToken timer;
@@ -61,7 +63,11 @@ public class StubSaga extends AbstractAnnotatedSaga {
     @SagaEventHandler(associationProperty = "identifier")
     public void handleEvent(TriggerExistingSagaEvent event) {
         handledEvents.add(event);
-        eventBus.publish(new GenericEventMessage<SagaWasTriggeredEvent>(new SagaWasTriggeredEvent(this)));
+        if (event.isUseEventTemplate()) {
+            eventTemplate.publishEvent(new SagaWasTriggeredEvent(this));
+        } else {
+            eventBus.publish(new GenericEventMessage<SagaWasTriggeredEvent>(new SagaWasTriggeredEvent(this)));
+        }
     }
 
     @EndSaga
@@ -99,6 +105,14 @@ public class StubSaga extends AbstractAnnotatedSaga {
 
     public void setEventBus(EventBus eventBus) {
         this.eventBus = eventBus;
+    }
+
+    public EventTemplate getEventTemplate() {
+        return eventTemplate;
+    }
+
+    public void setEventTemplate(EventTemplate eventTemplate) {
+        this.eventTemplate = eventTemplate;
     }
 
     public EventScheduler getScheduler() {

--- a/test/src/test/java/org/axonframework/test/saga/TriggerExistingSagaEvent.java
+++ b/test/src/test/java/org/axonframework/test/saga/TriggerExistingSagaEvent.java
@@ -22,12 +22,22 @@ package org.axonframework.test.saga;
 public class TriggerExistingSagaEvent {
 
     private String identifier;
+    private boolean useEventTemplate;
 
     public TriggerExistingSagaEvent(String identifier) {
+        this(identifier, false);
+    }
+
+    public TriggerExistingSagaEvent(String identifier, boolean useEventTemplate) {
         this.identifier = identifier;
+        this.useEventTemplate = useEventTemplate;
     }
 
     public String getIdentifier() {
         return identifier;
+    }
+
+    public boolean isUseEventTemplate() {
+        return useEventTemplate;
     }
 }


### PR DESCRIPTION
This allows Sagas that use EventTemplate rather than EventBus to be tested using the test fixture's fluent API rather than by mocking an EventTemplate instance in the test code.