### PR TITLE
WIP: Add ClassLoader of XStreamSerializer to XStream instance.

### DIFF
--- a/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.converters.collections.MapConverter;
+import com.thoughtworks.xstream.core.util.CompositeClassLoader;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.CannotResolveClassException;
@@ -145,6 +146,16 @@ public abstract class AbstractXStreamSerializer implements Serializer {
 
         xStream.alias("meta-data", MetaData.class);
         xStream.registerConverter(new MetaDataConverter(xStream.getMapper()));
+
+        // Make sure ClassLoader of this instance is registered - required by spring devtools RestartClassLoader
+        if (CompositeClassLoader.class.isAssignableFrom(xStream.getClassLoader().getClass())) {
+            ((CompositeClassLoader)xStream.getClassLoader()).add(this.getClass().getClassLoader());
+        } else {
+            final CompositeClassLoader compositeClassLoader = new CompositeClassLoader();
+            compositeClassLoader.add(this.getClass().getClassLoader());
+            xStream.setClassLoader(compositeClassLoader);
+        }
+
     }
 
     /**

--- a/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -153,6 +153,8 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         } else {
             final CompositeClassLoader compositeClassLoader = new CompositeClassLoader();
             compositeClassLoader.add(this.getClass().getClassLoader());
+            compositeClassLoader.add(xStream.getClassLoader());
+            
             xStream.setClassLoader(compositeClassLoader);
         }
 


### PR DESCRIPTION
Register the ClassLoader of the serializer instance in xstream.
Uses CompositeClassLoader to ensure that existing loaders are not lost.

Fixes classloader issues when using spring-boot-devtools.
See #282 for more.

Needs review:
All existing tests are green, but I could not figure out how to write a new test for this change.



