### PR TITLE
SpringCloud Distributed CommandBus: Member URI path should be incorporated to the request URI

### DIFF
--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -69,7 +69,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         if (optionalEndpoint.isPresent()) {
             URI endpointUri = optionalEndpoint.get();
             URI destinationUri = buildURIForPath(endpointUri.getScheme(), endpointUri.getUserInfo(),
-                    endpointUri.getHost(), endpointUri.getPort());
+                    endpointUri.getHost(), endpointUri.getPort(), endpointUri.getPath());
 
             SpringHttpDispatchMessage<C> dispatchMessage =
                     new SpringHttpDispatchMessage<>(commandMessage, serializer, expectReply);
@@ -83,9 +83,9 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         }
     }
 
-    private URI buildURIForPath(String scheme, String userInfo, String host, int port) {
+    private URI buildURIForPath(String scheme, String userInfo, String host, int port, String path) {
         try {
-            return new URI(scheme, userInfo, host, port, COMMAND_BUS_CONNECTOR_PATH, null, null);
+            return new URI(scheme, userInfo, host, port, path + COMMAND_BUS_CONNECTOR_PATH, null, null);
         } catch (URISyntaxException e) {
             LOGGER.error("Failed to build URI for [{}{}{}], with user info [{}] and path [{}]",
                     scheme, host, port, userInfo, COMMAND_BUS_CONNECTOR_PATH, e);

--- a/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
+++ b/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
@@ -70,7 +70,7 @@ public class SpringHttpCommandBusConnectorTest {
     @Before
     public void setUp() throws Exception {
         expectedUri = new URI(ENDPOINT.getScheme(), ENDPOINT.getUserInfo(), ENDPOINT.getHost(),
-                ENDPOINT.getPort(), "/spring-command-bus-connector/command", null, null);
+                ENDPOINT.getPort(), ENDPOINT.getPath() + "/spring-command-bus-connector/command", null, null);
 
         when(serializedMetaData.getContentType()).thenReturn(byte[].class);
         when(serializedMetaData.getData()).thenReturn(SERIALIZED_COMMAND_METADATA);


### PR DESCRIPTION
Currently the member URI path is not used by the SpringCloud CommandBus connector.
This makes it impossible to use this distributed command bus with applications running inside a webapp container.