### PR TITLE
Fix: ExtendedUpcaster#upcast(SerializedType serializedType, Serialize…

### DIFF
--- a/core/src/main/java/org/axonframework/upcasting/AbstractUpcasterChain.java
+++ b/core/src/main/java/org/axonframework/upcasting/AbstractUpcasterChain.java
@@ -125,8 +125,9 @@ public abstract class AbstractUpcasterChain implements UpcasterChain {
             if (currentUpcaster.canUpcast(serializedObject.getType())) {
                 List<SerializedType> upcastTypes;
                 if (currentUpcaster instanceof ExtendedUpcaster) {
-                    upcastTypes = ((ExtendedUpcaster) currentUpcaster).upcast(serializedObject.getType(),
-                                                                              serializedObject);
+                    upcastTypes = ((ExtendedUpcaster) currentUpcaster).upcast(
+                            serializedObject.getType(),
+                            ensureCorrectContentType(serializedObject, currentUpcaster.expectedRepresentationType()));
                 } else {
                     upcastTypes = currentUpcaster.upcast(serializedObject.getType());
                 }

--- a/core/src/test/java/org/axonframework/upcasting/LazyUpcasterChainTest.java
+++ b/core/src/test/java/org/axonframework/upcasting/LazyUpcasterChainTest.java
@@ -74,6 +74,14 @@ public class LazyUpcasterChainTest extends UpcasterChainTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void testUpcastingChainWithExtendedUpcasterThroughDataTypeConversion() {
+        Upcaster<String> upcaster = spy(new StubExtendedUpcaster("1", "2"));
+        LazyUpcasterChain testSubject = new LazyUpcasterChain(Arrays.<Upcaster>asList(upcaster));
+        testSubject.upcast(new SimpleSerializedObject<byte[]>("upcast object".getBytes(), byte[].class, "type", "1"), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void testUpcastingChainWithExtendedUpcaster() {
         Upcaster<String> firstUpcaster = spy(new StubUpcaster("1", "2"));
         Upcaster<String> secondUpcaster = spy(new StubExtendedUpcaster("2", "3"));


### PR DESCRIPTION
…dObject<T> intermediateRepresentation) is called without ensuring that T matches the type declared by expectedRepresentationType().