### PR TITLE
Problem: If TrackingEventProcessor cannot connect to db, it tries to …

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/core/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -302,6 +302,12 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
                 logger.warn("Unexpected exception while attempting to retrieve token and open stream. " +
                                     "Retrying in 5 seconds.", e);
                 tx.rollback();
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException interrupt) {
+                    logger.info("Thread interrupted while waiting for new attempt to claim token");
+                    Thread.currentThread().interrupt();
+                }
             }
         }
         return eventStream;


### PR DESCRIPTION
…reconnect several times per second

Problem: If TrackingEventProcessor cannot connect to db, it waits 5 seconds before it tries to reconnect

Fixes #286 