### PR TITLE
Call correct MonitorCallback

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
+++ b/core/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
@@ -27,14 +27,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
@@ -125,21 +122,18 @@ public abstract class AbstractEventProcessor implements EventProcessor {
     protected void processInUnitOfWork(List<? extends EventMessage<?>> eventMessages,
                                        UnitOfWork<? extends EventMessage<?>> unitOfWork,
                                        Segment segment) throws Exception {
-        Map<? extends EventMessage<?>, MessageMonitor.MonitorCallback> monitorCallbacks =
-                eventMessages.stream().collect(toMap(Function.identity(), messageMonitor::onMessageIngested));
         try {
             unitOfWork.executeWithResult(() -> {
-                MessageMonitor.MonitorCallback monitorCallback = monitorCallbacks.get(unitOfWork.getMessage());
-                unitOfWork.onCleanup(uow -> {
-                    if (uow.isRolledBack()) {
-                        monitorCallback.reportFailure(uow.getExecutionResult().getExceptionResult());
-                    } else {
-                        monitorCallback.reportSuccess();
-                    }
-                });
+                MessageMonitor.MonitorCallback monitorCallback = messageMonitor.onMessageIngested(unitOfWork.getMessage());
                 return new DefaultInterceptorChain<>(unitOfWork, interceptors, m -> {
-                    eventHandlerInvoker.handle(m, segment);
-                    return null;
+                    try {
+                        eventHandlerInvoker.handle(m, segment);
+                        monitorCallback.reportSuccess();
+                        return null;
+                    } catch (Throwable throwable) {
+                        monitorCallback.reportFailure(throwable);
+                        throw throwable;
+                    }
                 }).proceed();
             }, rollbackConfiguration);
         } catch (Exception e) {

--- a/core/src/test/java/org/axonframework/eventhandling/AbstractEventProcessorTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/AbstractEventProcessorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.messaging.unitofwork.BatchingUnitOfWork;
+import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
+import org.axonframework.monitoring.MessageMonitor;
+import org.junit.*;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.createEvent;
+import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.createEvents;
+import static org.mockito.Mockito.*;
+
+public class AbstractEventProcessorTest {
+
+    private static class TestEventProcessor extends AbstractEventProcessor {
+        TestEventProcessor(String name, EventHandlerInvoker eventHandlerInvoker, MessageMonitor<EventMessage<?>> messageMonitor) {
+            super(name,
+                  eventHandlerInvoker,
+                  RollbackConfigurationType.ANY_THROWABLE,
+                  PropagatingErrorHandler.INSTANCE,
+                  messageMonitor);
+        }
+        @Override
+        public void start() {
+        }
+        @Override
+        public void shutDown() {
+        }
+        void processInBatchingUnitOfWork(List<? extends EventMessage<?>> eventMessages) throws Exception {
+            processInUnitOfWork(eventMessages, new BatchingUnitOfWork<>(eventMessages), Segment.ROOT_SEGMENT);
+        }
+    }
+
+    @Test
+    public void expectCallbackForAllMessages() throws Exception {
+        List<DomainEventMessage<?>> events = createEvents(2);
+        Set<DomainEventMessage<?>> pending = new HashSet<>(events);
+        MessageMonitor<EventMessage<?>> messageMonitor = (message) -> new MessageMonitor.MonitorCallback() {
+            @Override
+            public void reportSuccess() {
+                if (!pending.contains(message)) {
+                    fail("Message was presented to monitor twice: " + message);
+                }
+                pending.remove(message);
+            }
+            @Override
+            public void reportFailure(Throwable cause) {
+                fail("Test expects 'reportSuccess' to be called");
+            }
+            @Override
+            public void reportIgnored() {
+                fail("Test expects 'reportSuccess' to be called");
+            }
+        };
+
+        EventListener mockListener = mock(EventListener.class);
+        EventHandlerInvoker eventHandlerInvoker = new SimpleEventHandlerInvoker(mockListener);
+        TestEventProcessor testSubject = new TestEventProcessor("test", eventHandlerInvoker, messageMonitor);
+
+        // also test that the mechanism used to call the monitor can deal with the message in the unit of work being
+        // modified during processing
+        testSubject.registerInterceptor((unitOfWork, interceptorChain) -> {
+            unitOfWork.transformMessage(m -> createEvent());
+            return interceptorChain.proceed();
+        });
+
+        testSubject.processInBatchingUnitOfWork(events);
+
+        assertTrue("Not all events were presented to monitor", pending.isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes the bug that the AbstractEventProcessor does not call each MonitorCallback once. Created a test for this scenario that also contains a test of a previous bug in this area, where the MonitorCallback would not be called when the message was modified during processing.

[#432]