### PR TITLE
Support MessageHandler that throws checked exceptions in saga tests.

### DIFF
--- a/quickstart/src/main/java/org/axonframework/quickstart/annotated/ToDoEventHandler.java
+++ b/quickstart/src/main/java/org/axonframework/quickstart/annotated/ToDoEventHandler.java
@@ -25,6 +25,7 @@ import org.axonframework.quickstart.api.ToDoItemCompletedEvent;
 import org.axonframework.quickstart.api.ToDoItemCreatedEvent;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 
@@ -35,7 +36,8 @@ import java.time.format.DateTimeFormatter;
  */
 public class ToDoEventHandler {
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d-M-y H:m");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("d-M-y H:m").withZone(ZoneId.systemDefault());
 
     @EventHandler
     public void handle(ToDoItemCreatedEvent event, @Timestamp Instant time) {

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationEventListenerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationEventListenerBeanPostProcessorTest.java
@@ -45,7 +45,7 @@ public class AnnotationEventListenerBeanPostProcessorTest {
     }
 
     @Test
-    public void testEventHandlerCallsRedirectToAdapter() {
+    public void testEventHandlerCallsRedirectToAdapter() throws Exception {
         Object result1 = testSubject.postProcessBeforeInitialization(new SyncEventListener(), "beanName");
         Object postProcessedBean = testSubject.postProcessAfterInitialization(result1, "beanName");
 
@@ -82,7 +82,7 @@ public class AnnotationEventListenerBeanPostProcessorTest {
 
     @Test
     // verifies issue #73
-    public void testEventHandlerCallsRedirectToAdapter_ExceptionPropagated() {
+    public void testEventHandlerCallsRedirectToAdapter_ExceptionPropagated() throws Exception {
         Object result1 = testSubject.postProcessBeforeInitialization(new SyncEventListener(), "beanName");
         Object postProcessedBean = testSubject.postProcessAfterInitialization(result1, "beanName");
 

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationEventListenerBeanPostProcessorTest_DoubleAnnotated.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationEventListenerBeanPostProcessorTest_DoubleAnnotated.java
@@ -68,7 +68,7 @@ public class AnnotationEventListenerBeanPostProcessorTest_DoubleAnnotated {
     }
 
     @Test
-    public void testInitializeProxiedInstance() {
+    public void testInitializeProxiedInstance() throws Exception {
         assertNotNull(transactionalListener);
         eventBus.publish(new GenericEventMessage<>(new Object()));
 

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactoryTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactoryTest.java
@@ -66,7 +66,7 @@ public class SpringBeanParameterResolverFactoryTest {
     }
 
     @Test
-    public void testMethodsAreProperlyInjected() {
+    public void testMethodsAreProperlyInjected() throws Exception {
         assertNotNull(annotatedHandler);
         assertTrue(annotatedHandler instanceof EventListener);
         ((EventListener) annotatedHandler).handle(asEventMessage("Hello"));
@@ -75,7 +75,7 @@ public class SpringBeanParameterResolverFactoryTest {
     }
 
     @Test
-    public void testNewInstanceIsCreatedEachTimePrototypeResourceIsInjected() {
+    public void testNewInstanceIsCreatedEachTimePrototypeResourceIsInjected() throws Exception {
         EventListener handler = (EventListener) applicationContext.getBean("prototypeResourceHandler");
         handler.handle(asEventMessage("Hello1"));
         handler.handle(asEventMessage("Hello2"));

--- a/spring/src/test/java/org/axonframework/spring/config/xml/AnnotationConfigurationBeanDefinitionParserTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/xml/AnnotationConfigurationBeanDefinitionParserTest.java
@@ -111,7 +111,7 @@ public class AnnotationConfigurationBeanDefinitionParserTest {
 
     @Test
     @DirtiesContext
-    public void testSagaManagerWiring() {
+    public void testSagaManagerWiring() throws Exception {
         // this part should prove correct autowiring of the saga manager
         SagaManager sagaManager = beanFactory.getBean("sagaManager", SagaManager.class);
         assertNotNull(sagaManager);
@@ -172,7 +172,7 @@ public class AnnotationConfigurationBeanDefinitionParserTest {
 
     @Test
     @DirtiesContext
-    public void testAsyncSagaManagerWiring() throws InterruptedException {
+    public void testAsyncSagaManagerWiring() throws Exception {
 
         // this part should prove correct autowiring of the saga manager
         SagaManager sagaManager = beanFactory.getBean("asyncSagaManager", SagaManager.class);

--- a/test/src/main/java/org/axonframework/test/eventscheduler/EventConsumer.java
+++ b/test/src/main/java/org/axonframework/test/eventscheduler/EventConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2014. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.test.eventscheduler;
+
+/**
+ * A consumer that allows implementations to throw a exceptions.
+ *
+ * @author Steve Chernyak
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface EventConsumer<T> {
+
+    void accept(T var) throws Exception;
+}

--- a/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
+++ b/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
@@ -138,7 +138,7 @@ public class StubEventScheduler implements EventScheduler {
      * @param newDateTime The time to advance the "current time" of the scheduler to
      * @param eventConsumer The function to invoke for each event to trigger
      */
-    public void advanceTime(ZonedDateTime newDateTime, Consumer<EventMessage<?>> eventConsumer) {
+    public void advanceTime(ZonedDateTime newDateTime, EventConsumer<EventMessage<?>> eventConsumer) throws Exception {
         while (!scheduledEvents.isEmpty() && !scheduledEvents.first().getScheduleTime().isAfter(newDateTime)) {
             eventConsumer.accept(advanceToNextTrigger());
         }
@@ -154,7 +154,7 @@ public class StubEventScheduler implements EventScheduler {
      * @param duration The amount of time to advance the "current time" of the scheduler with
      * @param eventConsumer The function to invoke for each event to trigger
      */
-    public void advanceTime(Duration duration, Consumer<EventMessage<?>> eventConsumer) {
+    public void advanceTime(Duration duration, EventConsumer<EventMessage<?>> eventConsumer) throws Exception {
         advanceTime(currentDateTime.plus(duration), eventConsumer);
     }
 }

--- a/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/AnnotatedSagaTestFixture.java
@@ -89,7 +89,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     }
 
     @Override
-    public FixtureExecutionResult whenTimeElapses(Duration elapsedTime) {
+    public FixtureExecutionResult whenTimeElapses(Duration elapsedTime) throws Exception {
         try {
             fixtureExecutionResult.startRecording();
             eventScheduler.advanceTime(elapsedTime, sagaManager::handle);
@@ -100,7 +100,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     }
 
     @Override
-    public FixtureExecutionResult whenTimeAdvancesTo(ZonedDateTime newDateTime) {
+    public FixtureExecutionResult whenTimeAdvancesTo(ZonedDateTime newDateTime) throws Exception {
         try {
             fixtureExecutionResult.startRecording();
             eventScheduler.advanceTime(newDateTime, sagaManager::handle);
@@ -128,7 +128,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     }
 
     @Override
-    public ContinuedGivenState givenAPublished(Object event) {
+    public ContinuedGivenState givenAPublished(Object event) throws Exception {
         sagaManager.handle(GenericEventMessage.asEventMessage(event));
         return this;
     }
@@ -144,19 +144,19 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     }
 
     @Override
-    public ContinuedGivenState andThenTimeElapses(final Duration elapsedTime) {
+    public ContinuedGivenState andThenTimeElapses(final Duration elapsedTime) throws Exception {
         eventScheduler.advanceTime(elapsedTime, sagaManager::handle);
         return this;
     }
 
     @Override
-    public ContinuedGivenState andThenTimeAdvancesTo(final ZonedDateTime newDateTime) {
+    public ContinuedGivenState andThenTimeAdvancesTo(final ZonedDateTime newDateTime) throws Exception {
         eventScheduler.advanceTime(newDateTime, sagaManager::handle);
         return this;
     }
 
     @Override
-    public ContinuedGivenState andThenAPublished(Object event) {
+    public ContinuedGivenState andThenAPublished(Object event) throws Exception {
         sagaManager.handle(GenericEventMessage.asEventMessage(event));
         return this;
     }
@@ -168,7 +168,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
     }
 
     @Override
-    public FixtureExecutionResult whenPublishingA(Object event) {
+    public FixtureExecutionResult whenPublishingA(Object event) throws Exception {
         try {
             fixtureExecutionResult.startRecording();
             sagaManager.handle(GenericEventMessage.asEventMessage(event));
@@ -287,13 +287,13 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
         }
 
         @Override
-        public ContinuedGivenState published(Object... events) {
+        public ContinuedGivenState published(Object... events) throws Exception {
             publish(events);
             return AnnotatedSagaTestFixture.this;
         }
 
         @Override
-        public FixtureExecutionResult publishes(Object event) {
+        public FixtureExecutionResult publishes(Object event) throws Exception {
             try {
                 publish(event);
             } finally {
@@ -302,7 +302,7 @@ public class AnnotatedSagaTestFixture implements FixtureConfiguration, Continued
             return fixtureExecutionResult;
         }
 
-        private void publish(Object... events) {
+        private void publish(Object... events) throws Exception {
             GenericEventMessage.clock = Clock.fixed(currentTime().toInstant(),currentTime().getZone());
 
             try {

--- a/test/src/main/java/org/axonframework/test/saga/ContinuedGivenState.java
+++ b/test/src/main/java/org/axonframework/test/saga/ContinuedGivenState.java
@@ -47,7 +47,7 @@ public interface ContinuedGivenState extends WhenState {
      * @param elapsedTime The amount of time that will elapse
      * @return an object that allows registration of the actual events to send
      */
-    ContinuedGivenState andThenTimeElapses(Duration elapsedTime);
+    ContinuedGivenState andThenTimeElapses(Duration elapsedTime) throws Exception;
 
     /**
      * Simulate time shifts in the current given state. This can be useful when the time between given events is of
@@ -56,7 +56,7 @@ public interface ContinuedGivenState extends WhenState {
      * @param newDateTime The time to advance the clock to
      * @return an object that allows registration of the actual events to send
      */
-    ContinuedGivenState andThenTimeAdvancesTo(ZonedDateTime newDateTime);
+    ContinuedGivenState andThenTimeAdvancesTo(ZonedDateTime newDateTime) throws Exception;
 
     /**
      * Indicates that the given <code>event</code> has been published in the past. This event is sent to the associated
@@ -65,5 +65,5 @@ public interface ContinuedGivenState extends WhenState {
      * @param event The event to publish
      * @return an object that allows chaining of more given state
      */
-    ContinuedGivenState andThenAPublished(Object event);
+    ContinuedGivenState andThenAPublished(Object event) throws Exception;
 }

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -130,7 +130,7 @@ public interface FixtureConfiguration {
      * @param event The event to publish
      * @return an object that allows chaining of more given state
      */
-    ContinuedGivenState givenAPublished(Object event);
+    ContinuedGivenState givenAPublished(Object event) throws Exception;
 
     /**
      * Indicates that no relevant activity has occurred in the past.

--- a/test/src/main/java/org/axonframework/test/saga/GivenAggregateEventPublisher.java
+++ b/test/src/main/java/org/axonframework/test/saga/GivenAggregateEventPublisher.java
@@ -34,5 +34,5 @@ public interface GivenAggregateEventPublisher {
      * @param events The events published by the aggregate
      * @return a reference to the fixture to support a fluent interface
      */
-    ContinuedGivenState published(Object... events);
+    ContinuedGivenState published(Object... events) throws Exception;
 }

--- a/test/src/main/java/org/axonframework/test/saga/WhenAggregateEventPublisher.java
+++ b/test/src/main/java/org/axonframework/test/saga/WhenAggregateEventPublisher.java
@@ -33,5 +33,5 @@ public interface WhenAggregateEventPublisher {
      * @param event The event published by the aggregate
      * @return a reference to the test results for the validation  phase
      */
-    FixtureExecutionResult publishes(Object event);
+    FixtureExecutionResult publishes(Object event) throws Exception;
 }

--- a/test/src/main/java/org/axonframework/test/saga/WhenState.java
+++ b/test/src/main/java/org/axonframework/test/saga/WhenState.java
@@ -54,7 +54,7 @@ public interface WhenState {
      * @param event the event to publish
      * @return an object allowing you to verify the test results
      */
-    FixtureExecutionResult whenPublishingA(Object event);
+    FixtureExecutionResult whenPublishingA(Object event) throws Exception;
 
     /**
      * Mimic an elapsed time with no relevant activity for the Saga. If any Events are scheduled to be published within
@@ -67,7 +67,7 @@ public interface WhenState {
      * @param elapsedTime The amount of time to elapse
      * @return an object allowing you to verify the test results
      */
-    FixtureExecutionResult whenTimeElapses(Duration elapsedTime);
+    FixtureExecutionResult whenTimeElapses(Duration elapsedTime) throws Exception;
 
     /**
      * Mimic an elapsed time with no relevant activity for the Saga. If any Events are scheduled to be published within
@@ -80,5 +80,5 @@ public interface WhenState {
      * @param newDateTime The time to advance the clock to
      * @return an object allowing you to verify the test results
      */
-    FixtureExecutionResult whenTimeAdvancesTo(ZonedDateTime newDateTime);
+    FixtureExecutionResult whenTimeAdvancesTo(ZonedDateTime newDateTime) throws Exception;
 }

--- a/test/src/test/java/org/axonframework/test/MyCommandHandler.java
+++ b/test/src/test/java/org/axonframework/test/MyCommandHandler.java
@@ -39,7 +39,7 @@ class MyCommandHandler {
     }
 
     @CommandHandler
-    public void createAggregate(CreateAggregateCommand command) {
+    public void createAggregate(CreateAggregateCommand command) throws Exception {
         repository.newInstance(() -> new StandardAggregate(0, command.getAggregateIdentifier()));
     }
 

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
 public class AnnotatedSagaTest {
 
     @Test
-    public void testFixtureApi_WhenEventOccurs() {
+    public void testFixtureApi_WhenEventOccurs() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
@@ -66,7 +66,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_AggregatePublishedEvent_NoHistoricActivity() {
+    public void testFixtureApi_AggregatePublishedEvent_NoHistoricActivity() throws Exception {
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenAggregate("id").publishes(new TriggerSagaStartEvent("id"))
@@ -75,7 +75,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test // testing issue AXON-279
-    public void testFixtureApi_PublishedEvent_NoHistoricActivity() {
+    public void testFixtureApi_PublishedEvent_NoHistoricActivity() throws Exception {
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenPublishingA(new GenericEventMessage<>(new TriggerSagaStartEvent("id")))
@@ -84,7 +84,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WithApplicationEvents() {
+    public void testFixtureApi_WithApplicationEvents() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
@@ -102,7 +102,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenEventIsPublishedToEventBus() {
+    public void testFixtureApi_WhenEventIsPublishedToEventBus() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
@@ -121,7 +121,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() {
+    public void testFixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);
         FixtureExecutionResult validator = fixture
@@ -211,7 +211,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenTimeAdvances() {
+    public void testFixtureApi_WhenTimeAdvances() throws Exception {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         AnnotatedSagaTestFixture fixture = new AnnotatedSagaTestFixture(StubSaga.class);

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -204,7 +204,7 @@ public class FixtureExecutionResultImplTest {
     }
 
     @Test(expected = AxonAssertionError.class)
-    public void testExpectScheduledEvent_WrongDateTime() {
+    public void testExpectScheduledEvent_WrongDateTime() throws Exception {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(
                 applicationEvent));
         eventScheduler.advanceTime(Duration.ofMillis(500), i -> {});
@@ -212,7 +212,7 @@ public class FixtureExecutionResultImplTest {
     }
 
     @Test(expected = AxonAssertionError.class)
-    public void testExpectScheduledEvent_WrongClass() {
+    public void testExpectScheduledEvent_WrongClass() throws Exception {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(
                 applicationEvent));
         eventScheduler.advanceTime(Duration.ofMillis(500), i -> {});
@@ -220,7 +220,7 @@ public class FixtureExecutionResultImplTest {
     }
 
     @Test(expected = AxonAssertionError.class)
-    public void testExpectScheduledEvent_WrongEvent() {
+    public void testExpectScheduledEvent_WrongEvent() throws Exception {
         eventScheduler.schedule(Duration.ofSeconds(1),
                                 new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTime(Duration.ofMillis(500), i -> {});
@@ -231,7 +231,7 @@ public class FixtureExecutionResultImplTest {
 
     @SuppressWarnings({"unchecked"})
     @Test(expected = AxonAssertionError.class)
-    public void testExpectScheduledEvent_FailedMatcher() {
+    public void testExpectScheduledEvent_FailedMatcher() throws Exception {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(
                 applicationEvent));
         eventScheduler.advanceTime(Duration.ofMillis(500), i -> {});
@@ -240,7 +240,7 @@ public class FixtureExecutionResultImplTest {
     }
 
     @Test
-    public void testExpectScheduledEvent_Found() {
+    public void testExpectScheduledEvent_Found() throws Exception {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(
                 applicationEvent));
         eventScheduler.advanceTime(Duration.ofMillis(500), i -> {});


### PR DESCRIPTION
Commit 28ce88ef88150e731f0839e676b8d4e9843cdec1 caused saga test fixture to break due to unchecked calls to MessageHandler. This commit adds "throws Exception" clause where required and intruduces a custom Consumer with a throws clause.