### PR TITLE
Upgrading xstream dependency to 1.4.10

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.9</version>
+            <version>1.4.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>xpp3</groupId>


### PR DESCRIPTION
Upgrading xstream dependency to 1.4.10
Fix #579