### PR TITLE
[refs #240] CorrelationDataProviders now also available as Spring Bean

### DIFF
--- a/core/src/main/java/org/axonframework/messaging/correlation/CorrelationDataProvider.java
+++ b/core/src/main/java/org/axonframework/messaging/correlation/CorrelationDataProvider.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 import java.util.Map;
 
 /**
- * Object defining the the data from a Message that should be attached as correlation data to messages generated as
+ * Object defining the data from a Message that should be attached as correlation data to messages generated as
  * result of the processing of that message.
  *
  * @author Allard Buijze

--- a/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
@@ -86,6 +86,7 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
         return config.messageMonitor(componentType, componentName);
     }
 
+    @Bean
     @Override
     public List<CorrelationDataProvider> correlationDataProviders() {
         return config.correlationDataProviders();
@@ -104,7 +105,7 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Override
     public void start() {
         config.start();
-        this.running = true;
+        running = true;
     }
 
     @Override
@@ -115,7 +116,7 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Override
     public void stop() {
         shutdown();
-        this.running = false;
+        running = false;
     }
 
     @Override


### PR DESCRIPTION
Made a bean of the CorrelationDataProviders

Second part of issue "CorrelationDataProvider instances available in the Application Context should automatically be configured" seems to be done already in the DefaultConfigurer
` private final Component<List<CorrelationDataProvider>> correlationProviders =
            new Component<>(config, "correlationProviders",
                            c -> Collections.singletonList(new MessageOriginProvider()));`
