### PR TITLE
Id sequence generator

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
@@ -16,7 +16,11 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.eventsourcing.DomainEventMessage;
 import org.axonframework.serialization.Serializer;
 
-import javax.persistence.*;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.SequenceGenerator;
 
 /**
  * Abstract base class of a serialized domain event. Fields in this class contain JPA annotations that direct JPA event

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
@@ -16,9 +16,7 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.eventsourcing.DomainEventMessage;
 import org.axonframework.serialization.Serializer;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
 /**
  * Abstract base class of a serialized domain event. Fields in this class contain JPA annotations that direct JPA event
@@ -30,7 +28,8 @@ import javax.persistence.MappedSuperclass;
 public abstract class AbstractSequencedDomainEventEntry<T> extends AbstractDomainEventEntry<T> implements DomainEventData<T> {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "axonSequenceGenerator")
+    @SequenceGenerator(name = "axonSequenceGenerator", sequenceName = "axon_sequence")
     @SuppressWarnings("unused")
     private long globalIndex;
 


### PR DESCRIPTION
Specify a sequence name for axon entities' IDs

This makes the default strategy, AUTO, explicit, and names the generated sequence to avoid conflicts with other strategies which also use the default name, 'hibernate_sequence'.  For example, if one uses an H2 database, without specifying a @SequenceGenerator, it chooses a NoopOptimizer resulting in a sequence named 'hibernate_sequence' with an increment of 1. If a domain entity does specify a @SequenceGenerator, without a unique name, it will try to define 'hibernate_sequence' with the default increment of 50, and validation will fail with "HibernateException: Multiple references to database sequence [hibernate_sequence] were encountered attempting toset conflicting values for 'increment size'.  Found [1] and [50]"