### PR TITLE
auto detect DB2 UDB using DataSource

### DIFF
--- a/core/src/main/resources/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCode.properties
+++ b/core/src/main/resources/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCode.properties
@@ -29,6 +29,8 @@ Apache_Derby.transientErrorCodes=40XL1,40001
 
 DB2.duplicateKeyCodes=-803
 
+DB2_UDB_for_AS/400.duplicateKeyCodes=-803
+
 H2.duplicateKeyCodes=23001,23505
 H2.transientErrorCodes=50200
 

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolverTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolverTest.java
@@ -78,6 +78,21 @@ public class SQLErrorCodesResolverTest {
     }
 
     @Test
+    public void testIsDuplicateKey_isDuplicateKey_usingAS400DataSource() throws Exception {
+        String databaseProductName = "DB2 UDB for AS/400";
+        DataSource dataSource = createMockDataSource(databaseProductName);
+
+        SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesResolver(dataSource);
+
+        SQLException sqlException = new SQLException("test", "error", -803);
+
+        boolean isDuplicateKey = sqlErrorCodesResolver.isDuplicateKeyViolation(new PersistenceException("error",
+                sqlException));
+
+        assertTrue(isDuplicateKey);
+    }
+
+    @Test
     public void testIsDuplicateKey_isDuplicateKey_usingProductName() throws Exception {
         String databaseProductName = "HSQL Database Engine";
 


### PR DESCRIPTION
DB2 for iSeries (former AS400) uses the same SQL error code as DB2 for LUW but with a different JDBC driver and database product name. 

With this change, DataSources with this driver will be auto detected.  