### PR TITLE
Allow customization of event message serialization to Quart…

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/EventJobDataBinder.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/EventJobDataBinder.java
@@ -1,0 +1,34 @@
+package org.axonframework.eventhandling.scheduling.quartz;
+
+import org.quartz.JobDataMap;
+
+/**
+ * Strategy towards reading/writing an Axon EventMessage from/to a Quartz {@link JobDataMap}.
+ * <p>
+ * Implementors may choose how to store the event message as serializable data in {@link JobDataMap}.
+ * This is useful when one does not want to be limited to event payloads requiring to be {@link java.io.Serializable}
+ * (used by Quartz job data map serialization).
+ * </p>
+ *
+ * @see QuartzEventScheduler
+ * @see FireEventJob
+ */
+public interface EventJobDataBinder {
+
+    /**
+     * Write an {@code eventMessage} (or its payload) to a {@link JobDataMap}.
+     *
+     * @param eventMessage to write to the {@link JobDataMap}
+     * @return {@link JobDataMap} written to (must not be null)
+     */
+    JobDataMap toJobData(Object eventMessage);
+
+    /**
+     * Read an {@link org.axonframework.domain.EventMessage} (or its payload) from a {@link JobDataMap}.
+     *
+     * @param jobData to read from
+     * @return event message (or its payload)
+     */
+    Object fromJobData(JobDataMap jobData);
+
+}

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -42,7 +42,7 @@ public class FireEventJob implements Job {
     /**
      * The key used to locate the {@link EventJobDataBinder} in the scheduler context.
      */
-    public static final String EVENT_MESSAGE_BINDER_KEY = EventJobDataBinder.class.getName();
+    public static final String EVENT_JOB_DATA_BINDER_KEY = EventJobDataBinder.class.getName();
 
     /**
      * The key used to locate the Event Bus in the scheduler context.
@@ -63,7 +63,7 @@ public class FireEventJob implements Job {
         try {
             SchedulerContext schedulerContext = context.getScheduler().getContext();
 
-            EventJobDataBinder jobDataBinder = (EventJobDataBinder) schedulerContext.get(EVENT_MESSAGE_BINDER_KEY);
+            EventJobDataBinder jobDataBinder = (EventJobDataBinder) schedulerContext.get(EVENT_JOB_DATA_BINDER_KEY);
             Object event = jobDataBinder.fromJobData(jobData);
             EventMessage<?> eventMessage = createMessage(event);
 

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -22,27 +22,27 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.unitofwork.TransactionManager;
 import org.axonframework.unitofwork.UnitOfWork;
 import org.axonframework.unitofwork.UnitOfWorkFactory;
-import org.quartz.Job;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Quartz Job that publishes an event on an Event Bus. The event is retrieved from the JobExecutionContext. The Event
- * Bus is fetched from the scheduler context.
+ * Quartz Job that publishes an event on an Event Bus. The event is retrieved from the JobExecutionContexts
+ * {@link org.quartz.JobDataMap}. Both the {@link EventBus} and {@link EventJobDataBinder} are fetched from the
+ * scheduler context.
  *
  * @author Allard Buijze
  * @since 0.7
+ * @see EventJobDataBinder
  */
 public class FireEventJob implements Job {
 
     private static final Logger logger = LoggerFactory.getLogger(FireEventJob.class);
 
     /**
-     * The key used to locate the event in the JobExecutionContext.
+     * The key used to locate the {@link EventJobDataBinder} in the scheduler context.
      */
-    public static final String EVENT_KEY = EventMessage.class.getName();
+    public static final String EVENT_MESSAGE_BINDER_KEY = EventJobDataBinder.class.getName();
 
     /**
      * The key used to locate the Event Bus in the scheduler context.
@@ -56,12 +56,20 @@ public class FireEventJob implements Job {
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         logger.debug("Starting job to publish a scheduled event");
-        Object event = context.getJobDetail().getJobDataMap().get(EVENT_KEY);
-        EventMessage<?> eventMessage = createMessage(event);
+
+        JobDetail jobDetail = context.getJobDetail();
+        JobDataMap jobData = jobDetail.getJobDataMap();
+
         try {
-            EventBus eventBus = (EventBus) context.getScheduler().getContext().get(EVENT_BUS_KEY);
-            UnitOfWorkFactory unitOfWorkFactory =
-                    (UnitOfWorkFactory) context.getScheduler().getContext().get(UNIT_OF_WORK_FACTORY_KEY);
+            SchedulerContext schedulerContext = context.getScheduler().getContext();
+
+            EventJobDataBinder jobDataBinder = (EventJobDataBinder) schedulerContext.get(EVENT_MESSAGE_BINDER_KEY);
+            Object event = jobDataBinder.fromJobData(jobData);
+            EventMessage<?> eventMessage = createMessage(event);
+
+            EventBus eventBus = (EventBus) schedulerContext.get(EVENT_BUS_KEY);
+            UnitOfWorkFactory unitOfWorkFactory = (UnitOfWorkFactory) schedulerContext.get(UNIT_OF_WORK_FACTORY_KEY);
+
             UnitOfWork uow = unitOfWorkFactory.createUnitOfWork();
             try {
                 uow.publishEvent(eventMessage, eventBus);
@@ -70,11 +78,10 @@ public class FireEventJob implements Job {
             }
             if (logger.isInfoEnabled()) {
                 logger.info("Job successfully executed. Scheduled Event [{}] has been published.",
-                            eventMessage.getPayloadType().getSimpleName());
+                        eventMessage.getPayloadType().getSimpleName());
             }
         } catch (Exception e) {
-            logger.warn("Exception occurred while publishing scheduled event [{}]",
-                        eventMessage.getPayloadType().getSimpleName());
+            logger.warn("Exception occurred while publishing scheduled event [{}]", jobDetail.getDescription());
             throw new JobExecutionException(e);
         }
     }

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -47,6 +47,8 @@ import static org.quartz.JobKey.jobKey;
  *
  * @author Allard Buijze
  * @since 0.7
+ * @see EventJobDataBinder
+ * @see FireEventJob
  */
 public class QuartzEventScheduler implements org.axonframework.eventhandling.scheduling.EventScheduler {
 
@@ -55,6 +57,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     private static final String DEFAULT_GROUP_NAME = "AxonFramework-Events";
     private String groupIdentifier = DEFAULT_GROUP_NAME;
     private Scheduler scheduler;
+    private EventJobDataBinder jobDataBinder = new DirectEventJobDataBinder();
     private EventBus eventBus;
     private volatile boolean initialized;
     private UnitOfWorkFactory unitOfWorkFactory = new DefaultUnitOfWorkFactory();
@@ -88,13 +91,12 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
      * @return a JobDetail describing the Job to be executed
      */
     protected JobDetail buildJobDetail(EventMessage event, JobKey jobKey) {
-        JobDataMap jobDataMap = new JobDataMap();
-        jobDataMap.put(FireEventJob.EVENT_KEY, event);
+        JobDataMap jobData = jobDataBinder.toJobData(event);
         return JobBuilder.newJob(FireEventJob.class)
-                         .withDescription(event.getPayloadType().getName())
-                         .withIdentity(jobKey)
-                         .usingJobData(jobDataMap)
-                         .build();
+                .withDescription(event.getPayloadType().getName())
+                .withIdentity(jobKey)
+                .usingJobData(jobData)
+                .build();
     }
 
     /**
@@ -135,7 +137,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     }
 
     /**
-     * Initializes the QuartzEventScheduler. Will make the configured Event Bus available to the Quartz Scheduler
+     * Initializes the QuartzEventScheduler. Makes the configured {@link EventBus} available to the Quartz Scheduler.
      *
      * @throws SchedulerException if an error occurs preparing the Quartz Scheduler for use.
      */
@@ -143,8 +145,10 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     public void initialize() throws SchedulerException {
         Assert.notNull(scheduler, "A Scheduler must be provided.");
         Assert.notNull(eventBus, "An EventBus must be provided.");
+        Assert.notNull(jobDataBinder, "An EventJobDataBinder must be provided.");
         scheduler.getContext().put(FireEventJob.EVENT_BUS_KEY, eventBus);
         scheduler.getContext().put(FireEventJob.UNIT_OF_WORK_FACTORY_KEY, unitOfWorkFactory);
+        scheduler.getContext().put(FireEventJob.EVENT_MESSAGE_BINDER_KEY, jobDataBinder);
         initialized = true;
     }
 
@@ -197,5 +201,39 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
      */
     public void setUnitOfWorkFactory(UnitOfWorkFactory unitOfWorkFactory) {
         this.unitOfWorkFactory = unitOfWorkFactory;
+    }
+
+    /**
+     * Sets the {@link EventJobDataBinder} instance which reads / writes the event message to publish to the
+     * {@link JobDataMap}. Defaults to {@link }.
+     *
+     * @param jobDataBinder to use
+     */
+    public void setEventJobDataBinder(EventJobDataBinder jobDataBinder) {
+        this.jobDataBinder = jobDataBinder;
+    }
+
+    /**
+     * Binds the {@link EventMessage} as is to {@link JobDataMap}. In order for {@link JobDataMap} to successfully
+     * serialize, the payload of the {@link EventMessage} must be {@link java.io.Serializable}.
+     */
+    public static class DirectEventJobDataBinder implements EventJobDataBinder {
+
+        /**
+         * The key used to locate the event in the JobExecutionContext.
+         */
+        public static final String EVENT_KEY = EventMessage.class.getName();
+
+        @Override
+        public JobDataMap toJobData(Object eventMessage) {
+            JobDataMap jobData = new JobDataMap();
+            jobData.put(EVENT_KEY, eventMessage);
+            return jobData;
+        }
+
+        @Override
+        public Object fromJobData(JobDataMap jobData) {
+            return jobData.get(EVENT_KEY);
+        }
     }
 }

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -205,7 +205,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
 
     /**
      * Sets the {@link EventJobDataBinder} instance which reads / writes the event message to publish to the
-     * {@link JobDataMap}. Defaults to {@link }.
+     * {@link JobDataMap}. Defaults to {@link DirectEventJobDataBinder}.
      *
      * @param jobDataBinder to use
      */
@@ -214,13 +214,14 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     }
 
     /**
-     * Binds the {@link EventMessage} as is to {@link JobDataMap}. In order for {@link JobDataMap} to successfully
-     * serialize, the payload of the {@link EventMessage} must be {@link java.io.Serializable}.
+     * Binds the {@link EventMessage} as is to {@link JobDataMap} under {@link #EVENT_KEY}. In order for
+     * {@link JobDataMap} to successfully serialize, the payload of the {@link EventMessage} must be
+     * {@link java.io.Serializable}.
      */
     public static class DirectEventJobDataBinder implements EventJobDataBinder {
 
         /**
-         * The key used to locate the event in the JobExecutionContext.
+         * The key used to locate the event in the {@link JobDataMap}.
          */
         public static final String EVENT_KEY = EventMessage.class.getName();
 

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -148,7 +148,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         Assert.notNull(jobDataBinder, "An EventJobDataBinder must be provided.");
         scheduler.getContext().put(FireEventJob.EVENT_BUS_KEY, eventBus);
         scheduler.getContext().put(FireEventJob.UNIT_OF_WORK_FACTORY_KEY, unitOfWorkFactory);
-        scheduler.getContext().put(FireEventJob.EVENT_MESSAGE_BINDER_KEY, jobDataBinder);
+        scheduler.getContext().put(FireEventJob.EVENT_JOB_DATA_BINDER_KEY, jobDataBinder);
         initialized = true;
     }
 

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
@@ -18,6 +18,7 @@ package org.axonframework.eventhandling.scheduling.quartz;
 
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.unitofwork.SpringTransactionManager;
+import org.quartz.JobDataMap;
 import org.quartz.Scheduler;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
@@ -44,6 +45,7 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
     private Scheduler scheduler;
     private EventBus eventBus;
     private String groupIdentifier;
+    private EventJobDataBinder eventJobDataBinder;
     private PlatformTransactionManager transactionManager;
     private TransactionDefinition transactionDefinition;
 
@@ -77,6 +79,9 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
         eventScheduler.setEventBus(eventBus);
         if (groupIdentifier != null) {
             eventScheduler.setGroupIdentifier(groupIdentifier);
+        }
+        if (eventJobDataBinder != null) {
+            eventScheduler.setEventJobDataBinder(eventJobDataBinder);
         }
         if (transactionManager != null) {
             eventScheduler.setTransactionManager(new SpringTransactionManager(transactionManager,
@@ -115,6 +120,16 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
      */
     public void setGroupIdentifier(String groupIdentifier) {
         this.groupIdentifier = groupIdentifier;
+    }
+
+    /**
+     * Sets the {@link EventJobDataBinder} instance which reads / writes the event message to publish to the
+     * {@link JobDataMap}. Defaults to {@link QuartzEventScheduler.DirectEventJobDataBinder}.
+     *
+     * @param eventJobDataBinder to use
+     */
+    public void setEventJobDataBinder(EventJobDataBinder eventJobDataBinder) {
+        this.eventJobDataBinder = eventJobDataBinder;
     }
 
     /**


### PR DESCRIPTION
…z storage

Introduced EventJobDataBinder to allow for custom serialization of event message
payload into the Quartz job data map. This removes the limitation that event
message payload itself should be serializable in order to make use of the Quartz
scheduler.

Defaults to original behavior of requiring payload to be serializable.
Fixes http://issues.axonframework.org/youtrack/issue/AXON-340