### PR TITLE
Fixed HHH000207 in Hibernate when overriding JPA mapping for domain event global index

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractSequencedDomainEventEntry.java
@@ -13,6 +13,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.axonframework.eventsourcing.DomainEventMessage;
 import org.axonframework.serialization.Serializer;
 
@@ -31,8 +32,7 @@ public abstract class AbstractSequencedDomainEventEntry<T> extends AbstractDomai
 
     @Id
     @GeneratedValue
-    @SuppressWarnings("unused")
-    private long globalIndex;
+    private Long globalIndex;
 
     /**
      * Construct a new default domain event entry from a published domain event message to enable storing the event or
@@ -54,5 +54,12 @@ public abstract class AbstractSequencedDomainEventEntry<T> extends AbstractDomai
      * Default constructor required by JPA
      */
     protected AbstractSequencedDomainEventEntry() {
+    }
+
+
+    @JsonIgnore
+    @SuppressWarnings("unused")
+    public Long getGlobalIndex() {
+        return globalIndex;
     }
 }


### PR DESCRIPTION
Overriding identifier using orm.xml (as described in axon-schema-generator) results in:
```
HHH000207: Property org.axonframework.eventsourcing.eventstore.AbstractSequencedDomainEventEntry.globalIndex not found in class but described in <mapping-file/> (possible typo error)
```
The solution is simply to add a getter on globalIndex field to AbstractSequencedDomainEventEntry.