### PR TITLE
Use columnName parameter in setProcessorNameColumn

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/TokenSchema.java
+++ b/core/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/TokenSchema.java
@@ -144,7 +144,7 @@ public class TokenSchema {
          * @return the modified Builder instance
          */
         public Builder setProcessorNameColumn(String columnName) {
-            this.processorNameColumn = processorNameColumn;
+            this.processorNameColumn = columnName;
             return this;
         }
 


### PR DESCRIPTION
There's a small bug in `TokenSchema.Builder`, calling `setProcessorNameColumn` does not have any effect because the parameter isn't used.