### PR TITLE
issue 499: support @Qualifier annotation in SpringBeanParameterResolverFactory

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactory.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactory.java
@@ -17,6 +17,7 @@
 package org.axonframework.spring.config.annotation;
 
 import org.axonframework.common.Priority;
+import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.ParameterResolver;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
@@ -33,6 +34,7 @@ import org.springframework.context.ApplicationContextAware;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * ParameterResolverFactory implementation that resolves parameters in the Spring Application Context. A parameter can
@@ -81,10 +83,12 @@ public class SpringBeanParameterResolverFactory implements ParameterResolverFact
             if (beanFactory instanceof ConfigurableListableBeanFactory) {
                 final ConfigurableListableBeanFactory clBeanFactory = (ConfigurableListableBeanFactory) beanFactory;
                 // find @Qualifier matching candidate
-                for (Map.Entry<String, ?> bean : beansFound.entrySet()) {
-                    final Qualifier qualifier = parameters[parameterIndex].getAnnotation(Qualifier.class);
-                    if (qualifier != null && SpringUtils.isQualifierMatch(bean.getKey(), clBeanFactory, qualifier.value())) {
-                        return new SpringBeanParameterResolver(beanFactory, bean.getKey());
+                final Optional<Map<String, Object>> qualifier = AnnotationUtils.findAnnotationAttributes(parameters[parameterIndex], Qualifier.class);
+                if (qualifier.isPresent()) {
+                    for (Map.Entry<String, ?> bean : beansFound.entrySet()) {
+                        if (SpringUtils.isQualifierMatch(bean.getKey(), clBeanFactory, (String) qualifier.get().get("qualifier"))) {
+                            return new SpringBeanParameterResolver(beanFactory, bean.getKey());
+                        }
                     }
                 }
                 // find @Primary matching candidate

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactory.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactory.java
@@ -89,12 +89,12 @@ public class SpringBeanParameterResolverFactory implements ParameterResolverFact
             }
             if (logger.isWarnEnabled()) {
                 logger.warn("{} beans of type {} found, but none was marked as primary and parameter lacks @Qualifier. Ignoring this parameter.",
-                            beansFound.size(), parameterType.getSimpleName());
+                        beansFound.size(), parameterType.getSimpleName());
             }
             return null;
         } else {
             return new SpringBeanParameterResolver(applicationContext.getAutowireCapableBeanFactory(),
-                                                   beansFound.keySet().iterator().next());
+                    beansFound.keySet().iterator().next());
         }
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactoryTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanParameterResolverFactoryTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.*;
@@ -62,6 +63,8 @@ public class SpringBeanParameterResolverFactoryTest {
     @Before
     public void setUp() throws Exception {
         counter.set(0);
+        assertTrue(applicationContext.getBean("duplicateResourceWithPrimary1", DuplicateResourceWithPrimary.class).isPrimary());
+        assertFalse(applicationContext.getBean("duplicateResourceWithPrimary2", DuplicateResourceWithPrimary.class).isPrimary());
     }
 
     @Test
@@ -96,9 +99,39 @@ public class SpringBeanParameterResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    public void testMethodsAreProperlyInjected_DuplicateParameterTypeWithPrimary() {
+    public void testMethodsAreProperlyInjected_DuplicateParameterTypeWithPrimary() throws Exception {
         // this should generate an error
-        assertNotNull(applicationContext.getBean("duplicateResourceHandlerWithPrimary"));
+        new AnnotationEventListenerAdapter(applicationContext.getBean("duplicateResourceHandlerWithPrimary"), parameterResolver).handle(asEventMessage("Hi there"));
+
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    @DirtiesContext
+    public void testMethodsAreProperlyInjected_DuplicateParameterTypeWithQualifier() throws Exception {
+        new AnnotationEventListenerAdapter(applicationContext.getBean("duplicateResourceHandlerWithQualifier"), parameterResolver).handle(asEventMessage("Hi there"));
+
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    @DirtiesContext
+    public void testMethodsAreProperlyInjected_QualifierPrecedesPrimary() throws Exception {
+        new AnnotationEventListenerAdapter(applicationContext.getBean("duplicateResourceHandlerWithQualifierAndPrimary"), parameterResolver).handle(asEventMessage("Hi there"));
+
+        assertEquals(1, counter.get());
+    }
+
+    public interface DuplicateResourceWithPrimary {
+        boolean isPrimary();
+    }
+
+    public interface DuplicateResource {
+
+    }
+
+    public interface DuplicateResourceWithQualifier {
+
     }
 
     @AnnotationDriven
@@ -130,6 +163,18 @@ public class SpringBeanParameterResolverFactoryTest {
 
         @Lazy
         @Bean
+        public DuplicateResourceHandlerWithQualifier duplicateResourceHandlerWithQualifier() {
+            return new DuplicateResourceHandlerWithQualifier();
+        }
+
+        @Lazy
+        @Bean
+        public DuplicateResourceHandlerWithQualifierAndPrimary duplicateResourceHandlerWithQualifierAndPrimary() {
+            return new DuplicateResourceHandlerWithQualifierAndPrimary();
+        }
+
+        @Lazy
+        @Bean
         public PrototypeResourceHandler prototypeResourceHandler() {
             return new PrototypeResourceHandler();
         }
@@ -150,12 +195,32 @@ public class SpringBeanParameterResolverFactoryTest {
         @Bean
         public DuplicateResourceWithPrimary duplicateResourceWithPrimary1() {
             return new DuplicateResourceWithPrimary() {
+                @Override
+                public boolean isPrimary() {
+                    return true;
+                }
             };
         }
 
         @Bean
         public DuplicateResourceWithPrimary duplicateResourceWithPrimary2() {
             return new DuplicateResourceWithPrimary() {
+                @Override
+                public boolean isPrimary() {
+                    return false;
+                }
+            };
+        }
+
+        @Bean
+        public DuplicateResourceWithQualifier duplicateResourceWithQualifier1() {
+            return new DuplicateResourceWithQualifier() {
+            };
+        }
+
+        @Bean("qualifiedByName")
+        public DuplicateResourceWithQualifier duplicateResourceWithQualifier2() {
+            return new DuplicateResourceWithQualifier() {
             };
         }
 
@@ -175,14 +240,6 @@ public class SpringBeanParameterResolverFactoryTest {
         public EventBus eventBus() {
             return new SimpleEventBus();
         }
-    }
-
-    public interface DuplicateResource {
-
-    }
-
-    public interface DuplicateResourceWithPrimary {
-
     }
 
     public interface PrototypeResource {
@@ -209,6 +266,23 @@ public class SpringBeanParameterResolverFactoryTest {
 
         @EventHandler
         public void handle(String message, DuplicateResourceWithPrimary dataSource) {
+            counter.incrementAndGet();
+        }
+    }
+
+    public static class DuplicateResourceHandlerWithQualifier {
+
+        @EventHandler
+        public void handle(String message, @Qualifier("qualifiedByName") DuplicateResourceWithQualifier resource) {
+            counter.incrementAndGet();
+        }
+    }
+
+    public static class DuplicateResourceHandlerWithQualifierAndPrimary {
+
+        @EventHandler
+        public void handle(String message, @Qualifier("duplicateResourceWithPrimary2") DuplicateResourceWithPrimary resource) {
+            assertFalse("expect the non-primary bean to be autowired here", resource.isPrimary());
             counter.incrementAndGet();
         }
     }


### PR DESCRIPTION
support for @Qualifier annotation in SpringBeanParameterResolverFactory

- @Qualifier annotation on event handlers' parameter take precedence over @Primary annotated bean candidates
- no support for custom @Qualifier annotations