### PR TITLE
Bugfix for an OutOfMemoryError

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -413,7 +413,17 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      * @throws SQLException when an exception occurs while creating the event data
      */
     protected DomainEventData<?> getDomainEventData(ResultSet resultSet) throws SQLException {
-        return (DomainEventData<?>) getTrackedEventData(resultSet, null);
+        long globalSequence = resultSet.getLong(schema.globalIndexColumn());
+        TrackingToken trackingToken = new GlobalSequenceTrackingToken(globalSequence);
+        return new GenericTrackedDomainEventEntry<>(trackingToken, resultSet.getString(schema.typeColumn()),
+                resultSet.getString(schema.aggregateIdentifierColumn()),
+                resultSet.getLong(schema.sequenceNumberColumn()),
+                resultSet.getString(schema.eventIdentifierColumn()),
+                readTimeStamp(resultSet, schema.timestampColumn()),
+                resultSet.getString(schema.payloadTypeColumn()),
+                resultSet.getString(schema.payloadRevisionColumn()),
+                readPayload(resultSet, schema.payloadColumn()),
+                readPayload(resultSet, schema.metaDataColumn()));
     }
 
     /**

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -413,17 +413,15 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      * @throws SQLException when an exception occurs while creating the event data
      */
     protected DomainEventData<?> getDomainEventData(ResultSet resultSet) throws SQLException {
-        long globalSequence = resultSet.getLong(schema.globalIndexColumn());
-        TrackingToken trackingToken = new GlobalSequenceTrackingToken(globalSequence);
-        return new GenericTrackedDomainEventEntry<>(trackingToken, resultSet.getString(schema.typeColumn()),
-                resultSet.getString(schema.aggregateIdentifierColumn()),
-                resultSet.getLong(schema.sequenceNumberColumn()),
-                resultSet.getString(schema.eventIdentifierColumn()),
-                readTimeStamp(resultSet, schema.timestampColumn()),
-                resultSet.getString(schema.payloadTypeColumn()),
-                resultSet.getString(schema.payloadRevisionColumn()),
-                readPayload(resultSet, schema.payloadColumn()),
-                readPayload(resultSet, schema.metaDataColumn()));
+        return new GenericDomainEventEntry<>(resultSet.getString(schema.typeColumn()),
+                                             resultSet.getString(schema.aggregateIdentifierColumn()),
+                                             resultSet.getLong(schema.sequenceNumberColumn()),
+                                             resultSet.getString(schema.eventIdentifierColumn()),
+                                             readTimeStamp(resultSet, schema.timestampColumn()),
+                                             resultSet.getString(schema.payloadTypeColumn()),
+                                             resultSet.getString(schema.payloadRevisionColumn()),
+                                             readPayload(resultSet, schema.payloadColumn()),
+                                             readPayload(resultSet, schema.metaDataColumn()));
     }
 
     /**


### PR DESCRIPTION
When loading events by only `aggregateIdentifier` and `sequenceNumber` a `GlobalSequenceTrackingToken` should be used instead of a `GapAwareTrackingToken`.

Using a `GapAwareTrackingToken` causes an `OutOfMemoryError` when the `globalIndex` of the loaded event is very high, because the resulting gap is always 1 ... `globalIndex`.