### PR TITLE
Catch ServiceConfigurationErrors when the ServiceLoader finds IdentifierFactory

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/AggregateAnnotationCommandHandler.java
+++ b/core/src/main/java/org/axonframework/commandhandling/AggregateAnnotationCommandHandler.java
@@ -25,6 +25,7 @@ import org.axonframework.common.Assert;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
@@ -88,6 +89,29 @@ public class AggregateAnnotationCommandHandler<T> implements MessageHandler<Comm
                                              ParameterResolverFactory parameterResolverFactory) {
         this(repository, commandTargetResolver,
              AnnotatedAggregateMetaModelFactory.inspectAggregate(aggregateType, parameterResolverFactory));
+    }
+
+    /**
+     * Initializes an AnnotationCommandHandler based on the annotations on given {@code aggregateType}, using the given
+     * {@code repository} to add and load aggregate instances, the given {@code parameterResolverFactory} to resolve
+     * parameters which are required by handlers and the given {@code handlerDefinition} used to create handlers.
+     *
+     * @param aggregateType            The type of aggregate
+     * @param repository               The repository providing access to aggregate instances
+     * @param commandTargetResolver    The target resolution strategy
+     * @param parameterResolverFactory The strategy for resolving parameter values for handler methods
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    public AggregateAnnotationCommandHandler(Class<T> aggregateType,
+                                             Repository<T> repository,
+                                             CommandTargetResolver commandTargetResolver,
+                                             ParameterResolverFactory parameterResolverFactory,
+                                             HandlerDefinition handlerDefinition) {
+        this(repository,
+             commandTargetResolver,
+             AnnotatedAggregateMetaModelFactory.inspectAggregate(aggregateType,
+                                                                 parameterResolverFactory,
+                                                                 handlerDefinition));
     }
 
     /**

--- a/core/src/main/java/org/axonframework/commandhandling/AnnotationCommandHandlerAdapter.java
+++ b/core/src/main/java/org/axonframework/commandhandling/AnnotationCommandHandlerAdapter.java
@@ -21,7 +21,9 @@ import org.axonframework.commandhandling.model.inspection.AnnotatedAggregateMeta
 import org.axonframework.common.Assert;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
 import java.util.ArrayDeque;
@@ -58,12 +60,29 @@ public class AnnotationCommandHandlerAdapter implements MessageHandler<CommandMe
      * @param annotatedCommandHandler  The object containing the @CommandHandler annotated methods
      * @param parameterResolverFactory The strategy for resolving handler method parameter values
      */
-    @SuppressWarnings("unchecked")
     public AnnotationCommandHandlerAdapter(Object annotatedCommandHandler,
                                            ParameterResolverFactory parameterResolverFactory) {
+        this(annotatedCommandHandler,
+             parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(annotatedCommandHandler.getClass()));
+    }
+
+    /**
+     * Wraps the given {@code annotatedCommandHandler}, allowing it to be subscribed to a Command Bus.
+     *
+     * @param annotatedCommandHandler  The object containing the @CommandHandler annotated methods
+     * @param parameterResolverFactory The strategy for resolving handler method parameter values
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    @SuppressWarnings("unchecked")
+    public AnnotationCommandHandlerAdapter(Object annotatedCommandHandler,
+                                           ParameterResolverFactory parameterResolverFactory,
+                                           HandlerDefinition handlerDefinition) {
         Assert.notNull(annotatedCommandHandler, () -> "annotatedCommandHandler may not be null");
-        this.modelInspector = AnnotatedAggregateMetaModelFactory.inspectAggregate((Class<Object>)annotatedCommandHandler.getClass(),
-                                                                                  parameterResolverFactory);
+        this.modelInspector = AnnotatedAggregateMetaModelFactory
+                .inspectAggregate((Class<Object>) annotatedCommandHandler.getClass(),
+                                  parameterResolverFactory,
+                                  handlerDefinition);
 
         this.target = annotatedCommandHandler;
     }

--- a/core/src/main/java/org/axonframework/commandhandling/disruptor/DisruptorCommandBus.java
+++ b/core/src/main/java/org/axonframework/commandhandling/disruptor/DisruptorCommandBus.java
@@ -34,7 +34,9 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.monitoring.MessageMonitor;
 import org.slf4j.Logger;
@@ -342,13 +344,10 @@ public class DisruptorCommandBus implements CommandBus {
 
     /**
      * Creates a repository instance for an Event Sourced aggregate that is created by the given
-     * {@code aggregateFactory}. The given {@code decorator} is used to decorate event streams.
+     * {@code aggregateFactory}.
      * <p>
      * The repository returned must be used by Command Handlers subscribed to this Command Bus for loading aggregate
      * instances. Using any other repository instance may result in undefined outcome (a.k.a. concurrency problems).
-     * <p>
-     * Note that a second invocation of this method with an aggregate factory for the same aggregate type <em>may</em>
-     * return the same instance as the first invocation, even if the given {@code decorator} is different.
      *
      * @param aggregateFactory          The factory creating uninitialized instances of the Aggregate
      * @param snapshotTriggerDefinition The trigger definition for creating snapshots
@@ -367,13 +366,10 @@ public class DisruptorCommandBus implements CommandBus {
 
     /**
      * Creates a repository instance for an Event Sourced aggregate, source from given {@code eventStore}, that is
-     * created by the given {@code aggregateFactory}. The given {@code decorator} is used to decorate event streams.
+     * created by the given {@code aggregateFactory}.
      * <p>
      * The repository returned must be used by Command Handlers subscribed to this Command Bus for loading aggregate
      * instances. Using any other repository instance may result in undefined outcome (a.k.a. concurrency problems).
-     * <p>
-     * Note that a second invocation of this method with an aggregate factory for the same aggregate type <em>may</em>
-     * return the same instance as the first invocation, even if the given {@code decorator} is different.
      *
      * @param eventStore                The Event Store to retrieve and persist events
      * @param aggregateFactory          The factory creating uninitialized instances of the Aggregate
@@ -413,6 +409,7 @@ public class DisruptorCommandBus implements CommandBus {
                                 aggregateFactory,
                                 snapshotTriggerDefinition,
                                 ClasspathParameterResolverFactory.forClass(aggregateFactory.getAggregateType()),
+                                ClasspathHandlerDefinition.forClass(aggregateFactory.getAggregateType()),
                                 repositoryProvider);
     }
 
@@ -428,7 +425,7 @@ public class DisruptorCommandBus implements CommandBus {
      * @return the repository that provides access to stored aggregates
      *
      * @deprecated Use {@link #createRepository(EventStore, AggregateFactory, ParameterResolverFactory,
-     * RepositoryProvider)} instead.
+     * HandlerDefinition, RepositoryProvider)} instead.
      */
     @Deprecated
     public <T> Repository<T> createRepository(AggregateFactory<T> aggregateFactory,
@@ -459,27 +456,34 @@ public class DisruptorCommandBus implements CommandBus {
     /**
      * Creates a repository instance for an Event Sourced aggregate that is created by the given
      * {@code aggregateFactory} and sourced from given {@code eventStore}. Parameters of the annotated methods are
-     * resolved using the given {@code parameterResolverFactory}.
+     * resolved using the given {@code parameterResolverFactory}. The given {@code handlerDefinition} is used to create
+     * handler instances.
      *
      * @param eventStore               The Event Store to retrieve and persist events
      * @param aggregateFactory         The factory creating uninitialized instances of the Aggregate
      * @param parameterResolverFactory The ParameterResolverFactory to resolve parameter values of annotated handler
      *                                 with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
      * @param repositoryProvider       Provides specific for given aggregate types
      * @param <T>                      The type of aggregate managed by this repository
      * @return the repository that provides access to stored aggregates
      */
     public <T> Repository<T> createRepository(EventStore eventStore, AggregateFactory<T> aggregateFactory,
                                               ParameterResolverFactory parameterResolverFactory,
+                                              HandlerDefinition handlerDefinition,
                                               RepositoryProvider repositoryProvider) {
-        return createRepository(eventStore, aggregateFactory, NoSnapshotTriggerDefinition.INSTANCE,
-                                parameterResolverFactory, repositoryProvider);
+        return createRepository(eventStore,
+                                aggregateFactory,
+                                NoSnapshotTriggerDefinition.INSTANCE,
+                                parameterResolverFactory,
+                                handlerDefinition,
+                                repositoryProvider);
     }
 
     /**
      * Creates a repository instance for an Event Sourced aggregate that is created by the given
      * {@code aggregateFactory}. Parameters of the annotated methods are resolved using the given
-     * {@code parameterResolverFactory}. The given {@code decorator} is used to intercept incoming streams of events
+     * {@code parameterResolverFactory}.
      *
      * @param aggregateFactory          The factory creating uninitialized instances of the Aggregate
      * @param snapshotTriggerDefinition The trigger definition for snapshots
@@ -489,7 +493,7 @@ public class DisruptorCommandBus implements CommandBus {
      * @return the repository that provides access to stored aggregates
      *
      * @deprecated Use {@link #createRepository(EventStore, AggregateFactory, SnapshotTriggerDefinition,
-     * ParameterResolverFactory, RepositoryProvider)} instead
+     * ParameterResolverFactory, HandlerDefinition, RepositoryProvider)} instead
      */
     @Deprecated
     public <T> Repository<T> createRepository(AggregateFactory<T> aggregateFactory,
@@ -501,7 +505,7 @@ public class DisruptorCommandBus implements CommandBus {
     /**
      * Creates a repository instance for an Event Sourced aggregate, sourced from given {@code eventStore}, that is
      * created by the given {@code aggregateFactory}. Parameters of the annotated methods are resolved using the given
-     * {@code parameterResolverFactory}. The given {@code decorator} is used to intercept incoming streams of events
+     * {@code parameterResolverFactory}.
      *
      * @param eventStore                The Event Store to retrieve and persist events
      * @param aggregateFactory          The factory creating uninitialized instances of the Aggregate
@@ -514,25 +518,25 @@ public class DisruptorCommandBus implements CommandBus {
     public <T> Repository<T> createRepository(EventStore eventStore, AggregateFactory<T> aggregateFactory,
                                               SnapshotTriggerDefinition snapshotTriggerDefinition,
                                               ParameterResolverFactory parameterResolverFactory) {
-        for (CommandHandlerInvoker invoker : commandHandlerInvokers) {
-            invoker.createRepository(eventStore,
-                                     aggregateFactory,
-                                     snapshotTriggerDefinition,
-                                     parameterResolverFactory);
-        }
-        return new DisruptorRepository<>(aggregateFactory.getAggregateType());
+        return createRepository(eventStore,
+                                aggregateFactory,
+                                snapshotTriggerDefinition,
+                                parameterResolverFactory,
+                                ClasspathHandlerDefinition.forClass(aggregateFactory.getAggregateType()),
+                                null);
     }
 
     /**
      * Creates a repository instance for an Event Sourced aggregate, sourced from given {@code eventStore}, that is
      * created by the given {@code aggregateFactory}. Parameters of the annotated methods are resolved using the given
-     * {@code parameterResolverFactory}. The given {@code decorator} is used to intercept incoming streams of events
+     * {@code parameterResolverFactory}. The given {@code handlerDefinition} is used to create handler instances.
      *
      * @param eventStore                The Event Store to retrieve and persist events
      * @param aggregateFactory          The factory creating uninitialized instances of the Aggregate
      * @param snapshotTriggerDefinition The trigger definition for snapshots
      * @param parameterResolverFactory  The ParameterResolverFactory to resolve parameter values of annotated handler
      *                                  with
+     * @param handlerDefinition         The handler definition used to create concrete handlers
      * @param repositoryProvider        Provides repositories for specific aggregate types
      * @param <T>                       The type of aggregate managed by this repository
      * @return the repository that provides access to stored aggregates
@@ -540,13 +544,15 @@ public class DisruptorCommandBus implements CommandBus {
     public <T> Repository<T> createRepository(EventStore eventStore, AggregateFactory<T> aggregateFactory,
                                               SnapshotTriggerDefinition snapshotTriggerDefinition,
                                               ParameterResolverFactory parameterResolverFactory,
+                                              HandlerDefinition handlerDefinition,
                                               RepositoryProvider repositoryProvider) {
         for (CommandHandlerInvoker invoker : commandHandlerInvokers) {
             invoker.createRepository(eventStore,
                                      repositoryProvider,
                                      aggregateFactory,
                                      snapshotTriggerDefinition,
-                                     parameterResolverFactory);
+                                     parameterResolverFactory,
+                                     handlerDefinition);
         }
         return new DisruptorRepository<>(aggregateFactory.getAggregateType());
     }

--- a/core/src/main/java/org/axonframework/commandhandling/model/AbstractRepository.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/AbstractRepository.java
@@ -19,6 +19,7 @@ package org.axonframework.commandhandling.model;
 import org.axonframework.commandhandling.model.inspection.AggregateModel;
 import org.axonframework.commandhandling.model.inspection.AnnotatedAggregateMetaModelFactory;
 import org.axonframework.common.Assert;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
@@ -66,6 +67,23 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
     protected AbstractRepository(Class<T> aggregateType, ParameterResolverFactory parameterResolverFactory) {
         this(AnnotatedAggregateMetaModelFactory.inspectAggregate(nonNull(aggregateType, () -> "aggregateType may not be null"),
                                                                  nonNull(parameterResolverFactory, () -> "parameterResolverFactory may not be null")));
+    }
+
+    /**
+     * Initializes a repository that stores aggregate of the given {@code aggregateType}. All aggregates in this
+     * repository must be {@code instanceOf} this aggregate type.
+     *
+     * @param aggregateType            The type of aggregate stored in this repository
+     * @param parameterResolverFactory The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    protected AbstractRepository(Class<T> aggregateType, ParameterResolverFactory parameterResolverFactory,
+                                 HandlerDefinition handlerDefinition) {
+        this(AnnotatedAggregateMetaModelFactory
+                     .inspectAggregate(nonNull(aggregateType, () -> "aggregateType may not be null"),
+                                       nonNull(parameterResolverFactory,
+                                               () -> "parameterResolverFactory may not be null"),
+                                       nonNull(handlerDefinition, () -> "handler definition may not be null")));
     }
 
     /**

--- a/core/src/main/java/org/axonframework/commandhandling/model/GenericJpaRepository.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/GenericJpaRepository.java
@@ -24,6 +24,8 @@ import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.NullLockFactory;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
 import java.util.Optional;
@@ -184,16 +186,19 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
      * @param eventBus                 the event bus to which new events are published
      * @param repositoryProvider       Provides repositories for specific aggregate types
      * @param parameterResolverFactory the component to resolve parameter values of annotated message handlers with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
      */
     public GenericJpaRepository(EntityManagerProvider entityManagerProvider, Class<T> aggregateType,
                                 EventBus eventBus, RepositoryProvider repositoryProvider,
-                                ParameterResolverFactory parameterResolverFactory) {
+                                ParameterResolverFactory parameterResolverFactory,
+                                HandlerDefinition handlerDefinition) {
         this(entityManagerProvider,
              aggregateType,
              eventBus,
              repositoryProvider,
              NullLockFactory.INSTANCE,
-             parameterResolverFactory);
+             parameterResolverFactory,
+             handlerDefinition);
     }
 
     /**
@@ -368,16 +373,19 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
      * @param repositoryProvider       Provides repositories for specific aggregate types
      * @param lockFactory              the additional locking strategy for this repository
      * @param parameterResolverFactory the component to resolve parameter values of annotated message handlers with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
      */
     public GenericJpaRepository(EntityManagerProvider entityManagerProvider, Class<T> aggregateType, EventBus eventBus,
                                 RepositoryProvider repositoryProvider, LockFactory lockFactory,
-                                ParameterResolverFactory parameterResolverFactory) {
+                                ParameterResolverFactory parameterResolverFactory,
+                                HandlerDefinition handlerDefinition) {
         this(entityManagerProvider,
              aggregateType,
              eventBus,
              repositoryProvider,
              lockFactory,
              parameterResolverFactory,
+             handlerDefinition,
              Function.identity());
     }
 
@@ -404,6 +412,7 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
              null,
              lockFactory,
              parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(aggregateType),
              identifierConverter);
     }
 
@@ -419,14 +428,15 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
      * @param repositoryProvider       Provides repositories for specific aggregate types
      * @param lockFactory              the additional locking strategy for this repository
      * @param parameterResolverFactory the component to resolve parameter values of annotated message handlers with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
      * @param identifierConverter      the function that converts the String based identifier to the Identifier object
      *                                 used in the Entity
      */
     public GenericJpaRepository(EntityManagerProvider entityManagerProvider, Class<T> aggregateType, EventBus eventBus,
                                 RepositoryProvider repositoryProvider, LockFactory lockFactory,
                                 ParameterResolverFactory parameterResolverFactory,
-                                Function<String, ?> identifierConverter) {
-        super(aggregateType, lockFactory, parameterResolverFactory);
+                                HandlerDefinition handlerDefinition, Function<String, ?> identifierConverter) {
+        super(aggregateType, lockFactory, parameterResolverFactory, handlerDefinition);
         Assert.notNull(entityManagerProvider, () -> "entityManagerProvider may not be null");
         this.entityManagerProvider = entityManagerProvider;
         this.eventBus = eventBus;

--- a/core/src/main/java/org/axonframework/commandhandling/model/LockingRepository.java
+++ b/core/src/main/java/org/axonframework/commandhandling/model/LockingRepository.java
@@ -21,6 +21,7 @@ import org.axonframework.common.Assert;
 import org.axonframework.common.lock.Lock;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.PessimisticLockFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.slf4j.Logger;
@@ -83,7 +84,22 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends Abstr
     }
 
     /**
-     * Initialize the repository with the given {@code LockFactory}.
+     * Initialize a repository with a pessimistic locking strategy and a parameter resolver factory.
+     *
+     * @param aggregateType            The type of aggregate stored in this repository
+     * @param parameterResolverFactory The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    protected LockingRepository(Class<T> aggregateType, ParameterResolverFactory parameterResolverFactory,
+                                HandlerDefinition handlerDefinition) {
+        this(aggregateType,
+             new PessimisticLockFactory(),
+             parameterResolverFactory,
+             handlerDefinition);
+    }
+
+    /**
+     * Initialize the repository with the given {@code lockFactory}.
      *
      * @param aggregateType The type of aggregate stored in this repository
      * @param lockFactory   the lock factory to use
@@ -95,7 +111,7 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends Abstr
     }
 
     /**
-     * Initialize the repository with the given {@code LockFactory} and {@code aggregateModel}
+     * Initialize the repository with the given {@code lockFactory} and {@code aggregateModel}
      *
      * @param aggregateModel The model describing the structure of the aggregate
      * @param lockFactory    the lock factory to use
@@ -107,7 +123,7 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends Abstr
     }
 
     /**
-     * Initialize the repository with the given {@code LockFactory} and {@code ParameterResolverFactory}.
+     * Initialize the repository with the given {@code lockFactory} and {@code parameterResolverFactory}.
      *
      * @param aggregateType            The type of aggregate stored in this repository
      * @param lockFactory              The lock factory to use
@@ -116,6 +132,23 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends Abstr
     protected LockingRepository(Class<T> aggregateType, LockFactory lockFactory,
                                 ParameterResolverFactory parameterResolverFactory) {
         super(aggregateType, parameterResolverFactory);
+        Assert.notNull(lockFactory, () -> "LockFactory may not be null");
+        this.lockFactory = lockFactory;
+    }
+
+    /**
+     * Initialize the repository with the given {@code lockFactory}, {@code parameterResolverFactory} and {@code
+     * handlerDefinition}.
+     *
+     * @param aggregateType            The type of aggregate stored in this repository
+     * @param lockFactory              The lock factory to use
+     * @param parameterResolverFactory The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    protected LockingRepository(Class<T> aggregateType, LockFactory lockFactory,
+                                ParameterResolverFactory parameterResolverFactory,
+                                HandlerDefinition handlerDefinition) {
+        super(aggregateType, parameterResolverFactory, handlerDefinition);
         Assert.notNull(lockFactory, () -> "LockFactory may not be null");
         this.lockFactory = lockFactory;
     }

--- a/core/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/core/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -68,7 +68,8 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
 
         metaModel = new Component<>(() -> parent, "aggregateMetaModel<" + aggregate.getSimpleName() + ">",
                                     c -> c.getComponent(AggregateMetaModelFactory.class,
-                                                        () -> new AnnotatedAggregateMetaModelFactory(c.parameterResolverFactory()))
+                                                        () -> new AnnotatedAggregateMetaModelFactory(c.parameterResolverFactory(),
+                                                                                                     c.handlerDefinition(aggregate)))
                                           .createModel(aggregate));
         commandTargetResolver = new Component<>(() -> parent, name("commandTargetResolver"),
                                                 c -> c.getComponent(CommandTargetResolver.class,
@@ -87,6 +88,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                                                                                aggregateFactory.get(),
                                                                                snapshotTriggerDefinition.get(),
                                                                                c.parameterResolverFactory(),
+                                                                               c.handlerDefinition(aggregate),
                                                                                c::repository);
             }
             return new EventSourcingRepository<>(metaModel.get(),

--- a/core/src/main/java/org/axonframework/config/Configuration.java
+++ b/core/src/main/java/org/axonframework/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.axonframework.eventhandling.saga.ResourceInjector;
 import org.axonframework.eventhandling.saga.repository.NoResourceInjector;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.monitoring.MessageMonitor;
@@ -120,6 +121,7 @@ public interface Configuration {
     default QueryGateway queryGateway() {
         return getComponent(QueryGateway.class);
     }
+
     /**
      * Returns the Repository configured for the given {@code aggregateType}.
      *
@@ -215,6 +217,14 @@ public interface Configuration {
     default ParameterResolverFactory parameterResolverFactory() {
         return getComponent(ParameterResolverFactory.class);
     }
+
+    /**
+     * Returns the Handler Definition defined in this Configuration for the given {@code inspectedType}.
+     *
+     * @param inspectedType The class to being inspected for handlers
+     * @return the Handler Definition defined in this Configuration
+     */
+    HandlerDefinition handlerDefinition(Class<?> inspectedType);
 
     /**
      * Returns all modules that have been registered with this Configuration.

--- a/core/src/main/java/org/axonframework/config/Configurer.java
+++ b/core/src/main/java/org/axonframework/config/Configurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.axonframework.eventhandling.saga.ResourceInjector;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.queryhandling.QueryBus;
@@ -190,7 +191,6 @@ public interface Configurer {
      *
      * @param module The module to register
      * @return the current instance of the Configurer, for chaining purposes
-     *
      * @see SagaConfiguration
      * @see EventHandlingConfiguration
      */
@@ -394,7 +394,6 @@ public interface Configurer {
      * @param aggregateConfiguration The instance describing the configuration of an Aggregate
      * @param <A>                    The type of aggregate the configuration is for
      * @return the current instance of the Configurer, for chaining purposes
-     *
      * @see AggregateConfigurer
      */
     <A> Configurer configureAggregate(AggregateConfiguration<A> aggregateConfiguration);
@@ -411,6 +410,15 @@ public interface Configurer {
     default <A> Configurer configureAggregate(Class<A> aggregate) {
         return configureAggregate(AggregateConfigurer.defaultConfiguration(aggregate));
     }
+
+    /**
+     * Registers the definition of a Handler class. Defaults to annotation based recognition of handler methods.
+     *
+     * @param handlerDefinitionClass A function providing the definition based on the current Configuration as well
+     *                               as the class being inspected.
+     * @return the current instance of the Configurer, for chaining purposes
+     */
+    Configurer registerHandlerDefinition(BiFunction<Configuration, Class, HandlerDefinition> handlerDefinitionClass);
 
     /**
      * Returns the completely initialized Configuration built using this configurer. It is not recommended to change

--- a/core/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/core/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 import org.axonframework.commandhandling.model.Repository;
+import org.axonframework.common.IdentifierFactory;
+import org.axonframework.common.Assert;
 import org.axonframework.common.Registration;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -39,9 +41,7 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.messaging.Message;
-import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
-import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
-import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.annotation.*;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.MessageOriginProvider;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
@@ -102,6 +102,10 @@ public class DefaultConfigurer implements Configurer {
             c -> new EventUpcasterChain(upcasters.stream().map(Component::get).collect(toList()))
     );
 
+    private final Component<Function<Class, HandlerDefinition>> handlerDefinition = new Component<>(
+            config, "handlerDefinition",
+            c -> this::defaultHandlerDefinition);
+
     private final Map<Class<?>, AggregateConfiguration> aggregateConfigurations = new HashMap<>();
 
     private final List<ConsumerHandler> initHandlers = new ArrayList<>();
@@ -110,28 +114,6 @@ public class DefaultConfigurer implements Configurer {
     private final List<ModuleConfiguration> modules = new ArrayList<>();
 
     private boolean initialized = false;
-
-    /**
-     * Initialize the Configurer.
-     */
-    protected DefaultConfigurer() {
-        components.put(ParameterResolverFactory.class,
-                       new Component<>(config, "parameterResolverFactory", this::defaultParameterResolverFactory));
-        components.put(Serializer.class, new Component<>(config, "serializer", this::defaultSerializer));
-        components.put(CommandBus.class, new Component<>(config, "commandBus", this::defaultCommandBus));
-        components.put(EventBus.class, new Component<>(config, "eventBus", this::defaultEventBus));
-        components.put(EventStore.class, new Component<>(config, "eventStore", Configuration::eventStore));
-        components.put(CommandGateway.class, new Component<>(config, "commandGateway", this::defaultCommandGateway));
-        components.put(QueryBus.class, new Component<>(config, "queryBus", this::defaultQueryBus));
-        components.put(QueryGateway.class, new Component<>(config, "queryGateway", this::defaultQueryGateway));
-        components.put(ResourceInjector.class,
-                       new Component<>(config, "resourceInjector", this::defaultResourceInjector));
-
-        eventProcessorRegistry = new Component<>(config,
-                                                 "eventProcessorRegistry",
-                                                 c -> defaultEventProcessorRegistry());
-        components.put(EventProcessorRegistry.class, eventProcessorRegistry);
-    }
 
     /**
      * Returns a Configurer instance with default components configured, such as a {@link SimpleCommandBus} and
@@ -192,6 +174,28 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
+     * Initialize the Configurer.
+     */
+    protected DefaultConfigurer() {
+        components.put(ParameterResolverFactory.class,
+                       new Component<>(config, "parameterResolverFactory", this::defaultParameterResolverFactory));
+        components.put(Serializer.class, new Component<>(config, "serializer", this::defaultSerializer));
+        components.put(CommandBus.class, new Component<>(config, "commandBus", this::defaultCommandBus));
+        components.put(EventBus.class, new Component<>(config, "eventBus", this::defaultEventBus));
+        components.put(EventStore.class, new Component<>(config, "eventStore", Configuration::eventStore));
+        components.put(CommandGateway.class, new Component<>(config, "commandGateway", this::defaultCommandGateway));
+        components.put(QueryBus.class, new Component<>(config, "queryBus", this::defaultQueryBus));
+        components.put(QueryGateway.class, new Component<>(config, "queryGateway", this::defaultQueryGateway));
+        components.put(ResourceInjector.class,
+                       new Component<>(config, "resourceInjector", this::defaultResourceInjector));
+
+        eventProcessorRegistry = new Component<>(config,
+                                                 "eventProcessorRegistry",
+                                                 c -> defaultEventProcessorRegistry());
+        components.put(EventProcessorRegistry.class, eventProcessorRegistry);
+    }
+
+    /**
      * Returns a {@link DefaultCommandGateway} that will use the configuration's {@link CommandBus} to dispatch
      * commands.
      *
@@ -233,6 +237,16 @@ public class DefaultConfigurer implements Configurer {
     protected ParameterResolverFactory defaultParameterResolverFactory(Configuration config) {
         return MultiParameterResolverFactory.ordered(ClasspathParameterResolverFactory.forClass(getClass()),
                                                      new ConfigurationParameterResolverFactory(config));
+    }
+
+    /**
+     * Provides the default HandlerDefinition. Subclasses may override this method to provide their own default.
+     *
+     * @param inspectedClass The class being inspected for handlers
+     * @return The default HandlerDefinition to use
+     */
+    protected HandlerDefinition defaultHandlerDefinition(Class<?> inspectedClass) {
+        return ClasspathHandlerDefinition.forClass(inspectedClass);
     }
 
     /**
@@ -346,9 +360,12 @@ public class DefaultConfigurer implements Configurer {
     @Override
     public Configurer registerCommandHandler(int phase, Function<Configuration, Object> annotatedCommandHandlerBuilder) {
         startHandlers.add(new RunnableHandler(phase, () -> {
+            Object handler = annotatedCommandHandlerBuilder.apply(config);
+            Assert.notNull(handler, () -> "annotatedCommandHandler may not be null");
             Registration registration =
-                    new AnnotationCommandHandlerAdapter(annotatedCommandHandlerBuilder.apply(config),
-                                                        config.parameterResolverFactory())
+                    new AnnotationCommandHandlerAdapter(handler,
+                                                        config.parameterResolverFactory(),
+                                                        config.handlerDefinition(handler.getClass()))
                             .subscribe(config.commandBus());
             shutdownHandlers.add(new RunnableHandler(phase, registration::cancel));
         }));
@@ -359,9 +376,13 @@ public class DefaultConfigurer implements Configurer {
     @SuppressWarnings("unchecked")
     public Configurer registerQueryHandler(int phase, Function<Configuration, Object> annotatedQueryHandlerBuilder) {
         startHandlers.add(new RunnableHandler(phase, () -> {
-            Registration registration = new AnnotationQueryHandlerAdapter(
-                    annotatedQueryHandlerBuilder.apply(config), config.parameterResolverFactory()
-            ).subscribe(config.queryBus());
+            Object annotatedHandler = annotatedQueryHandlerBuilder.apply(config);
+            Assert.notNull(annotatedHandler, () -> "annotatedQueryHandler may not be null");
+
+            Registration registration = new AnnotationQueryHandlerAdapter(annotatedHandler,
+                                                                          config.parameterResolverFactory(),
+                                                                          config.handlerDefinition(annotatedHandler.getClass()))
+                    .subscribe(config.queryBus());
             shutdownHandlers.add(new RunnableHandler(phase, registration::cancel));
         }));
         return this;
@@ -408,11 +429,31 @@ public class DefaultConfigurer implements Configurer {
     }
 
     @Override
+    public Configurer registerHandlerDefinition(BiFunction<Configuration, Class, HandlerDefinition> handlerDefinitionClass) {
+        this.handlerDefinition.update(c -> clazz -> handlerDefinitionClass.apply(c, clazz));
+        return this;
+    }
+
+    @Override
     public Configuration buildConfiguration() {
         if (!initialized) {
+            verifyIdentifierFactory();
             invokeInitHandlers();
         }
         return config;
+    }
+
+    /**
+     * Verifies that a valid {@link IdentifierFactory} class has been configured.
+     *
+     * @throws IllegalArgumentException if the configured factory is not valid
+     */
+    private void verifyIdentifierFactory() {
+        try {
+            IdentifierFactory.getInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("The configured IdentifierFactory could not be instantiated.", e);
+        }
     }
 
     /**
@@ -460,6 +501,42 @@ public class DefaultConfigurer implements Configurer {
      */
     public Map<Class<?>, Component<?>> getComponents() {
         return components;
+    }
+
+    private static class ConsumerHandler {
+        private final int phase;
+        private final Consumer<Configuration> handler;
+
+        private ConsumerHandler(int phase, Consumer<Configuration> handler) {
+            this.phase = phase;
+            this.handler = handler;
+        }
+
+        public int phase() {
+            return phase;
+        }
+
+        public void accept(Configuration configuration) {
+            handler.accept(configuration);
+        }
+    }
+
+    private static class RunnableHandler {
+        private final int phase;
+        private final Runnable handler;
+
+        private RunnableHandler(int phase, Runnable handler) {
+            this.phase = phase;
+            this.handler = handler;
+        }
+
+        public int phase() {
+            return phase;
+        }
+
+        public void run() {
+            handler.run();
+        }
     }
 
     private class ConfigurationImpl implements Configuration {
@@ -533,41 +610,10 @@ public class DefaultConfigurer implements Configurer {
         public void onStart(int phase, Runnable startHandler) {
             startHandlers.add(new RunnableHandler(phase, startHandler));
         }
-    }
 
-    private static class ConsumerHandler {
-        private final int phase;
-        private final Consumer<Configuration> handler;
-
-        private ConsumerHandler(int phase, Consumer<Configuration> handler) {
-            this.phase = phase;
-            this.handler = handler;
-        }
-
-        public int phase() {
-            return phase;
-        }
-
-        public void accept(Configuration configuration) {
-            handler.accept(configuration);
-        }
-    }
-
-    private static class RunnableHandler {
-        private final int phase;
-        private final Runnable handler;
-
-        private RunnableHandler(int phase, Runnable handler) {
-            this.phase = phase;
-            this.handler = handler;
-        }
-
-        public int phase() {
-            return phase;
-        }
-
-        public void run() {
-            handler.run();
+        @Override
+        public HandlerDefinition handlerDefinition(Class<?> inspectedType) {
+            return handlerDefinition.get().apply(inspectedType);
         }
     }
 }

--- a/core/src/main/java/org/axonframework/config/SagaConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/SagaConfiguration.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -272,11 +273,16 @@ public class SagaConfiguration<S> implements ModuleConfiguration {
                                                 c -> c.getComponent(RollbackConfiguration.class,
                                                                     () -> RollbackConfigurationType.ANY_THROWABLE));
         sagaStore = new Component<>(() -> config, "sagaStore", c -> c.getComponent(SagaStore.class, InMemorySagaStore::new));
-        sagaRepository = new Component<>(() -> config, repositoryName,
-                                         c -> new AnnotatedSagaRepository<>(sagaType, sagaStore.get(), c.resourceInjector(),
-                                                                            c.parameterResolverFactory()));
+        sagaRepository = new Component<>(() -> config,
+                                         repositoryName,
+                                         c -> new AnnotatedSagaRepository<>(sagaType,
+                                                                            sagaStore.get(),
+                                                                            c.resourceInjector(),
+                                                                            c.parameterResolverFactory(),
+                                                                            c.handlerDefinition(sagaType)));
         sagaManager = new Component<>(() -> config, managerName, c -> new AnnotatedSagaManager<>(sagaType, sagaRepository.get(),
                                                                                                  c.parameterResolverFactory(),
+                                                                                                 c.handlerDefinition(sagaType),
                                                                                                  listenerInvocationErrorHandler
                                                                                                          .get()));
         trackingEventProcessorConfiguration = new Component<>(() -> config, "ProcessorConfiguration",

--- a/core/src/main/java/org/axonframework/eventhandling/AnnotationEventListenerAdapter.java
+++ b/core/src/main/java/org/axonframework/eventhandling/AnnotationEventListenerAdapter.java
@@ -17,7 +17,9 @@
 package org.axonframework.eventhandling;
 
 import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
@@ -51,13 +53,30 @@ public class AnnotationEventListenerAdapter implements EventListenerProxy {
      * @param annotatedEventListener   the annotated event listener
      * @param parameterResolverFactory the strategy for resolving handler method parameter values
      */
-    @SuppressWarnings("unchecked")
     public AnnotationEventListenerAdapter(Object annotatedEventListener,
                                           ParameterResolverFactory parameterResolverFactory) {
+        this(annotatedEventListener,
+             parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(annotatedEventListener.getClass()));
+    }
+
+    /**
+     * Wraps the given {@code annotatedEventListener}, allowing it to be subscribed to an Event Bus. The given {@code
+     * parameterResolverFactory} is used to resolve parameter values for handler methods. Handler definition is used to
+     * create concrete handlers.
+     *
+     * @param annotatedEventListener   the annotated event listener
+     * @param parameterResolverFactory the strategy for resolving handler method parameter values
+     * @param handlerDefinition        the handler definition used to create concrete handlers
+     */
+    public AnnotationEventListenerAdapter(Object annotatedEventListener,
+                                          ParameterResolverFactory parameterResolverFactory,
+                                          HandlerDefinition handlerDefinition) {
         this.annotatedEventListener = annotatedEventListener;
         this.listenerType = annotatedEventListener.getClass();
         this.inspector = AnnotatedHandlerInspector.inspectType(annotatedEventListener.getClass(),
-                                                               parameterResolverFactory);
+                                                               parameterResolverFactory,
+                                                               handlerDefinition);
     }
 
     @Override

--- a/core/src/main/java/org/axonframework/eventhandling/Segment.java
+++ b/core/src/main/java/org/axonframework/eventhandling/Segment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventhandling;
 
 
@@ -25,6 +41,7 @@ public class Segment implements Comparable<Segment> {
      * Represents the Segment that matches against all input, but can be split to start processing elements in parallel.
      */
     public static final Segment ROOT_SEGMENT = new Segment(0, ZERO_MASK);
+    public static final Segment[] EMPTY_SEGMENTS = new Segment[0];
 
     private final int segmentId;
     private final int mask;
@@ -59,12 +76,14 @@ public class Segment implements Comparable<Segment> {
      * @return an array of computed {@link Segment}
      */
     public static Segment[] computeSegments(int... segments) {
-
+        if (segments == null || segments.length == 0) {
+            return EMPTY_SEGMENTS;
+        }
         final Set<Segment> resolvedSegments = new HashSet<>();
         computeSegments(ROOT_SEGMENT, stream(segments).boxed().collect(toList()), resolvedSegments);
 
-        // As we split and compute segmentmasks branching by first entry, the resolved segmentmask is not guaranteed to
-        // be added to the collection in natural order.
+        // As we split and compute segment masks branching by first entry, the resolved segment mask is not guaranteed
+        // to be added to the collection in natural order.
         return resolvedSegments.stream().sorted().collect(toList()).toArray(new Segment[resolvedSegments.size()]);
     }
 

--- a/core/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
+++ b/core/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
@@ -140,7 +140,8 @@ public class SimpleEventHandlerInvoker implements EventHandlerInvoker {
      * triggered during event handling it will be handled by the given {@code listenerErrorHandler}.
      *
      * @param eventListeners                 list of event listeners to register with this invoker
-     * @param parameterResolverFactory       The parameter resolver factory to resolve parameters of the Event Handler methods with
+     * @param parameterResolverFactory       The parameter resolver factory to resolve parameters of the Event Handler
+     *                                       methods with
      * @param listenerInvocationErrorHandler error handler that handles exceptions during processing
      * @param sequencingPolicy               The policy describing the expectations of sequential processing
      */

--- a/core/src/main/java/org/axonframework/eventhandling/saga/AnnotatedSagaManager.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/AnnotatedSagaManager.java
@@ -22,6 +22,7 @@ import org.axonframework.eventhandling.LoggingErrorHandler;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.saga.metamodel.AnnotationSagaMetaModelFactory;
 import org.axonframework.eventhandling.saga.metamodel.SagaModel;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
 import java.util.List;
@@ -70,8 +71,7 @@ public class AnnotatedSagaManager<T> extends AbstractSagaManager<T> {
      * @param sagaType                       The saga target type
      * @param sagaRepository                 The repository providing access to the Saga instances
      * @param parameterResolverFactory       The ParameterResolverFactory instance to resolve parameter values for
-     *                                       annotated
-     *                                       handlers with
+     *                                       annotated handlers with
      * @param listenerInvocationErrorHandler The error handler to invoke when an error occurs
      */
     public AnnotatedSagaManager(Class<T> sagaType, SagaRepository<T> sagaRepository,
@@ -81,6 +81,29 @@ public class AnnotatedSagaManager<T> extends AbstractSagaManager<T> {
              sagaRepository,
              () -> newInstance(sagaType),
              new AnnotationSagaMetaModelFactory(parameterResolverFactory).modelOf(sagaType),
+             listenerInvocationErrorHandler);
+    }
+
+    /**
+     * Initialize the AnnotatedSagaManager using given {@code repository} to load sagas. To create a new saga this
+     * manager uses {@link #newInstance(Class)}. Uses a {@link AnnotationSagaMetaModelFactory} for the saga's meta
+     * model.
+     *
+     * @param sagaType                       The saga target type
+     * @param sagaRepository                 The repository providing access to the Saga instances
+     * @param parameterResolverFactory       The ParameterResolverFactory instance to resolve parameter values for
+     *                                       annotated handlers with
+     * @param handlerDefinition              The handler definition used to create concrete handlers
+     * @param listenerInvocationErrorHandler The error handler to invoke when an error occurs
+     */
+    public AnnotatedSagaManager(Class<T> sagaType, SagaRepository<T> sagaRepository,
+                                ParameterResolverFactory parameterResolverFactory,
+                                HandlerDefinition handlerDefinition,
+                                ListenerInvocationErrorHandler listenerInvocationErrorHandler) {
+        this(sagaType,
+             sagaRepository,
+             () -> newInstance(sagaType),
+             new AnnotationSagaMetaModelFactory(parameterResolverFactory, handlerDefinition).modelOf(sagaType),
              listenerInvocationErrorHandler);
     }
 

--- a/core/src/main/java/org/axonframework/eventhandling/saga/metamodel/AnnotationSagaMetaModelFactory.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/metamodel/AnnotationSagaMetaModelFactory.java
@@ -21,7 +21,9 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.saga.AssociationValue;
 import org.axonframework.eventhandling.saga.SagaMethodMessageHandlingMember;
 import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
@@ -37,21 +39,38 @@ public class AnnotationSagaMetaModelFactory implements SagaMetaModelFactory {
     private final Map<Class<?>, SagaModel<?>> registry = new ConcurrentHashMap<>();
 
     private final ParameterResolverFactory parameterResolverFactory;
+    private final HandlerDefinition handlerDefinition;
 
     /**
-     * Initializes a {@link AnnotationSagaMetaModelFactory} with {@link ClasspathParameterResolverFactory}.
+     * Initializes a {@link AnnotationSagaMetaModelFactory} with {@link ClasspathParameterResolverFactory} and {@link
+     * ClasspathHandlerDefinition}.
      */
     public AnnotationSagaMetaModelFactory() {
-        parameterResolverFactory = ClasspathParameterResolverFactory.forClassLoader(getClass().getClassLoader());
+        this(ClasspathParameterResolverFactory.forClassLoader(Thread.currentThread().getContextClassLoader()));
     }
 
     /**
-     * Initializes a {@link AnnotationSagaMetaModelFactory} with given {@code parameterResolverFactory}.
+     * Initializes a {@link AnnotationSagaMetaModelFactory} with given {@code parameterResolverFactory} and {@link
+     * ClasspathHandlerDefinition}.
      *
      * @param parameterResolverFactory factory for event handler parameter resolvers
      */
     public AnnotationSagaMetaModelFactory(ParameterResolverFactory parameterResolverFactory) {
+        this(parameterResolverFactory,
+             ClasspathHandlerDefinition.forClassLoader(Thread.currentThread().getContextClassLoader()));
+    }
+
+    /**
+     * Initializes a {@link AnnotationSagaMetaModelFactory} with given {@code parameterResolverFactory} and given {@code
+     * handlerDefinition}.
+     *
+     * @param parameterResolverFactory factory for event handler parameter resolvers
+     * @param handlerDefinition        the handler definition used to create concrete handlers
+     */
+    public AnnotationSagaMetaModelFactory(ParameterResolverFactory parameterResolverFactory,
+                                          HandlerDefinition handlerDefinition) {
         this.parameterResolverFactory = parameterResolverFactory;
+        this.handlerDefinition = handlerDefinition;
     }
 
     @SuppressWarnings("unchecked")
@@ -62,7 +81,9 @@ public class AnnotationSagaMetaModelFactory implements SagaMetaModelFactory {
 
     private <T> SagaModel<T> doCreateModel(Class<T> sagaType) {
         AnnotatedHandlerInspector<T> handlerInspector =
-                AnnotatedHandlerInspector.inspectType(sagaType, parameterResolverFactory);
+                AnnotatedHandlerInspector.inspectType(sagaType,
+                                                      parameterResolverFactory,
+                                                      handlerDefinition);
 
         return new InspectedSagaModel<>(handlerInspector.getHandlers());
     }

--- a/core/src/main/java/org/axonframework/eventhandling/saga/repository/AnnotatedSagaRepository.java
+++ b/core/src/main/java/org/axonframework/eventhandling/saga/repository/AnnotatedSagaRepository.java
@@ -25,6 +25,7 @@ import org.axonframework.eventhandling.saga.ResourceInjector;
 import org.axonframework.eventhandling.saga.Saga;
 import org.axonframework.eventhandling.saga.metamodel.AnnotationSagaMetaModelFactory;
 import org.axonframework.eventhandling.saga.metamodel.SagaModel;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
@@ -97,6 +98,31 @@ public class AnnotatedSagaRepository<T> extends LockingSagaRepository<T> {
                                    ResourceInjector resourceInjector,
                                    ParameterResolverFactory parameterResolverFactory) {
         this(sagaType, sagaStore, new AnnotationSagaMetaModelFactory(parameterResolverFactory).modelOf(sagaType), resourceInjector,
+             new PessimisticLockFactory());
+    }
+
+    /**
+     * Initializes an AnnotatedSagaRepository for given {@code sagaType} that stores sagas in the given {@code
+     * sagaStore}. The repository will use given {@code resourceInjector} and {@link AnnotationSagaMetaModelFactory} to
+     * initialize {@link Saga} instances after a target instance is created or loaded from the store. This repository
+     * uses a {@link PessimisticLockFactory} when a {@link Saga} is loaded.
+     *
+     * @param sagaType                 the saga target type
+     * @param sagaStore                the saga store for saving and loading of sagas
+     * @param resourceInjector         the resource injector used to initialize {@link Saga Sagas} that delegate to the
+     *                                 target
+     * @param parameterResolverFactory The ParameterResolverFactory instance to resolve parameter values for annotated
+     *                                 handlers with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    public AnnotatedSagaRepository(Class<T> sagaType, SagaStore<? super T> sagaStore,
+                                   ResourceInjector resourceInjector,
+                                   ParameterResolverFactory parameterResolverFactory,
+                                   HandlerDefinition handlerDefinition) {
+        this(sagaType,
+             sagaStore,
+             new AnnotationSagaMetaModelFactory(parameterResolverFactory, handlerDefinition).modelOf(sagaType),
+             resourceInjector,
              new PessimisticLockFactory());
     }
 

--- a/core/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
@@ -23,6 +23,8 @@ import org.axonframework.common.caching.Cache;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.PessimisticLockFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 
@@ -191,6 +193,7 @@ public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T
              lockFactory,
              cache,
              parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(aggregateFactory.getAggregateType()),
              snapshotTriggerDefinition,
              null);
     }
@@ -205,6 +208,7 @@ public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T
      * @param lockFactory               The lock factory restricting concurrent access to aggregate instances
      * @param cache                     The cache in which entries will be stored
      * @param parameterResolverFactory  The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition         The handler definition used to create concrete handlers
      * @param snapshotTriggerDefinition The definition describing when to trigger a snapshot
      * @param repositoryProvider        Provides repositories for specific aggregate types
      * @see LockingRepository#LockingRepository(Class)
@@ -212,12 +216,14 @@ public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T
     public CachingEventSourcingRepository(AggregateFactory<T> aggregateFactory, EventStore eventStore,
                                           LockFactory lockFactory, Cache cache,
                                           ParameterResolverFactory parameterResolverFactory,
+                                          HandlerDefinition handlerDefinition,
                                           SnapshotTriggerDefinition snapshotTriggerDefinition,
                                           RepositoryProvider repositoryProvider) {
         super(aggregateFactory,
               eventStore,
               lockFactory,
               parameterResolverFactory,
+              handlerDefinition,
               snapshotTriggerDefinition,
               repositoryProvider);
         this.cache = cache;

--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -28,6 +28,8 @@ import org.axonframework.common.Assert;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 
@@ -251,7 +253,12 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
     public EventSourcingRepository(AggregateFactory<T> aggregateFactory, EventStore eventStore,
                                    ParameterResolverFactory parameterResolverFactory,
                                    SnapshotTriggerDefinition snapshotTriggerDefinition) {
-        this(aggregateFactory, eventStore, parameterResolverFactory, snapshotTriggerDefinition, null);
+        this(aggregateFactory,
+             eventStore,
+             parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(aggregateFactory.getAggregateType()),
+             snapshotTriggerDefinition,
+             null);
     }
 
 
@@ -262,15 +269,17 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
      * @param aggregateFactory          The factory for new aggregate instances
      * @param eventStore                The event store that holds the event streams for this repository
      * @param parameterResolverFactory  The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition         The handler definition used to create concrete handlers
      * @param snapshotTriggerDefinition The definition describing when to trigger a snapshot
      * @param repositoryProvider        Provides repositories for specific aggregate types
      * @see LockingRepository#LockingRepository(Class)
      */
     public EventSourcingRepository(AggregateFactory<T> aggregateFactory, EventStore eventStore,
                                    ParameterResolverFactory parameterResolverFactory,
+                                   HandlerDefinition handlerDefinition,
                                    SnapshotTriggerDefinition snapshotTriggerDefinition,
                                    RepositoryProvider repositoryProvider) {
-        super(aggregateFactory.getAggregateType(), parameterResolverFactory);
+        super(aggregateFactory.getAggregateType(), parameterResolverFactory, handlerDefinition);
         Assert.notNull(eventStore, () -> "eventStore may not be null");
         this.snapshotTriggerDefinition = snapshotTriggerDefinition;
         this.eventStore = eventStore;
@@ -323,7 +332,13 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
     public EventSourcingRepository(AggregateFactory<T> aggregateFactory, EventStore eventStore, LockFactory lockFactory,
                                    ParameterResolverFactory parameterResolverFactory,
                                    SnapshotTriggerDefinition snapshotTriggerDefinition) {
-        this(aggregateFactory, eventStore, lockFactory, parameterResolverFactory, snapshotTriggerDefinition, null);
+        this(aggregateFactory,
+             eventStore,
+             lockFactory,
+             parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(aggregateFactory.getAggregateType()),
+             snapshotTriggerDefinition,
+             null);
     }
 
     /**
@@ -333,14 +348,16 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
      * @param eventStore                The event store that holds the event streams for this repository
      * @param lockFactory               The locking strategy to apply to this repository
      * @param parameterResolverFactory  The parameter resolver factory used to resolve parameters of annotated handlers
+     * @param handlerDefinition         The handler definition used to create concrete handlers
      * @param snapshotTriggerDefinition The definition describing when to trigger a snapshot
      * @param repositoryProvider        Provides repositories for specific aggregate types
      */
     public EventSourcingRepository(AggregateFactory<T> aggregateFactory, EventStore eventStore, LockFactory lockFactory,
                                    ParameterResolverFactory parameterResolverFactory,
+                                   HandlerDefinition handlerDefinition,
                                    SnapshotTriggerDefinition snapshotTriggerDefinition,
                                    RepositoryProvider repositoryProvider) {
-        super(aggregateFactory.getAggregateType(), lockFactory, parameterResolverFactory);
+        super(aggregateFactory.getAggregateType(), lockFactory, parameterResolverFactory, handlerDefinition);
         Assert.notNull(eventStore, () -> "eventStore may not be null");
         this.eventStore = eventStore;
         this.aggregateFactory = aggregateFactory;

--- a/core/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -33,21 +33,24 @@ public class AnnotatedHandlerInspector<T> {
     private final Map<Class<?>, AnnotatedHandlerInspector> registry;
     private final List<AnnotatedHandlerInspector<? super T>> superClassInspectors;
     private final List<MessageHandlingMember<? super T>> handlers;
+    private final HandlerDefinition handlerDefinition;
 
     private AnnotatedHandlerInspector(Class<T> inspectedType,
                                       List<AnnotatedHandlerInspector<? super T>> superClassInspectors,
                                       ParameterResolverFactory parameterResolverFactory,
+                                      HandlerDefinition handlerDefinition,
                                       Map<Class<?>, AnnotatedHandlerInspector> registry) {
         this.inspectedType = inspectedType;
         this.parameterResolverFactory = parameterResolverFactory;
         this.registry = registry;
         this.superClassInspectors = new ArrayList<>(superClassInspectors);
         this.handlers = new ArrayList<>();
+        this.handlerDefinition = handlerDefinition;
     }
 
     /**
      * Create an inspector for given {@code handlerType} that uses a {@link ClasspathParameterResolverFactory} to
-     * resolve method parameters.
+     * resolve method parameters and {@link ClasspathHandlerDefinition} to create handlers.
      *
      * @param handlerType the target handler type
      * @param <T>         the handler's type
@@ -68,15 +71,41 @@ public class AnnotatedHandlerInspector<T> {
      */
     public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType,
                                                                ParameterResolverFactory parameterResolverFactory) {
-        return createInspector(handlerType, parameterResolverFactory, new HashMap<>());
+        return inspectType(handlerType,
+                           parameterResolverFactory,
+                           ClasspathHandlerDefinition.forClass(handlerType));
+    }
+
+    /**
+     * Create an inspector for given {@code handlerType} that uses given {@code parameterResolverFactory} to resolve
+     * method parameters and given {@code handlerDefinition} to create handlers.
+     *
+     * @param handlerType              the target handler type
+     * @param parameterResolverFactory the resolver factory to use during detection
+     * @param handlerDefinition        the handler definition used to create concrete handlers
+     * @param <T>                      the handler's type
+     * @return a new inspector instance for the inspected class
+     */
+    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType,
+                                                               ParameterResolverFactory parameterResolverFactory,
+                                                               HandlerDefinition handlerDefinition) {
+        return createInspector(handlerType,
+                               parameterResolverFactory,
+                               handlerDefinition,
+                               new HashMap<>());
     }
 
 
     private static <T> AnnotatedHandlerInspector<T> createInspector(Class<? extends T> inspectedType,
                                                                     ParameterResolverFactory parameterResolverFactory,
+                                                                    HandlerDefinition handlerDefinition,
                                                                     Map<Class<?>, AnnotatedHandlerInspector> registry) {
         if (!registry.containsKey(inspectedType)) {
-            registry.put(inspectedType, AnnotatedHandlerInspector.initialize(inspectedType, parameterResolverFactory, registry));
+            registry.put(inspectedType,
+                         AnnotatedHandlerInspector.initialize(inspectedType,
+                                                              parameterResolverFactory,
+                                                              handlerDefinition,
+                                                              registry));
         }
         //noinspection unchecked
         return registry.get(inspectedType);
@@ -84,48 +113,43 @@ public class AnnotatedHandlerInspector<T> {
 
     private static <T> AnnotatedHandlerInspector<T> initialize(Class<T> inspectedType,
                                                                ParameterResolverFactory parameterResolverFactory,
+                                                               HandlerDefinition handlerDefinition,
                                                                Map<Class<?>, AnnotatedHandlerInspector> registry) {
         List<AnnotatedHandlerInspector<? super T>> parents = new ArrayList<>();
         for (Class<?> iFace : inspectedType.getInterfaces()) {
             //noinspection unchecked
-            parents.add(createInspector(iFace, parameterResolverFactory, registry));
+            parents.add(createInspector(iFace,
+                                        parameterResolverFactory,
+                                        handlerDefinition,
+                                        registry));
         }
         if (inspectedType.getSuperclass() != null && !Object.class.equals(inspectedType.getSuperclass())) {
-            parents.add(createInspector(inspectedType.getSuperclass(), parameterResolverFactory, registry));
+            parents.add(createInspector(inspectedType.getSuperclass(),
+                                        parameterResolverFactory,
+                                        handlerDefinition,
+                                        registry));
         }
-        AnnotatedHandlerInspector<T> inspector =
-                new AnnotatedHandlerInspector<>(inspectedType, parents, parameterResolverFactory, registry);
-        inspector.initializeMessageHandlers(parameterResolverFactory);
+        AnnotatedHandlerInspector<T> inspector = new AnnotatedHandlerInspector<>(inspectedType,
+                                                                                 parents,
+                                                                                 parameterResolverFactory,
+                                                                                 handlerDefinition,
+                                                                                 registry);
+        inspector.initializeMessageHandlers(parameterResolverFactory, handlerDefinition);
         return inspector;
     }
 
-    private void initializeMessageHandlers(ParameterResolverFactory parameterResolverFactory) {
-        List<HandlerDefinition> definitions = new ArrayList<>();
-        ServiceLoader.load(HandlerDefinition.class).forEach(definitions::add);
-        List<HandlerEnhancerDefinition> wrapperDefinitions = new ArrayList<>();
-        ServiceLoader.load(HandlerEnhancerDefinition.class).forEach(wrapperDefinitions::add);
+    private void initializeMessageHandlers(ParameterResolverFactory parameterResolverFactory,
+                                           HandlerDefinition handlerDefinition) {
         for (Method method : inspectedType.getDeclaredMethods()) {
-            definitions.forEach(definition -> definition.createHandler(inspectedType, method, parameterResolverFactory)
-                    .ifPresent(handler -> registerHandler(wrapped(handler, wrapperDefinitions))));
+            handlerDefinition.createHandler(inspectedType, method, parameterResolverFactory)
+                             .ifPresent(this::registerHandler);
         }
         for (Constructor<?> constructor : inspectedType.getDeclaredConstructors()) {
-            definitions.forEach(
-                    definition -> definition.createHandler(inspectedType, constructor, parameterResolverFactory)
-                            .ifPresent(handler -> registerHandler(wrapped(handler, wrapperDefinitions))));
+            handlerDefinition.createHandler(inspectedType, constructor, parameterResolverFactory)
+                            .ifPresent(this::registerHandler);
         }
         superClassInspectors.forEach(sci -> handlers.addAll(sci.getHandlers()));
         handlers.sort(HandlerComparator.instance());
-    }
-
-    private MessageHandlingMember<T> wrapped(MessageHandlingMember<T> handler,
-                                             Iterable<HandlerEnhancerDefinition> wrapperDefinitions) {
-        MessageHandlingMember<T> wrappedHandler = handler;
-        if (wrapperDefinitions != null) {
-            for (HandlerEnhancerDefinition definition : wrapperDefinitions) {
-                wrappedHandler = definition.wrapHandler(wrappedHandler);
-            }
-        }
-        return wrappedHandler;
     }
 
     private void registerHandler(MessageHandlingMember<T> handler) {
@@ -137,11 +161,14 @@ public class AnnotatedHandlerInspector<T> {
      * by Axon to inspect child entities of an aggregate.
      *
      * @param entityType the type of the handler to inspect
-     * @param <C> the handler's type
+     * @param <C>        the handler's type
      * @return a new inspector for the given type
      */
     public <C> AnnotatedHandlerInspector<C> inspect(Class<? extends C> entityType) {
-        return AnnotatedHandlerInspector.createInspector(entityType, parameterResolverFactory, registry);
+        return AnnotatedHandlerInspector.createInspector(entityType,
+                                                         parameterResolverFactory,
+                                                         handlerDefinition,
+                                                         registry);
     }
 
     /**

--- a/core/src/main/java/org/axonframework/messaging/annotation/ClasspathHandlerDefinition.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/ClasspathHandlerDefinition.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.WeakHashMap;
+
+import static java.util.ServiceLoader.load;
+
+/**
+ * HandlerDefinition instance that locates other HandlerDefinition instances on the class path. It uses the {@link
+ * ServiceLoader} mechanism to locate and initialize them.
+ * <p/>
+ * This means for this class to find implementations, their fully qualified class name has to be put into a file called
+ * {@code META-INF/services/org.axonframework.messaging.annotation.HandlerDefinition}. For more details, see
+ * {@link ServiceLoader}.
+ *
+ * @author Tyler Thrailkill
+ * @author Milan Savic
+ * @see ServiceLoader
+ * @since 3.3
+ */
+public final class ClasspathHandlerDefinition {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClasspathHandlerDefinition.class);
+    private static final Object MONITOR = new Object();
+    private static final Map<ClassLoader, WeakReference<MultiHandlerDefinition>> FACTORIES = new WeakHashMap<>();
+
+    private ClasspathHandlerDefinition() {
+        // not meant to be publicly instantiated
+    }
+
+    /**
+     * Creates an instance for the given {@code clazz}. Effectively, the class loader of the given class is used to
+     * locate implementations.
+     *
+     * @param clazz The class for which the handler definition must be returned
+     * @return a MultiHandlerDefinition that can create handlers for the given class
+     */
+    public static MultiHandlerDefinition forClass(Class<?> clazz) {
+        return forClassLoader(clazz == null ? null : clazz.getClassLoader());
+    }
+
+    /**
+     * Creates an instance using the given {@code classLoader}. Implementations are located using this class loader.
+     *
+     * @param classLoader The class loader to locate the implementations with
+     * @return a MultiHandlerDefinition instance using the given classLoader
+     */
+    public static MultiHandlerDefinition forClassLoader(ClassLoader classLoader) {
+        synchronized (MONITOR) {
+            MultiHandlerDefinition handlerDefinition;
+            if (!FACTORIES.containsKey(classLoader)) {
+                handlerDefinition = MultiHandlerDefinition.ordered(findDelegates(classLoader));
+                FACTORIES.put(classLoader, new WeakReference<>(handlerDefinition));
+                return handlerDefinition;
+            }
+            handlerDefinition = FACTORIES.get(classLoader).get();
+            if (handlerDefinition == null) {
+                handlerDefinition = MultiHandlerDefinition.ordered(findDelegates(classLoader));
+                FACTORIES.put(classLoader, new WeakReference<>(handlerDefinition));
+            }
+            return handlerDefinition;
+        }
+    }
+
+    private static MultiHandlerDefinition findDelegates(ClassLoader classLoader) {
+        Iterator<HandlerDefinition> iterator = load(HandlerDefinition.class, classLoader == null ?
+                Thread.currentThread().getContextClassLoader() : classLoader).iterator();
+        //noinspection WhileLoopReplaceableByForEach
+        final List<HandlerDefinition> definitions = new ArrayList<>();
+        while (iterator.hasNext()) {
+            try {
+                HandlerDefinition factory = iterator.next();
+                definitions.add(factory);
+            } catch (ServiceConfigurationError e) {
+                LOGGER.info(
+                        "HandlerDefinition instance ignored, as one of the required classes is not available" +
+                                "on the classpath: {}", e.getMessage());
+            } catch (NoClassDefFoundError e) {
+                LOGGER.info("HandlerDefinition instance ignored. It relies on a class that cannot be found: {}",
+                            e.getMessage());
+            }
+        }
+        return new MultiHandlerDefinition(definitions);
+    }
+}

--- a/core/src/main/java/org/axonframework/messaging/annotation/ClasspathHandlerEnhancerDefinition.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/ClasspathHandlerEnhancerDefinition.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.WeakHashMap;
+
+import static java.util.ServiceLoader.load;
+
+/**
+ * HandlerEnhancerDefinition instance that locates other HandlerEnhancerDefinition instances on the class path. It uses
+ * the {@link ServiceLoader} mechanism to locate and initialize them.
+ * <p/>
+ * This means for this class to find implementations, their fully qualified class name has to be put into a file called
+ * {@code META-INF/services/org.axonframework.messaging.annotation.HandlerEnhancerDefinition}. For more details, see
+ * {@link ServiceLoader}.
+ *
+ * @author Tyler Thrailkill
+ * @author Milan Savic
+ * @see ServiceLoader
+ * @since 3.3
+ */
+public final class ClasspathHandlerEnhancerDefinition {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClasspathHandlerEnhancerDefinition.class);
+    private static final Object MONITOR = new Object();
+    private static final Map<ClassLoader, WeakReference<MultiHandlerEnhancerDefinition>> FACTORIES = new WeakHashMap<>();
+
+    private ClasspathHandlerEnhancerDefinition() {
+        // not meant to be publicly instantiated
+    }
+
+    /**
+     * Creates an instance for the given {@code clazz}. Effectively, the class loader of the given class is used to
+     * locate implementations.
+     *
+     * @param clazz The class for which the handler definition must be returned
+     * @return a MultiHandlerEnhancerDefinition that can create handlers for the given class
+     */
+    public static MultiHandlerEnhancerDefinition forClass(Class<?> clazz) {
+        return forClassLoader(clazz == null ? null : clazz.getClassLoader());
+    }
+
+    /**
+     * Creates an instance using the given {@code classLoader}. Implementations are located using this class loader.
+     *
+     * @param classLoader The class loader to locate the implementations with
+     * @return a MultiHandlerEnhancerDefinition instance using the given classLoader
+     */
+    public static MultiHandlerEnhancerDefinition forClassLoader(ClassLoader classLoader) {
+        synchronized (MONITOR) {
+            MultiHandlerEnhancerDefinition enhancerDefinition;
+            if (!FACTORIES.containsKey(classLoader)) {
+                enhancerDefinition = MultiHandlerEnhancerDefinition.ordered(findDelegates(classLoader));
+                FACTORIES.put(classLoader, new WeakReference<>(enhancerDefinition));
+                return enhancerDefinition;
+            }
+            enhancerDefinition = FACTORIES.get(classLoader).get();
+            if (enhancerDefinition == null) {
+                enhancerDefinition = MultiHandlerEnhancerDefinition.ordered(findDelegates(classLoader));
+                FACTORIES.put(classLoader, new WeakReference<>(enhancerDefinition));
+            }
+            return enhancerDefinition;
+        }
+    }
+
+    private static MultiHandlerEnhancerDefinition findDelegates(ClassLoader classLoader) {
+        Iterator<HandlerEnhancerDefinition> iterator = load(HandlerEnhancerDefinition.class, classLoader == null ?
+                Thread.currentThread().getContextClassLoader() : classLoader).iterator();
+        //noinspection WhileLoopReplaceableByForEach
+        final List<HandlerEnhancerDefinition> enhancers = new ArrayList<>();
+        while (iterator.hasNext()) {
+            try {
+                HandlerEnhancerDefinition factory = iterator.next();
+                enhancers.add(factory);
+            } catch (ServiceConfigurationError e) {
+                LOGGER.info(
+                        "HandlerEnhancerDefinition instance ignored, as one of the required classes is not available" +
+                                "on the classpath: {}", e.getMessage());
+            } catch (NoClassDefFoundError e) {
+                LOGGER.info("HandlerEnhancerDefinition instance ignored. It relies on a class that cannot be found: {}",
+                            e.getMessage());
+            }
+        }
+        return new MultiHandlerEnhancerDefinition(enhancers);
+    }
+
+}

--- a/core/src/main/java/org/axonframework/messaging/annotation/HandlerDefinition.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/HandlerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,5 +36,5 @@ public interface HandlerDefinition {
      * @return An optional containing the handler if the method is suitable, or an empty Nullable otherwise
      */
     <T> Optional<MessageHandlingMember<T>> createHandler(Class<T> declaringType, Executable executable,
-                                                  ParameterResolverFactory parameterResolverFactory);
+                                                         ParameterResolverFactory parameterResolverFactory);
 }

--- a/core/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2010-2016. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.common.annotation.PriorityAnnotationComparator;
+
+import java.lang.reflect.Executable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * HandlerDefinition instance that delegates to multiple other instances, in the order provided. Also, it wraps the
+ * delegate with {@link HandlerEnhancerDefinition}.
+ *
+ * @author Tyler Thrailkill
+ * @author Milan Savic
+ * @since 3.3
+ */
+public class MultiHandlerDefinition implements HandlerDefinition {
+
+    private final List<HandlerDefinition> handlerDefinitions;
+    private final HandlerEnhancerDefinition handlerEnhancerDefinition;
+
+    /**
+     * Creates a MultiHandlerDefinition instance with the given {@code delegates}, which are automatically ordered
+     * based
+     * on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes. Classes with
+     * the same Priority are kept in the order as provided in the {@code delegates}. As an enhancer, {@link
+     * ClasspathHandlerEnhancerDefinition} is used.
+     * <p>
+     * If one of the delegates is a MultiHandlerDefinition itself, that factory's delegates are 'mixed' with the given
+     * {@code delegates}, based on their respective order.
+     *
+     * @param delegates The delegates to include in the factory
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerDefinition ordered(HandlerDefinition... delegates) {
+        return ordered(Arrays.asList(delegates));
+    }
+
+    /**
+     * Creates a MultiHandlerDefinition instance with the given {@code delegates}, which are automatically ordered
+     * based
+     * on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes. Classes with
+     * the same Priority are kept in the order as provided in the {@code delegates}. As an enhancer, provided one is
+     * used.
+     * <p>
+     * If one of the delegates is a MultiHandlerDefinition itself, that factory's delegates are 'mixed' with the given
+     * {@code delegates}, based on their respective order.
+     *
+     * @param handlerEnhancerDefinition The enhancer used to wrap the delegates
+     * @param delegates                 The delegates to include in the factory
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerDefinition ordered(HandlerEnhancerDefinition handlerEnhancerDefinition,
+                                                 HandlerDefinition... delegates) {
+        return ordered(Arrays.asList(delegates), handlerEnhancerDefinition);
+    }
+
+    /**
+     * Creates a MultiHandlerDefinition instance with the given {@code delegates}, which are automatically ordered based
+     * on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes. Classes with
+     * the same Priority are kept in the order as provided in the {@code delegates}. As an enhancer, {@link
+     * ClasspathHandlerEnhancerDefinition} is used.
+     * <p>
+     * If one of the delegates is a MultiHandlerDefinition itself, that factory's delegates are 'mixed' with the given
+     * {@code delegates}, based on their respective order.
+     *
+     * @param delegates The delegates to include in the factory
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerDefinition ordered(List<HandlerDefinition> delegates) {
+        return new MultiHandlerDefinition(delegates);
+    }
+
+    /**
+     * Creates a MultiHandlerDefinition instance with the given {@code delegates}, which are automatically ordered based
+     * on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes. Classes with
+     * the same Priority are kept in the order as provided in the {@code delegates}. As an enhancer, provided one is
+     * used.
+     * <p>
+     * If one of the delegates is a MultiHandlerDefinition itself, that factory's delegates are 'mixed' with the given
+     * {@code delegates}, based on their respective order.
+     *
+     * @param delegates                 The delegates to include in the factory
+     * @param handlerEnhancerDefinition The enhancer used to wrap the delegates
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerDefinition ordered(List<HandlerDefinition> delegates,
+                                                 HandlerEnhancerDefinition handlerEnhancerDefinition) {
+        return new MultiHandlerDefinition(delegates, handlerEnhancerDefinition);
+    }
+
+    /**
+     * Initializes an instance that delegates to the given {@code delegates}, in the order provided. Changes in
+     * the given array are not reflected in the created instance.
+     *
+     * @param delegates The handlerDefinitions providing the parameter values to use
+     */
+    public MultiHandlerDefinition(HandlerDefinition... delegates) {
+        this(Arrays.asList(delegates));
+    }
+
+    /**
+     * Initializes an instance that delegates to the given {@code delegates}, in the order provided. Changes in
+     * the given list are not reflected in the created instance.
+     *
+     * @param delegates The handlerDefinitions providing the parameter values to use
+     */
+    public MultiHandlerDefinition(List<HandlerDefinition> delegates) {
+        this(delegates,
+             ClasspathHandlerEnhancerDefinition.forClassLoader(Thread.currentThread().getContextClassLoader()));
+    }
+
+    /**
+     * Initializes an instance that delegates to the given {@code delegates}, in the order provided. Changes in
+     * the given List are not reflected in the created instance.
+     *
+     * @param delegates                 The list of handlerDefinitions providing the parameter values to use
+     * @param handlerEnhancerDefinition The enhancer used to wrap the delegates
+     */
+    public MultiHandlerDefinition(List<HandlerDefinition> delegates,
+                                  HandlerEnhancerDefinition handlerEnhancerDefinition) {
+        this.handlerDefinitions = flatten(delegates);
+        this.handlerEnhancerDefinition = handlerEnhancerDefinition;
+    }
+
+    private static List<HandlerDefinition> flatten(List<HandlerDefinition> handlerDefinitions) {
+        List<HandlerDefinition> flattened = new ArrayList<>(handlerDefinitions.size());
+        for (HandlerDefinition handlerDefinition : handlerDefinitions) {
+            if (handlerDefinition instanceof MultiHandlerDefinition) {
+                flattened.addAll(((MultiHandlerDefinition) handlerDefinition).getDelegates());
+            } else {
+                flattened.add(handlerDefinition);
+            }
+        }
+        flattened.sort(PriorityAnnotationComparator.getInstance());
+        return flattened;
+    }
+
+    /**
+     * Returns the delegates of this instance, in the order they are evaluated to resolve parameters.
+     *
+     * @return the delegates of this instance, in the order they are evaluated to resolve parameters
+     */
+    public List<HandlerDefinition> getDelegates() {
+        return Collections.unmodifiableList(handlerDefinitions);
+    }
+
+    /**
+     * Returns handler enhancer definition used to wrap handlers.
+     *
+     * @return handler enhancer definition
+     */
+    public HandlerEnhancerDefinition getHandlerEnhancerDefinition() {
+        return handlerEnhancerDefinition;
+    }
+
+    @Override
+    public <T> Optional<MessageHandlingMember<T>> createHandler(Class<T> declaringType,
+                                                                Executable executable,
+                                                                ParameterResolverFactory parameterResolverFactory) {
+        Optional<MessageHandlingMember<T>> handler = Optional.empty();
+        for (HandlerDefinition handlerDefinition : handlerDefinitions) {
+            handler = handlerDefinition.createHandler(declaringType, executable, parameterResolverFactory);
+            if (handler.isPresent()) {
+                return Optional.of(handlerEnhancerDefinition.wrapHandler(handler.get()));
+            }
+        }
+        return handler;
+    }
+}

--- a/core/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
+++ b/core/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.axonframework.common.annotation.PriorityAnnotationComparator;
+
+/**
+ * HandlerEnhancerDefinition instance that delegates to multiple other instances, in the order provided.
+ *
+ * @author Tyler Thrailkill
+ * @since 3.3
+ */
+public class MultiHandlerEnhancerDefinition implements HandlerEnhancerDefinition {
+
+    private final HandlerEnhancerDefinition[] enhancers;
+
+    /**
+     * Creates a MultiHandlerEnhancerDefinition instance with the given {@code delegates}, which are automatically
+     * ordered based on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes.
+     * Classes with the same Priority are kept in the order as provided in the {@code delegates}.
+     * <p>
+     * If one of the delegates is a MultiHandlerEnhancerDefinition itself, that factory's delegates are 'mixed' with
+     * the given {@code delegates}, based on their respective order.
+     *
+     * @param delegates The delegates to include in the factory
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerEnhancerDefinition ordered(HandlerEnhancerDefinition... delegates) {
+        return ordered(Arrays.asList(delegates));
+    }
+
+    /**
+     * Creates a MultiHandlerEnhancerDefinition instance with the given {@code delegates}, which are automatically
+     * ordered based on the {@link org.axonframework.common.Priority @Priority} annotation on their respective classes.
+     * Classes with the same Priority are kept in the order as provided in the {@code delegates}.
+     * <p>
+     * If one of the delegates is a MultiHandlerEnhancerDefinition itself, that factory's delegates are 'mixed' with
+     * the given {@code delegates}, based on their respective order.
+     *
+     * @param delegates The delegates to include in the factory
+     * @return an instance delegating to the given {@code delegates}
+     */
+    public static MultiHandlerEnhancerDefinition ordered(List<HandlerEnhancerDefinition> delegates) {
+        return new MultiHandlerEnhancerDefinition(flatten(delegates));
+    }
+
+    /**
+     * Initializes an instance that delegates to the given {@code delegates}, in the order provided. Changes in
+     * the given array are not reflected in the created instance.
+     *
+     * @param delegates The enhancers providing the parameter values to use
+     */
+    public MultiHandlerEnhancerDefinition(HandlerEnhancerDefinition... delegates) {
+        this.enhancers = Arrays.copyOf(delegates, delegates.length);
+    }
+
+    /**
+     * Initializes an instance that delegates to the given {@code delegates}, in the order provided. Changes in
+     * the given List are not reflected in the created instance.
+     *
+     * @param delegates The list of enhancers providing the parameter values to use
+     */
+    public MultiHandlerEnhancerDefinition(Collection<HandlerEnhancerDefinition> delegates) {
+        this.enhancers = delegates.toArray(new HandlerEnhancerDefinition[delegates.size()]);
+    }
+
+    private static HandlerEnhancerDefinition[] flatten(List<HandlerEnhancerDefinition> factories) {
+        List<HandlerEnhancerDefinition> flattened = new ArrayList<>(factories.size());
+        for (HandlerEnhancerDefinition handlerEnhancer : factories) {
+            if (handlerEnhancer instanceof MultiHandlerEnhancerDefinition) {
+                flattened.addAll(((MultiHandlerEnhancerDefinition) handlerEnhancer).getDelegates());
+            } else {
+                flattened.add(handlerEnhancer);
+            }
+        }
+        flattened.sort(PriorityAnnotationComparator.getInstance());
+        return flattened.toArray(new HandlerEnhancerDefinition[flattened.size()]);
+    }
+
+    /**
+     * Returns the delegates of this instance, in the order they are evaluated to resolve parameters.
+     *
+     * @return the delegates of this instance, in the order they are evaluated to resolve parameters
+     */
+    public List<HandlerEnhancerDefinition> getDelegates() {
+        return Arrays.asList(enhancers);
+    }
+
+    @Override
+    public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
+        MessageHandlingMember<T> resolver = original;
+        for (HandlerEnhancerDefinition enhancer : enhancers) {
+            resolver = enhancer.wrapHandler(resolver);
+        }
+        return resolver;
+    }
+}

--- a/core/src/main/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapter.java
+++ b/core/src/main/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapter.java
@@ -18,7 +18,9 @@ package org.axonframework.queryhandling.annotation;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.queryhandling.*;
@@ -58,9 +60,26 @@ public class AnnotationQueryHandlerAdapter<T> implements QueryHandlerAdapter,
      * @param target                   The instance with {@link QueryHandler} annotated methods
      * @param parameterResolverFactory The parameter resolver factory to resolve handler parameters with
      */
-    @SuppressWarnings("unchecked")
     public AnnotationQueryHandlerAdapter(T target, ParameterResolverFactory parameterResolverFactory) {
-        this.model = AnnotatedHandlerInspector.inspectType((Class<T>) target.getClass(), parameterResolverFactory);
+        this(target,
+             parameterResolverFactory,
+             ClasspathHandlerDefinition.forClass(target.getClass()));
+    }
+
+    /**
+     * Initializes the adapter, forwarding call to the given {@code target}, resolving parameters using the given
+     * {@code parameterResolverFactory} and creating handlers using {@code handlerDefinition}.
+     *
+     * @param target                   The instance with {@link QueryHandler} annotated methods
+     * @param parameterResolverFactory The parameter resolver factory to resolve handler parameters with
+     * @param handlerDefinition        The handler definition used to create concrete handlers
+     */
+    @SuppressWarnings("unchecked")
+    public AnnotationQueryHandlerAdapter(T target, ParameterResolverFactory parameterResolverFactory,
+                                         HandlerDefinition handlerDefinition) {
+        this.model = AnnotatedHandlerInspector.inspectType((Class<T>) target.getClass(),
+                                                           parameterResolverFactory,
+                                                           handlerDefinition);
         this.target = target;
     }
 

--- a/core/src/test/java/org/axonframework/eventhandling/SegmentTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/SegmentTest.java
@@ -193,6 +193,12 @@ public class SegmentTest {
     @Test
     public void testSegmentResolve() {
         {
+            final int[] segments = {};
+            final Segment[] segmentMasks = Segment.computeSegments(segments);
+            assertThat(segmentMasks.length, is(0));
+        }
+
+        {
             final int[] segments = {0};
             final Segment[] segmentMasks = Segment.computeSegments(segments);
             assertThat(segmentMasks.length, is(1));

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/EventProcessorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,19 +71,25 @@ public class EventProcessorProperties {
         /**
          * Indicates the number of segments that should be created when the processor starts for the first time.
          */
-        private int initialSegmentCount;
+        private int initialSegmentCount = 1;
 
         /**
          * The maximum number of threads the processor should process events with. Defaults to the number of initial
          * segments if this is not further specified.
          */
-        private int threadCount = 0;
+        private int threadCount = -1;
 
         /**
          * The maximum number of events a processor should process as part of a single batch.
          */
         private int batchSize = 1;
 
+        /**
+         * The name of the bean that represents the sequencing policy for processing events. If no name is specified,
+         * the processor defaults to a {@link org.axonframework.eventhandling.async.SequentialPerAggregatePolicy}, which
+         * guarantees to process events originating from the same Aggregate instance sequentially, while events from
+         * different Aggregate instances may be processed concurrently.
+         */
         private String sequencingPolicy;
 
         /**
@@ -150,12 +156,15 @@ public class EventProcessorProperties {
          * @return the number of threads to use to process Events.
          */
         public int getThreadCount() {
-            return threadCount <= 0 ? initialSegmentCount : threadCount;
+            return threadCount < 0 ? initialSegmentCount : threadCount;
         }
 
         /**
          * Sets the number of threads to use to process Events, when in "tracking" mode. Defaults to the number of
          * initial segments.
+         * <p>
+         * A provided {@code threadCount} < 0 will result in a number of threads equal to the configured number of
+         * {@link #setInitialSegmentCount(int) initial segments}.
          *
          * @param threadCount the number of threads to use to process Events.
          */

--- a/spring/src/main/java/org/axonframework/spring/config/AnnotationDrivenRegistrar.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AnnotationDrivenRegistrar.java
@@ -18,12 +18,12 @@ package org.axonframework.spring.config;
 
 import org.axonframework.spring.config.annotation.AnnotationCommandHandlerBeanPostProcessor;
 import org.axonframework.spring.config.annotation.AnnotationQueryHandlerBeanPostProcessor;
+import org.axonframework.spring.config.annotation.SpringContextHandlerDefinitionBuilder;
+import org.axonframework.spring.config.annotation.SpringContextParameterResolverFactoryBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
-
-import static org.axonframework.spring.config.annotation.SpringContextParameterResolverFactoryBuilder.getBeanReference;
 
 /**
  * Spring @Configuration related class that adds Axon Annotation PostProcessors to the BeanDefinitionRegistry.
@@ -57,7 +57,10 @@ public class AnnotationDrivenRegistrar implements ImportBeanDefinitionRegistrar 
     public void registerAnnotationCommandHandlerBeanPostProcessor(BeanDefinitionRegistry registry) {
         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
         beanDefinition.setBeanClass(AnnotationCommandHandlerBeanPostProcessor.class);
-        beanDefinition.getPropertyValues().add("parameterResolverFactory", getBeanReference(registry));
+        beanDefinition.getPropertyValues().add("parameterResolverFactory",
+                                               SpringContextParameterResolverFactoryBuilder.getBeanReference(registry));
+        beanDefinition.getPropertyValues().add("handlerDefinition",
+                                               SpringContextHandlerDefinitionBuilder.getBeanReference(registry));
 
         registry.registerBeanDefinition(COMMAND_HANDLER_BEAN_NAME, beanDefinition);
     }
@@ -65,7 +68,10 @@ public class AnnotationDrivenRegistrar implements ImportBeanDefinitionRegistrar 
     public void registerAnnotationQueryHandlerBeanPostProcessor(BeanDefinitionRegistry registry) {
         GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
         beanDefinition.setBeanClass(AnnotationQueryHandlerBeanPostProcessor.class);
-        beanDefinition.getPropertyValues().add("parameterResolverFactory", getBeanReference(registry));
+        beanDefinition.getPropertyValues().add("parameterResolverFactory",
+                                               SpringContextParameterResolverFactoryBuilder.getBeanReference(registry));
+        beanDefinition.getPropertyValues().add("handlerDefinition",
+                                               SpringContextHandlerDefinitionBuilder.getBeanReference(registry));
 
         registry.registerBeanDefinition(QUERY_HANDLER_BEAN_NAME, beanDefinition);
     }

--- a/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.axonframework.config.ModuleConfiguration;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.saga.ResourceInjector;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.queryhandling.DefaultQueryGateway;
@@ -147,6 +148,11 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Override
     public List<CorrelationDataProvider> correlationDataProviders() {
         return config.correlationDataProviders();
+    }
+
+    @Override
+    public HandlerDefinition handlerDefinition(Class<?> inspectedType) {
+        return config.handlerDefinition(inspectedType);
     }
 
     @Override

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessor.java
@@ -22,6 +22,7 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.SupportedCommandNamesAware;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.MessageHandler;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.spring.config.AbstractAnnotationHandlerBeanPostProcessor;
 import org.springframework.util.ReflectionUtils;
@@ -51,8 +52,9 @@ public class AnnotationCommandHandlerBeanPostProcessor
 
     @Override
     protected AnnotationCommandHandlerAdapter initializeAdapterFor(Object bean,
-                                                                   ParameterResolverFactory parameterResolverFactory) {
-        return new AnnotationCommandHandlerAdapter(bean, parameterResolverFactory);
+                                                                   ParameterResolverFactory parameterResolverFactory,
+                                                                   HandlerDefinition handlerDefinition) {
+        return new AnnotationCommandHandlerAdapter(bean, parameterResolverFactory, handlerDefinition);
     }
 
     private boolean hasCommandHandlerMethod(Class<?> beanClass) {

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessor.java
@@ -17,6 +17,7 @@ package org.axonframework.spring.config.annotation;
 
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.MessageHandler;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.queryhandling.QueryHandler;
 import org.axonframework.queryhandling.QueryHandlerAdapter;
@@ -51,9 +52,12 @@ public class AnnotationQueryHandlerBeanPostProcessor extends AbstractAnnotationH
         return result.get();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected AnnotationQueryHandlerAdapter initializeAdapterFor(Object o, ParameterResolverFactory parameterResolverFactory) {
-        return new AnnotationQueryHandlerAdapter<>(o, parameterResolverFactory);
+    protected AnnotationQueryHandlerAdapter initializeAdapterFor(Object o,
+                                                                 ParameterResolverFactory parameterResolverFactory,
+                                                                 HandlerDefinition handlerDefinition) {
+        return new AnnotationQueryHandlerAdapter<>(o, parameterResolverFactory, handlerDefinition);
     }
 
     private class HasQueryHandlerAnnotationMethodCallback implements ReflectionUtils.MethodCallback {

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringContextHandlerDefinitionBuilder.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringContextHandlerDefinitionBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config.annotation;
+
+import org.axonframework.messaging.annotation.MultiHandlerDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+
+/**
+ * Creates and registers a bean definition for a Spring Context aware HandlerDefinition. It ensures that only
+ * one such instance exists for each ApplicationContext.
+ *
+ * @author Tyler Thrailkill
+ * @author Milan Savic
+ * @since 3.3
+ */
+public final class SpringContextHandlerDefinitionBuilder {
+
+    private static final String HANDLER_DEFINITION_BEAN_NAME = "__axon-handler-definition";
+
+    private SpringContextHandlerDefinitionBuilder() {
+    }
+
+    /**
+     * Create, if necessary, a bean definition for a HandlerDefinition and returns the reference to bean for use in
+     * other Bean Definitions.
+     *
+     * @param registry The registry in which to look for an already existing instance
+     * @return a BeanReference to the BeanDefinition for the HandlerDefinition
+     */
+    public static RuntimeBeanReference getBeanReference(BeanDefinitionRegistry registry) {
+        if (!registry.containsBeanDefinition(HANDLER_DEFINITION_BEAN_NAME)) {
+            BeanDefinition definition = BeanDefinitionBuilder
+                    .genericBeanDefinition(SpringHandlerDefinitionBean.class).getBeanDefinition();
+            BeanDefinition enhancer = BeanDefinitionBuilder
+                    .genericBeanDefinition(SpringHandlerEnhancerDefinitionBean.class).getBeanDefinition();
+
+            AbstractBeanDefinition def = BeanDefinitionBuilder.genericBeanDefinition(MultiHandlerDefinition.class)
+                                                              .addConstructorArgValue(definition)
+                                                              .addConstructorArgValue(enhancer)
+                                                              .getBeanDefinition();
+            def.setPrimary(true);
+            registry.registerBeanDefinition(HANDLER_DEFINITION_BEAN_NAME, def);
+        }
+        return new RuntimeBeanReference(HANDLER_DEFINITION_BEAN_NAME);
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringHandlerDefinitionBean.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringHandlerDefinitionBean.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config.annotation;
+
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.MultiHandlerDefinition;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spring factory bean that creates a HandlerDefinition instance that is capable of resolving parameter values as Spring
+ * Beans, in addition to the default behavior defined by Axon.
+ *
+ * @author Tyler Thrailkill
+ * @author Milan Savic
+ * @see ClasspathHandlerDefinition
+ * @since 3.3
+ */
+public class SpringHandlerDefinitionBean implements FactoryBean<HandlerDefinition>,
+        BeanClassLoaderAware, InitializingBean, ApplicationContextAware {
+
+    private final List<HandlerDefinition> definitions = new ArrayList<>();
+    private ClassLoader classLoader;
+    private ApplicationContext applicationContext;
+
+    /**
+     * Initializes definition bean with assumption that application context will be injected.
+     */
+    public SpringHandlerDefinitionBean() {
+        // nothing to do, application context will be injected by spring
+    }
+
+    /**
+     * Initializes definition bean with given application context.
+     *
+     * @param applicationContext application context
+     */
+    public SpringHandlerDefinitionBean(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        initialize();
+    }
+
+    @Override
+    public HandlerDefinition getObject() {
+        return MultiHandlerDefinition.ordered(definitions);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return HandlerDefinition.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        initialize();
+    }
+
+    /**
+     * Defines any additional handler definitions that should be used. By default, the HandlerDefinitions are found on
+     * the classpath, as well as a SpringBeanParameterResolverFactory are registered.
+     *
+     * @param additionalFactories The extra definitions to register
+     * @see SpringBeanParameterResolverFactory
+     * @see ClasspathHandlerDefinition
+     */
+    public void setAdditionalHandlers(List<HandlerDefinition> additionalFactories) {
+        this.definitions.addAll(additionalFactories);
+    }
+
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    private void initialize() {
+        definitions.addAll(ClasspathHandlerDefinition.forClassLoader(classLoader).getDelegates());
+        Map<String, HandlerDefinition> definitionsFound = applicationContext.getBeansOfType(HandlerDefinition.class);
+        definitions.addAll(definitionsFound.values());
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringHandlerEnhancerDefinitionBean.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringHandlerEnhancerDefinitionBean.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config.annotation;
+
+import org.axonframework.messaging.annotation.ClasspathHandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.MultiHandlerEnhancerDefinition;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spring factory bean that creates a HandlerEnhancerDefinition instance that is capable of resolving parameter values
+ * as Spring Beans, in addition to the default behavior defined by Axon.
+ *
+ * @author Milan Savic
+ * @see ClasspathHandlerEnhancerDefinition
+ * @since 3.3
+ */
+public class SpringHandlerEnhancerDefinitionBean implements FactoryBean<HandlerEnhancerDefinition>,
+        BeanClassLoaderAware, InitializingBean, ApplicationContextAware {
+
+    private final List<HandlerEnhancerDefinition> enhancers = new ArrayList<>();
+    private ClassLoader classLoader;
+    private ApplicationContext applicationContext;
+
+    /**
+     * Initializes definition bean with assumption that application context will be injected.
+     */
+    public SpringHandlerEnhancerDefinitionBean() {
+        // nothing to do, application context will be injected by spring
+    }
+
+    /**
+     * Initializes definition bean with given application context.
+     *
+     * @param applicationContext application context
+     */
+    public SpringHandlerEnhancerDefinitionBean(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        initialize();
+    }
+
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public HandlerEnhancerDefinition getObject() {
+        return MultiHandlerEnhancerDefinition.ordered(enhancers);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return HandlerEnhancerDefinition.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        initialize();
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    /**
+     * Defines any additional handler enhancer definitions that should be used. By default, the
+     * HandlerEnhancerDefinitions are found on the classpath, as well as a SpringBeanParameterResolverFactory are
+     * registered.
+     *
+     * @param additionalFactories The extra definitions to register
+     * @see SpringBeanParameterResolverFactory
+     * @see ClasspathHandlerEnhancerDefinition
+     */
+    public void setAdditionalHandlers(List<HandlerEnhancerDefinition> additionalFactories) {
+        this.enhancers.addAll(additionalFactories);
+    }
+
+    private void initialize() {
+        enhancers.addAll(ClasspathHandlerEnhancerDefinition.forClassLoader(classLoader).getDelegates());
+        Map<String, HandlerEnhancerDefinition> enhancersFound = applicationContext.getBeansOfType(
+                HandlerEnhancerDefinition.class);
+        enhancers.addAll(enhancersFound.values());
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
@@ -21,7 +21,7 @@ import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.AggregateSnapshotter;
 import org.axonframework.eventsourcing.EventSourcingRepository;
 import org.axonframework.eventsourcing.eventstore.EventStore;
-import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -48,14 +48,12 @@ public class SpringAggregateSnapshotter extends AggregateSnapshotter implements 
     private ApplicationContext applicationContext;
 
     /**
-     * Initializes a snapshotter using the ParameterResolverFactory instances available on the classpath.
-     * The given Aggregate Factories are lazily retrieved from the application context.
+     * Initializes a snapshotter. The given Aggregate Factories are lazily retrieved from the application context.
      *
      * @param eventStore               The Event Store to store snapshots in
      * @param parameterResolverFactory The parameterResolverFactory used to reconstruct aggregates
      * @param executor                 The executor that processes the snapshotting requests
      * @param txManager                The transaction manager to manage the persistence transactions with
-     * @see ClasspathParameterResolverFactory
      */
     public SpringAggregateSnapshotter(EventStore eventStore, ParameterResolverFactory parameterResolverFactory,
                                       Executor executor, TransactionManager txManager) {
@@ -68,15 +66,21 @@ public class SpringAggregateSnapshotter extends AggregateSnapshotter implements 
      *
      * @param eventStore               The Event Store to store snapshots in
      * @param parameterResolverFactory The parameterResolverFactory used to reconstruct aggregates
+     * @param handlerDefinition        The handler definition used to create concrete handlers
      * @param executor                 The executor that processes the snapshotting requests
      * @param txManager                The transaction manager to manage the persistence transactions with
      * @param repositoryProvider       Provides repositories for specific aggregate types
-     * @see ClasspathParameterResolverFactory
      */
     public SpringAggregateSnapshotter(EventStore eventStore, ParameterResolverFactory parameterResolverFactory,
-                                      Executor executor, TransactionManager txManager,
-                                      RepositoryProvider repositoryProvider) {
-        super(eventStore, Collections.emptyList(), parameterResolverFactory, executor, txManager, repositoryProvider);
+                                      HandlerDefinition handlerDefinition, Executor executor,
+                                      TransactionManager txManager, RepositoryProvider repositoryProvider) {
+        super(eventStore,
+              Collections.emptyList(),
+              parameterResolverFactory,
+              handlerDefinition,
+              executor,
+              txManager,
+              repositoryProvider);
     }
 
     @Override

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,19 +16,17 @@
 
 package org.axonframework.spring.config;
 
-import org.axonframework.commandhandling.AsynchronousCommandBus;
-import org.axonframework.commandhandling.CommandBus;
-import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.commandhandling.CommandTargetResolver;
-import org.axonframework.commandhandling.SimpleCommandBus;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
-import org.axonframework.commandhandling.VersionedAggregateIdentifier;
+import org.axonframework.commandhandling.*;
 import org.axonframework.commandhandling.callbacks.FutureCallback;
 import org.axonframework.commandhandling.model.AggregateIdentifier;
+import org.axonframework.commandhandling.model.inspection.MethodCommandHandlerDefinition;
+import org.axonframework.commandhandling.model.inspection.MethodCommandHandlerInterceptorDefinition;
 import org.axonframework.config.SagaConfiguration;
 import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.replay.ReplayAwareMessageHandlerWrapper;
 import org.axonframework.eventhandling.saga.AssociationValue;
 import org.axonframework.eventhandling.saga.SagaEventHandler;
+import org.axonframework.eventhandling.saga.SagaMethodMessageHandlerDefinition;
 import org.axonframework.eventhandling.saga.StartSaga;
 import org.axonframework.eventhandling.saga.repository.SagaStore;
 import org.axonframework.eventhandling.saga.repository.inmemory.InMemorySagaStore;
@@ -35,11 +34,13 @@ import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.messaging.annotation.*;
+import org.axonframework.queryhandling.annotation.MethodQueryMessageHandlerDefinition;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.*;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -52,9 +53,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.lang.reflect.Executable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -64,9 +67,7 @@ import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -204,6 +205,31 @@ public class SpringAxonAutoConfigurerTest {
         assertTrue(Context.MySaga.events.containsAll(Arrays.asList("id", "id")));
         assertEquals(1, myListenerInvocationErrorHandler.received.size());
         assertEquals("Ooops! I failed.", myListenerInvocationErrorHandler.received.get(0).getMessage());
+    }
+
+    @Test
+    public void testHandlerDefinitionAndHandlerEnhancerBeansRegistered() {
+        MultiHandlerDefinition handlerDefinition = (MultiHandlerDefinition) axonConfig.handlerDefinition(getClass());
+        MultiHandlerEnhancerDefinition handlerEnhancerDefinition = (MultiHandlerEnhancerDefinition) handlerDefinition
+                .getHandlerEnhancerDefinition();
+
+        assertEquals(AnnotatedMessageHandlingMemberDefinition.class,
+                     handlerDefinition.getDelegates().get(0).getClass());
+        assertEquals(Context.HandlerDefinitionWithInjectedResource.class,
+                     handlerDefinition.getDelegates().get(1).getClass());
+        assertEquals(MyHandlerDefinition.class, handlerDefinition.getDelegates().get(2).getClass());
+        assertEquals(MyHandlerDefinition.class, handlerDefinition.getDelegates().get(3).getClass());
+
+        assertEquals(SagaMethodMessageHandlerDefinition.class,
+                     handlerEnhancerDefinition.getDelegates().get(0).getClass());
+        assertEquals(MethodCommandHandlerDefinition.class, handlerEnhancerDefinition.getDelegates().get(1).getClass());
+        assertEquals(MethodQueryMessageHandlerDefinition.class,
+                     handlerEnhancerDefinition.getDelegates().get(2).getClass());
+        assertEquals(ReplayAwareMessageHandlerWrapper.class,
+                     handlerEnhancerDefinition.getDelegates().get(3).getClass());
+        assertEquals(MethodCommandHandlerInterceptorDefinition.class,
+                     handlerEnhancerDefinition.getDelegates().get(4).getClass());
+        assertEquals(MyHandlerEnhancerDefinition.class, handlerEnhancerDefinition.getDelegates().get(5).getClass());
     }
 
     @SuppressWarnings("unchecked")
@@ -431,6 +457,38 @@ public class SpringAxonAutoConfigurerTest {
             return SagaConfiguration.subscribingSagaManager(MySaga.class)
                     .configureSagaStore(c -> customSagaStore);
         }
+
+        @Bean
+        public HandlerDefinition myHandlerDefinition1() {
+            return new MyHandlerDefinition();
+        }
+
+        @Bean
+        public HandlerDefinition myHandlerDefinition2() {
+            return new MyHandlerDefinition();
+        }
+
+        @Bean
+        public HandlerEnhancerDefinition myHandlerEnhancerDefinition() {
+            return new MyHandlerEnhancerDefinition();
+        }
+
+        @Component
+        public static class HandlerDefinitionWithInjectedResource implements HandlerDefinition {
+
+            private final CommandBus commandBus;
+
+            public HandlerDefinitionWithInjectedResource(CommandBus commandBus) {
+                this.commandBus = commandBus;
+            }
+
+            @Override
+            public <T> Optional<MessageHandlingMember<T>> createHandler(Class<T> declaringType, Executable executable,
+                                                                        ParameterResolverFactory parameterResolverFactory) {
+                assertNotNull(commandBus);
+                return Optional.empty();
+            }
+        }
     }
 
     public static class SomeEvent {
@@ -459,5 +517,20 @@ public class SpringAxonAutoConfigurerTest {
         }
     }
 
+    private static class MyHandlerDefinition implements HandlerDefinition {
 
+        @Override
+        public <T> Optional<MessageHandlingMember<T>> createHandler(Class<T> declaringType, Executable executable,
+                                                                    ParameterResolverFactory parameterResolverFactory) {
+            return Optional.empty();
+        }
+    }
+
+    private static class MyHandlerEnhancerDefinition implements HandlerEnhancerDefinition {
+
+        @Override
+        public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
+            return new MethodCommandHandlerDefinition().wrapHandler(original);
+        }
+    }
 }

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.*;
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.matchers.FieldFilter;
 
@@ -206,6 +207,15 @@ public interface FixtureConfiguration<T> {
      * @throws FixtureExecutionException when no such field is declared
      */
     FixtureConfiguration<T> registerIgnoredField(Class<?> declaringClass, String fieldName);
+
+    /**
+     * Registers handler definition within this fixture. This {@code handlerDefinition} will replace existing one within
+     * this fixture.
+     *
+     * @param handlerDefinition used to create concrete handlers
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    FixtureConfiguration<T> registerHandlerDefinition(HandlerDefinition handlerDefinition);
 
     /**
      * Configures the given {@code domainEvents} as the "given" events. These are the events returned by the event

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.test.saga;
 
+import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.aggregate.ResultValidator;
 import org.axonframework.test.matchers.FieldFilter;
@@ -115,6 +116,15 @@ public interface FixtureConfiguration {
      * @throws FixtureExecutionException when no such field is declared
      */
     FixtureConfiguration registerIgnoredField(Class<?> declaringClass, String fieldName);
+
+    /**
+     * Registers handler definition within this fixture. This {@code handlerDefinition} will replace existing one within
+     * this fixture.
+     *
+     * @param handlerDefinition used to create concrete handlers
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    FixtureConfiguration registerHandlerDefinition(HandlerDefinition handlerDefinition);
 
     /**
      * Sets the instance that defines the behavior of the Command Bus when a command is dispatched with a callback.


### PR DESCRIPTION
Solves one of the concerns raised in #619 by catching the ServiceConfigurationError and allowing to fallback to the default UUID.

I cannot easily provide a test for this, IdentifierFactory really was not made for testing :/