### PR TITLE
Added a SimpleResourceParameterResolverFactory

### DIFF
--- a/core/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
@@ -1,0 +1,36 @@
+package org.axonframework.messaging.annotation;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Parameter;
+
+import org.axonframework.common.Priority;
+
+/**
+ * A {@link ParameterResolverFactory} implementation for simple resource injections.
+ * Uses the {@link FixedValueParameterResolver} to inject a resource as a fixed value
+ * on message handling if the resource equals a message handling method parameter.
+ */
+@Priority(Priority.LOW)
+public class SimpleResourceParameterResolverFactory implements ParameterResolverFactory {
+
+    private final Object resource;
+
+    /**
+     * Initialize the ParameterResolverFactory to inject the given
+     * <code>resource</code> in applicable parameters.
+     *
+     * @param resource The resource to inject
+     */
+    public SimpleResourceParameterResolverFactory(Object resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    public ParameterResolver createInstance(Executable executable, Parameter[] parameters, int parameterIndex) {
+        if (parameters[parameterIndex].getType().isInstance(resource)) {
+            return new FixedValueParameterResolver<>(resource);
+        }
+        return null;
+    }
+
+}

--- a/core/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
+++ b/core/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
@@ -1,0 +1,70 @@
+package org.axonframework.messaging.annotation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.Message;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SimpleResourceParameterResolverFactoryTest {
+
+    private static final String TEST_RESOURCE = "testResource";
+
+    private SimpleResourceParameterResolverFactory testSubject;
+
+    private Method messageHandlingMethodWithResourceParameter;
+    private Method messageHandlingMethodWithoutResourceParameter;
+    private Method messageHandlingMethodWithResourceParameterOfDifferentType;
+
+    @Before
+    public void setUp() throws Exception {
+        testSubject = new SimpleResourceParameterResolverFactory(TEST_RESOURCE);
+
+        messageHandlingMethodWithResourceParameter = getClass().getMethod("someMessageHandlingMethodWithResource", Message.class, String.class);
+        messageHandlingMethodWithoutResourceParameter = getClass().getMethod("someMessageHandlingMethodWithoutResource", Message.class);
+        messageHandlingMethodWithResourceParameterOfDifferentType =
+                getClass().getMethod("someMessageHandlingMethodWithResourceOfDifferentType", Message.class, Integer.class);
+    }
+
+    @SuppressWarnings("unused") //Used in setUp()
+    public void someMessageHandlingMethodWithResource(Message message, String resource) {
+    }
+
+    @SuppressWarnings("unused") //Used in setUp()
+    public void someMessageHandlingMethodWithoutResource(Message message) {
+    }
+
+    @SuppressWarnings("unused") //Used in setUp()
+    public void someMessageHandlingMethodWithResourceOfDifferentType(Message message, Integer resourceOfDifferentType) {
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testResolvesToResourceWhenMessageHandlingMethodHasResourceParameter() throws Exception {
+        ParameterResolver resolver =
+                testSubject.createInstance(messageHandlingMethodWithResourceParameter, messageHandlingMethodWithResourceParameter.getParameters(), 1);
+        final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        assertTrue(resolver.matches(eventMessage));
+        assertEquals(TEST_RESOURCE, resolver.resolveParameterValue(eventMessage));
+    }
+
+    @Test
+    public void testIgnoredWhenMessageHandlingMethodHasNoResourceParameter() throws Exception {
+        ParameterResolver resolver =
+                testSubject.createInstance(messageHandlingMethodWithoutResourceParameter, messageHandlingMethodWithoutResourceParameter.getParameters(), 0);
+        assertNull(resolver);
+    }
+
+    @Test
+    public void testIgnoredWhenMessageHandlingMethodHasResourceParameterOfDifferentType() throws Exception {
+        ParameterResolver resolver = testSubject.createInstance(messageHandlingMethodWithResourceParameterOfDifferentType, messageHandlingMethodWithResourceParameterOfDifferentType.getParameters(), 1);
+        assertNull(resolver);
+    }
+
+}


### PR DESCRIPTION
The SimpleResourceParameterResolverFactory is used to inject a resource of any type into message handling methods.
This is done by creating a SimpleResourceParameterResolverFactory with the resource you want it to inject.
By adding SimpleResourceParameterResolverFactory to the ParameterResolverFactories used by the Axon application,
 any message handling method with a parameter similar to the type of resource will get the resource injected.