### PR TITLE
SpringMessage: Use a converter to parse aggregate sequence long value

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
@@ -7,6 +7,7 @@ import org.axonframework.eventsourcing.GenericDomainEventMessage;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.NumberUtils;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -63,7 +64,7 @@ public class DefaultEventMessageConverter implements EventMessageConverter {
         if (headers.containsKey(AGGREGATE_ID)) {
             return new GenericDomainEventMessage<>(Objects.toString(headers.get(AGGREGATE_TYPE)),
                                                    Objects.toString(headers.get(AGGREGATE_ID)),
-                                                   (Long) headers.get(AGGREGATE_SEQ),
+                                                   NumberUtils.convertNumberToTargetClass(headers.get(AGGREGATE_SEQ, Number.class), Long.class),
                                                    genericMessage, () -> Instant.ofEpochMilli(timestamp));
         } else {
             return new GenericEventMessage<>(genericMessage, () -> Instant.ofEpochMilli(timestamp));


### PR DESCRIPTION
Spring Cloud Stream deserialize message headers with Jackson using `objectMapper.fromJson(headerValue, Object.class)` in `org.springframework.cloud.stream.binder.EmbeddedHeadersMessageConverter`.
When the `headerValue` contains a number which fits into an Integer, Jackson returns an Integer value.

Therefore we cannot cast directly to long, but we must perform a toLong conversion to be certain that no exception will be thrown.