### PR TITLE
Future as response type to query handlers.

### DIFF
--- a/core/src/main/java/org/axonframework/common/ObjectUtils.java
+++ b/core/src/main/java/org/axonframework/common/ObjectUtils.java
@@ -78,4 +78,17 @@ public abstract class ObjectUtils {
         }
         return (Class<T>) instance.getClass();
     }
+
+    /**
+     * Gets number of millis which are remaining of current deadline to be reached by {@link
+     * System#currentTimeMillis()}. If deadline is passed, 0 will be returned.
+     *
+     * @param deadline deadline to be met
+     * @return number of millis to deadline
+     */
+    public static long getRemainingOfDeadline(long deadline) {
+        long leftTimeout = deadline - System.currentTimeMillis();
+        leftTimeout = leftTimeout < 0 ? 0 : leftTimeout;
+        return leftTimeout;
+    }
 }

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -333,6 +334,9 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
         return uow.executeWithResult(() -> {
             ResponseType<R> responseType = uow.getMessage().getResponseType();
             Object queryResponse = new DefaultInterceptorChain<>(uow, handlerInterceptors, handler).proceed();
+            if (queryResponse instanceof Future) {
+                queryResponse = ((Future) queryResponse).get();
+            }
             return GenericQueryResponseMessage.asNullableResponseMessage(
                     responseType.responseMessagePayloadType(),
                     responseType.convert(queryResponse));

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -333,7 +333,7 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
 
     @SuppressWarnings("unchecked")
     private <Q, R> CompletableFuture<QueryResponseMessage<R>> interceptAndInvoke(UnitOfWork<QueryMessage<Q, R>> uow,
-                                                              MessageHandler<? super QueryMessage<?, R>> handler)
+                                                                                 MessageHandler<? super QueryMessage<?, R>> handler)
             throws Exception {
         return uow.executeWithResult(() -> {
             ResponseType<R> responseType = uow.getMessage().getResponseType();
@@ -345,8 +345,8 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
                 return CompletableFuture.supplyAsync(() -> {
                     try {
                         return ((Future) queryResponse).get();
-                    } catch (InterruptedException|ExecutionException e) {
-                        throw new RuntimeException(e);
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new QueryExecutionException("Error happened while trying to execute query handler", e);
                     }
                 });
             }

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -53,6 +53,7 @@ import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
+import static org.axonframework.common.ObjectUtils.getRemainingOfDeadline;
 
 /**
  * Implementation of the QueryBus that dispatches queries to the handlers within the JVM. Any timeouts are ignored by
@@ -207,8 +208,7 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
         return handlers.stream()
                        .map(handler -> {
                            try {
-                               long leftTimeout = deadline - System.currentTimeMillis();
-                               leftTimeout = leftTimeout < 0 ? 0 : leftTimeout;
+                               long leftTimeout = getRemainingOfDeadline(deadline);
                                QueryResponseMessage<R> response =
                                        interceptAndInvoke(DefaultUnitOfWork.startAndGet(interceptedQuery), handler)
                                                .get(leftTimeout, TimeUnit.MILLISECONDS);

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -142,8 +143,8 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     public <Q, R> CompletableFuture<QueryResponseMessage<R>> query(QueryMessage<Q, R> query) {
         MessageMonitor.MonitorCallback monitorCallback = messageMonitor.onMessageIngested(query);
         QueryMessage<Q, R> interceptedQuery = intercept(query);
-        CompletableFuture<QueryResponseMessage<R>> completableFuture = new CompletableFuture<>();
         List<MessageHandler<? super QueryMessage<?, ?>>> handlers = getHandlersForMessage(interceptedQuery);
+        CompletableFuture<QueryResponseMessage<R>> result = new CompletableFuture<>();
         try {
             if (handlers.isEmpty()) {
                 throw new NoHandlerForQueryException(format("No handler found for %s with response type %s",
@@ -152,14 +153,10 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
             }
             Iterator<MessageHandler<? super QueryMessage<?, ?>>> handlerIterator = handlers.iterator();
             boolean invocationSuccess = false;
-            QueryResponseMessage<R> result = null;
             while (!invocationSuccess && handlerIterator.hasNext()) {
                 try {
                     DefaultUnitOfWork<QueryMessage<Q, R>> uow = DefaultUnitOfWork.startAndGet(interceptedQuery);
-                    result = GenericQueryResponseMessage.asNullableResponseMessage(
-                            query.getResponseType().responseMessagePayloadType(),
-                            interceptAndInvoke(uow, handlerIterator.next())
-                    );
+                    result = interceptAndInvoke(uow, handlerIterator.next());
                     invocationSuccess = true;
                 } catch (NoHandlerForQueryException e) {
                     // Ignore this Query Handler, as we may have another one which is suitable
@@ -170,13 +167,12 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
                                                             interceptedQuery.getQueryName(),
                                                             interceptedQuery.getResponseType()));
             }
-            completableFuture.complete(result);
             monitorCallback.reportSuccess();
         } catch (Exception e) {
-            completableFuture.completeExceptionally(e);
+            result.completeExceptionally(e);
             monitorCallback.reportFailure(e);
         }
-        return completableFuture;
+        return result;
     }
 
     @Override
@@ -189,20 +185,23 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
             return Stream.empty();
         }
 
+        long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
         return handlers.stream()
-                       .map(mh -> {
-                           QueryResponseMessage<R> result = null;
+                       .map(handler -> {
                            try {
-                               result = interceptAndInvoke(DefaultUnitOfWork.startAndGet(interceptedQuery), mh);
+                               long leftTimeout = deadline - System.currentTimeMillis();
+                               leftTimeout = leftTimeout < 0 ? 0 : leftTimeout;
+                               QueryResponseMessage<R> response =
+                                       interceptAndInvoke(DefaultUnitOfWork.startAndGet(interceptedQuery), handler)
+                                               .get(leftTimeout, TimeUnit.MILLISECONDS);
                                monitorCallback.reportSuccess();
-                               return result;
+                               return response;
                            } catch (Exception e) {
                                monitorCallback.reportFailure(e);
-                               errorHandler.onError(e, interceptedQuery, mh);
+                               errorHandler.onError(e, interceptedQuery, handler);
+                               return null;
                            }
-                           return result;
-                       })
-                       .filter(Objects::nonNull);
+                       }).filter(Objects::nonNull);
     }
 
     @SuppressWarnings("unchecked")
@@ -228,11 +227,19 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
             while (!invocationSuccess && handlerIterator.hasNext()) {
                 try {
                     DefaultUnitOfWork<QueryMessage<Q, I>> uow = DefaultUnitOfWork.startAndGet(interceptedQuery);
-                    I initialResponse = interceptAndInvoke(uow, handlerIterator.next()).getPayload();
-
-                    updateHandler.onInitialResult(initialResponse);
-
-                    updateHandlers.put(query, updateHandler);
+                    interceptAndInvoke(uow, handlerIterator.next())
+                            .thenAccept(responseMessage -> {
+                                try {
+                                    I initialResponse = responseMessage.getPayload();
+                                    updateHandler.onInitialResult(initialResponse);
+                                    updateHandlers.put(query, updateHandler);
+                                    registeringSubscriptionQueryLocks.remove(interceptedQuery);
+                                    monitorCallback.reportSuccess();
+                                } catch (Exception e) {
+                                    monitorCallback.reportFailure(e);
+                                    updateHandler.onCompletedExceptionally(e);
+                                }
+                            });
 
                     invocationSuccess = true;
                 } catch (NoHandlerForQueryException e) {
@@ -246,15 +253,12 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
                                interceptedQuery.getResponseType(),
                                interceptedQuery.getUpdateResponseType()));
             }
-            monitorCallback.reportSuccess();
         } catch (Exception e) {
             monitorCallback.reportFailure(e);
             updateHandler.onCompletedExceptionally(e);
         } finally {
             rwLock.writeLock().unlock();
         }
-
-        registeringSubscriptionQueryLocks.remove(interceptedQuery);
 
         return () -> {
             updateHandlers.remove(query);
@@ -328,19 +332,33 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     }
 
     @SuppressWarnings("unchecked")
-    private <Q, R> QueryResponseMessage<R> interceptAndInvoke(UnitOfWork<QueryMessage<Q, R>> uow,
+    private <Q, R> CompletableFuture<QueryResponseMessage<R>> interceptAndInvoke(UnitOfWork<QueryMessage<Q, R>> uow,
                                                               MessageHandler<? super QueryMessage<?, R>> handler)
             throws Exception {
         return uow.executeWithResult(() -> {
             ResponseType<R> responseType = uow.getMessage().getResponseType();
             Object queryResponse = new DefaultInterceptorChain<>(uow, handlerInterceptors, handler).proceed();
-            if (queryResponse instanceof Future) {
-                queryResponse = ((Future) queryResponse).get();
+            if (queryResponse instanceof CompletableFuture) {
+                return ((CompletableFuture) queryResponse).thenCompose(
+                        result -> buildCompletableFuture(responseType, result));
+            } else if (queryResponse instanceof Future) {
+                return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return ((Future) queryResponse).get();
+                    } catch (InterruptedException|ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
             }
-            return GenericQueryResponseMessage.asNullableResponseMessage(
-                    responseType.responseMessagePayloadType(),
-                    responseType.convert(queryResponse));
+            return buildCompletableFuture(responseType, queryResponse);
         });
+    }
+
+    private <R> CompletableFuture<QueryResponseMessage<R>> buildCompletableFuture(ResponseType<R> responseType,
+                                                                                  Object queryResponse) {
+        return CompletableFuture.completedFuture(GenericQueryResponseMessage.asNullableResponseMessage(
+                responseType.responseMessagePayloadType(),
+                responseType.convert(queryResponse)));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/AbstractResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/AbstractResponseType.java
@@ -38,7 +38,13 @@ public abstract class AbstractResponseType<R> implements ResponseType<R> {
         this.expectedResponseType = expectedResponseType;
     }
 
-    protected Type unwrapFuture(Type type) {
+    /**
+     * Tries to unwrap generic type if provided {@code type} is of type {@link Future}.
+     *
+     * @param type to be unwrapped
+     * @return unwrapped generic, or original if provided {@code type} is not of type {@link Future}
+     */
+    protected Type unwrapIfTypeFuture(Type type) {
         Type futureType = TypeReflectionUtils.getExactSuperType(type, Future.class);
         if (futureType instanceof ParameterizedType) {
             Type[] actualTypeArguments = ((ParameterizedType) futureType).getActualTypeArguments();

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/AbstractResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/AbstractResponseType.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 /**
@@ -35,6 +36,17 @@ public abstract class AbstractResponseType<R> implements ResponseType<R> {
      */
     protected AbstractResponseType(Class<?> expectedResponseType) {
         this.expectedResponseType = expectedResponseType;
+    }
+
+    protected Type unwrapFuture(Type type) {
+        Type futureType = TypeReflectionUtils.getExactSuperType(type, Future.class);
+        if (futureType instanceof ParameterizedType) {
+            Type[] actualTypeArguments = ((ParameterizedType) futureType).getActualTypeArguments();
+            if (actualTypeArguments.length == 1) {
+                return actualTypeArguments[0];
+            }
+        }
+        return type;
     }
 
     protected boolean isIterableOfExpectedType(Type responseType) {

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/InstanceResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/InstanceResponseType.java
@@ -35,7 +35,7 @@ public class InstanceResponseType<R> extends AbstractResponseType<R> {
      */
     @Override
     public boolean matches(Type responseType) {
-        Type unwrapped = unwrapFuture(responseType);
+        Type unwrapped = unwrapIfTypeFuture(responseType);
         return isGenericAssignableFrom(unwrapped) || isAssignableFrom(unwrapped);
     }
 

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/InstanceResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/InstanceResponseType.java
@@ -35,7 +35,8 @@ public class InstanceResponseType<R> extends AbstractResponseType<R> {
      */
     @Override
     public boolean matches(Type responseType) {
-        return isGenericAssignableFrom(responseType) || isAssignableFrom(responseType);
+        Type unwrapped = unwrapFuture(responseType);
+        return isGenericAssignableFrom(unwrapped) || isAssignableFrom(unwrapped);
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseType.java
@@ -56,10 +56,11 @@ public class MultipleInstancesResponseType<R> extends AbstractResponseType<List<
      */
     @Override
     public boolean matches(Type responseType) {
-        return isIterableOfExpectedType(responseType) ||
-                isStreamOfExpectedType(responseType) ||
-                isGenericArrayOfExpectedType(responseType) ||
-                isArrayOfExpectedType(responseType);
+        Type unwrapped = unwrapFuture(responseType);
+        return isIterableOfExpectedType(unwrapped) ||
+                isStreamOfExpectedType(unwrapped) ||
+                isGenericArrayOfExpectedType(unwrapped) ||
+                isArrayOfExpectedType(unwrapped);
     }
 
     /**

--- a/core/src/main/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseType.java
+++ b/core/src/main/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseType.java
@@ -56,7 +56,7 @@ public class MultipleInstancesResponseType<R> extends AbstractResponseType<List<
      */
     @Override
     public boolean matches(Type responseType) {
-        Type unwrapped = unwrapFuture(responseType);
+        Type unwrapped = unwrapIfTypeFuture(responseType);
         return isIterableOfExpectedType(unwrapped) ||
                 isStreamOfExpectedType(unwrapped) ||
                 isGenericArrayOfExpectedType(unwrapped) ||

--- a/core/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.common.Registration;
+import org.axonframework.messaging.Message;
+import org.axonframework.queryhandling.annotation.AnnotationQueryHandlerAdapter;
+import org.axonframework.queryhandling.responsetypes.ResponseTypes;
+import org.junit.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for different types of queries hitting query handlers with Future as a response type.
+ *
+ * @author Milan Savic
+ */
+public class FutureAsResponseTypeToQueryHandlersTest {
+
+    private final SimpleQueryBus queryBus = new SimpleQueryBus();
+    private final MyQueryHandler myQueryHandler = new MyQueryHandler();
+    private final AnnotationQueryHandlerAdapter<MyQueryHandler> annotationQueryHandlerAdapter = new AnnotationQueryHandlerAdapter<>(
+            myQueryHandler);
+
+    @Before
+    public void setUp() {
+        annotationQueryHandlerAdapter.subscribe(queryBus);
+    }
+
+    @Test
+    public void testQueryWithMultipleResponses() throws ExecutionException, InterruptedException {
+        QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
+                "criteria", "myQueryWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class));
+
+        List<String> response = queryBus.query(queryMessage).get().getPayload();
+
+        assertEquals(Arrays.asList("Response1", "Response2"), response);
+    }
+
+    @Test
+    public void testQueryWithSingleResponse() throws ExecutionException, InterruptedException {
+        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>(
+                "criteria", "myQueryWithSingleResponse", ResponseTypes.instanceOf(String.class));
+
+        String response = queryBus.query(queryMessage).get().getPayload();
+
+        assertEquals("Response", response);
+    }
+
+    @Test
+    public void testScatterGatherQueryWithMultipleResponses() {
+        QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
+                "criteria", "myQueryWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class));
+
+        List<String> response = queryBus
+                .scatterGather(queryMessage, 10, TimeUnit.MILLISECONDS)
+                .map(Message::getPayload)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertEquals(Arrays.asList("Response1", "Response2"), response);
+    }
+
+    @Test
+    public void testScatterGatherQueryWithSingleResponse() {
+        QueryMessage<String, String> queryMessage = new GenericQueryMessage<>(
+                "criteria", "myQueryWithSingleResponse", ResponseTypes.instanceOf(String.class));
+
+        String response = queryBus
+                .scatterGather(queryMessage, 10, TimeUnit.MILLISECONDS)
+                .map(Message::getPayload)
+                .findFirst()
+                .orElse(null);
+
+        assertEquals("Response", response);
+    }
+
+    @Test
+    public void testSubscriptionQueryWithMultipleResponses() {
+        SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
+                "criteria",
+                "myQueryWithMultipleResponses",
+                ResponseTypes.multipleInstancesOf(String.class),
+                ResponseTypes.instanceOf(String.class));
+        @SuppressWarnings("unchecked")
+        UpdateHandler<List<String>, String> updateHandler = mock(UpdateHandler.class);
+
+        Registration registration = queryBus.subscriptionQuery(queryMessage, updateHandler);
+
+        verify(updateHandler).onInitialResult(Arrays.asList("Response1", "Response2"));
+
+        registration.close();
+    }
+
+    @Test
+    public void testSubscriptionQueryWithSingleResponse() {
+        SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
+                "criteria",
+                "myQueryWithSingleResponse",
+                ResponseTypes.instanceOf(String.class),
+                ResponseTypes.instanceOf(String.class));
+        @SuppressWarnings("unchecked")
+        UpdateHandler<String, String> updateHandler = mock(UpdateHandler.class);
+
+        Registration registration = queryBus.subscriptionQuery(queryMessage, updateHandler);
+
+        verify(updateHandler).onInitialResult("Response");
+
+        registration.close();
+    }
+
+    @SuppressWarnings("unused")
+    private static class MyQueryHandler {
+
+        @QueryHandler(queryName = "myQueryWithMultipleResponses")
+        public CompletableFuture<List<String>> queryHandler1(String criteria) {
+            CompletableFuture<List<String>> completableFuture = new CompletableFuture<>();
+            completableFuture.complete(Arrays.asList("Response1", "Response2"));
+            return completableFuture;
+        }
+
+        @QueryHandler(queryName = "myQueryWithSingleResponse")
+        public CompletableFuture<String> queryHandler2(String criteria) {
+            CompletableFuture<String> completableFuture = new CompletableFuture<>();
+            completableFuture.complete("Response");
+            return completableFuture;
+        }
+    }
+}

--- a/core/src/test/java/org/axonframework/queryhandling/responsetypes/AbstractResponseTypeTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/responsetypes/AbstractResponseTypeTest.java
@@ -3,11 +3,14 @@ package org.axonframework.queryhandling.responsetypes;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import static org.axonframework.common.ReflectionUtils.methodOf;
@@ -224,6 +227,16 @@ public abstract class AbstractResponseTypeTest<R> {
     @SuppressWarnings("unused")
     public Map<QueryResponse, QueryResponse> someMapQuery() {
         return new HashMap<>();
+    }
+
+    @SuppressWarnings("unused")
+    public Future<QueryResponse> someFutureQuery() {
+        return CompletableFuture.completedFuture(new QueryResponse());
+    }
+
+    @SuppressWarnings("unused")
+    public Future<List<QueryResponse>> someFutureListQuery() {
+        return CompletableFuture.completedFuture(Collections.singletonList(new QueryResponse()));
     }
 
     static class QueryResponse {

--- a/core/src/test/java/org/axonframework/queryhandling/responsetypes/InstanceResponseTypeTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/responsetypes/InstanceResponseTypeTest.java
@@ -175,6 +175,11 @@ public class InstanceResponseTypeTest extends AbstractResponseTypeTest<AbstractR
     }
 
     @Test
+    public void testMatchesReturnsTrueIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
+        testMatches("someFutureQuery", MATCHES);
+    }
+
+    @Test
     public void testConvertReturnsSingleResponseAsIs() {
         QueryResponse testResponse = new QueryResponse();
 

--- a/core/src/test/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseTypeTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/responsetypes/MultipleInstancesResponseTypeTest.java
@@ -227,6 +227,11 @@ public class MultipleInstancesResponseTypeTest
         testMatches("someMapQuery", DOES_NOT_MATCHES);
     }
 
+    @Test
+    public void testMatchesReturnsTrueIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
+        testMatches("someFutureListQuery", MATCHES);
+    }
+
     @SuppressWarnings("unused")
     @Test(expected = Exception.class)
     public void testConvertThrowsExceptionForSingleInstanceResponse() {


### PR DESCRIPTION
Added support for future as response type for query handlers: If return type of query handler is of type future, query bus will block until computation is done and inform query side about result.

Resolves #554 