### PR TITLE
Multiple code improvements - squid:MethodCyclomaticComplexity, squid:S00119, squid:S134, squid:RedundantThrowsDeclarationCheck, squid:SwitchLastCaseIsDefaultCheck, squid:UselessParenthesesCheck

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/disruptor/DisruptorCommandBus.java
+++ b/core/src/main/java/org/axonframework/commandhandling/disruptor/DisruptorCommandBus.java
@@ -224,7 +224,7 @@ public class DisruptorCommandBus implements CommandBus {
         RingBuffer<CommandHandlingEntry> ringBuffer = disruptor.getRingBuffer();
         int invokerSegment = 0;
         int publisherSegment = 0;
-        if ((commandHandlerInvokers.length > 1 || publisherCount > 1)) {
+        if (commandHandlerInvokers.length > 1 || publisherCount > 1) {
             String aggregateIdentifier = commandTargetResolver.resolveTarget(command).getIdentifier();
             if (aggregateIdentifier != null) {
                 int idHash = aggregateIdentifier.hashCode() & Integer.MAX_VALUE;

--- a/core/src/main/java/org/axonframework/commandhandling/gateway/GatewayProxyFactory.java
+++ b/core/src/main/java/org/axonframework/commandhandling/gateway/GatewayProxyFactory.java
@@ -191,9 +191,7 @@ public class GatewayProxyFactory {
                                                                     arguments.length - 1);
                 } else {
                     Timeout timeout = gatewayMethod.getAnnotation(Timeout.class);
-                    if (timeout == null) {
-                        timeout = gatewayMethod.getDeclaringClass().getAnnotation(Timeout.class);
-                    }
+                    timeout = resolveTimeout(gatewayMethod, timeout);
                     if (timeout != null) {
                         dispatcher = wrapToReturnWithFixedTimeout(dispatcher, timeout.value(), timeout.unit());
                     } else if (!Void.TYPE.equals(gatewayMethod.getReturnType())
@@ -223,6 +221,13 @@ public class GatewayProxyFactory {
                                        new Class[]{gatewayInterface},
                                        new GatewayInvocationHandler(dispatchers, commandBus, retryScheduler,
                                                                     dispatchInterceptors)));
+    }
+
+    private Timeout resolveTimeout(Method gatewayMethod, Timeout timeout) {
+        if (timeout == null) {
+            timeout = gatewayMethod.getDeclaringClass().getAnnotation(Timeout.class);
+        }
+        return timeout;
     }
 
     private boolean hasCallbackParameters(Method gatewayMethod) {

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
@@ -60,6 +60,8 @@ public abstract class AbstractRoutingStrategy implements RoutingStrategy {
                     return Long.toHexString(counter.getAndIncrement());
                 case STATIC_KEY:
                     return STATIC_ROUTING_KEY;
+                default:
+                    break;
             }
         }
         return routingKey;

--- a/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
+++ b/distributed-commandbus/src/main/java/org/axonframework/commandhandling/distributed/jgroups/JGroupsConnectorFactoryBean.java
@@ -276,7 +276,7 @@ public class JGroupsConnectorFactoryBean implements FactoryBean, InitializingBea
     }
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S00119 - Type parameter names should comply with a naming convention.
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
This pull request removes 44 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S00119
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava