### PR TITLE
Resolve #293 Allow saga event handler to resolve property name against metadata

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/saga/AssociationResolver.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/AssociationResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.saga;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+/**
+ * Used to derive the value of an association property as designated by the association property name.
+ * 
+ * @author Sofia Guy Ang
+ */
+public interface AssociationResolver {
+
+    /**
+     * Validates that the associationPropertyName supplied is compatible with the handler.
+     */
+    <T> void validate(String associationPropertyName, MessageHandlingMember<T> handler);
+
+    /**
+     * Resolves the associationPropertyName as a value.
+     */
+    <T> Object resolve(String associationPropertyName, EventMessage<?> message, MessageHandlingMember<T> handler);
+}

--- a/core/src/main/java/org/axonframework/eventhandling/saga/MetaDataAssociationResolver.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/MetaDataAssociationResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.saga;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+/**
+ * Used to derive the value of an association property by looking it up the event message's
+ * {@link org.axonframework.messaging.MetaData}.
+ *
+ * @author Sofia Guy Ang
+ */
+public class MetaDataAssociationResolver implements AssociationResolver {
+
+    /**
+     * Does nothing because we can only check for existence of property in the metadata during event handling.
+     */
+    @Override
+    public <T> void validate(String associationPropertyName, MessageHandlingMember<T> handler) {
+        // Do nothing
+    }
+
+    /**
+     * Finds the association property value by looking up the association property name in the event message's
+     * {@link org.axonframework.messaging.MetaData}.
+     */
+    @Override
+    public <T> Object resolve(String associationPropertyName, EventMessage<?> message,
+                              MessageHandlingMember<T> handler) {
+        return message.getMetaData().get(associationPropertyName);
+    }
+}

--- a/core/src/main/java/org/axonframework/eventhandling/saga/PayloadAssociationResolver.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/PayloadAssociationResolver.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.saga;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.property.Property;
+import org.axonframework.common.property.PropertyAccessStrategy;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+import java.lang.reflect.Executable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * Used to derive the value of an association property by looking it up the event message's payload.
+ *
+ * @author Sofia Guy Ang
+ */
+public class PayloadAssociationResolver implements AssociationResolver {
+
+    private Map<String, Property<?>> propertyMap = new HashMap<>();
+
+    /**
+     * Validates that the association property name exists as checked with the payload type. This is done by attempting
+     * to create a {@link Property}. It also caches the resulting {@link Property} instance.
+     */
+    @Override
+    public <T> void validate(String associationPropertyName, MessageHandlingMember<T> handler) {
+        getProperty(associationPropertyName, handler);
+    }
+
+    /**
+     * Finds the association property value in the message's payload.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Object resolve(String associationPropertyName, EventMessage<?> message,
+                              MessageHandlingMember<T> handler) {
+        return getProperty(associationPropertyName, handler).getValue(message.getPayload());
+    }
+
+    private <T> Property getProperty(String associationPropertyName, MessageHandlingMember<T> handler) {
+        return propertyMap.computeIfAbsent(handler.payloadType().getCanonicalName() + associationPropertyName,
+                                           k -> createProperty(associationPropertyName, handler));
+    }
+
+    private <T> Property createProperty(String associationPropertyName, MessageHandlingMember<T> handler) {
+        Property<?> associationProperty = PropertyAccessStrategy.getProperty(handler.payloadType(),
+                                                                             associationPropertyName);
+        if (associationProperty == null) {
+            String handlerName = handler.unwrap(Executable.class).map(Executable::toGenericString).orElse("unknown");
+            throw new AxonConfigurationException(format(
+                    "SagaEventHandler %s defines a property %s that is not defined on the Event it declares to handle (%s)",
+                    handlerName,
+                    associationPropertyName,
+                    handler.payloadType().getName()
+            ));
+        }
+        return associationProperty;
+    }
+}

--- a/core/src/main/java/org/axonframework/eventhandling/saga/SagaEventHandler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/SagaEventHandler.java
@@ -77,4 +77,10 @@ public @interface SagaEventHandler {
      * of supported event.
      */
     Class<?> payloadType() default Object.class;
+
+    /**
+     * The type of AssociationResolver that will resolve the association property value. Defaults to finding the
+     * association property in the payload.
+     */
+    Class<? extends AssociationResolver> associationResolver() default PayloadAssociationResolver.class;
 }


### PR DESCRIPTION
This follows @abuijze's proposed specification described in #293. 