### PR TITLE
Return CompletableFuture from CommandGateway#send

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/core/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -16,11 +16,12 @@
 
 package org.axonframework.commandhandling.gateway;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.messaging.Message;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Interface towards the Command Handling components of an application. This interface provides a friendlier API toward
@@ -100,6 +101,7 @@ public interface CommandGateway {
      * CommandMessage is constructed from that message's payload and MetaData.
      *
      * @param command The command to dispatch
+     * @return a {@link CompletableFuture<R>} which is resolved when the command is executed
      */
-    void send(Object command);
+    <R> CompletableFuture<R> send(Object command);
 }

--- a/core/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/core/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -16,17 +16,17 @@
 
 package org.axonframework.commandhandling.gateway;
 
+import static java.util.Arrays.asList;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.callbacks.FutureCallback;
-import org.axonframework.commandhandling.callbacks.NoOpCallback;
 import org.axonframework.messaging.MessageDispatchInterceptor;
-
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static java.util.Arrays.asList;
 
 /**
  * Default implementation of the CommandGateway interface. It allow configuration of a {@link RetryScheduler} and
@@ -132,13 +132,10 @@ public class DefaultCommandGateway extends AbstractCommandGateway implements Com
         return (R) futureCallback.getResult(timeout, unit);
     }
 
-    /**
-     * Sends the given {@code command} and returns immediately. This implementation
-     *
-     * @param command The command to send
-     */
     @Override
-    public void send(Object command) {
-        send(command, new NoOpCallback());
+    public <R> CompletableFuture<R> send(Object command) {
+        FutureCallback<Object, R> callback = new FutureCallback<>();
+        send(command, callback);
+        return callback.toCompletableFuture();
     }
 }


### PR DESCRIPTION
Convert CommandGateway#send from a void return to a CompletableFuture, in order to allow resolving callbacks in a different location than CommandGateway#send is called

