### PR TITLE
OutboundEventMessageChannelAdapter: wrong conversion of GenericDomainEventMessage

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
@@ -1,0 +1,77 @@
+package org.axonframework.spring.messaging;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.NumberUtils;
+
+/**
+ * An {@link EventMessageConverter} that will convert an Axon event message into a Spring message by:
+ * - Copying axon event payload into Spring message payload
+ * - Copying axon event metadata into Spring message headers
+ * - Adding axon event message specific attributes - that are not part of axon metadata - to the Spring message Headers.
+ *   Among those specific attributes are {@link DomainEventMessage} specific properties.
+ *
+ * @author Reda.Housni-Alaoui
+ * @since 3.1
+ */
+public class DefaultEventMessageConverter implements EventMessageConverter {
+
+	private static final String AXON_MESSAGE_PREFIX = "axon-message-";
+	private static final String MESSAGE_ID = AXON_MESSAGE_PREFIX + "id";
+	private static final String AGGREGATE_ID = AXON_MESSAGE_PREFIX + "aggregate-id";
+	private static final String AGGREGATE_SEQ = AXON_MESSAGE_PREFIX + "aggregate-seq";
+	private static final String AGGREGATE_TYPE = AXON_MESSAGE_PREFIX + "aggregate-type";
+
+	@Override
+	public <T> Message<T> convertToOutboundMessage(EventMessage<T> event) {
+		Map<String, Object> headers = new HashMap<>();
+		event.getMetaData().forEach(headers::put);
+		headers.put(MESSAGE_ID, event.getIdentifier());
+		if (event instanceof DomainEventMessage) {
+			headers.put(AGGREGATE_ID, ((DomainEventMessage) event).getAggregateIdentifier());
+			headers.put(AGGREGATE_SEQ, ((DomainEventMessage) event).getSequenceNumber());
+			headers.put(AGGREGATE_TYPE, ((DomainEventMessage) event).getType());
+		}
+		return new GenericMessage<>(event.getPayload(), new SettableTimestampMessageHeaders(headers, event.getTimestamp().toEpochMilli()));
+	}
+
+	@Override
+	public <T> EventMessage<T> convertFromInboundMessage(Message<T> message) {
+		MessageHeaders headers = message.getHeaders();
+		Map<String, ?> metaData = headers.entrySet()
+				.stream()
+				.filter(entry -> !entry.getKey().startsWith(AXON_MESSAGE_PREFIX))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+		String messageId = Objects.toString(headers.get(MESSAGE_ID));
+		Long timestamp = headers.getTimestamp();
+
+		org.axonframework.messaging.GenericMessage<T> genericMessage
+				= new org.axonframework.messaging.GenericMessage<>(messageId, message.getPayload(), metaData);
+		if (headers.containsKey(AGGREGATE_ID)) {
+			return new GenericDomainEventMessage<>(Objects.toString(headers.get(AGGREGATE_TYPE)),
+					Objects.toString(headers.get(AGGREGATE_ID)),
+					NumberUtils.convertNumberToTargetClass(headers.get(AGGREGATE_SEQ, Number.class), Long.class),
+					genericMessage, () -> Instant.ofEpochMilli(timestamp));
+		} else {
+			return new GenericEventMessage<>(genericMessage, () -> Instant.ofEpochMilli(timestamp));
+		}
+	}
+
+	private static class SettableTimestampMessageHeaders extends MessageHeaders {
+		protected SettableTimestampMessageHeaders(Map<String, Object> headers, Long timestamp) {
+			super(headers, null, timestamp);
+		}
+	}
+}

--- a/spring/src/main/java/org/axonframework/spring/messaging/EventMessageConverter.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/EventMessageConverter.java
@@ -1,0 +1,31 @@
+package org.axonframework.spring.messaging;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.springframework.messaging.Message;
+
+/**
+ * Interface describing a mechanism that converts Spring Messages from an Axon Event Messages and vice versa.
+ *
+ * @author Reda.Housni-Alaoui
+ * @since 3.1
+ */
+public interface EventMessageConverter {
+
+	/**
+	 * Converts Axon {@code event} into Spring message.
+	 *
+	 * @param event The Axon event to convert
+	 * @param <T>   The event payload type
+	 * @return The outbound Spring message
+	 */
+	<T> Message<T> convertToOutboundMessage(EventMessage<T> event);
+
+	/**
+	 * Converts a Spring inbound {@code message} into an Axon event Message
+	 *
+	 * @param message The Spring message to convert
+	 * @param <T>     The message payload type
+	 * @return The inbound Axon event message
+	 */
+	<T> EventMessage<T> convertFromInboundMessage(Message<T> message);
+}

--- a/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
@@ -1,0 +1,84 @@
+package org.axonframework.spring.messaging;
+
+
+import static org.junit.Assert.*;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.junit.Test;
+
+/**
+ * Created on 04/02/17.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class DefaultEventMessageConverterTest {
+
+	private EventMessageConverter eventMessageConverter = new DefaultEventMessageConverter();
+
+	@Test
+	public void given_generic_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
+		Instant instant = Instant.EPOCH;
+		String id = UUID.randomUUID().toString();
+
+		Map<String, Object> metaData = new HashMap<>();
+		metaData.put("number", 100);
+		metaData.put("string", "world");
+
+		EventPayload payload = new EventPayload("hello");
+
+		EventMessage<EventPayload> axonMessage = new GenericEventMessage<>(id, payload, metaData, instant);
+
+		EventMessage<EventPayload> convertedAxonMessage = eventMessageConverter.convertFromInboundMessage(eventMessageConverter.convertToOutboundMessage(axonMessage));
+
+		assertEquals(instant, convertedAxonMessage.getTimestamp());
+		assertEquals(100, convertedAxonMessage.getMetaData().get("number"));
+		assertEquals("world", convertedAxonMessage.getMetaData().get("string"));
+		assertEquals("hello", convertedAxonMessage.getPayload().name);
+		assertEquals(id, convertedAxonMessage.getIdentifier());
+	}
+
+	@Test
+	public void given_domain_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
+		Instant instant = Instant.EPOCH;
+		String id = UUID.randomUUID().toString();
+		String aggId = UUID.randomUUID().toString();
+
+		Map<String, Object> metaData = new HashMap<>();
+		metaData.put("number", 100);
+		metaData.put("string", "world");
+
+		EventPayload payload = new EventPayload("hello");
+
+		EventMessage<EventPayload> axonMessage = new GenericDomainEventMessage<>("foo", aggId, 1, payload, metaData, id, instant);
+		EventMessage<EventPayload> convertedAxonMessage = eventMessageConverter.convertFromInboundMessage(eventMessageConverter.convertToOutboundMessage(axonMessage));
+
+		assertTrue(convertedAxonMessage instanceof DomainEventMessage);
+
+		DomainEventMessage<EventPayload> convertDomainMessage = (DomainEventMessage<EventPayload>) convertedAxonMessage;
+		assertEquals(instant, convertDomainMessage.getTimestamp());
+		assertEquals(100, convertDomainMessage.getMetaData().get("number"));
+		assertEquals("world", convertDomainMessage.getMetaData().get("string"));
+		assertEquals("hello", convertDomainMessage.getPayload().name);
+		assertEquals(id, convertDomainMessage.getIdentifier());
+		assertEquals("foo", convertDomainMessage.getType());
+		assertEquals(aggId, convertDomainMessage.getAggregateIdentifier());
+		assertEquals(1, convertDomainMessage.getSequenceNumber());
+	}
+
+	private class EventPayload{
+		private final String name;
+
+		EventPayload(String name){
+			this.name = name;
+		}
+	}
+
+}


### PR DESCRIPTION
Same as #267 but targeting 3.0.x.
Also contains fix of #273