### PR TITLE
[#500] Allow setting of ErrorHandler through Configuration API

### DIFF
--- a/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
@@ -97,7 +97,7 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
                                                                                    LoggingErrorHandler::new)),
                                              messageSource.apply(conf),
                                              DirectEventProcessingStrategy.INSTANCE,
-                                             PropagatingErrorHandler.INSTANCE,
+                                             getErrorHandler(conf, name),
                                              getMessageMonitor(conf, SubscribingEventProcessor.class, name));
     }
 

--- a/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
@@ -107,6 +107,7 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param configuration The main configuration
      * @param processorName The name of the processor to retrieve interceptors for
      * @return a list of Interceptors
+     *
      * @see EventHandlingConfiguration#registerHandlerInterceptor(BiFunction)
      * @see EventHandlingConfiguration#registerHandlerInterceptor(String, Function)
      */
@@ -158,8 +159,9 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param sequencingPolicy The policy for processing events sequentially
      * @return this EventHandlingConfiguration instance for further configuration
      */
-    public EventHandlingConfiguration usingTrackingProcessors(Function<Configuration, TrackingEventProcessorConfiguration> config,
-                                                              Function<Configuration, SequencingPolicy<? super EventMessage<?>>> sequencingPolicy) {
+    public EventHandlingConfiguration usingTrackingProcessors(
+            Function<Configuration, TrackingEventProcessorConfiguration> config,
+            Function<Configuration, SequencingPolicy<? super EventMessage<?>>> sequencingPolicy) {
         return registerEventProcessorFactory(
                 (conf, name, handlers) -> buildTrackingEventProcessor(conf, name, handlers, config,
                                                                       Configuration::eventBus,
@@ -189,10 +191,15 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @return this EventHandlingConfiguration instance for further configuration
      */
     @SuppressWarnings("unchecked")
-    public EventHandlingConfiguration registerTrackingProcessor(String name, Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source) {
-        return registerTrackingProcessor(name, source,
-                                         c -> c.getComponent(TrackingEventProcessorConfiguration.class, TrackingEventProcessorConfiguration::forSingleThreadedProcessing),
-                                         c -> c.getComponent(SequencingPolicy.class, SequentialPerAggregatePolicy::new));
+    public EventHandlingConfiguration registerTrackingProcessor(String name,
+                                                                Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source) {
+        return registerTrackingProcessor(
+                name,
+                source,
+                c -> c.getComponent(TrackingEventProcessorConfiguration.class,
+                                    TrackingEventProcessorConfiguration::forSingleThreadedProcessing),
+                c -> c.getComponent(SequencingPolicy.class, SequentialPerAggregatePolicy::new)
+        );
     }
 
     /**
@@ -222,7 +229,8 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param sequencingPolicy       The sequencing policy to apply when processing events in parallel
      * @return this EventHandlingConfiguration instance for further configuration
      */
-    public EventHandlingConfiguration registerTrackingProcessor(String name, Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source,
+    public EventHandlingConfiguration registerTrackingProcessor(String name,
+                                                                Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source,
                                                                 Function<Configuration, TrackingEventProcessorConfiguration> processorConfiguration,
                                                                 Function<Configuration, SequencingPolicy<? super EventMessage<?>>> sequencingPolicy) {
         return registerEventProcessor(name, (conf, n, handlers) ->
@@ -241,7 +249,10 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
                                                                                 LoggingErrorHandler::new),
                                                                         sequencingPolicy.apply(conf)),
                                           source.apply(conf),
-                                          tokenStore.getOrDefault(name, c -> c.getComponent(TokenStore.class, InMemoryTokenStore::new)).apply(conf),
+                                          tokenStore.getOrDefault(
+                                                  name,
+                                                  c -> c.getComponent(TokenStore.class, InMemoryTokenStore::new)
+                                          ).apply(conf),
                                           conf.getComponent(TransactionManager.class, NoTransactionManager::instance),
                                           getMessageMonitor(conf, EventProcessor.class, name),
                                           RollbackConfigurationType.ANY_THROWABLE,
@@ -249,7 +260,9 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
                                           config.apply(conf));
     }
 
-    private MessageMonitor<? super Message<?>> getMessageMonitor(Configuration configuration, Class<?> componentType, String componentName) {
+    private MessageMonitor<? super Message<?>> getMessageMonitor(Configuration configuration,
+                                                                 Class<?> componentType,
+                                                                 String componentName) {
         if (messageMonitorFactories.containsKey(componentName)) {
             return messageMonitorFactories.get(componentName).create(configuration, componentType, componentName);
         } else {
@@ -335,7 +348,8 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param interceptorBuilder The builder function that provides an interceptor for each available processor
      * @return this EventHandlingConfiguration instance for further configuration
      */
-    public EventHandlingConfiguration registerHandlerInterceptor(BiFunction<Configuration, String, MessageHandlerInterceptor<? super EventMessage<?>>> interceptorBuilder) {
+    public EventHandlingConfiguration registerHandlerInterceptor(
+            BiFunction<Configuration, String, MessageHandlerInterceptor<? super EventMessage<?>>> interceptorBuilder) {
         defaultHandlerInterceptors.add(interceptorBuilder);
         return this;
     }
@@ -534,9 +548,12 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param messageMonitorBuilder The builder function to use
      * @return this EventHandlingConfiguration instance for further configuration
      */
-    public EventHandlingConfiguration configureMessageMonitor(String name, Function<Configuration, MessageMonitor<Message<?>>> messageMonitorBuilder) {
-        return configureMessageMonitor(name,
-                                       (configuration, componentType, componentName) -> messageMonitorBuilder.apply(configuration));
+    public EventHandlingConfiguration configureMessageMonitor(String name,
+                                                              Function<Configuration, MessageMonitor<Message<?>>> messageMonitorBuilder) {
+        return configureMessageMonitor(
+                name,
+                (configuration, componentType, componentName) -> messageMonitorBuilder.apply(configuration)
+        );
     }
 
     /**
@@ -547,7 +564,8 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param messageMonitorFactory The factory to use
      * @return this EventHandlingConfiguration instance for further configuration
      */
-    public EventHandlingConfiguration configureMessageMonitor(String name, MessageMonitorFactory messageMonitorFactory) {
+    public EventHandlingConfiguration configureMessageMonitor(String name,
+                                                              MessageMonitorFactory messageMonitorFactory) {
         messageMonitorFactories.put(name, messageMonitorFactory);
         return this;
     }
@@ -599,7 +617,6 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
          * @return a fully initialized Event Processor
          */
         EventProcessor createEventProcessor(Configuration configuration, String name, List<?> eventHandlers);
-
     }
 
     private static class ProcessorSelector {

--- a/core/src/test/java/org/axonframework/config/EventHandlingConfigurationTest.java
+++ b/core/src/test/java/org/axonframework/config/EventHandlingConfigurationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
- *
+ * Copyright (c) 2010-2018. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,10 +16,7 @@
 package org.axonframework.config;
 
 import org.axonframework.common.Registration;
-import org.axonframework.eventhandling.EventHandler;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.EventProcessor;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.messaging.InterceptorChain;
@@ -104,9 +100,11 @@ public class EventHandlingConfigurationTest {
 
         assertEquals(3, processors.size());
         assertTrue(processors.get("java.util.concurrent2").getEventHandlers().contains("concurrent"));
-        assertTrue(processors.get("java.util.concurrent2").getInterceptors().get(0) instanceof CorrelationDataInterceptor);
+        assertTrue(processors.get("java.util.concurrent2").getInterceptors()
+                             .get(0) instanceof CorrelationDataInterceptor);
         assertTrue(processors.get("java.util.concurrent").getEventHandlers().contains(map));
-        assertTrue(processors.get("java.util.concurrent").getInterceptors().get(0) instanceof CorrelationDataInterceptor);
+        assertTrue(processors.get("java.util.concurrent").getInterceptors()
+                             .get(0) instanceof CorrelationDataInterceptor);
         assertTrue(processors.get("java.lang").getEventHandlers().contains(""));
         assertTrue(processors.get("java.lang").getInterceptors().get(0) instanceof CorrelationDataInterceptor);
         assertEquals(1, config.getModules().size());
@@ -143,10 +141,7 @@ public class EventHandlingConfigurationTest {
     public void testAssignInterceptors() {
         EventHandlingConfiguration module = new EventHandlingConfiguration()
                 .usingTrackingProcessors()
-                .registerEventProcessor("default", (config, name, handlers) -> {
-                    StubEventProcessor processor = new StubEventProcessor(name, handlers);
-                    return processor;
-                });
+                .registerEventProcessor("default", (config, name, handlers) -> new StubEventProcessor(name, handlers));
         module.byDefaultAssignTo("default");
         module.assignHandlersMatching("concurrent", 1, "concurrent"::equals);
         module.registerEventHandler(c -> new Object()); // --> java.lang
@@ -160,7 +155,7 @@ public class EventHandlingConfigurationTest {
         Configuration config = configurer.start();
 
         // CorrelationDataInterceptor is automatically configured
-        assertEquals(3, ((StubEventProcessor)module.getProcessor("default").get()).getInterceptors().size());
+        assertEquals(3, ((StubEventProcessor) module.getProcessor("default").get()).getInterceptors().size());
         assertEquals(1, config.getModules().size());
     }
 
@@ -168,32 +163,17 @@ public class EventHandlingConfigurationTest {
     public void testConfigureMonitor() throws Exception {
         MessageCollectingMonitor subscribingMonitor = new MessageCollectingMonitor();
         MessageCollectingMonitor trackingMonitor = new MessageCollectingMonitor(1);
-
-        // Use InMemoryEventStorageEngine so tracking processors don't miss events
-        configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
         CountDownLatch tokenStoreInvocation = new CountDownLatch(1);
-        EventHandlingConfiguration module = new EventHandlingConfiguration()
-                .registerSubscribingEventProcessor("subscribing")
-                .registerTrackingProcessor("tracking")
+
+        EventHandlingConfiguration module = buildComplexEventHandlingConfiguration(tokenStoreInvocation)
                 .configureMessageMonitor("subscribing", c -> subscribingMonitor)
-                .configureMessageMonitor("tracking", c -> trackingMonitor)
-                .assignHandlersMatching("subscribing", eh -> eh.getClass().isAssignableFrom(SubscribingEventHandler.class))
-                .assignHandlersMatching("tracking", eh -> eh.getClass().isAssignableFrom(TrackingEventHandler.class))
-                .registerEventHandler(c -> new SubscribingEventHandler())
-                .registerEventHandler(c -> new TrackingEventHandler())
-                .registerTokenStore("tracking", c-> new InMemoryTokenStore() {
-                    @Override
-                    public int[] fetchSegments(String processorName) {
-                        tokenStoreInvocation.countDown();
-                        return super.fetchSegments(processorName);
-                    }
-                });
+                .configureMessageMonitor("tracking", c -> trackingMonitor);
         configurer.registerModule(module);
         Configuration config = configurer.start();
 
         try {
             config.eventBus().publish(new GenericEventMessage<Object>("test"));
-            
+
             assertEquals(1, subscribingMonitor.getMessages().size());
             assertTrue(trackingMonitor.await(10, TimeUnit.SECONDS));
             assertTrue(tokenStoreInvocation.await(10, TimeUnit.SECONDS));
@@ -202,6 +182,79 @@ public class EventHandlingConfigurationTest {
         }
     }
 
+    @Test
+    public void testConfigureDefaultErrorHandler() throws Exception {
+        int expectedErrorHandlerCalls = 2;
+
+        StubErrorHandler errorHandler = new StubErrorHandler(2);
+        CountDownLatch tokenStoreInvocation = new CountDownLatch(1);
+
+        EventHandlingConfiguration module = buildComplexEventHandlingConfiguration(tokenStoreInvocation)
+                .configureErrorHandler(config -> errorHandler);
+        configurer.registerModule(module);
+        Configuration config = configurer.start();
+
+        try {
+            config.eventBus().publish(new GenericEventMessage<>(1000));
+            assertTrue(tokenStoreInvocation.await(10, TimeUnit.SECONDS));
+
+            assertTrue(errorHandler.await(10, TimeUnit.SECONDS));
+            assertEquals(expectedErrorHandlerCalls, errorHandler.getErrorCounter());
+        } finally {
+            config.shutdown();
+        }
+    }
+
+    @Test
+    public void testConfigureErrorHandlerPerEventProcessor() throws Exception {
+        GenericEventMessage<Integer> failingEventMessage = new GenericEventMessage<>(1000);
+
+        int expectedErrorHandlerCalls = 1;
+
+        StubErrorHandler subscribingErrorHandler = new StubErrorHandler(1);
+        StubErrorHandler trackingErrorHandler = new StubErrorHandler(1);
+        CountDownLatch tokenStoreInvocation = new CountDownLatch(1);
+
+        EventHandlingConfiguration module = buildComplexEventHandlingConfiguration(tokenStoreInvocation)
+                .configureErrorHandler("subscribing", config -> subscribingErrorHandler)
+                .configureErrorHandler("tracking", config -> trackingErrorHandler);
+        configurer.registerModule(module);
+        Configuration config = configurer.start();
+
+        try {
+            config.eventBus().publish(failingEventMessage);
+
+            assertEquals(expectedErrorHandlerCalls, subscribingErrorHandler.getErrorCounter());
+
+            assertTrue(tokenStoreInvocation.await(10, TimeUnit.SECONDS));
+            assertTrue(trackingErrorHandler.await(10, TimeUnit.SECONDS));
+            assertEquals(expectedErrorHandlerCalls, trackingErrorHandler.getErrorCounter());
+        } finally {
+            config.shutdown();
+        }
+    }
+
+    private EventHandlingConfiguration buildComplexEventHandlingConfiguration(CountDownLatch tokenStoreInvocation) {
+        // Use InMemoryEventStorageEngine so tracking processors don't miss events
+        configurer.configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine());
+        return new EventHandlingConfiguration()
+                .registerSubscribingEventProcessor("subscribing")
+                .registerTrackingProcessor("tracking")
+                .assignHandlersMatching("subscribing",
+                                        eh -> eh.getClass().isAssignableFrom(SubscribingEventHandler.class))
+                .assignHandlersMatching("tracking", eh -> eh.getClass().isAssignableFrom(TrackingEventHandler.class))
+                .registerEventHandler(c -> new SubscribingEventHandler())
+                .registerEventHandler(c -> new TrackingEventHandler())
+                .registerTokenStore("tracking", c -> new InMemoryTokenStore() {
+                    @Override
+                    public int[] fetchSegments(String processorName) {
+                        tokenStoreInvocation.countDown();
+                        return super.fetchSegments(processorName);
+                    }
+                });
+    }
+
+    @SuppressWarnings("WeakerAccess")
     private static class StubEventProcessor implements EventProcessor {
 
         private final String name;
@@ -243,25 +296,37 @@ public class EventHandlingConfigurationTest {
         }
     }
 
+    @SuppressWarnings("WeakerAccess")
     @ProcessingGroup("processingGroup")
     public static class AnnotatedBean {
+
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class AnnotatedBeanSubclass extends AnnotatedBean {
 
     }
 
     private static class StubInterceptor implements MessageHandlerInterceptor<EventMessage<?>> {
+
         @Override
-        public Object handle(UnitOfWork<? extends EventMessage<?>> unitOfWork, InterceptorChain interceptorChain) throws Exception {
+        public Object handle(UnitOfWork<? extends EventMessage<?>> unitOfWork, InterceptorChain interceptorChain)
+                throws Exception {
             return interceptorChain.proceed();
         }
     }
 
+    @SuppressWarnings("unused")
     @ProcessingGroup("subscribing")
     private class SubscribingEventHandler {
+
+        @EventHandler
+        public void handle(Integer event, UnitOfWork unitOfWork) {
+            unitOfWork.rollback(new IllegalStateException());
+        }
     }
 
+    @SuppressWarnings("unused")
     @ProcessingGroup("tracking")
     private class TrackingEventHandler {
 
@@ -269,6 +334,35 @@ public class EventHandlingConfigurationTest {
         public void handle(String event) {
 
         }
+
+        @EventHandler
+        public void handle(Integer event, UnitOfWork unitOfWork) {
+            unitOfWork.rollback(new IllegalStateException());
+        }
     }
 
+    private class StubErrorHandler implements ErrorHandler {
+
+        private long errorCounter = 0;
+        private final CountDownLatch latch;
+
+        private StubErrorHandler(int count) {
+            this.latch = new CountDownLatch(count);
+        }
+
+        @Override
+        public void handleError(ErrorContext errorContext) {
+            errorCounter++;
+            latch.countDown();
+        }
+
+        @SuppressWarnings("WeakerAccess")
+        public long getErrorCounter() {
+            return errorCounter;
+        }
+
+        public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+            return latch.await(timeout, timeUnit);
+        }
+    }
 }

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
- *
+ * Copyright (c) 2010-2018. Axon Framework
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,6 +24,7 @@ import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.NullLockFactory;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.*;
+import org.axonframework.eventhandling.ErrorHandler;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
@@ -156,8 +156,9 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
         findComponent(ListenerInvocationErrorHandler.class).ifPresent(
                 handler -> configurer.registerComponent(ListenerInvocationErrorHandler.class, c -> getBean(handler, c))
         );
-        findComponent(ListenerInvocationErrorHandler.class).ifPresent(handler -> configurer
-                .registerComponent(ListenerInvocationErrorHandler.class, c -> getBean(handler, c)));
+        findComponent(ErrorHandler.class).ifPresent(
+                handler -> configurer.registerComponent(ErrorHandler.class, c -> getBean(handler, c))
+        );
 
         String resourceInjector = findComponent(ResourceInjector.class, registry,
                                                 () -> genericBeanDefinition(SpringResourceInjector.class)


### PR DESCRIPTION
This PR adds the option to configure an `ErrorHandler` in the `EventHandlingConfiguration`.
It allows to either adjust the default `ErrorHandler` or adjust an `ErrorHandler` per `EventProcessor`.

This PR resolves #500