### PR TITLE
Fix for issue 559

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/core/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -38,7 +38,11 @@ public class ReplayToken implements TrackingToken, WrappedToken {
      * @param tokenAtReset The token representing the position at which the reset was triggered.
      */
     public ReplayToken(TrackingToken tokenAtReset) {
-        this.tokenAtReset = tokenAtReset;
+        if (tokenAtReset instanceof ReplayToken) {
+            this.tokenAtReset = ((ReplayToken)tokenAtReset).tokenAtReset;
+        } else {
+            this.tokenAtReset = tokenAtReset;
+        }
         this.currentToken = null;
     }
 
@@ -74,9 +78,9 @@ public class ReplayToken implements TrackingToken, WrappedToken {
     @Override
     public TrackingToken lowerBound(TrackingToken other) {
         if (other instanceof ReplayToken) {
-            return new ReplayToken(this, ((ReplayToken) other).currentToken);
+            return new ReplayToken(this.tokenAtReset, ((ReplayToken) other).currentToken);
         }
-        return new ReplayToken(this, other);
+        return new ReplayToken(this.tokenAtReset, other);
     }
 
     @Override


### PR DESCRIPTION
In some cases a ReplayToken becomes a tokenAtReset. If this is the case
the tokenAtReset field is used instead of the ReplayToken itself.
So the tokenAtReset field is never a ReplayToken.