### PR TITLE
[#488] Update spring-cloud-commons to 1.3.1 and replace deprecated calls

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/distributed/ConsistentHashChangeListener.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/ConsistentHashChangeListener.java
@@ -16,7 +16,7 @@
 package org.axonframework.commandhandling.distributed;
 
 /**
- * Represents a listener that is notified when a ConsistentHash instance of the component it is regisered with has
+ * Represents a listener that is notified when a ConsistentHash instance of the component it is registered with has
  * changed.
  *
  * @author Allard Buijze
@@ -24,8 +24,6 @@ package org.axonframework.commandhandling.distributed;
  */
 @FunctionalInterface
 public interface ConsistentHashChangeListener {
-
-    ConsistentHashChangeListener NO_OP_CONSISTENT_HASH_CHANGE_LISTENER = newConsistentHash -> { };
 
     /**
      * Notification that a consistent hash has changed. Implementations should take into account that this listener
@@ -37,4 +35,14 @@ public interface ConsistentHashChangeListener {
      */
     void onConsistentHashChanged(ConsistentHash newConsistentHash);
 
+    /**
+     * Returns a No-op version of the functional interface {@link ConsistentHashChangeListener}.
+     *
+     * @return a no-op lambda taking a {@link org.axonframework.commandhandling.distributed.ConsistentHash} as its only
+     * parameter.
+     */
+    static ConsistentHashChangeListener noOp() {
+        return newConsistentHash -> {
+        };
+    }
 }

--- a/core/src/main/java/org/axonframework/commandhandling/distributed/ConsistentHashChangeListener.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/ConsistentHashChangeListener.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2010-2018. Axon Framework
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,6 +24,8 @@ package org.axonframework.commandhandling.distributed;
  */
 @FunctionalInterface
 public interface ConsistentHashChangeListener {
+
+    ConsistentHashChangeListener NO_OP_CONSISTENT_HASH_CHANGE_LISTENER = newConsistentHash -> { };
 
     /**
      * Notification that a consistent hash has changed. Implementations should take into account that this listener

--- a/core/src/main/java/org/axonframework/commandhandling/distributed/SimpleMember.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/SimpleMember.java
@@ -26,6 +26,10 @@ import java.util.function.Consumer;
  * @param <E> The type of the identifier of this entry in the set of nodes
  */
 public class SimpleMember<E> implements Member {
+
+    public static final Boolean LOCAL_MEMBER = true;
+    public static final Boolean REMOTE_MEMBER = false;
+
     private final Consumer<SimpleMember<E>> suspectHandler;
     private final String name;
     private final E endpoint;
@@ -33,6 +37,7 @@ public class SimpleMember<E> implements Member {
 
     /**
      * Create the service member
+     *
      * @param name           the member name
      * @param endpoint       The object describing the endpoint
      * @param local          True if the member is local. False if the member is remote or if this information is unknown.

--- a/core/src/main/java/org/axonframework/commandhandling/distributed/SimpleMember.java
+++ b/core/src/main/java/org/axonframework/commandhandling/distributed/SimpleMember.java
@@ -27,7 +27,14 @@ import java.util.function.Consumer;
  */
 public class SimpleMember<E> implements Member {
 
+    /**
+     * Denotes that a {@link SimpleMember} is a representation of a Local Member, thus a representation of the instance
+     * itself.
+     */
     public static final Boolean LOCAL_MEMBER = true;
+    /**
+     * Denotes that a {@link SimpleMember} is a representation of a Remote Member.
+     */
     public static final Boolean REMOTE_MEMBER = false;
 
     private final Consumer<SimpleMember<E>> suspectHandler;

--- a/distributed-commandbus-springcloud/pom.xml
+++ b/distributed-commandbus-springcloud/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>1.1.5.RELEASE</version>
+            <version>1.3.1.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/distributed-commandbus-springcloud/pom.xml
+++ b/distributed-commandbus-springcloud/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>1.3.1.RELEASE</version>
+            <version>1.3.2.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -33,6 +33,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
+import static org.axonframework.commandhandling.distributed.ConsistentHashChangeListener.NO_OP_CONSISTENT_HASH_CHANGE_LISTENER;
+
 /**
  * A {@link org.axonframework.commandhandling.distributed.CommandRouter} implementation which uses Spring Cloud's
  * {@link org.springframework.cloud.client.discovery.DiscoveryClient}s to propagate its CommandMessage Routing
@@ -110,7 +112,11 @@ public class SpringCloudCommandRouter implements CommandRouter {
                                     Registration localServiceInstance,
                                     RoutingStrategy routingStrategy,
                                     Predicate<ServiceInstance> serviceInstanceFilter) {
-        this(discoveryClient, localServiceInstance, routingStrategy, serviceInstanceFilter, h -> {/*noop*/});
+        this(discoveryClient,
+             localServiceInstance,
+             routingStrategy,
+             serviceInstanceFilter,
+             NO_OP_CONSISTENT_HASH_CHANGE_LISTENER);
     }
 
     /**

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -275,7 +275,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
      */
     protected Member buildMember(ServiceInstance serviceInstance) {
         String serviceId = serviceInstance.getServiceId();
-        if (serviceInstance == localServiceInstance) {
+        if (serviceInstance.equals(localServiceInstance)) {
             return new SimpleMember<>(serviceId.toUpperCase() + "[local-instance]", null, true, this::suspect);
         }
 

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -238,14 +238,14 @@ public class SpringCloudCommandRouter implements CommandRouter {
 
     private Optional<ConsistentHash> updateMembershipForServiceInstance(ServiceInstance serviceInstance,
                                                                         AtomicReference<ConsistentHash> atomicConsistentHash) {
-        SimpleMember<URI> simpleMember = buildSimpleMember(serviceInstance);
+        Member member = buildMember(serviceInstance);
 
         Optional<MessageRoutingInformation> optionalMessageRoutingInfo = getMessageRoutingInformation(serviceInstance);
 
         if (optionalMessageRoutingInfo.isPresent()) {
             MessageRoutingInformation messageRoutingInfo = optionalMessageRoutingInfo.get();
             return Optional.of(atomicConsistentHash.updateAndGet(
-                    consistentHash -> consistentHash.with(simpleMember,
+                    consistentHash -> consistentHash.with(member,
                                                           messageRoutingInfo.getLoadFactor(),
                                                           messageRoutingInfo.getCommandFilter(serializer))
             ));
@@ -261,14 +261,13 @@ public class SpringCloudCommandRouter implements CommandRouter {
     }
 
     /**
-     * Instantiate a {@link SimpleMember} of type {@link java.net.URI} based on the provided {@code serviceInstance}.
-     * This SimpleMember is later used to send, for example, Command messages to.
+     * Instantiate a {@link Member} of type {@link java.net.URI} based on the provided {@code serviceInstance}.
+     * This Member is later used to send, for example, Command messages to.
      *
-     * @param serviceInstance A {@link org.springframework.cloud.client.ServiceInstance} to build a {@link SimpleMember}
-     *                        for.
-     * @return A {@link SimpleMember} based on the contents of the provided {@code serviceInstance}.
+     * @param serviceInstance A {@link org.springframework.cloud.client.ServiceInstance} to build a {@link Member} for
+     * @return A {@link Member} based on the contents of the provided {@code serviceInstance}
      */
-    protected SimpleMember<URI> buildSimpleMember(ServiceInstance serviceInstance) {
+    protected Member buildMember(ServiceInstance serviceInstance) {
         URI serviceUri = serviceInstance.getUri();
         String serviceId = serviceInstance.getServiceId();
 
@@ -283,7 +282,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
         );
     }
 
-    private ConsistentHash suspect(SimpleMember<URI> member) {
+    private ConsistentHash suspect(Member member) {
         ConsistentHash newConsistentHash =
                 atomicConsistentHash.updateAndGet(consistentHash -> consistentHash.without(member));
         consistentHashChangeListener.onConsistentHashChanged(newConsistentHash);

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -33,8 +33,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
-import static org.axonframework.commandhandling.distributed.ConsistentHashChangeListener.NO_OP_CONSISTENT_HASH_CHANGE_LISTENER;
-
 /**
  * A {@link org.axonframework.commandhandling.distributed.CommandRouter} implementation which uses Spring Cloud's
  * {@link org.springframework.cloud.client.discovery.DiscoveryClient}s to propagate its CommandMessage Routing
@@ -116,7 +114,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
              localServiceInstance,
              routingStrategy,
              serviceInstanceFilter,
-             NO_OP_CONSISTENT_HASH_CHANGE_LISTENER);
+             ConsistentHashChangeListener.noOp());
     }
 
     /**

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -41,6 +41,8 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static org.axonframework.commandhandling.distributed.ConsistentHashChangeListener.NO_OP_CONSISTENT_HASH_CHANGE_LISTENER;
+
 /**
  * Implementation of the {@link org.axonframework.springcloud.commandhandling.SpringCloudCommandRouter} which has a
  * backup mechanism to provide Message Routing Information for other nodes and to retrieve Message Routing Information
@@ -150,7 +152,7 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
              localServiceInstance,
              routingStrategy,
              serviceInstanceFilter,
-             h -> { }, // NoOp ConsistentHashChangeListener
+             NO_OP_CONSISTENT_HASH_CHANGE_LISTENER,
              restTemplate,
              messageRoutingInformationEndpoint);
     }

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -255,9 +255,9 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
                                 + "as requesting message routing information from it resulted in an exception.", e);
             return Optional.empty();
         } catch (Exception e) {
-            logger.info("Failed to receive message routing information from Service [" +
-                                serviceInstance.getServiceId() + "] due to in an exception. "
-                                + "Will temporarily set that this instance denies all incoming messages", e);
+            logger.info("Failed to receive message routing information from Service ["
+                                + serviceInstance.getServiceId() + "] due to an exception. "
+                                + "Will temporarily set this instance to deny all incoming messages", e);
             return Optional.of(unreachableService);
         }
     }

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -17,8 +17,8 @@ package org.axonframework.springcloud.commandhandling;
 
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.ConsistentHashChangeListener;
+import org.axonframework.commandhandling.distributed.Member;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
-import org.axonframework.commandhandling.distributed.SimpleMember;
 import org.axonframework.commandhandling.distributed.commandfilter.DenyAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -230,17 +230,17 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
     }
 
     private Optional<MessageRoutingInformation> requestMessageRoutingInformation(ServiceInstance serviceInstance) {
-        SimpleMember<URI> simpleMember = buildSimpleMember(serviceInstance);
-        if (simpleMember.local()) {
+        Member member = buildMember(serviceInstance);
+        if (member.local()) {
             return Optional.of(getLocalMessageRoutingInformation());
         }
 
-        URI endpoint = simpleMember.getConnectionEndpoint(URI.class)
-                                   .orElseThrow(() -> new IllegalArgumentException(String.format(
-                                           "No Connection Endpoint found in Member [%s] for protocol [%s] to send a " +
-                                                   "%s request to", simpleMember,
-                                           URI.class, MessageRoutingInformation.class.getSimpleName()
-                                   )));
+        URI endpoint = member.getConnectionEndpoint(URI.class)
+                             .orElseThrow(() -> new IllegalArgumentException(String.format(
+                                     "No Connection Endpoint found in Member [%s] for protocol [%s] to send a " +
+                                             "%s request to", member,
+                                     URI.class, MessageRoutingInformation.class.getSimpleName()
+                             )));
         URI destinationUri = buildURIForPath(endpoint, messageRoutingInformationEndpoint);
 
         try {

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -88,6 +89,9 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      * called if the ConsistentHash changed.
      *
      * @param discoveryClient                   The {@code DiscoveryClient} used to discovery and notify other nodes
+     * @param localServiceInstance              A {@link org.springframework.cloud.client.serviceregistry.Registration}
+     *                                          representing the local Service Instance of this application. Necessary
+     *                                          to differentiate between other instances for correct message routing
      * @param routingStrategy                   The strategy for routing Commands to a Node
      * @param restTemplate                      The {@code RestTemplate} used to request another member's {@link
      *                                          org.axonframework.springcloud.commandhandling.MessageRoutingInformation}
@@ -97,10 +101,12 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      */
     @Autowired
     public SpringCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
+                                              Registration localServiceInstance,
                                               RoutingStrategy routingStrategy,
                                               RestTemplate restTemplate,
                                               @Value("${axon.distributed.spring-cloud.fallback-url:/message-routing-information}") String messageRoutingInformationEndpoint) {
         this(discoveryClient,
+             localServiceInstance,
              routingStrategy,
              ACCEPT_ALL_INSTANCES_FILTER,
              restTemplate,
@@ -122,6 +128,9 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      * called if the ConsistentHash changed.
      *
      * @param discoveryClient                   The {@code DiscoveryClient} used to discovery and notify other nodes
+     * @param localServiceInstance              A {@link org.springframework.cloud.client.serviceregistry.Registration}
+     *                                          representing the local Service Instance of this application. Necessary
+     *                                          to differentiate between other instances for correct message routing
      * @param routingStrategy                   The strategy for routing Commands to a Node
      * @param serviceInstanceFilter             The {@code Predicate<ServiceInstance>} used to filter
      * @param restTemplate                      The {@code RestTemplate} used to request another member's {@link
@@ -132,11 +141,13 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      *                                          information from
      */
     public SpringCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
+                                              Registration localServiceInstance,
                                               RoutingStrategy routingStrategy,
                                               Predicate<ServiceInstance> serviceInstanceFilter,
                                               RestTemplate restTemplate,
                                               String messageRoutingInformationEndpoint) {
         this(discoveryClient,
+             localServiceInstance,
              routingStrategy,
              serviceInstanceFilter,
              h -> { }, // NoOp ConsistentHashChangeListener
@@ -159,6 +170,9 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      * {@link org.axonframework.springcloud.commandhandling.MessageRoutingInformation} with.
      *
      * @param discoveryClient                   The {@code DiscoveryClient} used to discovery and notify other nodes
+     * @param localServiceInstance              A {@link org.springframework.cloud.client.serviceregistry.Registration}
+     *                                          representing the local Service Instance of this application. Necessary
+     *                                          to differentiate between other instances for correct message routing
      * @param routingStrategy                   The strategy for routing Commands to a Node
      * @param serviceInstanceFilter             The {@code Predicate<ServiceInstance>} used to filter
      * @param consistentHashChangeListener      The callback to invoke when there is a change in the ConsistentHash
@@ -170,12 +184,17 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
      *                                          information from
      */
     public SpringCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
+                                              Registration localServiceInstance,
                                               RoutingStrategy routingStrategy,
                                               Predicate<ServiceInstance> serviceInstanceFilter,
                                               ConsistentHashChangeListener consistentHashChangeListener,
                                               RestTemplate restTemplate,
                                               String messageRoutingInformationEndpoint) {
-        super(discoveryClient, routingStrategy, serviceInstanceFilter, consistentHashChangeListener);
+        super(discoveryClient,
+              localServiceInstance,
+              routingStrategy,
+              serviceInstanceFilter,
+              consistentHashChangeListener);
         this.restTemplate = restTemplate;
         this.messageRoutingInformationEndpoint = messageRoutingInformationEndpoint;
         this.messageRoutingInfo = null;

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -41,8 +41,6 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import static org.axonframework.commandhandling.distributed.ConsistentHashChangeListener.NO_OP_CONSISTENT_HASH_CHANGE_LISTENER;
-
 /**
  * Implementation of the {@link org.axonframework.springcloud.commandhandling.SpringCloudCommandRouter} which has a
  * backup mechanism to provide Message Routing Information for other nodes and to retrieve Message Routing Information
@@ -152,7 +150,7 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
              localServiceInstance,
              routingStrategy,
              serviceInstanceFilter,
-             NO_OP_CONSISTENT_HASH_CHANGE_LISTENER,
+             ConsistentHashChangeListener.noOp(),
              restTemplate,
              messageRoutingInformationEndpoint);
     }

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>1.3.1.RELEASE</version>
+            <version>1.3.2.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-            <version>1.1.5.RELEASE</version>
+            <version>1.3.1.RELEASE</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
- *
+ * Copyright (c) 2010-2018. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -34,6 +33,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -61,9 +61,11 @@ public class SpringCloudAutoConfiguration {
     @ConditionalOnBean(DiscoveryClient.class)
     @ConditionalOnProperty(value = "axon.distributed.spring-cloud.fallback-to-http-get", matchIfMissing = true)
     public CommandRouter springCloudHttpBackupCommandRouter(DiscoveryClient discoveryClient,
+                                                            Registration localServiceInstance,
                                                             RestTemplate restTemplate,
                                                             RoutingStrategy routingStrategy) {
         return new SpringCloudHttpBackupCommandRouter(discoveryClient,
+                                                      localServiceInstance,
                                                       routingStrategy,
                                                       restTemplate,
                                                       properties.getSpringCloud().getFallbackUrl());
@@ -72,8 +74,10 @@ public class SpringCloudAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean(DiscoveryClient.class)
-    public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient, RoutingStrategy routingStrategy) {
-        return new SpringCloudCommandRouter(discoveryClient, routingStrategy);
+    public CommandRouter springCloudCommandRouter(DiscoveryClient discoveryClient,
+                                                  Registration localServiceInstance,
+                                                  RoutingStrategy routingStrategy) {
+        return new SpringCloudCommandRouter(discoveryClient, localServiceInstance, routingStrategy);
     }
 
     @Bean

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithSpringCloudTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithSpringCloudTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,11 +17,7 @@ package org.axonframework.boot;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
-import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
-import org.axonframework.commandhandling.distributed.CommandBusConnector;
-import org.axonframework.commandhandling.distributed.CommandRouter;
-import org.axonframework.commandhandling.distributed.DistributedCommandBus;
-import org.axonframework.commandhandling.distributed.RoutingStrategy;
+import org.axonframework.commandhandling.distributed.*;
 import org.axonframework.commandhandling.gateway.AbstractCommandGateway;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
@@ -29,8 +25,8 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springcloud.commandhandling.SpringCloudHttpBackupCommandRouter;
 import org.axonframework.springcloud.commandhandling.SpringHttpCommandBusConnector;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -38,9 +34,10 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.WebClientAutoConfiguration;
-import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClient;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryProperties;
+import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,9 +45,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 
 @ContextConfiguration(classes = AxonAutoConfigurationWithSpringCloudTest.TestContext.class)
@@ -119,7 +121,45 @@ public class AxonAutoConfigurationWithSpringCloudTest {
 
         @Bean
         public DiscoveryClient discoveryClient() {
-            return new NoopDiscoveryClient(new DefaultServiceInstance("TestServiceId", "localhost", 12345, true));
+            return new SimpleDiscoveryClient(new SimpleDiscoveryProperties());
+        }
+
+        @Bean
+        public Registration registration() {
+            return new Registration() {
+                @Override
+                public String getServiceId() {
+                    return "TestServiceId";
+                }
+
+                @Override
+                public String getHost() {
+                    return "localhost";
+                }
+
+                @Override
+                public int getPort() {
+                    return 12345;
+                }
+
+                @Override
+                public boolean isSecure() {
+                    return true;
+                }
+
+                @Override
+                public URI getUri() {
+                    return UriComponentsBuilder.fromUriString("localhost")
+                                               .port(12345)
+                                               .build()
+                                               .toUri();
+                }
+
+                @Override
+                public Map<String, String> getMetadata() {
+                    return new HashMap<>();
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
This PR adjusts the `spring-cloud-commons` version from `1.1.5.RELEASE` to `1.3.1.RELEASE` and replaces any deprecated calls to that package.

Main point of interested is the removal of the `DiscoveryClient#getLocalServiceInstance()` call for the `Registration` class. All usages of that call in the `SpringCloudCommandRouter` have been replaced  by introducing a global private `Registration localServiceInstance` variable which is set on construction of the router.

Additionally I did:
- Updated the javadoc accordingly.
- Remove the deprecated constructor from the `SpringCloudCommandRouter`.
- Added a NoOp constant for the `ConsistentHashChangeListener` for added clarity when no change listener is required.
- Adjust the auto configuration to require a `Registration` bean.

This PR will resolve #488