### PR TITLE
[#435] Allow initializing Saga fixture to specific date and time

### DIFF
--- a/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
+++ b/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
@@ -65,6 +65,21 @@ public class StubEventScheduler implements EventScheduler {
         this.currentDateTime = Instant.from(currentDateTime);
     }
 
+    /**
+     * Resets the initial "current time" of this SubEventScheduler. Must be called before any events are scheduled
+     *
+     * @param currentDateTime The instant to use as the current Date and Time
+     * @throws IllegalStateException when calling this method after events are scheduled
+     */
+    public void initializeAt(TemporalAccessor currentDateTime) {
+        if (!scheduledEvents.isEmpty()) {
+            throw new IllegalStateException("Initializing the scheduler at a specific dateTime must take place "
+                                                    + "before any events are scheduled");
+        }
+        this.currentDateTime = Instant.from(currentDateTime);
+    }
+
+
     @Override
     public ScheduleToken schedule(Instant triggerDateTime, Object event) {
         EventMessage eventMessage = GenericEventMessage.asEventMessage(event);

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -135,6 +135,15 @@ public interface FixtureConfiguration {
     GivenAggregateEventPublisher givenAggregate(String aggregateIdentifier);
 
     /**
+     * Use this method to indicate a specific moment as the initial current time "known" by the fixture at the start
+     * of the given state.
+     *
+     * @param currentTime The simulated "current time" at which the given state is initialized
+     * @return an object that allows chaining of more given state
+     */
+    ContinuedGivenState givenCurrentTime(Instant currentTime);
+
+    /**
      * Indicates that the given {@code applicationEvent} has been published in the past. This event is sent to the
      * associated sagas.
      *

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -116,8 +116,10 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
      */
     protected void ensureSagaManagerInitialized() {
         if (sagaManager == null) {
-            ParameterResolverFactory parameterResolverFactory = ordered(new SimpleResourceParameterResolverFactory(registeredResources),
-                                                                        ClasspathParameterResolverFactory.forClass(sagaType));
+            ParameterResolverFactory parameterResolverFactory = ordered(new SimpleResourceParameterResolverFactory(
+                                                                                registeredResources),
+                                                                        ClasspathParameterResolverFactory
+                                                                                .forClass(sagaType));
             SagaRepository<T> sagaRepository = new AnnotatedSagaRepository<>(sagaType, sagaStore,
                                                                              new TransienceValidatingResourceInjector(),
                                                                              parameterResolverFactory);
@@ -175,6 +177,12 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     @Override
     public ContinuedGivenState givenAPublished(Object event) {
         handleInSaga(timeCorrectedEventMessage(event));
+        return this;
+    }
+
+    @Override
+    public ContinuedGivenState givenCurrentTime(Instant currentTime) {
+        eventScheduler.initializeAt(currentTime);
         return this;
     }
 
@@ -390,16 +398,18 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
             super.injectResources(saga);
             if (transienceCheckEnabled) {
                 StreamSupport.stream(fieldsOf(saga.getClass()).spliterator(), false)
-                        .filter(f -> !Modifier.isTransient(f.getModifiers()))
-                        .filter(f -> registeredResources.contains(ReflectionUtils.getFieldValue(f, saga)))
-                        .findFirst()
-                        .ifPresent(field -> {
-                            throw new AssertionError(format("Field %s.%s is injected with a resource, " +
-                                                                    "but it doesn't have the 'transient' modifier.\n" +
-                                                                    "Mark field as 'transient' or disable this check using:\n" +
-                                                                    "fixture.withTransienceCheckDisabled()",
-                                                            field.getDeclaringClass(), field.getName()));
-                        });
+                             .filter(f -> !Modifier.isTransient(f.getModifiers()))
+                             .filter(f -> registeredResources.contains(ReflectionUtils.getFieldValue(f, saga)))
+                             .findFirst()
+                             .ifPresent(field -> {
+                                 throw new AssertionError(format("Field %s.%s is injected with a resource, " +
+                                                                         "but it doesn't have the 'transient' modifier.\n"
+                                                                         +
+                                                                         "Mark field as 'transient' or disable this check using:\n"
+                                                                         +
+                                                                         "fixture.withTransienceCheckDisabled()",
+                                                                 field.getDeclaringClass(), field.getName()));
+                             });
             }
         }
     }

--- a/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
+++ b/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
@@ -18,11 +18,12 @@ package org.axonframework.test.eventscheduler;
 
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.*;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -30,6 +31,9 @@ import static org.junit.Assert.assertEquals;
  * @author Allard Buijze
  */
 public class StubEventSchedulerTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     private StubEventScheduler testSubject;
 
@@ -42,6 +46,13 @@ public class StubEventSchedulerTest {
     public void testScheduleEvent() {
         testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
         assertEquals(1, testSubject.getScheduledItems().size());
+    }
+
+    @Test
+    public void testInitializeAtDateTimeAfterSchedulingEvent() throws Exception {
+        testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
+        exception.expect(IllegalStateException.class);
+        testSubject.initializeAt(Instant.now().minus(10, ChronoUnit.MINUTES));
     }
 
     private EventMessage<MockEvent> event(MockEvent mockEvent) {

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.axonframework.test.matchers.Matchers.*;
@@ -237,6 +238,19 @@ public class AnnotatedSagaTest {
         fixture.givenAPublished(GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(identifier.toString())))
                 .whenTimeElapses(Duration.ofMinutes(1))
                 .expectScheduledEventOfType(Duration.ofMinutes(9), TimerTriggeredEvent.class);
+    }
+
+    @Test
+    public void testFixtureApi_givenCurrentTime() throws Exception {
+        String identifier = UUID.randomUUID().toString();
+        Instant fourDaysAgo = Instant.now().minus(4, ChronoUnit.DAYS);
+        Instant fourDaysMinusTenMinutesAgo = fourDaysAgo.plus(10, ChronoUnit.MINUTES);
+
+        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
+        fixture
+                .givenCurrentTime(fourDaysAgo)
+                .whenPublishingA(new TriggerSagaStartEvent(identifier))
+                .expectScheduledEvent(fourDaysMinusTenMinutesAgo, new TimerTriggeredEvent(identifier));
     }
 
     @Test


### PR DESCRIPTION
This revision adds a new method to the `FixtureConfiguration` interface: `givenCurrentTime`. This method is implemented in the `SagaTestFixture` class. I think it is important to note that by adding a new method to a public interface, this breaks backwards compatibility for users who have written their own implementations of `FixtureConfiguration`. If this is undesirable, we could either move the method to a new interface (to be implemented by `SagaTestFixture`), or we could just make it a public method in `SagaTestFixture`, without adding it to any interface. I chose to add it to `FixtureConfiguration` for now, to remain consistent with the other public methods in `SagaTestFixture`.

In order to make the date-time initialization work, I had to add a new method to `StubEventScheduler`: ` public void initializeAt(TemporalAccessor currentDateTime)`. I first considered replacing the entire scheduler with a fresh one when `givenCurrentTime` was called, to be able to leave the `StubEventScheduler` as it was, but that turned out to be unpractical, as the scheduler is referred to from at least three places: `this.eventScheduler`, `this.registeredResources`, and `this.fixtureExecutionResult`. The `initializeAt` method is restrictive, in the sense that it throws an `IlegalStateException` when called after scheduling one or more events. The idea is to prevent subtle bugs or counterintuitive results when the current date-time is moved backwards or beyond schedule deadlines while events are already waiting to be triggered. 

