### PR TITLE
[#600] Inconsistent routing to local instance in SpringCloudCommandRouter

### DIFF
--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
 import java.net.URI;
@@ -60,6 +61,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
     private final ConsistentHashChangeListener consistentHashChangeListener;
     private final AtomicReference<ConsistentHash> atomicConsistentHash = new AtomicReference<>(new ConsistentHash());
     private final Set<ServiceInstance> blackListedServiceInstances = new HashSet<>();
+    private boolean afterStartUp = false;
 
     /**
      * Initialize a {@link org.axonframework.commandhandling.distributed.CommandRouter} with the given {@link
@@ -185,9 +187,50 @@ public class SpringCloudCommandRouter implements CommandRouter {
                 .ifPresent(consistentHashChangeListener::onConsistentHashChanged);
     }
 
+    /**
+     * Update the local member and all the other remote members known by the
+     * {@link org.springframework.cloud.client.discovery.DiscoveryClient} to be able to have an as up-to-date awareness
+     * of which actions which members can handle. This function is automatically triggered by an (unused)
+     * {@link org.springframework.context.event.ContextRefreshedEvent}. Upon this event we may assume that the
+     * application has fully start up. Because of this we can update the local member with the correct name and
+     * {@link java.net.URI}, as initially these were not provided by the
+     * {@link org.springframework.cloud.client.serviceregistry.Registration} yet.
+     *
+     * @param event an unused {@link org.springframework.context.event.ContextRefreshedEvent}, serves as a trigger for
+     *              this function
+     * @see SpringCloudCommandRouter#buildMember(ServiceInstance)
+     */
+    @EventListener
+    @SuppressWarnings("UnusedParameters")
+    public void resetLocalMembership(ContextRefreshedEvent event) {
+        afterStartUp = true;
+        Member startUpPhaseLocalMember =
+                atomicConsistentHash.get().getMembers().stream()
+                                    .filter(Member::local)
+                                    .findFirst()
+                                    .orElseThrow(() -> new IllegalStateException(
+                                            "There should be no scenario were the local member does not exist."
+                                    ));
+        updateMemberships();
+        atomicConsistentHash.updateAndGet(consistentHash -> consistentHash.without(startUpPhaseLocalMember));
+    }
+
+    /**
+     * Update the memberships of all nodes known by the
+     * {@link org.springframework.cloud.client.discovery.DiscoveryClient} to be able to have an as up-to-date awareness
+     * of which actions which members can handle. This function is automatically triggered by
+     * an (unused) {@link org.springframework.cloud.client.discovery.event.HeartbeatEvent}.
+     *
+     * @param event an unused {@link org.springframework.cloud.client.discovery.event.HeartbeatEvent}, serves as a
+     *              trigger for this function
+     */
     @EventListener
     @SuppressWarnings("UnusedParameters")
     public void updateMemberships(HeartbeatEvent event) {
+        updateMemberships();
+    }
+
+    private void updateMemberships() {
         AtomicReference<ConsistentHash> updatedConsistentHash = new AtomicReference<>(new ConsistentHash());
 
         discoveryClient.getServices().stream()
@@ -275,10 +318,9 @@ public class SpringCloudCommandRouter implements CommandRouter {
      * @return A {@link Member} based on the contents of the provided {@code serviceInstance}
      */
     protected Member buildMember(ServiceInstance serviceInstance) {
-        String serviceId = serviceInstance.getServiceId();
         return isLocalServiceInstance(serviceInstance)
-                ? buildLocalMember(serviceId)
-                : buildRemoteMember(serviceId, serviceInstance.getUri());
+                ? buildLocalMember(serviceInstance)
+                : buildRemoteMember(serviceInstance);
     }
 
     private boolean isLocalServiceInstance(ServiceInstance serviceInstance) {
@@ -286,20 +328,31 @@ public class SpringCloudCommandRouter implements CommandRouter {
                 || Objects.equals(serviceInstance.getUri(), localServiceInstance.getUri());
     }
 
-    private Member buildLocalMember(String serviceId) {
+    private Member buildLocalMember(ServiceInstance localServiceInstance) {
+        String localServiceId = localServiceInstance.getServiceId();
         URI emptyEndpoint = null;
         //noinspection ConstantConditions | added null variable for clarity
-        return new SimpleMember<>(serviceId.toUpperCase() + "[LOCAL]",
-                                  emptyEndpoint,
-                                  SimpleMember.LOCAL_MEMBER,
+        return afterStartUp
+                ? new SimpleMember<>(buildSimpleMemberName(localServiceId, localServiceInstance.getUri()),
+                                     localServiceInstance.getUri(),
+                                     SimpleMember.LOCAL_MEMBER,
+                                     this::suspect)
+                : new SimpleMember<>(localServiceId.toUpperCase() + "[LOCAL]",
+                                     emptyEndpoint,
+                                     SimpleMember.LOCAL_MEMBER,
+                                     this::suspect);
+    }
+
+    private Member buildRemoteMember(ServiceInstance remoteServiceInstance) {
+        URI remoteServiceUri = remoteServiceInstance.getUri();
+        return new SimpleMember<>(buildSimpleMemberName(remoteServiceInstance.getServiceId(), remoteServiceUri),
+                                  remoteServiceUri,
+                                  SimpleMember.REMOTE_MEMBER,
                                   this::suspect);
     }
 
-    private Member buildRemoteMember(String serviceId, URI serviceUri) {
-        return new SimpleMember<>(serviceId.toUpperCase() + "[" + serviceUri + "]",
-                                  serviceUri,
-                                  SimpleMember.REMOTE_MEMBER,
-                                  this::suspect);
+    private String buildSimpleMemberName(String serviceId, URI serviceUri) {
+        return serviceId.toUpperCase() + "[" + serviceUri + "]";
     }
 
     private ConsistentHash suspect(Member member) {

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -61,7 +61,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
     private final ConsistentHashChangeListener consistentHashChangeListener;
     private final AtomicReference<ConsistentHash> atomicConsistentHash = new AtomicReference<>(new ConsistentHash());
     private final Set<ServiceInstance> blackListedServiceInstances = new HashSet<>();
-    private boolean afterStartUp = false;
+    private volatile boolean afterStartUp = false;
 
     /**
      * Initialize a {@link org.axonframework.commandhandling.distributed.CommandRouter} with the given {@link
@@ -209,7 +209,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
                                     .filter(Member::local)
                                     .findFirst()
                                     .orElseThrow(() -> new IllegalStateException(
-                                            "There should be no scenario were the local member does not exist."
+                                            "There should be no scenario where the local member does not exist."
                                     ));
         updateMemberships();
         atomicConsistentHash.updateAndGet(consistentHash -> consistentHash.without(startUpPhaseLocalMember));

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -61,7 +61,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
     private final ConsistentHashChangeListener consistentHashChangeListener;
     private final AtomicReference<ConsistentHash> atomicConsistentHash = new AtomicReference<>(new ConsistentHash());
     private final Set<ServiceInstance> blackListedServiceInstances = new HashSet<>();
-    private volatile boolean afterStartUp = false;
+    private volatile boolean registered = false;
 
     /**
      * Initialize a {@link org.axonframework.commandhandling.distributed.CommandRouter} with the given {@link
@@ -203,7 +203,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
     @EventListener
     @SuppressWarnings("UnusedParameters")
     public void resetLocalMembership(InstanceRegisteredEvent event) {
-        afterStartUp = true;
+        registered = true;
         Member startUpPhaseLocalMember =
                 atomicConsistentHash.get().getMembers().stream()
                                     .filter(Member::local)
@@ -332,7 +332,7 @@ public class SpringCloudCommandRouter implements CommandRouter {
         String localServiceId = localServiceInstance.getServiceId();
         URI emptyEndpoint = null;
         //noinspection ConstantConditions | added null variable for clarity
-        return afterStartUp
+        return registered
                 ? new SimpleMember<>(buildSimpleMemberName(localServiceId, localServiceInstance.getUri()),
                                      localServiceInstance.getUri(),
                                      SimpleMember.LOCAL_MEMBER,

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouter.java
@@ -25,8 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.serviceregistry.Registration;
-import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
 import java.net.URI;
@@ -191,18 +191,18 @@ public class SpringCloudCommandRouter implements CommandRouter {
      * Update the local member and all the other remote members known by the
      * {@link org.springframework.cloud.client.discovery.DiscoveryClient} to be able to have an as up-to-date awareness
      * of which actions which members can handle. This function is automatically triggered by an (unused)
-     * {@link org.springframework.context.event.ContextRefreshedEvent}. Upon this event we may assume that the
-     * application has fully start up. Because of this we can update the local member with the correct name and
+     * {@link org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent}. Upon this event we may assume
+     * that the application has fully start up. Because of this we can update the local member with the correct name and
      * {@link java.net.URI}, as initially these were not provided by the
      * {@link org.springframework.cloud.client.serviceregistry.Registration} yet.
      *
-     * @param event an unused {@link org.springframework.context.event.ContextRefreshedEvent}, serves as a trigger for
-     *              this function
+     * @param event an unused {@link org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent}, serves
+     *              as a trigger for this function
      * @see SpringCloudCommandRouter#buildMember(ServiceInstance)
      */
     @EventListener
     @SuppressWarnings("UnusedParameters")
-    public void resetLocalMembership(ContextRefreshedEvent event) {
+    public void resetLocalMembership(InstanceRegisteredEvent event) {
         afterStartUp = true;
         Member startUpPhaseLocalMember =
                 atomicConsistentHash.get().getMembers().stream()

--- a/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -31,8 +31,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.serviceregistry.Registration;
-import org.springframework.context.event.ContextRefreshedEvent;
 
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -198,7 +198,7 @@ public class SpringCloudCommandRouterTest {
                      resultMemberSet.iterator().next(),
                      DURING_START_UP);
 
-        testSubject.resetLocalMembership(mock(ContextRefreshedEvent.class));
+        testSubject.resetLocalMembership(mock(InstanceRegisteredEvent.class));
 
         resultAtomicConsistentHash = getFieldValue(atomicConsistentHashField, testSubject);
         resultMemberSet = resultAtomicConsistentHash.get().getMembers();
@@ -214,13 +214,12 @@ public class SpringCloudCommandRouterTest {
         verify(discoveryClient).getInstances(SERVICE_INSTANCE_ID);
     }
 
-
     @Test
     public void testUpdateMembershipsOnHeartbeatEventUpdatesConsistentHash() {
         // Start up command router
         testSubject.updateMembership(LOAD_FACTOR, COMMAND_NAME_FILTER);
         // Set command router has passed the start up phase
-        testSubject.resetLocalMembership(mock(ContextRefreshedEvent.class));
+        testSubject.resetLocalMembership(mock(InstanceRegisteredEvent.class));
         serviceInstanceMetadata.put(LOAD_FACTOR_KEY, Integer.toString(LOAD_FACTOR));
         serviceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER_KEY, serializedCommandFilterData);
         serviceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER_CLASS_NAME_KEY, serializedCommandFilterClassName);
@@ -278,7 +277,7 @@ public class SpringCloudCommandRouterTest {
         // Start up command router
         testSubject.updateMembership(LOAD_FACTOR, COMMAND_NAME_FILTER);
         // Set router has passed the start up phase
-        testSubject.resetLocalMembership(mock(ContextRefreshedEvent.class));
+        testSubject.resetLocalMembership(mock(InstanceRegisteredEvent.class));
         // Update router memberships with local and remote service instance
         serviceInstanceMetadata.put(LOAD_FACTOR_KEY, Integer.toString(LOAD_FACTOR));
         serviceInstanceMetadata.put(SERIALIZED_COMMAND_FILTER_KEY, serializedCommandFilterData);

--- a/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -130,7 +130,7 @@ public class SpringCloudCommandRouterTest {
         assertTrue(resultOptional.isPresent());
         Member resultMember = resultOptional.orElseThrow(IllegalStateException::new);
 
-        assertMember(SERVICE_INSTANCE_ID, SERVICE_INSTANCE_URI, REMOTE_MEMBER, resultMember, DURING_START_UP);
+        assertMember(REMOTE_MEMBER, resultMember, DURING_START_UP);
 
         verify(routingStrategy).getRoutingKey(TEST_COMMAND);
     }
@@ -172,11 +172,10 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
         assertFalse(resultMemberSet.isEmpty());
 
-        assertMember(SERVICE_INSTANCE_ID,
-                     SERVICE_INSTANCE_URI,
-                     LOCAL_MEMBER,
-                     resultMemberSet.iterator().next(),
-                     DURING_START_UP);
+        assertMember(
+                LOCAL_MEMBER,
+                resultMemberSet.iterator().next(),
+                DURING_START_UP);
     }
 
     @Test
@@ -192,11 +191,10 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
 
         assertFalse(resultMemberSet.isEmpty());
-        assertMember(SERVICE_INSTANCE_ID,
-                     SERVICE_INSTANCE_URI,
-                     LOCAL_MEMBER,
-                     resultMemberSet.iterator().next(),
-                     DURING_START_UP);
+        assertMember(
+                LOCAL_MEMBER,
+                resultMemberSet.iterator().next(),
+                DURING_START_UP);
 
         testSubject.resetLocalMembership(mock(InstanceRegisteredEvent.class));
 
@@ -204,11 +202,10 @@ public class SpringCloudCommandRouterTest {
         resultMemberSet = resultAtomicConsistentHash.get().getMembers();
 
         assertFalse(resultMemberSet.isEmpty());
-        assertMember(SERVICE_INSTANCE_ID,
-                     SERVICE_INSTANCE_URI,
-                     LOCAL_MEMBER,
-                     resultMemberSet.iterator().next(),
-                     AFTER_START_UP);
+        assertMember(
+                LOCAL_MEMBER,
+                resultMemberSet.iterator().next(),
+                AFTER_START_UP);
 
         verify(discoveryClient).getServices();
         verify(discoveryClient).getInstances(SERVICE_INSTANCE_ID);
@@ -232,11 +229,10 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
         assertFalse(resultMemberSet.isEmpty());
 
-        assertMember(SERVICE_INSTANCE_ID,
-                     SERVICE_INSTANCE_URI,
-                     LOCAL_MEMBER,
-                     resultMemberSet.iterator().next(),
-                     AFTER_START_UP);
+        assertMember(
+                LOCAL_MEMBER,
+                resultMemberSet.iterator().next(),
+                AFTER_START_UP);
 
         verify(discoveryClient, times(2)).getServices();
         verify(discoveryClient, times(2)).getInstances(SERVICE_INSTANCE_ID);
@@ -309,11 +305,10 @@ public class SpringCloudCommandRouterTest {
 
         Set<Member> resultMemberSetAfterVanish = resultAtomicConsistentHashAfterVanish.get().getMembers();
         assertEquals(1, resultMemberSetAfterVanish.size());
-        assertMember(SERVICE_INSTANCE_ID,
-                     SERVICE_INSTANCE_URI,
-                     LOCAL_MEMBER,
-                     resultMemberSetAfterVanish.iterator().next(),
-                     AFTER_START_UP);
+        assertMember(
+                LOCAL_MEMBER,
+                resultMemberSetAfterVanish.iterator().next(),
+                AFTER_START_UP);
     }
 
     @Test
@@ -440,8 +435,10 @@ public class SpringCloudCommandRouterTest {
         assertEquals(expectedMemberSetSize, resultMemberSet.size());
     }
 
-    private void assertMember(String expectedMemberName, URI expectedEndpoint, boolean localMember,
-                              Member resultMember, Boolean afterStartUp) {
+    private void assertMember(boolean localMember, Member resultMember, Boolean afterStartUp) {
+        String expectedMemberName = SpringCloudCommandRouterTest.SERVICE_INSTANCE_ID;
+        URI expectedEndpoint = SpringCloudCommandRouterTest.SERVICE_INSTANCE_URI;
+
         assertEquals(resultMember.getClass(), ConsistentHash.ConsistentHashMember.class);
         ConsistentHash.ConsistentHashMember result = (ConsistentHash.ConsistentHashMember) resultMember;
         if (!afterStartUp && localMember) {

--- a/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
+++ b/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringCloudCommandRouterTest.java
@@ -172,10 +172,7 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
         assertFalse(resultMemberSet.isEmpty());
 
-        assertMember(
-                LOCAL_MEMBER,
-                resultMemberSet.iterator().next(),
-                DURING_START_UP);
+        assertMember(LOCAL_MEMBER, resultMemberSet.iterator().next(), DURING_START_UP);
     }
 
     @Test
@@ -191,10 +188,7 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
 
         assertFalse(resultMemberSet.isEmpty());
-        assertMember(
-                LOCAL_MEMBER,
-                resultMemberSet.iterator().next(),
-                DURING_START_UP);
+        assertMember(LOCAL_MEMBER, resultMemberSet.iterator().next(), DURING_START_UP);
 
         testSubject.resetLocalMembership(mock(InstanceRegisteredEvent.class));
 
@@ -202,10 +196,7 @@ public class SpringCloudCommandRouterTest {
         resultMemberSet = resultAtomicConsistentHash.get().getMembers();
 
         assertFalse(resultMemberSet.isEmpty());
-        assertMember(
-                LOCAL_MEMBER,
-                resultMemberSet.iterator().next(),
-                AFTER_START_UP);
+        assertMember(LOCAL_MEMBER, resultMemberSet.iterator().next(), AFTER_START_UP);
 
         verify(discoveryClient).getServices();
         verify(discoveryClient).getInstances(SERVICE_INSTANCE_ID);
@@ -229,10 +220,7 @@ public class SpringCloudCommandRouterTest {
         Set<Member> resultMemberSet = resultAtomicConsistentHash.get().getMembers();
         assertFalse(resultMemberSet.isEmpty());
 
-        assertMember(
-                LOCAL_MEMBER,
-                resultMemberSet.iterator().next(),
-                AFTER_START_UP);
+        assertMember(LOCAL_MEMBER, resultMemberSet.iterator().next(), AFTER_START_UP);
 
         verify(discoveryClient, times(2)).getServices();
         verify(discoveryClient, times(2)).getInstances(SERVICE_INSTANCE_ID);
@@ -305,10 +293,7 @@ public class SpringCloudCommandRouterTest {
 
         Set<Member> resultMemberSetAfterVanish = resultAtomicConsistentHashAfterVanish.get().getMembers();
         assertEquals(1, resultMemberSetAfterVanish.size());
-        assertMember(
-                LOCAL_MEMBER,
-                resultMemberSetAfterVanish.iterator().next(),
-                AFTER_START_UP);
+        assertMember(LOCAL_MEMBER, resultMemberSetAfterVanish.iterator().next(), AFTER_START_UP);
     }
 
     @Test

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/SpringCloudAutoConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,7 +42,11 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@AutoConfigureAfter(RoutingStrategyAutoConfiguration.class)
+@AutoConfigureAfter({
+        RoutingStrategyAutoConfiguration.class,
+        NoopDiscoveryClientAutoConfiguration.class,
+        SimpleDiscoveryClientAutoConfiguration.class
+})
 @AutoConfigureBefore(JGroupsAutoConfiguration.class)
 @ConditionalOnProperty("axon.distributed.enabled")
 @ConditionalOnClass(name = {


### PR DESCRIPTION
This PR introduces a solution to ensure the `SpringCloudCommandRouter` selects a consistent spot for the local-member in it's `ConsistentHash`. 

In a previous release we adjusted the local member's name to `{service-id}[LOCAL]`, instead of setting the name to `{service-id}{service-uri}`. 
We did this because Spring Cloud 1.3.1 and up threw a `NullPointerException` if the `URI` was requested from a local instance in the start-up phase. 

The name of a member is however used to create the hash were the member will live on the `ConsistenHash` ring. As such, each node would deem itself the best spot to have the 'local-spot' on the ring.

This fix introduces a solution which listens to the `InstanceRegisteredEvent` from Spring Cloud, which serves as a notifier that the local instance has been registered completely, thus allowing the retrieval of it's `URI`.

This issue resolves bug #600 