### PR TITLE
Added auto configuration for Routing Strategy (set to Annotation Routing

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -67,7 +67,7 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
      *                       targeted aggregate.
      */
     public AnnotationRoutingStrategy(Class<? extends Annotation> annotationType) {
-        this(annotationType, UnresolvedRoutingKeyPolicy.ERROR);
+        this(annotationType, UnresolvedRoutingKeyPolicy.RANDOM_KEY);
     }
 
     /**

--- a/core/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -67,7 +67,7 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
      *                       targeted aggregate.
      */
     public AnnotationRoutingStrategy(Class<? extends Annotation> annotationType) {
-        this(annotationType, UnresolvedRoutingKeyPolicy.RANDOM_KEY);
+        this(annotationType, UnresolvedRoutingKeyPolicy.ERROR);
     }
 
     /**

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/JGroupsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/JGroupsAutoConfiguration.java
@@ -19,6 +19,7 @@ import org.axonframework.boot.DistributedCommandBusProperties;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.distributed.CommandBusConnector;
 import org.axonframework.commandhandling.distributed.CommandRouter;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.commandhandling.distributed.jgroups.JGroupsConnectorFactoryBean;
 import org.jgroups.stack.GossipRouter;
@@ -74,7 +75,8 @@ public class JGroupsAutoConfiguration {
     @Bean
     public JGroupsConnectorFactoryBean jgroupsConnectorFactoryBean(Serializer serializer,
                                                                    @Qualifier("localSegment") CommandBus
-                                                                           localSegment) {
+                                                                           localSegment,
+                                                                   RoutingStrategy routingStrategy) {
         System.setProperty("jgroups.tunnel.gossip_router_hosts", properties.getJgroups().getGossip().getHosts());
         System.setProperty("jgroups.bind_addr", String.valueOf(properties.getJgroups().getBindAddr()));
         System.setProperty("jgroups.bind_port", String.valueOf(properties.getJgroups().getBindPort()));
@@ -84,6 +86,7 @@ public class JGroupsAutoConfiguration {
         jGroupsConnectorFactoryBean.setLocalSegment(localSegment);
         jGroupsConnectorFactoryBean.setSerializer(serializer);
         jGroupsConnectorFactoryBean.setConfiguration(properties.getJgroups().getConfigurationFile());
+        jGroupsConnectorFactoryBean.setRoutingStrategy(routingStrategy);
         return jGroupsConnectorFactoryBean;
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/RoutingStrategyAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/RoutingStrategyAutoConfiguration.java
@@ -20,7 +20,7 @@ package org.axonframework.boot.autoconfig;
 
 import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.axonframework.commandhandling.distributed.UnresolvedRoutingKeyPolicy;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Configuration;
  * @since 3.1.1
  */
 @Configuration
-@AutoConfigureAfter(JpaAutoConfiguration.class)
 @AutoConfigureBefore(SpringCloudAutoConfiguration.class)
 @ConditionalOnExpression("${axon.distributed.enabled:false} || ${axon.distributed.jgroups.enabled:false}")
 public class RoutingStrategyAutoConfiguration {
@@ -42,6 +41,6 @@ public class RoutingStrategyAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public RoutingStrategy routingStrategy() {
-        return new AnnotationRoutingStrategy();
+        return new AnnotationRoutingStrategy(UnresolvedRoutingKeyPolicy.RANDOM_KEY);
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/RoutingStrategyAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/RoutingStrategyAutoConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package org.axonframework.boot.autoconfig;
+
+import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto configuration for {@link RoutingStrategy}.
+ *
+ * @author Milan Savic
+ * @since 3.1.1
+ */
+@Configuration
+@AutoConfigureAfter(JpaAutoConfiguration.class)
+@AutoConfigureBefore(SpringCloudAutoConfiguration.class)
+@ConditionalOnExpression("${axon.distributed.enabled:false} || ${axon.distributed.jgroups.enabled:false}")
+public class RoutingStrategyAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RoutingStrategy routingStrategy() {
+        return new AnnotationRoutingStrategy();
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
@@ -17,9 +17,9 @@ package org.axonframework.boot.autoconfig;
 
 import org.axonframework.boot.DistributedCommandBusProperties;
 import org.axonframework.commandhandling.CommandBus;
-import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.CommandBusConnector;
 import org.axonframework.commandhandling.distributed.CommandRouter;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springcloud.commandhandling.SpringCloudCommandRouter;
 import org.axonframework.springcloud.commandhandling.SpringCloudHttpBackupCommandRouter;
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@AutoConfigureAfter(JpaAutoConfiguration.class)
+@AutoConfigureAfter(RoutingStrategyAutoConfiguration.class)
 @AutoConfigureBefore(JGroupsAutoConfiguration.class)
 @ConditionalOnProperty("axon.distributed.enabled")
 @ConditionalOnClass(name = {
@@ -60,9 +60,10 @@ public class SpringCloudAutoConfiguration {
     @ConditionalOnBean(DiscoveryClient.class)
     @ConditionalOnProperty(value = "axon.distributed.spring-cloud.fallback-to-http-get", matchIfMissing = true)
     public CommandRouter springCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
-                                                            RestTemplate restTemplate) {
+                                                            RestTemplate restTemplate,
+                                                            RoutingStrategy routingStrategy) {
         return new SpringCloudHttpBackupCommandRouter(discoveryClient,
-                                                      new AnnotationRoutingStrategy(),
+                                                      routingStrategy,
                                                       restTemplate,
                                                       properties.getSpringCloud().getFallbackUrl());
     }
@@ -70,8 +71,8 @@ public class SpringCloudAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(DiscoveryClient.class)
-    public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient) {
-        return new SpringCloudCommandRouter(discoveryClient, new AnnotationRoutingStrategy());
+    public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient, RoutingStrategy routingStrategy) {
+        return new SpringCloudCommandRouter(discoveryClient, routingStrategy);
     }
 
     @Bean

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.axonframework.boot.autoconfig.AxonAutoConfiguration,\
+  org.axonframework.boot.autoconfig.RoutingStrategyAutoConfiguration,\
   org.axonframework.boot.autoconfig.SpringCloudAutoConfiguration,\
   org.axonframework.boot.autoconfig.JGroupsAutoConfiguration,\
   org.axonframework.boot.autoconfig.AMQPAutoConfiguration,\

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithJGroupsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithJGroupsTest.java
@@ -17,9 +17,11 @@ package org.axonframework.boot;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.CommandBusConnector;
 import org.axonframework.commandhandling.distributed.CommandRouter;
 import org.axonframework.commandhandling.distributed.DistributedCommandBus;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.commandhandling.gateway.AbstractCommandGateway;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
@@ -60,6 +62,9 @@ public class AxonAutoConfigurationWithJGroupsTest {
     private CommandBus commandBus;
 
     @Autowired
+    private RoutingStrategy routingStrategy;
+
+    @Autowired
     private CommandRouter commandRouter;
 
     @Autowired
@@ -68,6 +73,9 @@ public class AxonAutoConfigurationWithJGroupsTest {
     @Test
     public void testContextInitialization() throws Exception {
         assertNotNull(applicationContext);
+
+        assertNotNull(applicationContext.getBean(RoutingStrategy.class));
+        assertEquals(AnnotationRoutingStrategy.class, routingStrategy.getClass());
 
         assertNotNull(commandRouter);
         assertEquals(JGroupsConnector.class, commandRouter.getClass());

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithSpringCloudTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithSpringCloudTest.java
@@ -17,9 +17,11 @@ package org.axonframework.boot;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.CommandBusConnector;
 import org.axonframework.commandhandling.distributed.CommandRouter;
 import org.axonframework.commandhandling.distributed.DistributedCommandBus;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.commandhandling.gateway.AbstractCommandGateway;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
@@ -71,6 +73,9 @@ public class AxonAutoConfigurationWithSpringCloudTest {
     private CommandBus commandBus;
 
     @Autowired
+    private RoutingStrategy routingStrategy;
+
+    @Autowired
     private CommandRouter commandRouter;
     @Autowired
     private CommandBusConnector commandBusConnector;
@@ -78,6 +83,9 @@ public class AxonAutoConfigurationWithSpringCloudTest {
     @Test
     public void testContextInitialization() throws Exception {
         assertNotNull(applicationContext);
+
+        assertNotNull(applicationContext.getBean(RoutingStrategy.class));
+        assertEquals(AnnotationRoutingStrategy.class, routingStrategy.getClass());
 
         assertNotNull(applicationContext.getBean(SpringCloudHttpBackupCommandRouter.class));
         assertEquals(SpringCloudHttpBackupCommandRouter.class, commandRouter.getClass());


### PR DESCRIPTION
Strategy). Also, if there is no @TargetIdentifier set on command payload
no error will be triggered, instead, random key policy will be used.

Resolves #450.