### PR TITLE
Name axon threads

### DIFF
--- a/core/src/main/java/org/axonframework/common/AxonThreadFactory.java
+++ b/core/src/main/java/org/axonframework/common/AxonThreadFactory.java
@@ -68,7 +68,7 @@ public class AxonThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread thread = new Thread(groupName, r);
+        Thread thread = new Thread(groupName, r, groupName.getName());
         thread.setPriority(priority);
         return thread;
     }


### PR DESCRIPTION
Give a name to threads generated by axon in order to be able to identify them easily in thread dumps.