### PR TITLE
Add an implementation of SQLErrorCodesResolver able to fallback on SQLState

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesOrStateResolver.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesOrStateResolver.java
@@ -1,0 +1,105 @@
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+import org.axonframework.common.AxonConfigurationException;
+
+/**
+ * A {@link SQLErrorCodesResolver} with fallback on SQL state.
+ *
+ * @author Reda.Housni-Alaoui
+ * @since 3.1
+ */
+public class SQLErrorCodesOrStateResolver extends SQLErrorCodesResolver {
+
+	/**
+	 * Initializes the SQLErrorCodesResolver using the given list of SQL Codes representing Key Constraint Violations.
+	 *
+	 * @param duplicateKeyCodes A list of Integer containing SQL Codes representing Key Constraint Violations
+	 */
+	public SQLErrorCodesOrStateResolver(List<Integer> duplicateKeyCodes) {
+		super(duplicateKeyCodes);
+	}
+
+	/**
+	 * Initialize a SQLErrorCodesResolver, automatically detecting the database name through the given dataSource. The
+	 * database product name is used to resolve the database error codes.
+	 *
+	 * @param dataSource The data source providing the information about the backing database.
+	 * @throws java.sql.SQLException      when retrieving the database product name fails
+	 * @throws AxonConfigurationException is the dataSource returns an unknown database product name. Use {@link
+	 *                                    #SQLErrorCodesOrStateResolver(java.util.Properties, javax.sql.DataSource)} instead.
+	 */
+	public SQLErrorCodesOrStateResolver(DataSource dataSource) throws SQLException {
+		super(dataSource);
+	}
+
+	/**
+	 * Initialize a SQLErrorCodesResolver, automatically detecting the database name through the given dataSource. The
+	 * database product name is used to resolve the database error codes. As an alternative you could set the property
+	 * databaseDuplicateKeyCodes
+	 *
+	 * @param databaseProductName The product name of the database
+	 * @throws AxonConfigurationException is the dataSource returns an unknown database product name. Use {@link
+	 *                                    #SQLErrorCodesOrStateResolver(java.util.Properties, String)} instead.
+	 */
+	public SQLErrorCodesOrStateResolver(String databaseProductName) {
+		super(databaseProductName);
+	}
+
+	/**
+	 * Initialize a SQLErrorCodesResolver, automatically detecting the database name through the given dataSource. The
+	 * database product name is used to resolve the database error codes. As an alternative you could set the property
+	 * databaseDuplicateKeyCodes
+	 * <p/>
+	 * The form of the properties is expected to be:<br/>
+	 * <em>{@code databaseName}</em>.duplicateKeyCodes=<code><em>keyCode</em>[,<em>keyCode</em>]*</code><br/>
+	 * Where <em>{@code databaseName}</em> is the database product name as returned by the driver, with spaces ('
+	 * ') replaced by underscore ('_'). The key codes must be a comma separated list of SQL Error code numbers (int).
+	 *
+	 * @param properties          the properties defining SQL Error Codes for Duplicate Key violations for different
+	 *                            databases
+	 * @param databaseProductName The product name of the database
+	 */
+	public SQLErrorCodesOrStateResolver(Properties properties, String databaseProductName) {
+		super(properties, databaseProductName);
+	}
+
+	/**
+	 * Initialize the SQLErrorCodesResolver with the given {@code properties} and use the {@code dataSource}
+	 * to automatically retrieve the database product name.
+	 * <p/>
+	 * The form of the properties is expected to be:<br/>
+	 * <em>{@code databaseName}</em>.duplicateKeyCodes=<code><em>keyCode</em>[,<em>keyCode</em>]*</code><br/>
+	 * Where <em>{@code databaseName}</em> is the database product name as returned by the driver, with spaces ('
+	 * ') replaced by underscore ('_'). The key codes must be a comma separated list of SQL Error code numbers (int).
+	 *
+	 * @param properties the properties defining SQL Error Codes for Duplicate Key violations for different databases
+	 * @param dataSource The data source providing the database product name
+	 * @throws java.sql.SQLException when retrieving the database product name fails
+	 */
+	public SQLErrorCodesOrStateResolver(Properties properties, DataSource dataSource) throws SQLException {
+		super(properties, dataSource);
+	}
+
+	@Override
+	protected boolean isDuplicateKeyViolation(List<Integer> duplicateKeyCodes, SQLException sqlException) {
+		if (super.isDuplicateKeyViolation(duplicateKeyCodes, sqlException)) {
+			return true;
+		}
+		if (sqlException.getSQLState() == null) {
+			return false;
+		}
+
+		try {
+			int sqlState = Integer.parseInt(sqlException.getSQLState());
+			return duplicateKeyCodes.contains(sqlState);
+		} catch (NumberFormatException ignored) {
+		}
+
+		return false;
+	}
+}

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolver.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolver.java
@@ -16,11 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore.jpa;
 
-import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.common.io.IOUtils;
-import org.axonframework.common.jdbc.PersistenceExceptionResolver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.axonframework.common.ExceptionUtils.*;
 
 import javax.persistence.EntityExistsException;
 import javax.sql.DataSource;
@@ -33,7 +29,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.axonframework.common.ExceptionUtils.findException;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.io.IOUtils;
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * SQLErrorCodesResolver is an implementation of PersistenceExceptionResolver used to resolve sql error codes to see if
@@ -144,7 +144,11 @@ public class SQLErrorCodesResolver implements PersistenceExceptionResolver {
     @Override
     public boolean isDuplicateKeyViolation(Exception exception) {
         return causeIsEntityExistsException(exception) || findException(exception, SQLException.class)
-                .map(sqlException -> duplicateKeyCodes.contains(sqlException.getErrorCode())).orElse(false);
+                .map(sqlException -> isDuplicateKeyViolation(duplicateKeyCodes, sqlException)).orElse(false);
+    }
+
+    protected boolean isDuplicateKeyViolation(List<Integer> duplicateKeyCodes, SQLException sqlException) {
+        return duplicateKeyCodes.contains(sqlException.getErrorCode());
     }
 
     private boolean causeIsEntityExistsException(Throwable exception) {

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesOrStateResolverTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesOrStateResolverTest.java
@@ -1,0 +1,69 @@
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import static org.junit.Assert.*;
+
+import javax.persistence.PersistenceException;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.junit.Test;
+
+/**
+ * Created on 10/02/17.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class SQLErrorCodesOrStateResolverTest {
+
+	@Test
+	public void testIsDuplicateKey_isDuplicateKey_usingSqlState() throws Exception {
+		Properties props = new Properties();
+		props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
+
+		String databaseProductName = "MyCustom Database Engine";
+
+		SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesOrStateResolver(props, databaseProductName);
+
+		SQLException sqlException = new SQLException("test", "-104");
+
+		boolean isDuplicateKey = sqlErrorCodesResolver.isDuplicateKeyViolation(new PersistenceException("error",
+				sqlException));
+
+		assertTrue(isDuplicateKey);
+	}
+
+	@Test
+	public void testIsDuplicateKey_isDuplicateKey_usingNonIntSqlState() throws Exception {
+		Properties props = new Properties();
+		props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
+
+		String databaseProductName = "MyCustom Database Engine";
+
+		SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesOrStateResolver(props, databaseProductName);
+
+		SQLException sqlException = new SQLException("test", "thisIsNotAnInt");
+
+		boolean isDuplicateKey = sqlErrorCodesResolver.isDuplicateKeyViolation(new PersistenceException("error",
+				sqlException));
+
+		assertFalse(isDuplicateKey);
+	}
+
+	@Test
+	public void testIsDuplicateKey_isDuplicateKey_usingNonNullSqlState() throws Exception {
+		Properties props = new Properties();
+		props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
+
+		String databaseProductName = "MyCustom Database Engine";
+
+		SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesOrStateResolver(props, databaseProductName);
+
+		SQLException sqlException = new SQLException("test", (String) null);
+
+		boolean isDuplicateKey = sqlErrorCodesResolver.isDuplicateKeyViolation(new PersistenceException("error",
+				sqlException));
+
+		assertFalse(isDuplicateKey);
+	}
+
+}


### PR DESCRIPTION
I am using Postgres JDBC driver 9.4.
Error message code are stored into SQLState field instead of the sql error code field.
This PR adds a resolver able to fallback on SQLState.