### PR TITLE
[ #589]  SerializationException when storing ScheduleToken in a Saga using JacksonSerializer

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/ScheduleToken.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/ScheduleToken.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling.scheduling;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,7 @@ import java.io.Serializable;
  * @author Allard Buijze
  * @since 0.7
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface ScheduleToken extends Serializable {
 
 }

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleScheduleToken.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleScheduleToken.java
@@ -16,7 +16,11 @@
 
 package org.axonframework.eventhandling.scheduling.java;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
+
+import java.util.Objects;
 
 /**
  * ScheduleToken for tasks event scheduled using the SimpleEventScheduler.
@@ -34,7 +38,8 @@ public class SimpleScheduleToken implements ScheduleToken {
      *
      * @param tokenId The identifier referencing the scheduled task.
      */
-    public SimpleScheduleToken(String tokenId) {
+    @JsonCreator
+    public SimpleScheduleToken(@JsonProperty("tokenId") String tokenId) {
         this.tokenId = tokenId;
     }
 
@@ -45,5 +50,29 @@ public class SimpleScheduleToken implements ScheduleToken {
      */
     public String getTokenId() {
         return tokenId;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleScheduleToken{" +
+                "tokenId='" + tokenId + '\'' +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tokenId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SimpleScheduleToken other = (SimpleScheduleToken) obj;
+        return Objects.equals(this.tokenId, other.tokenId);
     }
 }

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzScheduleToken.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzScheduleToken.java
@@ -16,7 +16,11 @@
 
 package org.axonframework.eventhandling.scheduling.quartz;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
+
+import java.util.Objects;
 
 import static java.lang.String.format;
 
@@ -39,7 +43,9 @@ public class QuartzScheduleToken implements ScheduleToken {
      * @param jobIdentifier   The identifier used when registering the job with quartz.
      * @param groupIdentifier The identifier of the group the job is part of.
      */
-    public QuartzScheduleToken(String jobIdentifier, String groupIdentifier) {
+    @JsonCreator
+    public QuartzScheduleToken(@JsonProperty("jobIdentifier") String jobIdentifier,
+                               @JsonProperty("groupIdentifier") String groupIdentifier) {
         this.jobIdentifier = jobIdentifier;
         this.groupIdentifier = groupIdentifier;
     }
@@ -65,5 +71,23 @@ public class QuartzScheduleToken implements ScheduleToken {
     @Override
     public String toString() {
         return format("Quartz Schedule token for job [%s] in group [%s]", jobIdentifier, groupIdentifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobIdentifier, groupIdentifier);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final QuartzScheduleToken other = (QuartzScheduleToken) obj;
+        return Objects.equals(this.jobIdentifier, other.jobIdentifier)
+                && Objects.equals(this.groupIdentifier, other.groupIdentifier);
     }
 }

--- a/core/src/test/java/org/axonframework/eventhandling/scheduling/ScheduleTokenJacksonSerializationTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/scheduling/ScheduleTokenJacksonSerializationTest.java
@@ -1,0 +1,37 @@
+package org.axonframework.eventhandling.scheduling;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.axonframework.eventhandling.scheduling.java.SimpleScheduleToken;
+import org.axonframework.eventhandling.scheduling.quartz.QuartzScheduleToken;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScheduleTokenJacksonSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testSerializationAndDeserializationOfSimpleScheduleToken() throws IOException {
+        ScheduleToken scheduleToken = new SimpleScheduleToken("tokenId");
+
+        String serializationResult = objectMapper.writeValueAsString(scheduleToken);
+        SimpleScheduleToken deserializationResult = objectMapper.readerFor(SimpleScheduleToken.class)
+                                                                .readValue(serializationResult);
+
+        assertEquals(scheduleToken, deserializationResult);
+    }
+
+    @Test
+    public void testSerializationAndDeserializationOfQuartzScheduleToken() throws IOException {
+        ScheduleToken scheduleToken = new QuartzScheduleToken("jobIdentifier", "groupIdentifier");
+
+        String serializationResult = objectMapper.writeValueAsString(scheduleToken);
+        QuartzScheduleToken deserializationResult = objectMapper.readerFor(QuartzScheduleToken.class)
+                                                                .readValue(serializationResult);
+
+        assertEquals(scheduleToken, deserializationResult);
+    }
+}


### PR DESCRIPTION
This PR adds `JsonTypeInfo` to the `ScheduleToken` interface to be able to let a `ScheduleToken` be de-/serialized by Jackson correctly.

This PR resolves #589 