### PR TITLE
Exposed aggregate version through static method in aggregate lifecycle.

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/model/AggregateLifecycle.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/AggregateLifecycle.java
@@ -85,7 +85,7 @@ public abstract class AggregateLifecycle {
      * @return the current version of the aggregate
      */
     public static Long getVersion() {
-        return getInstance().doGetVersion();
+        return getInstance().version();
     }
 
     /**
@@ -134,7 +134,7 @@ public abstract class AggregateLifecycle {
      *
      * @return the current version of the aggregate
      */
-    protected abstract Long doGetVersion();
+    protected abstract Long version();
 
     /**
      * Marks this aggregate as deleted. Implementations may react differently to aggregates marked for deletion.

--- a/core/src/main/java/org/axonframework/commandhandling/model/AggregateLifecycle.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/AggregateLifecycle.java
@@ -80,6 +80,15 @@ public abstract class AggregateLifecycle {
     }
 
     /**
+     * Gets the version of the aggregate.
+     *
+     * @return the current version of the aggregate
+     */
+    public static Long getVersion() {
+        return getInstance().doGetVersion();
+    }
+
+    /**
      * Marks this aggregate as deleted, instructing a repository to remove that aggregate at an appropriate time.
      * <p/>
      * Note that different repository implementations may react differently to aggregates marked for deletion.
@@ -119,6 +128,13 @@ public abstract class AggregateLifecycle {
      * historic events
      */
     protected abstract boolean getIsLive();
+
+    /**
+     * Gets the version of the aggregate.
+     *
+     * @return the current version of the aggregate
+     */
+    protected abstract Long doGetVersion();
 
     /**
      * Marks this aggregate as deleted. Implementations may react differently to aggregates marked for deletion.

--- a/core/src/main/java/org/axonframework/commandhandling/model/inspection/AnnotatedAggregate.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/inspection/AnnotatedAggregate.java
@@ -214,11 +214,6 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
     }
 
     @Override
-    protected Long doGetVersion() {
-        return version();
-    }
-
-    @Override
     public <R> R invoke(Function<T, R> invocation) {
         try {
             return executeWithResult(() -> invocation.apply(aggregateRoot));

--- a/core/src/main/java/org/axonframework/commandhandling/model/inspection/AnnotatedAggregate.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/inspection/AnnotatedAggregate.java
@@ -214,6 +214,11 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
     }
 
     @Override
+    protected Long doGetVersion() {
+        return version();
+    }
+
+    @Override
     public <R> R invoke(Function<T, R> invocation) {
         try {
             return executeWithResult(() -> invocation.apply(aggregateRoot));

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -220,10 +220,12 @@ public class EmbeddedEventStoreTest {
         when(mockIterator.hasNext()).thenReturn(false, true);
         when(mockIterator.next()).thenReturn(new GenericTrackedEventMessage<>(new GlobalSequenceTrackingToken(1), createEvent()));
         TrackingEventStream stream = testSubject.openStream(null);
-        assertFalse(stream.hasNextAvailable(10, MILLISECONDS));
+        assertFalse(stream.hasNextAvailable());
         testSubject.publish(createEvent());
+        // give some time consumer to consume the event
+        Thread.sleep(200);
         // if the stream correctly updates the token internally, it should not find events anymore
-        assertFalse(stream.hasNextAvailable(10, MILLISECONDS));
+        assertFalse(stream.hasNextAvailable());
     }
 
     @Test

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -67,6 +67,11 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
     }
 
     @Override
+    protected Long doGetVersion() {
+        return 0L;
+    }
+
+    @Override
     protected void doMarkDeleted() {
         this.deleted = true;
     }

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -67,7 +67,7 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
     }
 
     @Override
-    protected Long doGetVersion() {
+    protected Long version() {
         return 0L;
     }
 


### PR DESCRIPTION
Resolves #543.