### PR TITLE
Support public fields without get methods on Message

### DIFF
--- a/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
+++ b/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
@@ -1,0 +1,28 @@
+package org.axonframework.common.property;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.axonframework.common.ReflectionUtils.fieldsOf;
+
+/**
+ * Implementation of PropertyAccessStrategy that scans class hierarchy to get public field named "property"
+ */
+public class DirectPropertyAccessStrategy extends PropertyAccessStrategy {
+
+	@Override
+	protected int getPriority() {
+		return -2048;
+	}
+
+	@Override
+	protected <T> Property<T> propertyFor(Class<? extends T> targetClass, String property) {
+		Iterable<Field> fields = fieldsOf(targetClass);
+		for(Field field : fields) {
+			if (field.getName().equals(property) && ((field.getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC)) {
+				return new DirectlyAccessedProperty<>(field, property);
+			}
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
+++ b/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
@@ -19,7 +19,7 @@ public class DirectPropertyAccessStrategy extends PropertyAccessStrategy {
 	protected <T> Property<T> propertyFor(Class<? extends T> targetClass, String property) {
 		Iterable<Field> fields = fieldsOf(targetClass);
 		for(Field field : fields) {
-			if (field.getName().equals(property) && ((field.getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC)) {
+			if (field.getName().equals(property) && (field.getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC) {
 				return new DirectlyAccessedProperty<>(field, property);
 			}
 		}

--- a/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
+++ b/core/src/main/java/org/axonframework/common/property/DirectPropertyAccessStrategy.java
@@ -1,9 +1,6 @@
 package org.axonframework.common.property;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
-import static org.axonframework.common.ReflectionUtils.fieldsOf;
 
 /**
  * Implementation of PropertyAccessStrategy that scans class hierarchy to get public field named "property"
@@ -17,9 +14,9 @@ public class DirectPropertyAccessStrategy extends PropertyAccessStrategy {
 
 	@Override
 	protected <T> Property<T> propertyFor(Class<? extends T> targetClass, String property) {
-		Iterable<Field> fields = fieldsOf(targetClass);
+		Field[] fields = targetClass.getFields();
 		for(Field field : fields) {
-			if (field.getName().equals(property) && (field.getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC) {
+			if (field.getName().equals(property)) {
 				return new DirectlyAccessedProperty<>(field, property);
 			}
 		}

--- a/core/src/main/java/org/axonframework/common/property/DirectlyAccessedProperty.java
+++ b/core/src/main/java/org/axonframework/common/property/DirectlyAccessedProperty.java
@@ -1,0 +1,33 @@
+package org.axonframework.common.property;
+
+import java.lang.reflect.Field;
+
+import static java.lang.String.format;
+
+/**
+ * Property implementation that accesses public field to obtain a value of a property for a given instance.
+ * @param <T> The type of object defining this property
+ */
+public class DirectlyAccessedProperty<T> implements Property<T> {
+
+	private final Field field;
+	private final String property;
+
+	public DirectlyAccessedProperty(Field field, String property){
+		this.field = field;
+		this.property = property;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <V> V getValue(T target) {
+		try {
+			return (V)field.get(target);
+		}
+		catch (IllegalAccessException e) {
+			throw new PropertyAccessException(format(
+					"Failed to get value of '%s' in '%s'. Property should be accessible",
+					property, target.getClass().getName()), e);
+		}
+	}
+}

--- a/core/src/main/resources/META-INF/services/org.axonframework.common.property.PropertyAccessStrategy
+++ b/core/src/main/resources/META-INF/services/org.axonframework.common.property.PropertyAccessStrategy
@@ -16,3 +16,4 @@
 
 org.axonframework.common.property.UniformPropertyAccessStrategy
 org.axonframework.common.property.BeanPropertyAccessStrategy
+org.axonframework.common.property.DirectPropertyAccessStrategy

--- a/core/src/test/java/org/axonframework/common/property/DirectPropertyAccessStrategyTest.java
+++ b/core/src/test/java/org/axonframework/common/property/DirectPropertyAccessStrategyTest.java
@@ -1,0 +1,65 @@
+package org.axonframework.common.property;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DirectPropertyAccessStrategyTest {
+
+	@Test
+	public void testGetValue() {
+		final Property<TestMessage> actualProperty = getProperty(regularPropertyName());
+		assertNotNull(actualProperty);
+		assertNotNull(actualProperty.<String>getValue(propertyHoldingInstance()));
+	}
+
+	@Test
+	public void testGetValue_BogusProperty() {
+		assertNull(getProperty(unknownPropertyName()));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testGetValue_NullExceptionOnAccess() {
+		getProperty(privatePropertyName()).getValue(propertyHoldingInstance());
+	}
+
+	@Test
+	public void testOverriddenPropertyValue() {
+		assertEquals("realValue", getProperty(overriddenPropertyName()).getValue(propertyHoldingInstance()));
+	}
+
+	private String overriddenPropertyName() {
+		return "overriddenProperty1";
+	}
+
+	private String privatePropertyName() {
+		return "privateProperty1";
+	}
+
+	private String regularPropertyName() {
+		return "property1";
+	}
+
+	private String unknownPropertyName() {
+		return "unknownProperty";
+	}
+
+	private TestMessage propertyHoldingInstance() {
+		return new TestMessage();
+	}
+
+	private Property<TestMessage> getProperty(String property) {
+		return new DirectPropertyAccessStrategy().propertyFor(TestMessage.class, property);
+	}
+
+	class TestMessage extends TestMessageParent {
+		public String property1 = "property1Value";
+		private Integer privateProperty1;
+		private String overriddenProperty1 = "fakeValue";
+	}
+
+	class TestMessageParent{
+		public String parentProperty1 = "parentProperty1Value";
+		public String overriddenProperty1 = "realValue";
+	}
+}


### PR DESCRIPTION
Since I have Event message like

public class EventMsg{
  public String data;

   public EventMsg(String data){
     this.data = data;
   }
}

and current @SagaEventHandler(associationProperty = "data") is not supporting this, edited a property accessor methods. Don't know if there is some other way to access the fields directly.