### PR TITLE
Fail fast if the snapshot can't be read

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.AxonTransientException;
+import org.axonframework.common.jdbc.JdbcException;
 import org.axonframework.eventhandling.AbstractEventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventsourcing.DomainEventMessage;
@@ -78,9 +80,9 @@ public abstract class AbstractEventStore extends AbstractEventBus implements Eve
         try {
             optionalSnapshot = storageEngine.readSnapshot(aggregateIdentifier);
         } catch (Exception | LinkageError e) {
-            logger.warn("Error reading snapshot. Reconstructing aggregate from entire event stream. Caused by: {} {}",
-                        e.getClass().getName(), e.getMessage());
-            optionalSnapshot = Optional.empty();
+            String message = String.format("Error reading snapshot. I stop to read the events for aggregateIdentifier %s. Caused by: %s %s",
+                    aggregateIdentifier, e.getClass().getName(), e.getMessage());
+            throw new JdbcException(message, e);
         }
         DomainEventStream eventStream;
         if (optionalSnapshot.isPresent()) {

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
-import org.axonframework.common.AxonTransientException;
 import org.axonframework.common.jdbc.JdbcException;
 import org.axonframework.eventhandling.AbstractEventBus;
 import org.axonframework.eventhandling.EventMessage;

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.common.MockException;
+import org.axonframework.common.jdbc.JdbcException;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -231,15 +232,12 @@ public class EmbeddedEventStoreTest {
         assertFalse(stream.hasNextAvailable());
     }
 
-    @Test
+    @Test(expected = JdbcException.class)
     public void testLoadWithFailingSnapshot() {
         testSubject.publish(createEvents(110));
         storageEngine.storeSnapshot(createEvent(30));
         when(storageEngine.readSnapshot(AGGREGATE)).thenThrow(new MockException());
         List<DomainEventMessage<?>> eventMessages = testSubject.readEvents(AGGREGATE).asStream().collect(toList());
-        assertEquals(110, eventMessages.size());
-        assertEquals(0, eventMessages.get(0).getSequenceNumber());
-        assertEquals(109, eventMessages.get(eventMessages.size() - 1).getSequenceNumber());
     }
 
     @Test


### PR DESCRIPTION
As discussed here:
https://groups.google.com/forum/#!topic/axonframework/9JvWCyqXCc0
rebuilding the snapshot can be a denial-of-service-attack ;-) since we have hundred thousand events for an aggregate.

It seems to me that it would be better to fail fast and throw an exception, since rereading all events wouldn't help in some cases. What we noticed is that e.g. the snapshot can't be read because of a dead database connection or because the transaction has already been rolled back.

So throwing an exception and maybe retrying the command would be a valid way. Or am I missing something?