### PR TITLE
[Feature 394] Introduce Context Aware Upcasters

### DIFF
--- a/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryMultiUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryMultiUpcaster.java
@@ -1,0 +1,67 @@
+package org.axonframework.serialization.upcasting;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.stream.Stream;
+
+/**
+ * Abstract implementation of an {@link Upcaster} that eases the common process of upcasting one intermediate
+ * representation to several other representations by applying a simple flat mapping function to the input stream of
+ * intermediate representations.
+ * Additionally, it's a context aware implementation, which enables it to store and reuse context information from one
+ * entry to another during upcasting.
+ *
+ * @param <T> the type of entry to be upcasted as {@code T}
+ * @param <C> the type of context used as {@code C}
+ *
+ * @author Steven van Beelen
+ */
+public abstract class ContextAwareSingleEntryMultiUpcaster<T, C> implements Upcaster<T> {
+
+    @Override
+    public Stream<T> upcast(Stream<T> intermediateRepresentations) {
+        C context = buildContext();
+
+        return intermediateRepresentations.flatMap(entry -> {
+            if (!canUpcast(entry, context)) {
+                return Stream.of(entry);
+            }
+            return requireNonNull(doUpcast(entry, context));
+        });
+    }
+
+    /**
+     * Checks if this upcaster can upcast the given {@code intermediateRepresentation}.
+     * If the upcaster cannot upcast the representation the {@link #doUpcast(Object, Object)} is not invoked.
+     * The {@code context} can be used to store or retrieve entry specific information required to make the
+     * {@code canUpcast(Object, Object)} check.
+     *
+     * @param intermediateRepresentation the intermediate object representation to upcast as {@code T}
+     * @param context                    the context for this upcaster as {@code C}
+     * @return {@code true} if the representation can be upcast, {@code false} otherwise
+     */
+    protected abstract boolean canUpcast(T intermediateRepresentation, C context);
+
+    /**
+     * Upcasts the given {@code intermediateRepresentation}. This method is only invoked if {@link #canUpcast(Object,
+     * Object)} returned {@code true} for the given representation. The {@code context} can be used to store or retrieve
+     * entry specific information required to perform the upcasting process.
+     * <p>
+     * Note that the returned representation should not be {@code null}.
+     * To remove an intermediateRepresentation add a filter to the input stream.
+     *
+     * @param intermediateRepresentation the representation of the object to upcast as {@code T}
+     * @param context                    the context for this upcaster as {@code C}
+     * @return the upcasted representations as a {@code Stream} with generic type {@code T}
+     */
+    protected abstract Stream<T> doUpcast(T intermediateRepresentation, C context);
+
+    /**
+     * Builds a context of generic type {@code C} to be used when processing the stream of intermediate object
+     * representations {@code T}.
+     *
+     * @return a context of generic type {@code C}
+     */
+    protected abstract C buildContext();
+
+}

--- a/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryMultiUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryMultiUpcaster.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.serialization.upcasting;
 
 import static java.util.Objects.requireNonNull;
@@ -21,7 +36,6 @@ public abstract class ContextAwareSingleEntryMultiUpcaster<T, C> implements Upca
     @Override
     public Stream<T> upcast(Stream<T> intermediateRepresentations) {
         C context = buildContext();
-
         return intermediateRepresentations.flatMap(entry -> {
             if (!canUpcast(entry, context)) {
                 return Stream.of(entry);

--- a/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryUpcaster.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.serialization.upcasting;
 
 import static java.util.Objects.requireNonNull;
@@ -21,7 +36,6 @@ public abstract class ContextAwareSingleEntryUpcaster<T, C> implements Upcaster<
     @Override
     public Stream<T> upcast(Stream<T> intermediateRepresentations) {
         C context = buildContext();
-
         return intermediateRepresentations.map(entry -> {
             if (!canUpcast(entry, context)) {
                 return entry;

--- a/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/ContextAwareSingleEntryUpcaster.java
@@ -1,0 +1,69 @@
+package org.axonframework.serialization.upcasting;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.stream.Stream;
+
+/**
+ * Abstract implementation of an {@link Upcaster} that eases the common process of upcasting one intermediate
+ * representation to another representation by applying a simple mapping function to the input stream of intermediate
+ * representations.
+ * Additionally, it's a context aware implementation, which enables it to store and reuse context information from one
+ * entry to another during upcasting.
+ *
+ * @param <T> the type of entry to be upcasted as {@code T}
+ * @param <C> the type of context used as {@code C}
+ *
+ * @author Steven van Beelen
+ */
+public abstract class ContextAwareSingleEntryUpcaster<T, C> implements Upcaster<T> {
+
+    @Override
+    public Stream<T> upcast(Stream<T> intermediateRepresentations) {
+        C context = buildContext();
+
+        return intermediateRepresentations.map(entry -> {
+            if (!canUpcast(entry, context)) {
+                return entry;
+            }
+            return requireNonNull(doUpcast(entry, context),
+                                  "Result from #doUpcast() should not be null. To remove an " +
+                                          "intermediateRepresentation add a filter to the input stream.");
+        });
+    }
+
+    /**
+     * Checks if this upcaster can upcast the given {@code intermediateRepresentation}.
+     * If the upcaster cannot upcast the representation the {@link #doUpcast(Object, Object)} is not invoked.
+     * The {@code context} can be used to store or retrieve entry specific information required to make the
+     * {@code canUpcast(Object, Object)} check.
+     *
+     * @param intermediateRepresentation the intermediate object representation to upcast as {@code T}
+     * @param context                    the context for this upcaster as {@code C}
+     * @return {@code true} if the representation can be upcast, {@code false} otherwise
+     */
+    protected abstract boolean canUpcast(T intermediateRepresentation, C context);
+
+    /**
+     * Upcasts the given {@code intermediateRepresentation}. This method is only invoked if {@link #canUpcast(Object,
+     * Object)} returned {@code true} for the given representation. The {@code context} can be used to store or retrieve
+     * entry specific information required to perform the upcasting process.
+     * <p>
+     * Note that the returned representation should not be {@code null}.
+     * To remove an intermediateRepresentation add a filter to the input stream.
+     *
+     * @param intermediateRepresentation the representation of the object to upcast as {@code T}
+     * @param context                    the context for this upcaster as {@code C}
+     * @return the upcasted representation
+     */
+    protected abstract T doUpcast(T intermediateRepresentation, C context);
+
+    /**
+     * Builds a context of generic type {@code C} to be used when processing the stream of intermediate object
+     * representations {@code T}.
+     *
+     * @return a context of generic type {@code C}
+     */
+    protected abstract C buildContext();
+
+}

--- a/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcaster.java
@@ -1,0 +1,18 @@
+package org.axonframework.serialization.upcasting.event;
+
+import org.axonframework.serialization.upcasting.ContextAwareSingleEntryMultiUpcaster;
+import org.axonframework.serialization.upcasting.SingleEntryMultiUpcaster;
+
+/**
+ * Abstract implementation of a {@link SingleEntryMultiUpcaster} and an {@link EventUpcaster} that eases the common
+ * process of upcasting one intermediate event representation to several other representations by applying a flat
+ * mapping function to the input stream of intermediate representations.
+ * Additionally, it's a context aware implementation, which enables it to store and reuse context information from one
+ * entry to another during upcasting.
+ *
+ * @param <C> the type of context used as {@code C}
+ *
+ * @author Steven van Beelen
+ */
+public abstract class ContextAwareEventMultiUpcaster<C> extends ContextAwareSingleEntryMultiUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster {
+}

--- a/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcaster.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.serialization.upcasting.event;
 
 import org.axonframework.serialization.upcasting.ContextAwareSingleEntryMultiUpcaster;
@@ -14,5 +29,4 @@ import org.axonframework.serialization.upcasting.SingleEntryMultiUpcaster;
  *
  * @author Steven van Beelen
  */
-public abstract class ContextAwareEventMultiUpcaster<C> extends ContextAwareSingleEntryMultiUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster {
-}
+public abstract class ContextAwareEventMultiUpcaster<C> extends ContextAwareSingleEntryMultiUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster { }

--- a/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcaster.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+
+import org.axonframework.serialization.upcasting.ContextAwareSingleEntryUpcaster;
+import org.axonframework.serialization.upcasting.Upcaster;
+
+/**
+ * Abstract implementation of an event {@link Upcaster} that eases the common process of upcasting one intermediate
+ * event representation to another representation by applying a simple mapping function to the input stream of
+ * intermediate representations.
+ * Additionally, it's a context aware implementation, which enables it to store and reuse
+ * context information from one entry to another during upcasting.
+ *
+ * @param <C> the type of context used as {@code C}
+ * @author Steven van Beelen
+ */
+public abstract class ContextAwareSingleEventUpcaster<C> extends ContextAwareSingleEntryUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster {
+}

--- a/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcaster.java
+++ b/core/src/main/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcaster.java
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
+ * Copyright (c) 2010-2017. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,5 +29,4 @@ import org.axonframework.serialization.upcasting.Upcaster;
  * @param <C> the type of context used as {@code C}
  * @author Steven van Beelen
  */
-public abstract class ContextAwareSingleEventUpcaster<C> extends ContextAwareSingleEntryUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster {
-}
+public abstract class ContextAwareSingleEventUpcaster<C> extends ContextAwareSingleEntryUpcaster<IntermediateEventRepresentation, C> implements EventUpcaster { }

--- a/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareEventMultiUpcasterTest.java
+++ b/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareEventMultiUpcasterTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
- *
+ * Copyright (c) 2010-2017. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -55,12 +54,12 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
  */
 public class AbstractContextAwareEventMultiUpcasterTest {
 
+    private Upcaster<IntermediateEventRepresentation> upcaster;
+    private Serializer serializer;
+
     private String expectedNewString;
     private Integer expectedNewInteger;
     private List<Boolean> expectedNewBooleans;
-
-    private Serializer serializer;
-    private Upcaster<IntermediateEventRepresentation> upcaster;
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareEventMultiUpcasterTest.java
+++ b/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareEventMultiUpcasterTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.axonframework.eventsourcing.eventstore.EventData;
+import org.axonframework.eventsourcing.eventstore.jpa.DomainEventEntry;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedType;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.upcasting.Upcaster;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+/*
+ This test class should only assert whether the context map is created, filled with data and if that data is used to
+ upcast an event.
+ The other upcaster regularities are already asserted by the EventMultiUpcasterTest and can thus be skipped.
+ */
+public class AbstractContextAwareEventMultiUpcasterTest {
+
+    private String expectedNewString;
+    private Integer expectedNewInteger;
+    private List<Boolean> expectedNewBooleans;
+
+    private Serializer serializer;
+    private Upcaster<IntermediateEventRepresentation> upcaster;
+
+    @Before
+    public void setUp() throws Exception {
+        expectedNewString = "newNameValue";
+        expectedNewInteger = 42;
+        expectedNewBooleans = new ArrayList<>();
+        expectedNewBooleans.add(true);
+        expectedNewBooleans.add(false);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
+        serializer = new JacksonSerializer(objectMapper);
+        upcaster = new StubContextAwareEventMultiUpcaster(expectedNewString, expectedNewInteger, expectedNewBooleans);
+    }
+
+    @Test
+    public void testUpcastsAddsContextValueFromFirstEvent() throws IOException {
+        int expectedNumberOfEvents = 4;
+        String expectedContextEventString = "oldName";
+        Integer expectedContextEventNumber = 1;
+        String expectedRevisionNumber = "1";
+        String expectedNewString = this.expectedNewString + StubContextAwareEventMultiUpcaster.CONTEXT_FIELD_VALUE;
+
+        MetaData testMetaData = MetaData.with("key", "value");
+
+        GenericDomainEventMessage<SecondStubEvent> firstTestEventMessage = new GenericDomainEventMessage<>(
+                "test", "aggregateId", 0, new SecondStubEvent(expectedContextEventString, expectedContextEventNumber),
+                testMetaData
+        );
+        EventData<?> firstTestEventData = new DomainEventEntry(firstTestEventMessage, serializer);
+        InitialEventRepresentation firstTestRepresentation =
+                new InitialEventRepresentation(firstTestEventData, serializer);
+
+        GenericDomainEventMessage<StubEvent> secondTestEventMessage =
+                new GenericDomainEventMessage<>("test", "aggregateId", 0, new StubEvent("oldName"), testMetaData);
+        EventData<?> secondTestEventData = new DomainEventEntry(secondTestEventMessage, serializer);
+        InitialEventRepresentation secondTestRepresentation =
+                new InitialEventRepresentation(secondTestEventData, serializer);
+
+        Stream<IntermediateEventRepresentation> testEventRepresentationStream =
+                Stream.of(firstTestRepresentation, secondTestRepresentation);
+        List<IntermediateEventRepresentation> result = upcaster.upcast(testEventRepresentationStream)
+                                                               .collect(toList());
+
+        assertEquals(expectedNumberOfEvents, result.size());
+
+        IntermediateEventRepresentation firstEventResult = result.get(0);
+        assertNull(firstEventResult.getType().getRevision());
+        assertEquals(firstTestEventData.getEventIdentifier(), firstEventResult.getMessageIdentifier());
+        assertEquals(firstTestEventData.getTimestamp(), firstEventResult.getTimestamp());
+        assertEquals(testMetaData, firstEventResult.getMetaData().getObject());
+        SecondStubEvent contextEvent = serializer.deserialize(firstEventResult.getData());
+        assertEquals(expectedContextEventString, contextEvent.getName());
+        assertEquals(expectedContextEventNumber, contextEvent.getNumber());
+
+        IntermediateEventRepresentation secondEventResult = result.get(1);
+        assertEquals(expectedRevisionNumber, secondEventResult.getType().getRevision());
+        assertEquals(secondTestEventData.getEventIdentifier(), secondEventResult.getMessageIdentifier());
+        assertEquals(secondTestEventData.getTimestamp(), secondEventResult.getTimestamp());
+        assertEquals(testMetaData, secondEventResult.getMetaData().getObject());
+        StubEvent firstUpcastedEvent = serializer.deserialize(secondEventResult.getData());
+        assertEquals(expectedNewString, firstUpcastedEvent.getName());
+
+        IntermediateEventRepresentation thirdEventResult = result.get(2);
+        assertNull(thirdEventResult.getType().getRevision());
+        assertEquals(secondTestEventData.getEventIdentifier(), thirdEventResult.getMessageIdentifier());
+        assertEquals(secondTestEventData.getTimestamp(), thirdEventResult.getTimestamp());
+        assertEquals(testMetaData, thirdEventResult.getMetaData().getObject());
+        SecondStubEvent secondUpcastedEvent = serializer.deserialize(thirdEventResult.getData());
+        assertEquals(expectedNewString, secondUpcastedEvent.getName());
+        assertEquals(expectedNewInteger, secondUpcastedEvent.getNumber());
+
+        IntermediateEventRepresentation fourthEventResult = result.get(3);
+        assertNull(fourthEventResult.getType().getRevision());
+        assertEquals(secondTestEventData.getEventIdentifier(), fourthEventResult.getMessageIdentifier());
+        assertEquals(secondTestEventData.getTimestamp(), fourthEventResult.getTimestamp());
+        assertEquals(testMetaData, fourthEventResult.getMetaData().getObject());
+        ThirdStubEvent thirdUpcastedEvent = serializer.deserialize(fourthEventResult.getData());
+        assertEquals(expectedNewString, thirdUpcastedEvent.getName());
+        assertEquals(expectedNewInteger, thirdUpcastedEvent.getNumber());
+        assertEquals(expectedNewBooleans, thirdUpcastedEvent.getTruths());
+    }
+
+    private static class StubContextAwareEventMultiUpcaster extends ContextAwareEventMultiUpcaster<Map<Object, Object>> {
+
+        private static final String CONTEXT_FIELD_KEY = "ContextField";
+        static final String CONTEXT_FIELD_VALUE = "ContextAdded";
+
+        private final SerializedType contextType = new SimpleSerializedType(SecondStubEvent.class.getName(), null);
+        private final SerializedType targetType = new SimpleSerializedType(StubEvent.class.getName(), null);
+
+        private final String newStringValue;
+        private final Integer newIntegerValue;
+        private final List<Boolean> newBooleanValues;
+
+        private StubContextAwareEventMultiUpcaster(String newStringValue,
+                                                   Integer newIntegerValue,
+                                                   List<Boolean> newBooleanValues) {
+            this.newStringValue = newStringValue;
+            this.newIntegerValue = newIntegerValue;
+            this.newBooleanValues = newBooleanValues;
+        }
+
+        @Override
+        protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation,
+                                    Map<Object, Object> context) {
+            return isType(intermediateRepresentation.getType(), targetType) ||
+                    isType(intermediateRepresentation.getType(), contextType);
+        }
+
+        private boolean isType(SerializedType foundType, SerializedType expectedType) {
+            return foundType.equals(expectedType);
+        }
+
+        @Override
+        protected Stream<IntermediateEventRepresentation> doUpcast(IntermediateEventRepresentation ir,
+                                                                   Map<Object, Object> context) {
+            if (isContextEvent(ir)) {
+                context.put(CONTEXT_FIELD_KEY, CONTEXT_FIELD_VALUE);
+                return Stream.of(ir);
+            }
+
+            return Stream.of(
+                    ir.upcastPayload(new SimpleSerializedType(targetType.getName(), "1"),
+                                     JsonNode.class,
+                                     jsonNode -> doUpcast(jsonNode, context)),
+                    ir.upcastPayload(new SimpleSerializedType(SecondStubEvent.class.getName(), null),
+                                     JsonNode.class,
+                                     jsonNode -> doUpcastTwo(jsonNode, context)),
+                    ir.upcastPayload(new SimpleSerializedType(ThirdStubEvent.class.getName(), null),
+                                     JsonNode.class,
+                                     jsonNode -> doUpcastThree(jsonNode, context))
+            );
+        }
+
+        private boolean isContextEvent(IntermediateEventRepresentation intermediateRepresentation) {
+            return isType(intermediateRepresentation.getType(), contextType);
+        }
+
+        @Override
+        protected Map<Object, Object> buildContext() {
+            return new HashMap<>();
+        }
+
+        private JsonNode doUpcast(JsonNode eventJsonNode, Map<Object, Object> context) {
+            if (!eventJsonNode.isObject()) {
+                return eventJsonNode;
+            }
+            ObjectNode eventObjectNode = (ObjectNode) eventJsonNode;
+
+            eventObjectNode.set("name", new TextNode(newStringValue + context.get(CONTEXT_FIELD_KEY)));
+
+            return eventObjectNode;
+        }
+
+        private JsonNode doUpcastTwo(JsonNode eventJsonNode, Map<Object, Object> context) {
+            if (!eventJsonNode.isObject()) {
+                return eventJsonNode;
+            }
+            ObjectNode eventObjectNode = (ObjectNode) eventJsonNode;
+
+            eventObjectNode.set("name", new TextNode(newStringValue + context.get(CONTEXT_FIELD_KEY)));
+            eventObjectNode.set("number", new IntNode(newIntegerValue));
+
+            return eventJsonNode;
+        }
+
+        private JsonNode doUpcastThree(JsonNode eventJsonNode, Map<Object, Object> context) {
+            if (!eventJsonNode.isObject()) {
+                return eventJsonNode;
+            }
+            ObjectNode eventObjectNode = (ObjectNode) eventJsonNode;
+
+            eventObjectNode.set("name", new TextNode(newStringValue + context.get(CONTEXT_FIELD_KEY)));
+            eventObjectNode.set("number", new IntNode(newIntegerValue));
+            ArrayNode truthsArrayNode = eventObjectNode.withArray("truths");
+            newBooleanValues.forEach(truthsArrayNode::add);
+
+            return eventJsonNode;
+        }
+
+    }
+
+}

--- a/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareSingleEventUpcasterTest.java
+++ b/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareSingleEventUpcasterTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.axonframework.eventsourcing.GenericDomainEventMessage;
+import org.axonframework.eventsourcing.eventstore.EventData;
+import org.axonframework.eventsourcing.eventstore.jpa.DomainEventEntry;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedType;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.upcasting.Upcaster;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+/*
+ This test class should only assert whether the context map is created, filled with data and if that data is used to
+ upcast an event.
+ The other upcaster regularities are already asserted by the SingleEventUpcasterTest and can thus be skipped.
+ */
+public class AbstractContextAwareSingleEventUpcasterTest {
+
+    private String expectedNewString;
+
+    private Serializer serializer;
+    private Upcaster<IntermediateEventRepresentation> upcaster;
+
+    @Before
+    public void setUp() throws Exception {
+        expectedNewString = "newNameValue";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
+        serializer = new JacksonSerializer(objectMapper);
+        upcaster = new StubContextAwareSingleEventUpcaster(expectedNewString);
+    }
+
+    @Test
+    public void testUpcastsAddsContextValueFromFirstEvent() throws IOException {
+        int expectedNumberOfEvents = 2;
+        String expectedContextEventString = "oldName";
+        Integer expectedContextEventNumber = 1;
+        String expectedRevisionNumber = "1";
+        String expectedNewString = this.expectedNewString + StubContextAwareSingleEventUpcaster.CONTEXT_FIELD_VALUE;
+
+        MetaData testMetaData = MetaData.with("key", "value");
+
+        GenericDomainEventMessage<SecondStubEvent> firstTestEventMessage = new GenericDomainEventMessage<>(
+                "test", "aggregateId", 0, new SecondStubEvent(expectedContextEventString, expectedContextEventNumber),
+                testMetaData
+        );
+        EventData<?> firstTestEventData = new DomainEventEntry(firstTestEventMessage, serializer);
+        InitialEventRepresentation firstTestRepresentation =
+                new InitialEventRepresentation(firstTestEventData, serializer);
+
+        GenericDomainEventMessage<StubEvent> secondTestEventMessage =
+                new GenericDomainEventMessage<>("test", "aggregateId", 0, new StubEvent("oldName"), testMetaData);
+        EventData<?> secondTestEventData = new DomainEventEntry(secondTestEventMessage, serializer);
+        InitialEventRepresentation secondTestRepresentation =
+                new InitialEventRepresentation(secondTestEventData, serializer);
+
+        Stream<IntermediateEventRepresentation> testEventRepresentationStream =
+                Stream.of(firstTestRepresentation, secondTestRepresentation);
+        List<IntermediateEventRepresentation> result = upcaster.upcast(testEventRepresentationStream)
+                                                               .collect(toList());
+
+        assertEquals(expectedNumberOfEvents, result.size());
+
+        IntermediateEventRepresentation firstEventResult = result.get(0);
+        assertNull(firstEventResult.getType().getRevision());
+        assertEquals(firstTestEventData.getEventIdentifier(), firstEventResult.getMessageIdentifier());
+        assertEquals(firstTestEventData.getTimestamp(), firstEventResult.getTimestamp());
+        assertEquals(testMetaData, firstEventResult.getMetaData().getObject());
+        SecondStubEvent contextEvent = serializer.deserialize(firstEventResult.getData());
+        assertEquals(expectedContextEventString, contextEvent.getName());
+        assertEquals(expectedContextEventNumber, contextEvent.getNumber());
+
+        IntermediateEventRepresentation secondEventResult = result.get(1);
+        assertEquals(expectedRevisionNumber, secondEventResult.getType().getRevision());
+        assertEquals(secondTestEventData.getEventIdentifier(), secondEventResult.getMessageIdentifier());
+        assertEquals(secondTestEventData.getTimestamp(), secondEventResult.getTimestamp());
+        assertEquals(testMetaData, secondEventResult.getMetaData().getObject());
+        StubEvent upcastedEvent = serializer.deserialize(secondEventResult.getData());
+        assertEquals(expectedNewString, upcastedEvent.getName());
+    }
+
+    private static class StubContextAwareSingleEventUpcaster extends ContextAwareSingleEventUpcaster<Map<Object, Object>> {
+
+        private static final String CONTEXT_FIELD_KEY = "ContextField";
+        static final String CONTEXT_FIELD_VALUE = "ContextAdded";
+
+        private final SerializedType contextType = new SimpleSerializedType(SecondStubEvent.class.getName(), null);
+        private final SerializedType targetType = new SimpleSerializedType(StubEvent.class.getName(), null);
+
+        private final String newStringValue;
+
+        private StubContextAwareSingleEventUpcaster(String newStringValue) {
+            this.newStringValue = newStringValue;
+        }
+
+        @Override
+        protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation,
+                                    Map<Object, Object> context) {
+            return isType(intermediateRepresentation.getType(), targetType) ||
+                    isType(intermediateRepresentation.getType(), contextType);
+        }
+
+        private boolean isType(SerializedType foundType, SerializedType expectedType) {
+            return foundType.equals(expectedType);
+        }
+
+        @Override
+        protected IntermediateEventRepresentation doUpcast(IntermediateEventRepresentation intermediateRepresentation,
+                                                           Map<Object, Object> context) {
+            if (isContextEvent(intermediateRepresentation)) {
+                context.put(CONTEXT_FIELD_KEY, CONTEXT_FIELD_VALUE);
+                return intermediateRepresentation;
+            }
+            return intermediateRepresentation.upcastPayload(new SimpleSerializedType(targetType.getName(), "1"),
+                                                            JsonNode.class,
+                                                            jsonNode -> doUpcast(jsonNode, context));
+        }
+
+        private boolean isContextEvent(IntermediateEventRepresentation intermediateRepresentation) {
+            return isType(intermediateRepresentation.getType(), contextType);
+        }
+
+        @Override
+        protected Map<Object, Object> buildContext() {
+            return new HashMap<>();
+        }
+
+        private JsonNode doUpcast(JsonNode eventJsonNode, Map<Object, Object> context) {
+            if (!eventJsonNode.isObject()) {
+                return eventJsonNode;
+            }
+            ObjectNode eventObjectNode = (ObjectNode) eventJsonNode;
+
+            eventObjectNode.set("name", new TextNode(newStringValue + context.get(CONTEXT_FIELD_KEY)));
+
+            return eventObjectNode;
+        }
+
+    }
+
+}

--- a/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareSingleEventUpcasterTest.java
+++ b/core/src/test/java/org/axonframework/serialization/upcasting/event/AbstractContextAwareSingleEventUpcasterTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
- *
+ * Copyright (c) 2010-2017. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -52,10 +51,10 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
  */
 public class AbstractContextAwareSingleEventUpcasterTest {
 
-    private String expectedNewString;
-
-    private Serializer serializer;
     private Upcaster<IntermediateEventRepresentation> upcaster;
+    private Serializer serializer;
+
+    private String expectedNewString;
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
This PR introduces the following abstract classes:

- `ContextAwareSingleEntryUpcaster`
- `ContextAwareSingleEntryMultiUpcaster`
- `ContextAwareSingleEventUpcaster`
- `ContextAwareEventMultiUpcaster`

I thus introduces basic upcasters for single and multiple entries, and single and multiple events, which are context aware. The context aware versions require a user to implement a `createContext()` function with the desired context format they want (e.g. a `Map<Object, Object>`).
The upcaster implementation can then for example gather context information from earlier entries/events and use the information to populate fields in the upcasted events.

This solves issue #394 