### PR TITLE
Fixed IllegalArgumentException in AbstractAnnotationHandlerBeanPostProcessor when beanName is null

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -63,7 +63,7 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
      */
     @Override
     public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
-        if (beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName)) {
+        if (beanName != null && beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName)) {
             return bean;
         }
 


### PR DESCRIPTION
Fixed IllegalArgumentException in AbstractAnnotationHandlerBeanPostProcessor when beanName parameter is null.

postProcessAfterInitialization was calling beanFactory.containsBean() and beanFactory.isSingleton() without checking beanName for null.

Closes #585