### PR TITLE
Saga should not survive it's creation if it threw exception while being created

### DIFF
--- a/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
+++ b/core/src/main/java/org/axonframework/saga/AbstractSagaManager.java
@@ -188,7 +188,7 @@ public abstract class AbstractSagaManager extends AbstractReplayAwareSagaManager
         } else {
             CurrentUnitOfWork.get().registerListener(new UnitOfWorkListenerAdapter() {
                 @Override
-                public void afterCommit(UnitOfWork unitOfWork) {
+                public void onCleanup(UnitOfWork unitOfWork) {
                     sagaMap.remove(sagaIdentifier);
                 }
             });


### PR DESCRIPTION
Hi,
I found a bug in AbstractSagaManager. It doesn't clear its internal map "sagasInCreation" when Unit of Work is rollbacked.

When saga threw an exception while being created, it was still handled events in another units of work, but it shouldn't.

I think this bug doesn't appear in Axon 3.0, but let me know if I'm wrong.

Maciek