### PR TITLE
Payload type message monitor wrapper

### DIFF
--- a/metrics/src/main/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics/src/main/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapper.java
@@ -1,0 +1,85 @@
+package org.axonframework.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import org.axonframework.messaging.Message;
+import org.axonframework.monitoring.MessageMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A {@link MessageMonitor} implementation which creates a new MessageMonitor for every {@link Message} payload type
+ * ingested by it. The PayloadTypeMessageMonitorWrapper keeps track of all distinct payload types it has created
+ * and only creates a new one if there is none present.
+ *
+ * The type of MessageMonitor which is created for every payload type is configurable, as long as it implements
+ * MessageMonitor and {@link MetricSet}.
+ *
+ * @param <T> The type of the MessageMonitor created for every payload type.
+ *           Required to extends MessageMonitor and MetricSet
+ */
+public class PayloadTypeMessageMonitorWrapper<T extends MessageMonitor<Message<?>> & MetricSet> implements MessageMonitor<Message<?>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayloadTypeMessageMonitorWrapper.class);
+
+    private final Class<T> monitorClass;
+    private Map<Class<?>, MessageMonitor<Message<?>>> payloadTypeMonitors;
+
+    private final MetricRegistry metricRegistry;
+    private final String groupName;
+
+    /**
+     * Create a PayloadTypeMessageMonitorWrapper which builds monitors based on the given monitorClass,
+     * registers them to the given metricRegistry and prepend the metric names with the given groupName.
+     *
+     * @param monitorClass the MessageMonitor Class used to instantiate a monitor per payload type
+     * @param metricRegistry the MetricRegistry where newly created monitors will be registered to
+     * @param groupName a String used as a prepend for the metric name given upon registration to the MetricRegistry
+     */
+    public PayloadTypeMessageMonitorWrapper(Class<T> monitorClass, MetricRegistry metricRegistry, String groupName) {
+        this.monitorClass = monitorClass;
+        this.payloadTypeMonitors = new HashMap<>();
+
+        this.metricRegistry = metricRegistry;
+        this.groupName = groupName;
+    }
+
+    @Override
+    public MonitorCallback onMessageIngested(Message<?> message) {
+        Class<?> messagePayloadType = message.getPayloadType();
+
+        MessageMonitor<Message<?>> messageMonitorForPayloadType =
+                payloadTypeMonitors.computeIfAbsent(messagePayloadType, payloadType -> {
+                    try {
+                        MessageMonitor<Message<?>> newMessageMonitor = monitorClass.newInstance();
+                        registerMessageMonitor((MetricSet) newMessageMonitor, groupName, payloadType);
+                        return newMessageMonitor;
+                    } catch (InstantiationException | IllegalAccessException e) {
+                        String errorMessage = "Failed to create a MessageMonitor " +
+                                "of type [" + monitorClass.getSimpleName() + "] " +
+                                "for message payload type [" + payloadType.getSimpleName() + "]";
+                        LOGGER.error(errorMessage);
+                        throw new IllegalArgumentException(errorMessage, e);
+                    }
+                });
+
+        return messageMonitorForPayloadType.onMessageIngested(message);
+    }
+
+    private void registerMessageMonitor(MetricSet messageMonitor, String groupName, Class<?> payloadType) {
+        try {
+            String metricName = name(groupName, this.getClass().getSimpleName(), monitorClass.getSimpleName(),
+                    payloadType.getSimpleName());
+            metricRegistry.register(metricName, messageMonitor);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to register metric [{}] for payload type [{}]",
+                    monitorClass.getSimpleName(), payloadType.getSimpleName(), e);
+        }
+    }
+
+}

--- a/metrics/src/test/java/org/axonframework/metrics/GlobalMetricRegistryTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/GlobalMetricRegistryTest.java
@@ -25,8 +25,8 @@ public class GlobalMetricRegistryTest {
 
     @Test
     public void createEventProcessorMonitor() throws Exception {
-        MessageMonitor<EventMessage<?>> monitor1 = subject.registerEventProcessor("test1");
-        MessageMonitor<EventMessage<?>> monitor2 = subject.registerEventProcessor("test2");
+        MessageMonitor<? super EventMessage<?>> monitor1 = subject.registerEventProcessor("test1");
+        MessageMonitor<? super EventMessage<?>> monitor2 = subject.registerEventProcessor("test2");
 
         monitor1.onMessageIngested(asEventMessage("test")).reportSuccess();
         monitor2.onMessageIngested(asEventMessage("test")).reportSuccess();

--- a/metrics/src/test/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapperTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapperTest.java
@@ -1,0 +1,136 @@
+package org.axonframework.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import org.apache.log4j.Appender;
+import org.apache.log4j.Logger;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.common.ReflectionUtils;
+import org.axonframework.messaging.Message;
+import org.axonframework.monitoring.MessageMonitor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PayloadTypeMessageMonitorWrapperTest {
+
+    private static final String GROUP_NAME = "groupName";
+    private static final CommandMessage<Object> STRING_MESSAGE = asCommandMessage("stringCommand");
+    private static final CommandMessage<Object> INTEGER_MESSAGE = asCommandMessage(1);
+
+    private PayloadTypeMessageMonitorWrapper<CapacityMonitor> testSubject;
+
+    @Mock
+    private MetricRegistry metricRegistry;
+    private Class<CapacityMonitor> monitorClass;
+
+    private final Appender appender = mock(Appender.class);
+    private final Logger logger = Logger.getRootLogger();
+
+    @Before
+    public void setUp() throws Exception {
+        logger.addAppender(appender);
+
+        monitorClass = CapacityMonitor.class;
+        testSubject = new PayloadTypeMessageMonitorWrapper<>(monitorClass, metricRegistry, GROUP_NAME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        logger.removeAppender(appender);
+    }
+
+    @Test
+    public void testInstantiateMessageMonitorOfTypeMonitorOnMessageIngested() throws Exception {
+        Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
+        payloadTypeMonitorsField.setAccessible(true);
+
+        Message<?> testMessage = asCommandMessage("stringCommand");
+
+        testSubject.onMessageIngested(testMessage);
+
+        Map<Class<?>, MessageMonitor<Message<?>>> payloadTypeMonitors = ReflectionUtils.getFieldValue(payloadTypeMonitorsField, testSubject);
+        assertTrue(payloadTypeMonitors.size() == 1);
+        MessageMonitor<Message<?>> messageMessageMonitor = payloadTypeMonitors.get(testMessage.getPayloadType());
+        assertNotNull(messageMessageMonitor);
+        assertTrue(monitorClass.isInstance(messageMessageMonitor));
+    }
+
+    @Test
+    public void testInstantiatesOneMessageMonitorPerIngestedPayloadType() throws Exception {
+        Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
+        payloadTypeMonitorsField.setAccessible(true);
+
+        testSubject.onMessageIngested(STRING_MESSAGE); // First unique payload type
+        testSubject.onMessageIngested(STRING_MESSAGE);
+        testSubject.onMessageIngested(INTEGER_MESSAGE); // Second unique payload type
+
+        Map<Class<?>, MessageMonitor<Message<?>>> payloadTypeMonitors = ReflectionUtils.getFieldValue(payloadTypeMonitorsField, testSubject);
+        assertTrue(payloadTypeMonitors.size() == 2);
+
+        MessageMonitor<Message<?>> messageMessageMonitor = payloadTypeMonitors.get(STRING_MESSAGE.getPayloadType());
+        assertNotNull(messageMessageMonitor);
+        assertTrue(monitorClass.isInstance(messageMessageMonitor));
+
+        messageMessageMonitor = payloadTypeMonitors.get(INTEGER_MESSAGE.getPayloadType());
+        assertNotNull(messageMessageMonitor);
+        assertTrue(monitorClass.isInstance(messageMessageMonitor));
+    }
+
+    @Test
+    public void testRegistersAMessageMonitorOnMessageIngested() throws Exception {
+        String expectedMetricName = MetricRegistry.name(GROUP_NAME,
+                PayloadTypeMessageMonitorWrapper.class.getSimpleName(), monitorClass.getSimpleName(),
+                STRING_MESSAGE.getPayloadType().getSimpleName());
+
+        testSubject.onMessageIngested(STRING_MESSAGE);
+
+        ArgumentCaptor<Metric> registeredMetricCaptor = ArgumentCaptor.forClass(Metric.class);
+        verify(metricRegistry).register(eq(expectedMetricName), registeredMetricCaptor.capture());
+        Metric registeredMetric = registeredMetricCaptor.getValue();
+        assertTrue(monitorClass.isInstance(registeredMetric));
+    }
+
+    @Test
+    public void testRegistersAMessageMonitorPerIngestedPayloadType() throws Exception {
+        String expectedStringMetricName = MetricRegistry.name(GROUP_NAME,
+                PayloadTypeMessageMonitorWrapper.class.getSimpleName(), monitorClass.getSimpleName(),
+                STRING_MESSAGE.getPayloadType().getSimpleName());
+        String expectedIntegerMetricName = MetricRegistry.name(GROUP_NAME,
+                PayloadTypeMessageMonitorWrapper.class.getSimpleName(), monitorClass.getSimpleName(),
+                INTEGER_MESSAGE.getPayloadType().getSimpleName());
+
+        testSubject.onMessageIngested(STRING_MESSAGE); // First unique payload type
+        testSubject.onMessageIngested(INTEGER_MESSAGE); // Second unique payload type
+        testSubject.onMessageIngested(INTEGER_MESSAGE);
+
+        verify(metricRegistry, times(2)).register(anyString(), any());
+
+        ArgumentCaptor<Metric> registeredMetricCaptor = ArgumentCaptor.forClass(Metric.class);
+        verify(metricRegistry).register(eq(expectedStringMetricName), registeredMetricCaptor.capture());
+        Metric registeredMetric = registeredMetricCaptor.getValue();
+        assertTrue(monitorClass.isInstance(registeredMetric));
+
+        verify(metricRegistry).register(eq(expectedIntegerMetricName), registeredMetricCaptor.capture());
+        registeredMetric = registeredMetricCaptor.getValue();
+        assertTrue(monitorClass.isInstance(registeredMetric));
+    }
+
+}

--- a/quickstart/src/main/java/org/axonframework/quickstart/RunBasicCommandHandlingWithMetrics.java
+++ b/quickstart/src/main/java/org/axonframework/quickstart/RunBasicCommandHandlingWithMetrics.java
@@ -72,7 +72,7 @@ public class RunBasicCommandHandlingWithMetrics {
         commandBus.subscribe(MarkCompletedCommand.class.getName(), new MarkCompletedCommandHandler(repository));
 
         // Create a message monitor that will monitor the messages going through the event processor
-        MessageMonitor<EventMessage<?>> eventProcessorMessageMonitor = registry.registerEventProcessor("eventProcessing");
+        MessageMonitor<? super EventMessage<?>> eventProcessorMessageMonitor = registry.registerEventProcessor("eventProcessing");
 
         // We register an event listener to see which events are created
         new SubscribingEventProcessor("processor", new SimpleEventHandlerInvoker((EventListener) event -> System.out


### PR DESCRIPTION
A Message Monitor implementation which gets or creates a specified MessageMonitor for every payload type encountered during message ingestion and calls 'onMessageIngested' on that payload type specific MessageMonitor.