### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/org/axonframework/common/annotation/ClasspathParameterResolverFactory.java
+++ b/core/src/main/java/org/axonframework/common/annotation/ClasspathParameterResolverFactory.java
@@ -49,6 +49,11 @@ public final class ClasspathParameterResolverFactory {
             new WeakHashMap<>();
 
     /**
+     * Private default constructor
+     */
+    private ClasspathParameterResolverFactory() {}
+
+    /**
      * Creates an instance for the given <code>clazz</code>. Effectively, the class loader of the given class is used
      * to locate implementations.
      *

--- a/core/src/main/java/org/axonframework/common/jdbc/JdbcUtils.java
+++ b/core/src/main/java/org/axonframework/common/jdbc/JdbcUtils.java
@@ -31,6 +31,11 @@ import java.sql.Statement;
 public class JdbcUtils {
 
     /**
+     * Private default constructor
+     */
+    private JdbcUtils() {}
+
+    /**
      * Close the given <code>resultSet</code>, if possible. All exceptions are discarded.
      *
      * @param resultSet The resource to close. May be <code>null</code>.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava