### PR TITLE
Add aggregateType to AggregateNotFoundException

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/disruptor/CommandHandlerInvoker.java
+++ b/core/src/main/java/org/axonframework/commandhandling/disruptor/CommandHandlerInvoker.java
@@ -207,7 +207,7 @@ public class CommandHandlerInvoker implements EventHandler<CommandHandlingEntry>
                     }
                 } catch (EventStreamNotFoundException e) {
                     throw new AggregateNotFoundException(
-                            aggregateIdentifier,
+                            aggregateFactory.getAggregateType(), aggregateIdentifier,
                             "Aggregate not found. Possibly involves an aggregate being created, "
                                     + "or a command that was executed against an aggregate that did not yet "
                                     + "finish the creation process. It will be rescheduled for publication when it "

--- a/core/src/main/java/org/axonframework/eventsourcing/AggregateDeletedException.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/AggregateDeletedException.java
@@ -30,6 +30,18 @@ public class AggregateDeletedException extends AggregateNotFoundException {
     private static final long serialVersionUID = 6814686444144567614L;
 
     /**
+     * Initialize a AggregateDeletedException for an aggregate identifier given by <code>aggregateType</code> and <code>aggregateIdentifier</code>
+     * and given <code>message</code>.
+     *
+     * @param aggregateType       The type of the aggregate that has been deleted
+     * @param aggregateIdentifier The identifier of the aggregate that has been deleted
+     * @param message             The message describing the cause of the exception
+     */
+    public AggregateDeletedException(Class<?> aggregateType, Object aggregateIdentifier, String message) {
+        super(aggregateType, aggregateIdentifier, message);
+    }
+
+    /**
      * Initialize a AggregateDeletedException for an aggregate identifier by given <code>aggregateIdentifier</code> and
      * given <code>message</code>.
      *
@@ -44,10 +56,21 @@ public class AggregateDeletedException extends AggregateNotFoundException {
      * Initialize a AggregateDeletedException for an aggregate identifier by given <code>aggregateIdentifier</code> and
      * a default <code>message</code>.
      *
+     * @param aggregateType       The type of the aggregate that has been deleted
+     * @param aggregateIdentifier The identifier of the aggregate that has been deleted
+     */
+    public AggregateDeletedException(Class<?> aggregateType, Object aggregateIdentifier) {
+        this(aggregateType, aggregateIdentifier,
+             String.format("Aggregate with identifier [%s] not found. It has been deleted.", aggregateIdentifier));
+    }
+
+    /**
+     * Initialize a AggregateDeletedException for an aggregate identifier by given <code>aggregateIdentifier</code> and
+     * a default <code>message</code>.
+     *
      * @param aggregateIdentifier The identifier of the aggregate that has been deleted
      */
     public AggregateDeletedException(Object aggregateIdentifier) {
-        this(aggregateIdentifier,
-             String.format("Aggregate with identifier [%s] not found. It has been deleted.", aggregateIdentifier));
+        this((Class<?>) null, aggregateIdentifier);
     }
 }

--- a/core/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
@@ -115,7 +115,7 @@ public class CachingEventSourcingRepository<T extends EventSourcedAggregateRoot>
             resolveConflicts(aggregate, eventStore.readEvents(getTypeIdentifier(), aggregateIdentifier,
                                                               expectedVersion + 1, aggregate.getVersion()));
         } else if (aggregate.isDeleted()) {
-            throw new AggregateDeletedException(aggregateIdentifier);
+            throw new AggregateDeletedException(getAggregateType(), aggregateIdentifier);
         }
         CurrentUnitOfWork.get().registerListener(new CacheClearingUnitOfWorkListener(aggregateIdentifier));
         return aggregate;

--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -165,7 +165,7 @@ public class EventSourcingRepository<T extends EventSourcedAggregateRoot> extend
             try {
                 events = eventStore.readEvents(getTypeIdentifier(), aggregateIdentifier);
             } catch (EventStreamNotFoundException e) {
-                throw new AggregateNotFoundException(aggregateIdentifier, "The aggregate was not found", e);
+                throw new AggregateNotFoundException(getAggregateType(), aggregateIdentifier, "The aggregate was not found", e);
             }
             originalStream = events;
             for (EventStreamDecorator decorator : eventStreamDecorators) {
@@ -176,7 +176,7 @@ public class EventSourcingRepository<T extends EventSourcedAggregateRoot> extend
             List<DomainEventMessage> unseenEvents = new ArrayList<DomainEventMessage>();
             aggregate.initializeState(new CapturingEventStream(events, unseenEvents, expectedVersion));
             if (aggregate.isDeleted()) {
-                throw new AggregateDeletedException(aggregateIdentifier);
+                throw new AggregateDeletedException(getAggregateType(), aggregateIdentifier);
             }
             CurrentUnitOfWork.get().registerListener(new ConflictResolvingListener(aggregate, unseenEvents));
 

--- a/core/src/main/java/org/axonframework/repository/AggregateNotFoundException.java
+++ b/core/src/main/java/org/axonframework/repository/AggregateNotFoundException.java
@@ -27,6 +27,7 @@ import org.axonframework.common.AxonNonTransientException;
 public class AggregateNotFoundException extends AxonNonTransientException {
 
     private static final long serialVersionUID = 1343530021245649274L;
+    private final Class<?> aggregateType;
     private final Object aggregateIdentifier;
 
     /**
@@ -37,7 +38,20 @@ public class AggregateNotFoundException extends AxonNonTransientException {
      * @param message             The message describing the cause of the exception
      */
     public AggregateNotFoundException(Object aggregateIdentifier, String message) {
+        this(null, aggregateIdentifier, message);
+    }
+
+    /**
+     * Initialize a AggregateNotFoundException for an aggregate given by <code>aggregateType</code> and <code>aggregateIdentifier</code>
+     * and given <code>message</code>.
+     *
+     * @param aggregateType       The type of the aggregate that could not be found
+     * @param aggregateIdentifier The identifier of the aggregate that could not be found
+     * @param message             The message describing the cause of the exception
+     */
+    public AggregateNotFoundException(Class<?> aggregateType, Object aggregateIdentifier, String message) {
         super(message);
+        this.aggregateType = aggregateType;
         this.aggregateIdentifier = aggregateIdentifier;
     }
 
@@ -51,8 +65,32 @@ public class AggregateNotFoundException extends AxonNonTransientException {
      * @param cause               The underlying cause of the exception
      */
     public AggregateNotFoundException(Object aggregateIdentifier, String message, Throwable cause) {
+        this(null, aggregateIdentifier, message, cause);
+    }
+
+    /**
+     * Initialize a AggregateNotFoundException for an aggregate given by <code>aggregateType</code> and <code>aggregateIdentifier</code>
+     * and
+     * with the given <code>message</code> and <code>cause</code>.
+     *
+     * @param aggregateType       The type of the aggregate that could not be found
+     * @param aggregateIdentifier The identifier of the aggregate that could not be found
+     * @param message             The message describing the cause of the exception
+     * @param cause               The underlying cause of the exception
+     */
+    public AggregateNotFoundException(Class<?> aggregateType, Object aggregateIdentifier, String message, Throwable cause) {
         super(message, cause);
+        this.aggregateType = aggregateType;
         this.aggregateIdentifier = aggregateIdentifier;
+    }
+
+    /**
+     * Returns the type of the aggregate that could not be found or null if it is unknown.
+     *
+     * @return the type of the aggregate that could not be found or null if it is unknown
+     */
+    public Class<?> getAggregateType() {
+        return aggregateType;
     }
 
     /**

--- a/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
+++ b/core/src/main/java/org/axonframework/repository/GenericJpaRepository.java
@@ -119,7 +119,7 @@ public class GenericJpaRepository<T extends AggregateRoot> extends LockingReposi
     protected T doLoad(Object aggregateIdentifier, Long expectedVersion) {
         T aggregate = entityManagerProvider.getEntityManager().find(getAggregateType(), aggregateIdentifier);
         if (aggregate == null) {
-            throw new AggregateNotFoundException(aggregateIdentifier, format(
+            throw new AggregateNotFoundException(getAggregateType(), aggregateIdentifier, format(
                     "Aggregate [%s] with identifier [%s] not found",
                     getAggregateType().getSimpleName(),
                     aggregateIdentifier));

--- a/core/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
@@ -289,7 +289,7 @@ public class CachingEventSourcingRepositoryTest {
         public DomainEventStream readEvents(String type, Object identifier, long firstSequenceNumber,
                                             long lastSequenceNumber) {
             if (!store.containsKey(identifier)) {
-                throw new AggregateNotFoundException(identifier, "Aggregate not found");
+                throw new AggregateNotFoundException(StubAggregate.class, identifier, "Aggregate not found");
             }
             final List<DomainEventMessage> events = store.get(identifier);
             List<DomainEventMessage> filteredEvents = new ArrayList<DomainEventMessage>();
@@ -322,7 +322,7 @@ public class CachingEventSourcingRepositoryTest {
         @Override
         public DomainEventStream readEvents(String type, Object identifier) {
             if (!store.containsKey(identifier)) {
-                throw new AggregateNotFoundException(identifier, "Aggregate not found");
+                throw new AggregateNotFoundException(StubAggregate.class, identifier, "Aggregate not found");
             }
             return new SimpleDomainEventStream(store.get(identifier));
         }

--- a/test/src/main/java/org/axonframework/test/GivenWhenThenTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/GivenWhenThenTestFixture.java
@@ -512,7 +512,7 @@ public class GivenWhenThenTestFixture<T extends EventSourcedAggregateRoot>
             List<DomainEventMessage> allEvents = new ArrayList<DomainEventMessage>(givenEvents);
             allEvents.addAll(storedEvents);
             if (allEvents.isEmpty()) {
-                throw new AggregateNotFoundException(identifier,
+                throw new AggregateNotFoundException(aggregateType, identifier,
                                                      "No 'given' events were configured for this aggregate, "
                                                              + "nor have any events been stored.");
             }


### PR DESCRIPTION
I would like to propose the attached change. It introduces a new property to AggregateNotFoundException called aggregateType, together with matching constructors. The use case is that in our application I need to handle AggregateNotFoundException in a generic exception handler and tell the user what was not found exactly, i.e., the type of the entity/aggregate.

If you agree with this PR I will provide a separate one for the master branch.

Also, I haven't signed the CLA yet, but will do so if the PR is accepted (before it is merged, of course).