### PR TITLE
Add Sequence Name to @GeneratedValue() annotation

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/saga/repository/jpa/AssociationValueEntry.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/repository/jpa/AssociationValueEntry.java
@@ -16,9 +16,15 @@
 
 package org.axonframework.eventhandling.saga.repository.jpa;
 
-import org.axonframework.eventhandling.saga.AssociationValue;
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 
-import javax.persistence.*;
+import org.axonframework.eventhandling.saga.AssociationValue;
 
 /**
  * JPA wrapper around an Association Value. This entity is used to store relevant Association Values for Sagas.
@@ -31,7 +37,8 @@ import javax.persistence.*;
 public class AssociationValueEntry {
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name = "associationvalueentry_id_seq_generator", sequenceName = "associationvalueentry_id_seq")
+    @GeneratedValue(generator = "associationvalueentry_id_seq_generator")
     private Long id;
 
     @Basic(optional = false)

--- a/core/src/main/java/org/axonframework/eventhandling/saga/repository/jpa/AssociationValueEntry.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/repository/jpa/AssociationValueEntry.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling.saga.repository.jpa;
 
+import org.axonframework.eventhandling.saga.AssociationValue;
+
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -23,8 +25,6 @@ import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-
-import org.axonframework.eventhandling.saga.AssociationValue;
 
 /**
  * JPA wrapper around an Association Value. This entity is used to store relevant Association Values for Sagas.

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
@@ -13,13 +13,13 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.serialization.Serializer;
+
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.SequenceGenerator;
-
-import org.axonframework.eventsourcing.DomainEventMessage;
-import org.axonframework.serialization.Serializer;
 
 /**
  * Abstract base class of a serialized domain event. Fields in this class contain JPA annotations that direct JPA event

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
@@ -13,12 +13,13 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
-import org.axonframework.eventsourcing.DomainEventMessage;
-import org.axonframework.serialization.Serializer;
-
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.SequenceGenerator;
+
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.serialization.Serializer;
 
 /**
  * Abstract base class of a serialized domain event. Fields in this class contain JPA annotations that direct JPA event
@@ -30,7 +31,8 @@ import javax.persistence.MappedSuperclass;
 public abstract class AbstractSequencedDomainEventEntry<T> extends AbstractDomainEventEntry<T> implements DomainEventData<T> {
 
     @Id
-    @GeneratedValue
+    @SequenceGenerator(name = "domainevententry_globalindex_seq_generator", sequenceName = "domainevententry_globalindex_seq")
+    @GeneratedValue(generator = "domainevententry_globalindex_seq_generator")
     @SuppressWarnings("unused")
     private long globalIndex;
 


### PR DESCRIPTION
Add Sequence Name to `@GeneratedValue()` annotation to get a separate sequence table for the Association Value Id and Domain Event Entry's Global Index.