### PR TITLE
Auto registration of event upcasters

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -40,6 +40,7 @@ import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.spring.config.annotation.SpringContextParameterResolverFactoryBuilder;
 import org.axonframework.spring.eventsourcing.SpringPrototypeAggregateFactory;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
@@ -171,6 +172,7 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
         configurer.configureResourceInjector(c -> getBean(resourceInjector, c));
 
         registerCorrelationDataProviders(configurer);
+        registerEventUpcasters(configurer);
         registerAggregateBeanDefinitions(configurer, registry);
         registerSagaBeanDefinitions(configurer);
         registerModules(configurer);
@@ -197,6 +199,11 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                                  .map(n -> (CorrelationDataProvider) getBean(n, c))
                                  .collect(Collectors.toList());
                 });
+    }
+
+    private void registerEventUpcasters(Configurer configurer) {
+        Arrays.stream(beanFactory.getBeanNamesForType(EventUpcaster.class))
+              .forEach(name -> configurer.registerEventUpcaster(c -> getBean(name, c)));
     }
 
     @SuppressWarnings("unchecked")

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -61,7 +61,6 @@ import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -32,6 +32,8 @@ import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
 import org.junit.Test;
@@ -52,11 +54,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
 import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -96,6 +102,9 @@ public class SpringAxonAutoConfigurerTest {
 
     @Autowired
     private SagaConfiguration<Context.MySaga> mySagaConfiguration;
+
+    @Autowired
+    private EventUpcaster eventUpcaster;
 
     @Test
     public void contextWiresMainComponents() {
@@ -169,6 +178,14 @@ public class SpringAxonAutoConfigurerTest {
         assertEquals("Ooops! I failed.", myListenerInvocationErrorHandler.received.get(0).getMessage());
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEventUpcasterBeanPickedUp() {
+        Stream<IntermediateEventRepresentation> representationStream = mock(Stream.class);
+        axonConfig.upcasterChain().upcast(representationStream);
+        verify(eventUpcaster).upcast(representationStream);
+    }
+
     @EnableAxon
     @Scope
     @Configuration
@@ -198,6 +215,11 @@ public class SpringAxonAutoConfigurerTest {
         @Bean
         public SagaStore customSagaStore() {
             return new InMemorySagaStore();
+        }
+
+        @Bean
+        public EventUpcaster eventUpcaster() {
+            return mock(EventUpcaster.class);
         }
 
         @Aggregate


### PR DESCRIPTION
If event upcasters are declared as beans, they are now picked up and registered within configuration.

Resolves #560. 