### PR TITLE
Add duplicate key code for SAP HANA DB.

### DIFF
--- a/core/src/main/resources/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCode.properties
+++ b/core/src/main/resources/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCode.properties
@@ -47,3 +47,4 @@ sql_server.duplicateKeyCodes=2601
 Adaptive_Server_Enterprise.duplicateKeyCodes=2601
 ASE.duplicateKeyCodes=2601
 
+HDB.duplicateKeyCodes=349


### PR DESCRIPTION
We're using Axon with the HANA database from SAP. We're currently overriding the SQLErrorCode.properties to make it work properly.

