### PR TITLE
Send JGroups JoinMessage out-of-band [OOB] in order for them to take …

### DIFF
--- a/distributed-commandbus-jgroups/src/main/java/org/axonframework/jgroups/commandhandling/JGroupsConnector.java
+++ b/distributed-commandbus-jgroups/src/main/java/org/axonframework/jgroups/commandhandling/JGroupsConnector.java
@@ -122,7 +122,9 @@ public class JGroupsConnector implements CommandRouter, Receiver, CommandBusConn
         try {
             if (channel.isConnected()) {
                 Address localAddress = channel.getAddress();
-                channel.send(null, new JoinMessage(localAddress, loadFactor, commandFilter));
+                Message joinMessage = new Message(null, new JoinMessage(localAddress, loadFactor, commandFilter));
+                joinMessage.setFlag(Message.Flag.OOB);
+                channel.send(joinMessage);
             }
         } catch (Exception e) {
             throw new ServiceRegistryException("Could not broadcast local membership details to the cluster", e);
@@ -188,7 +190,9 @@ public class JGroupsConnector implements CommandRouter, Receiver, CommandBusConn
             stream(joined).filter(member -> !member.equals(channel.getAddress())).forEach(member -> {
                 logger.info("New member detected: [{}]. Sending it my configuration.", member);
                 try {
-                    channel.send(member, new JoinMessage(channel.getAddress(), loadFactor, commandFilter));
+                    Message joinMessage = new Message(member, new JoinMessage(channel.getAddress(), loadFactor, commandFilter));
+                    joinMessage.setFlag(Message.Flag.OOB);
+                    channel.send(joinMessage);
                 } catch (Exception e) {
                     throw new MembershipUpdateFailedException("Failed to notify my existence to " + member);
                 }


### PR DESCRIPTION
…precedence over regular command/reply Message while using Jgroups thread pool queue - thread_pool.queue_enabled.

(cherry picked from commit 1cbe8f91757a65f56e8a742b0c4abdcf0be4a283)

Need the fix in the branch 3.0.x