### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/mongo/src/main/java/org/axonframework/serialization/bson/DBObjectHierarchicalStreamReader.java
+++ b/mongo/src/main/java/org/axonframework/serialization/bson/DBObjectHierarchicalStreamReader.java
@@ -20,6 +20,8 @@ import com.mongodb.DBObject;
 import com.thoughtworks.xstream.converters.ErrorWriter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.Stack;
 
@@ -32,8 +34,8 @@ import java.util.Stack;
  */
 public class DBObjectHierarchicalStreamReader implements HierarchicalStreamReader {
 
-    private final Stack<BSONNode> itemStack = new Stack<>();
-    private final Stack<Iterator<BSONNode>> childrenStack = new Stack<>();
+    private final Deque<BSONNode> itemStack = new ArrayDeque<>();
+    private final Deque<Iterator<BSONNode>> childrenStack = new ArrayDeque<>();
 
     /**
      * Initialize the reader to read the structure of the given <code>root</code> DBObject.

--- a/mongo/src/main/java/org/axonframework/serialization/bson/DBObjectHierarchicalStreamWriter.java
+++ b/mongo/src/main/java/org/axonframework/serialization/bson/DBObjectHierarchicalStreamWriter.java
@@ -21,6 +21,8 @@ import com.thoughtworks.xstream.io.ExtendedHierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.axonframework.common.Assert;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Stack;
 
 /**
@@ -32,7 +34,7 @@ import java.util.Stack;
  */
 public class DBObjectHierarchicalStreamWriter implements ExtendedHierarchicalStreamWriter {
 
-    private final Stack<BSONNode> itemStack = new Stack<>();
+    private final Deque<BSONNode> itemStack = new ArrayDeque<>();
     private final DBObject root;
 
     /**
@@ -50,7 +52,7 @@ public class DBObjectHierarchicalStreamWriter implements ExtendedHierarchicalStr
     @SuppressWarnings("unchecked")
     @Override
     public void startNode(String name) {
-        if (itemStack.empty()) {
+        if (itemStack.isEmpty()) {
             itemStack.push(new BSONNode(name));
         } else {
             itemStack.push(itemStack.peek().addChildNode(name));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava