### PR TITLE
Add feature to ignore snapshot by applying some criteria on it. Reference issue #566

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -43,6 +43,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
     private final EventUpcaster upcasterChain;
     private final PersistenceExceptionResolver persistenceExceptionResolver;
     private final Serializer eventSerializer;
+    private final SnapshotJury snapshotJury;
 
     /**
      * Initializes an EventStorageEngine with given {@code serializer}, {@code upcasterChain} and {@code
@@ -60,7 +61,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
     @Deprecated
     protected AbstractEventStorageEngine(Serializer serializer, EventUpcaster upcasterChain,
                                          PersistenceExceptionResolver persistenceExceptionResolver) {
-        this(serializer, upcasterChain, persistenceExceptionResolver, serializer);
+        this(serializer, upcasterChain, persistenceExceptionResolver, serializer, null);
     }
 
     /**
@@ -75,15 +76,19 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
      *                                     persistence exceptions are not explicitly resolved.
      * @param eventSerializer              Used to serialize and deserialize event payload and metadata. If {@code null}
      *                                     a new {@link XStreamSerializer} is used.
+     * @param snapshotJury                 Decides whether to use a snapshot or not. If {@code null}
+     *                                     a new {@link NoOpSnapshotJury} is used.
      */
     protected AbstractEventStorageEngine(Serializer serializer,
                                          EventUpcaster upcasterChain,
                                          PersistenceExceptionResolver persistenceExceptionResolver,
-                                         Serializer eventSerializer) {
+                                         Serializer eventSerializer,
+                                         SnapshotJury snapshotJury) {
         this.serializer = getOrDefault(serializer, XStreamSerializer::new);
         this.upcasterChain = getOrDefault(upcasterChain, () -> NoOpEventUpcaster.INSTANCE);
         this.persistenceExceptionResolver = persistenceExceptionResolver;
         this.eventSerializer = getOrDefault(eventSerializer, XStreamSerializer::new);
+        this.snapshotJury = getOrDefault(snapshotJury, () -> NoOpSnapshotJury.INSTANCE);
     }
 
     @Override
@@ -100,7 +105,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
 
     @Override
     public Optional<DomainEventMessage<?>> readSnapshot(String aggregateIdentifier) {
-        return readSnapshotData(aggregateIdentifier).map(entry -> {
+        return readSnapshotData(aggregateIdentifier).filter(snapshotJury::decide).map(entry -> {
             DomainEventStream stream =
                     EventUtils.upcastAndDeserializeDomainEvents(Stream.of(entry), serializer, upcasterChain, false);
             return stream.hasNext() ? stream.next() : null;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -66,7 +66,37 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
     public BatchingEventStorageEngine(Serializer serializer, EventUpcaster upcasterChain,
                                       PersistenceExceptionResolver persistenceExceptionResolver,
                                       Serializer eventSerializer, Integer batchSize) {
-        super(serializer, upcasterChain, persistenceExceptionResolver, eventSerializer);
+        this(serializer, upcasterChain, persistenceExceptionResolver, eventSerializer, null, batchSize);
+    }
+
+    /**
+     * Initializes an EventStorageEngine with given {@code serializer}, {@code upcasterChain}, {@code
+     * persistenceExceptionResolver}, {@code eventSerializer} and {@code batchSize}.
+     *
+     * @param serializer                   Used to serialize and deserialize snapshots. If {@code null}
+     *                                     a {@link XStreamSerializer} is instantiated by the
+     *                                     {@link org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine}.
+     * @param upcasterChain                Allows older revisions of serialized objects to be deserialized. If {@code
+     *                                     null} a {@link NoOpEventUpcaster} is used.
+     * @param persistenceExceptionResolver Detects concurrency exceptions from the backing database. If {@code null}
+     *                                     persistence exceptions are not explicitly resolved.
+     * @param eventSerializer              Used to serialize and deserialize event payload and metadata.
+     *                                     If {@code null} a {@link XStreamSerializer} is instantiated by the
+     *                                     {@link org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine}.
+     * @param snapshotJury                 Decides whether to use a snapshot or not. If {@code null}
+     *                                     If {@code null} a {@link NoOpSnapshotJury} is instantiated by the
+     *                                     {@link org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine}.
+     * @param batchSize                    The number of events that should be read at each database access. When more
+     *                                     than this number of events must be read to rebuild an aggregate's state, the
+     *                                     events are read in batches of this size. If {@code null} a batch size of 100
+     *                                     is used. Tip: if you use a snapshotter, make sure to choose snapshot trigger
+     *                                     and batch size such that a single batch will generally retrieve all events
+     *                                     required to rebuild an aggregate's state.
+     */
+    public BatchingEventStorageEngine(Serializer serializer, EventUpcaster upcasterChain,
+                                      PersistenceExceptionResolver persistenceExceptionResolver,
+                                      Serializer eventSerializer, SnapshotJury snapshotJury, Integer batchSize) {
+        super(serializer, upcasterChain, persistenceExceptionResolver, eventSerializer, snapshotJury);
         this.batchSize = getOrDefault(batchSize, DEFAULT_BATCH_SIZE);
     }
 

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/NoOpSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/NoOpSnapshotJury.java
@@ -1,0 +1,22 @@
+package org.axonframework.eventsourcing.eventstore;
+
+/**
+ * NoOp Implementation of SnapshotJury. Always returns true, which means all snapshots are valid.
+ *
+ * @author Shyam Sankaran
+ */
+
+public enum NoOpSnapshotJury implements SnapshotJury {
+
+    INSTANCE;
+
+    public static NoOpSnapshotJury instance() {
+        return INSTANCE;
+    }
+
+
+    @Override
+    public boolean decide(DomainEventData<?> snapshot) {
+        return true;
+    }
+}

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/NoOpSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/NoOpSnapshotJury.java
@@ -4,8 +4,8 @@ package org.axonframework.eventsourcing.eventstore;
  * NoOp Implementation of SnapshotJury. Always returns true, which means all snapshots are valid.
  *
  * @author Shyam Sankaran
+ * @since 3.3
  */
-
 public enum NoOpSnapshotJury implements SnapshotJury {
 
     INSTANCE;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
@@ -3,6 +3,8 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.serialization.RevisionResolver;
 import org.axonframework.serialization.SerializedType;
 
+import java.util.Optional;
+
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
@@ -15,7 +17,6 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  */
 public class RevisionBasedSnapshotJury implements SnapshotJury {
 
-    private static final String NO_REVISION = "NO_REVISION";
     private final RevisionResolver resolver;
 
     /**
@@ -31,10 +32,10 @@ public class RevisionBasedSnapshotJury implements SnapshotJury {
     @Override
     public boolean decide(DomainEventData<?> snapshot) {
         final SerializedType payloadType = snapshot.getPayload().getType();
-        final String payloadRevision = getOrDefault(payloadType.getRevision(), NO_REVISION);
-        final String aggregateRevision;
+        final Optional<String> payloadRevision = Optional.ofNullable(payloadType.getRevision());
+        final Optional<String> aggregateRevision;
         try {
-            aggregateRevision = getOrDefault(resolver.revisionOf(Class.forName(payloadType.getName())), NO_REVISION);
+            aggregateRevision = Optional.ofNullable(resolver.revisionOf(Class.forName(payloadType.getName())));
         } catch (ClassNotFoundException e) {
             // Payload type is not found, just ignore the snapshot.
             return false;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
@@ -5,8 +5,6 @@ import org.axonframework.serialization.SerializedType;
 
 import java.util.Optional;
 
-import static org.axonframework.common.ObjectUtils.getOrDefault;
-
 /**
  * A simple {@link org.axonframework.serialization.RevisionResolver} based implementation of
  * SnapshotJury. Decides whether to use a snapshot based on the current aggregate revision and the current snapshot

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
@@ -3,40 +3,42 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.serialization.RevisionResolver;
 import org.axonframework.serialization.SerializedType;
 
+import static org.axonframework.common.ObjectUtils.getOrDefault;
+
 /**
- * A simple revision resolver based implementation of SnapshotJury. Decides whether to use a snapshot based on the current aggregate
- * revision and the current snapshot revision. It simply does an == match and does not consider the order of revisions.
+ * A simple {@link org.axonframework.serialization.RevisionResolver} based implementation of
+ * SnapshotJury. Decides whether to use a snapshot based on the current aggregate revision and the current snapshot
+ * revision. It simply does an 'equals' match and does not consider the order of revisions.
  *
  * @author Shyam Sankaran
+ * @since 3.3
  */
-
 public class RevisionBasedSnapshotJury implements SnapshotJury {
 
-    private static final String NO_REVSION = "NO_REVSION";
-    private RevisionResolver resolver;
+    private static final String NO_REVISION = "NO_REVISION";
+    private final RevisionResolver resolver;
 
+    /**
+     * Initializes a RevisionBasedSnapshotJury with given {@code resolver}.
+     *
+     * @param resolver Resolver of type {@link org.axonframework.serialization.RevisionResolver } to resolve the
+     *                 revision of aggregate corresponding to the snapshot
+     */
     public RevisionBasedSnapshotJury(RevisionResolver resolver) {
         this.resolver = resolver;
     }
 
-
     @Override
     public boolean decide(DomainEventData<?> snapshot) {
-
+        final SerializedType payloadType = snapshot.getPayload().getType();
+        final String payloadRevision = getOrDefault(payloadType.getRevision(), NO_REVISION);
+        final String aggregateRevision;
         try {
-            SerializedType payloadType = snapshot.getPayload().getType();
-
-            String payloadRevision = getOrDefault(payloadType.getRevision(), NO_REVSION);
-            String aggregateRevision = getOrDefault(resolver.revisionOf(Class.forName(payloadType.getName())), NO_REVSION);
-            return payloadRevision.equals(aggregateRevision);
+            aggregateRevision = getOrDefault(resolver.revisionOf(Class.forName(payloadType.getName())), NO_REVISION);
         } catch (ClassNotFoundException e) {
             // Payload type is not found, just ignore the snapshot.
             return false;
         }
-
-    }
-
-    private String getOrDefault(String revision, String defaultValue) {
-        return revision != null ? revision : defaultValue;
+        return payloadRevision.equals(aggregateRevision);
     }
 }

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJury.java
@@ -1,0 +1,42 @@
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.serialization.RevisionResolver;
+import org.axonframework.serialization.SerializedType;
+
+/**
+ * A simple revision resolver based implementation of SnapshotJury. Decides whether to use a snapshot based on the current aggregate
+ * revision and the current snapshot revision. It simply does an == match and does not consider the order of revisions.
+ *
+ * @author Shyam Sankaran
+ */
+
+public class RevisionBasedSnapshotJury implements SnapshotJury {
+
+    private static final String NO_REVSION = "NO_REVSION";
+    private RevisionResolver resolver;
+
+    public RevisionBasedSnapshotJury(RevisionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+
+    @Override
+    public boolean decide(DomainEventData<?> snapshot) {
+
+        try {
+            SerializedType payloadType = snapshot.getPayload().getType();
+
+            String payloadRevision = getOrDefault(payloadType.getRevision(), NO_REVSION);
+            String aggregateRevision = getOrDefault(resolver.revisionOf(Class.forName(payloadType.getName())), NO_REVSION);
+            return payloadRevision.equals(aggregateRevision);
+        } catch (ClassNotFoundException e) {
+            // Payload type is not found, just ignore the snapshot.
+            return false;
+        }
+
+    }
+
+    private String getOrDefault(String revision, String defaultValue) {
+        return revision != null ? revision : defaultValue;
+    }
+}

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotJury.java
@@ -1,0 +1,17 @@
+package org.axonframework.eventsourcing.eventstore;
+
+/**
+ * Interface for deciding if the given snapshot is valid for the current aggregate definition. This
+ * is useful when the aggregate definition is changed and the existing snapshot was created based on an
+ * older aggregate definition, resulting in an inconsistent aggregate state.
+ *
+ * @author Shyam Sankaran
+ */
+public interface SnapshotJury {
+
+    /**
+     * @param snapshot The snapshot that needs to be validated
+     * @return whether the snapshot is valid  {@code payloadType}
+     */
+    boolean decide(DomainEventData<?> snapshot);
+}

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotJury.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotJury.java
@@ -6,12 +6,17 @@ package org.axonframework.eventsourcing.eventstore;
  * older aggregate definition, resulting in an inconsistent aggregate state.
  *
  * @author Shyam Sankaran
+ * @since 3.3
  */
+@FunctionalInterface
 public interface SnapshotJury {
 
     /**
-     * @param snapshot The snapshot that needs to be validated
-     * @return whether the snapshot is valid  {@code payloadType}
+     * Decides whether the the given {@code snapshot} is valid so that it can be used to build the aggregate state.
+     *
+     * @param  snapshot The snapshot of type {@link org.axonframework.eventsourcing.eventstore.DomainEventData} that
+     *                 needs to be validated
+     * @return whether the snapshot is valid
      */
     boolean decide(DomainEventData<?> snapshot);
 }

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -182,7 +182,9 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      * @param upcasterChain                Allows older revisions of serialized objects to be deserialized.
      * @param persistenceExceptionResolver Detects concurrency exceptions from the backing database.
      * @param eventSerializer              Used to serialize and deserialize event payload and metadata.
-     * @param snapshotJury                 Used to decide whether to use a snapshot or not.
+     * @param snapshotJury                 Used to decide whether to use a snapshot or not.If {@code null} a
+     *                                     {@link NoOpSnapshotJury} is instantiated by the
+     *                                     {@link org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine}.
      * @param batchSize                    The number of events that should be read at each database access. When more
      *                                     than this number of events must be read to rebuild an aggregate's state, the
      *                                     events are read in batches of this size. Tip: if you use a snapshotter, make

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -171,8 +171,44 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
                                   Serializer eventSerializer, Integer batchSize, ConnectionProvider connectionProvider,
                                   TransactionManager transactionManager, Class<?> dataType, EventSchema schema,
                                   Integer maxGapOffset, Long lowestGlobalSequence) {
+        this(serializer, upcasterChain, persistenceExceptionResolver,eventSerializer, null, batchSize, connectionProvider,
+                transactionManager, dataType, schema, maxGapOffset, lowestGlobalSequence );
+    }
+
+    /**
+     * Initializes an EventStorageEngine that uses JDBC to store and load events.
+     *
+     * @param serializer                   Used to serialize and deserialize snapshots.
+     * @param upcasterChain                Allows older revisions of serialized objects to be deserialized.
+     * @param persistenceExceptionResolver Detects concurrency exceptions from the backing database.
+     * @param eventSerializer              Used to serialize and deserialize event payload and metadata.
+     * @param snapshotJury                 Used to decide whether to use a snapshot or not.
+     * @param batchSize                    The number of events that should be read at each database access. When more
+     *                                     than this number of events must be read to rebuild an aggregate's state, the
+     *                                     events are read in batches of this size. Tip: if you use a snapshotter, make
+     *                                     sure to choose snapshot trigger and batch size such that a single batch will
+     *                                     generally retrieve all events required to rebuild an aggregate's state.
+     * @param connectionProvider           The provider of connections to the underlying database.
+     * @param transactionManager           The instance managing transactions around fetching event data. Required by
+     *                                     certain databases for reading blob data.
+     * @param dataType                     The data type for serialized event payload and metadata.
+     * @param schema                       Object that describes the database schema of event entries.
+     * @param maxGapOffset                 The maximum distance in sequence numbers between a missing event and the
+     *                                     event with the highest known index. If the gap is bigger it is assumed that
+     *                                     the missing event will not be committed to the store anymore. This event
+     *                                     storage engine will no longer look for those events the next time a batch is
+     *                                     fetched.
+     * @param lowestGlobalSequence         The first expected auto generated sequence number. For most data stores this
+     *                                     is 1 unless the table has contained entries before.
+     */
+    public JdbcEventStorageEngine(Serializer serializer, EventUpcaster upcasterChain,
+                                  PersistenceExceptionResolver persistenceExceptionResolver,
+                                  Serializer eventSerializer, SnapshotJury snapshotJury, Integer batchSize,
+                                  ConnectionProvider connectionProvider,
+                                  TransactionManager transactionManager, Class<?> dataType, EventSchema schema,
+                                  Integer maxGapOffset, Long lowestGlobalSequence) {
         super(serializer, upcasterChain, getOrDefault(persistenceExceptionResolver, new JdbcSQLErrorCodesResolver()),
-              eventSerializer, batchSize);
+              eventSerializer, snapshotJury, batchSize);
         this.connectionProvider = connectionProvider;
         this.transactionManager = transactionManager;
         this.dataType = dataType;

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJuryTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJuryTest.java
@@ -13,8 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 public class RevisionBasedSnapshotJuryTest {
 
-
-    public static final String PAYLOAD = "payload", AGGREGATE = "aggregate", TYPE = "type", METADATA = "metadata";
+    private static final String PAYLOAD = "payload", AGGREGATE = "aggregate", TYPE = "type", METADATA = "metadata";
     private RevisionBasedSnapshotJury testSubject;
 
     @Before
@@ -24,30 +23,28 @@ public class RevisionBasedSnapshotJuryTest {
 
     @Test
     public void testSameRevisionForAggregateAndPayload() {
-        assertTrue(testSubject.decide(createEntry(WithAnnotation.class.getName(),
-                "2.3-TEST")));
+        assertTrue(testSubject.decide(createEntry(WithAnnotationAggregate.class.getName(), "2.3-TEST")));
     }
 
     @Test
     public void testDifferentRevisionsForAggregateAndPayload() {
-        assertFalse(testSubject.decide(createEntry(WithAnnotation.class.getName(), "2.3-TEST-DIFFERENT")));
+        assertFalse(testSubject.decide(createEntry(WithAnnotationAggregate.class.getName(), "2.3-TEST-DIFFERENT")));
     }
 
     @Test
     public void testNoRevisionForAggregateAndPayload() {
-        assertTrue(testSubject.decide(createEntry(WithoutAnnotation.class.getName())));
+        assertTrue(testSubject.decide(createEntry(WithoutAnnotationAggregate.class.getName())));
     }
 
     @Test
     public void testNoRevisionForPayload() {
-        assertFalse(testSubject.decide(createEntry(WithAnnotation.class.getName())));
+        assertFalse(testSubject.decide(createEntry(WithAnnotationAggregate.class.getName())));
     }
 
     @Test
     public void testNoRevisionForAggregate() {
-        assertFalse(testSubject.decide(createEntry(WithoutAnnotation.class.getName(), "2.3-TEST")));
+        assertFalse(testSubject.decide(createEntry(WithoutAnnotationAggregate.class.getName(), "2.3-TEST")));
     }
-
 
     private static DomainEventData<?> createEntry(String payloadType) {
         return createEntry(payloadType, null);
@@ -60,11 +57,11 @@ public class RevisionBasedSnapshotJuryTest {
     }
 
     @Revision("2.3-TEST")
-    private class WithAnnotation {
+    private class WithAnnotationAggregate {
 
     }
 
-    private class WithoutAnnotation {
+    private class WithoutAnnotationAggregate {
 
     }
 }

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJuryTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/RevisionBasedSnapshotJuryTest.java
@@ -1,0 +1,70 @@
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.common.IdentifierFactory;
+import org.axonframework.serialization.AnnotationRevisionResolver;
+import org.axonframework.serialization.Revision;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RevisionBasedSnapshotJuryTest {
+
+
+    public static final String PAYLOAD = "payload", AGGREGATE = "aggregate", TYPE = "type", METADATA = "metadata";
+    private RevisionBasedSnapshotJury testSubject;
+
+    @Before
+    public void setUp() throws Exception {
+        testSubject = new RevisionBasedSnapshotJury(new AnnotationRevisionResolver());
+    }
+
+    @Test
+    public void testSameRevisionForAggregateAndPayload() {
+        assertTrue(testSubject.decide(createEntry(WithAnnotation.class.getName(),
+                "2.3-TEST")));
+    }
+
+    @Test
+    public void testDifferentRevisionsForAggregateAndPayload() {
+        assertFalse(testSubject.decide(createEntry(WithAnnotation.class.getName(), "2.3-TEST-DIFFERENT")));
+    }
+
+    @Test
+    public void testNoRevisionForAggregateAndPayload() {
+        assertTrue(testSubject.decide(createEntry(WithoutAnnotation.class.getName())));
+    }
+
+    @Test
+    public void testNoRevisionForPayload() {
+        assertFalse(testSubject.decide(createEntry(WithAnnotation.class.getName())));
+    }
+
+    @Test
+    public void testNoRevisionForAggregate() {
+        assertFalse(testSubject.decide(createEntry(WithoutAnnotation.class.getName(), "2.3-TEST")));
+    }
+
+
+    private static DomainEventData<?> createEntry(String payloadType) {
+        return createEntry(payloadType, null);
+    }
+
+    private static DomainEventData<?> createEntry(String payloadType, String payloadRevision) {
+        return new GenericDomainEventEntry<>(TYPE, AGGREGATE, 0,
+                IdentifierFactory.getInstance().generateIdentifier(), Instant.now(),
+                payloadType, payloadRevision, PAYLOAD, METADATA);
+    }
+
+    @Revision("2.3-TEST")
+    private class WithAnnotation {
+
+    }
+
+    private class WithoutAnnotation {
+
+    }
+}


### PR DESCRIPTION
This is a fix related to issue #566 

Added a hook in AbstractEventStorageEngine to filter snapshot based on a criteria which can be customized by implementing SnapshotJury.

Provided a reference implementation which ignores snapshots by comparing the snapshot payload version with the aggregate revision using RevisionResolver (suggested by @abuijze ). Clients can have their own implementations, if they want.

Defaults to Noop filtering which behaves as per the existing code, by always loading snapshot, if present.

** Only implemented for JDBCEventStorageEngine. Its a similar procedure for other storage engines. If you are okay with this implementation, I can do it for the rest **
  
 