### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto detect text files and perform LF normalization
+*        text=auto
+
+*.java   text diff=java
+*.html   text diff=html
+*.css    text
+*.js     text
+*.sql    text


### PR DESCRIPTION
In its current state, the axon git repositories require correctly configured git clients regarding proper line endings. This is not a good setting since it possibly allows incorrect line endings to creep into the autorative repo (and it has already happened....)


The .gitattributes file makes the repository announce to the client what kind of line endings should be used, and will override any client-specific settings. You should really be adding these to all your repos and all branches in active development.

As a consequence of doing this, you may be getting line ending changes in the future, since git from this point on will enforce the proper line endings.

Alternately you may do something like this after adding this file:

find . -name *.java | xargs dos2unix
git commit -am"Fixed all line endings"
