### PR TITLE
Add 'connection.setAutoCommit(false)' to JdbcTokenStore

### DIFF
--- a/core/src/main/java/org/axonframework/common/jdbc/JdbcUtils.java
+++ b/core/src/main/java/org/axonframework/common/jdbc/JdbcUtils.java
@@ -90,6 +90,7 @@ public class JdbcUtils {
                 PreparedStatement preparedStatement = createSqlStatement(connection, sqlFunction);
                 try {
                     result[i] = preparedStatement.executeUpdate();
+                    connection.commit();
                 } catch (SQLException e) {
                     errorHandler.accept(e);
                 } finally {
@@ -116,7 +117,9 @@ public class JdbcUtils {
         try {
             PreparedStatement preparedStatement = createSqlStatement(connection, sqlFunction);
             try {
-                return preparedStatement.executeBatch();
+                int[] result = preparedStatement.executeBatch();
+                connection.commit();
+                return result;
             } catch (SQLException e) {
                 errorHandler.accept(e);
             } finally {

--- a/core/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/core/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -321,7 +321,9 @@ public class JdbcTokenStore implements TokenStore {
      */
     protected Connection getConnection() {
         try {
-            return connectionProvider.getConnection();
+            Connection connection = connectionProvider.getConnection();
+            connection.setAutoCommit(false);
+            return connection;
         } catch (SQLException e) {
             throw new JdbcException("Failed to obtain a database connection", e);
         }

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -513,7 +513,9 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      */
     protected Connection getConnection() {
         try {
-            return connectionProvider.getConnection();
+            Connection connection = connectionProvider.getConnection();
+            connection.setAutoCommit(false);
+            return connection;
         } catch (SQLException e) {
             throw new EventStoreException("Failed to obtain a database connection", e);
         }


### PR DESCRIPTION
Fixes #250.

The change to [`JdbcUtils.executeUpdates`](https://github.com/AxonFramework/AxonFramework/compare/master...donovanmuller:master#diff-c1f8f6009d3163919caef97f0310b2e0R93) is to accommodate the `JdbcTokenStoreTest#testClaimTokenConcurrentlyAfterRelease` test that failed when `autoCommit` was set to `false`. For reference, the exception stacktrace was:

```console
  org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException: Unable to claim token 'concurrent[0]'. It is owned by '4466@...'

	at org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore.claimToken(JdbcTokenStore.java:200)
	at org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore.loadOrInsertToken(JdbcTokenStore.java:229)
	at org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore.lambda$fetchToken$6(JdbcTokenStore.java:120)
	at org.axonframework.common.jdbc.JdbcUtils.executeQuery(JdbcUtils.java:61)
	at org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore.fetchToken(JdbcTokenStore.java:119)
	at org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStoreTest.lambda$testClaimTokenConcurrentlyAfterRelease$8(JdbcTokenStoreTest.java:110)
```

and a corresponding change to `JdbcUtils.executeBatch` and [`JdbcEventStorageEngine`](https://github.com/AxonFramework/AxonFramework/pull/251/files#diff-6df699ec811327f1e444eac5f80f6530R517) to prevent:

```console
Caused by: java.sql.SQLException: Can't call commit when autocommit=true
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:868) ~[mysql-connector-java-5.1.40.jar:5.1.40]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:864) ~[mysql-connector-java-5.1.40.jar:5.1.40]
	at com.mysql.jdbc.ConnectionImpl.commit(ConnectionImpl.java:1606) ~[mysql-connector-
...
org.axonframework.spring.jdbc.SpringDataSourceConnectionProvider$SpringConnectionCloseHandler.commit(SpringDataSourceConnectionProvider.java:71) ~[classes/:na]
	at org.axonframework.common.jdbc.ConnectionWrapperFactory.lambda$wrap$1(ConnectionWrapperFactory.java:109) ~[classes/:na]
	at com.sun.proxy.$Proxy133.commit(Unknown Source) ~[na:na]
	at org.axonframework.common.jdbc.JdbcUtils.lambda$executeUpdates$0(JdbcUtils.java:93) ~[classes/:na]
	... 81 common frames omitted
```
