### PR TITLE
[#647] QueryUpdateEmitter doesn't respect UnitOfWork lifecycle

### DIFF
--- a/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
@@ -20,6 +20,17 @@ import java.util.function.Predicate;
 
 /**
  * Component which informs subscription queries about updates, errors and when there are no more updates.
+ * <p>
+ * If any of the emitter functions in this interface are called from a message handling function (e.g. an {@link
+ * org.axonframework.eventhandling.EventHandler} annotated function), then that call will automatically be tied into the
+ * lifecycle of the current {@link org.axonframework.messaging.unitofwork.UnitOfWork} to ensure correct order of
+ * execution.
+ * <p>
+ * Added, implementations of this class should thus respect any current UnitOfWork in the
+ * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED} phase for any of the emitting functions. If
+ * this is the case then the emitter call action should be performed during the
+ * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT}. Otherwise the operation can be executed
+ * immediately.
  *
  * @author Milan Savic
  * @since 3.3
@@ -29,11 +40,6 @@ public interface QueryUpdateEmitter {
     /**
      * Emits incremental update (as return value of provided update function) to subscription queries matching given
      * filter.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update message
@@ -45,11 +51,6 @@ public interface QueryUpdateEmitter {
      * Emits given incremental update to subscription queries matching given filter. If an {@code update} is {@code
      * null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update
@@ -63,11 +64,6 @@ public interface QueryUpdateEmitter {
 
     /**
      * Emits given incremental update to subscription queries matching given query type and filter.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -87,11 +83,6 @@ public interface QueryUpdateEmitter {
      * Emits given incremental update to subscription queries matching given query type and filter. If an {@code update}
      * is {@code null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -107,11 +98,6 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes subscription queries matching given filter.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      */
@@ -119,11 +105,6 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes subscription queries matching given query type and filter.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -138,11 +119,6 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes with an error subscription queries matching given filter.
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param cause  the cause of an error
@@ -151,11 +127,6 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes with an error subscription queries matching given query type and filter
-     * <p>
-     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * lifecycle. This usually holds when this operation is called from any message handling function.
-     * If this is the case, then this action should be performed during the
-     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries

--- a/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
@@ -29,6 +29,11 @@ public interface QueryUpdateEmitter {
     /**
      * Emits incremental update (as return value of provided update function) to subscription queries matching given
      * filter.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update message
@@ -40,6 +45,11 @@ public interface QueryUpdateEmitter {
      * Emits given incremental update to subscription queries matching given filter. If an {@code update} is {@code
      * null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update
@@ -53,6 +63,11 @@ public interface QueryUpdateEmitter {
 
     /**
      * Emits given incremental update to subscription queries matching given query type and filter.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -72,6 +87,11 @@ public interface QueryUpdateEmitter {
      * Emits given incremental update to subscription queries matching given query type and filter. If an {@code update}
      * is {@code null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -87,6 +107,11 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes subscription queries matching given filter.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      */
@@ -94,6 +119,11 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes subscription queries matching given query type and filter.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -108,6 +138,11 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes with an error subscription queries matching given filter.
+     * <p>
+     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param cause  the cause of an error
@@ -116,6 +151,11 @@ public interface QueryUpdateEmitter {
 
     /**
      * Completes with an error subscription queries matching given query type and filter
+     * <p>
+     * Note that if this operation is called whilst a current{@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
+     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
+     * ensures this operation is done after a calling task has rounded up its process,
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries

--- a/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
@@ -30,10 +30,10 @@ public interface QueryUpdateEmitter {
      * Emits incremental update (as return value of provided update function) to subscription queries matching given
      * filter.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update message
@@ -46,10 +46,10 @@ public interface QueryUpdateEmitter {
      * null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param update incremental update
@@ -64,10 +64,10 @@ public interface QueryUpdateEmitter {
     /**
      * Emits given incremental update to subscription queries matching given query type and filter.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -88,10 +88,10 @@ public interface QueryUpdateEmitter {
      * is {@code null}, emit will be skipped. In order to send nullable updates, use {@link #emit(Class, Predicate,
      * SubscriptionQueryUpdateMessage)} or {@link #emit(Predicate, SubscriptionQueryUpdateMessage)} methods.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -108,10 +108,10 @@ public interface QueryUpdateEmitter {
     /**
      * Completes subscription queries matching given filter.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      */
@@ -120,10 +120,10 @@ public interface QueryUpdateEmitter {
     /**
      * Completes subscription queries matching given query type and filter.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries
@@ -139,10 +139,10 @@ public interface QueryUpdateEmitter {
     /**
      * Completes with an error subscription queries matching given filter.
      * <p>
-     * Note that if this operation is called whilst a current {@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param filter predicate on subscription query message used to filter subscription queries
      * @param cause  the cause of an error
@@ -152,10 +152,10 @@ public interface QueryUpdateEmitter {
     /**
      * Completes with an error subscription queries matching given query type and filter
      * <p>
-     * Note that if this operation is called whilst a current{@link org.axonframework.messaging.unitofwork.UnitOfWork}
-     * is active and {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#STARTED}, then this operation should
-     * be performed on the {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase. Doing so
-     * ensures this operation is done after a calling task has rounded up its process,
+     * Note that this operation should respect any started {@link org.axonframework.messaging.unitofwork.UnitOfWork}
+     * lifecycle. This usually holds when this operation is called from any message handling function.
+     * If this is the case, then this action should be performed during the
+     * {@link org.axonframework.messaging.unitofwork.UnitOfWork.Phase#AFTER_COMMIT} phase.
      *
      * @param queryType the type of the query
      * @param filter    predicate on query payload used to filter subscription queries

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -319,7 +319,7 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     /**
      * Either runs the provided {@link Runnable} immediately or adds it to a {@link List} as a resource to the current
      * {@link UnitOfWork} if {@link SimpleQueryBus#inStartedPhaseOfUnitOfWork} returns {@code true}. This is done to
-     * ensure the task is executed in the {@link UnitOfWork.Phase#AFTER_COMMIT} phase if its called from some message
+     * ensure the task is executed in the {@link UnitOfWork.Phase#AFTER_COMMIT} phase if it's called from some message
      * handling function.
      * <p>
      * The latter check requires the current UnitOfWork its Phase to be {@link UnitOfWork.Phase#STARTED}. This is done
@@ -347,10 +347,10 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     }
 
     /**
-     * Return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if it's {@link
-     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false.
+     * Return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if its {@link
+     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}.
      *
-     * @return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if it's {@link
+     * @return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if its {@link
      * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}
      */
     private boolean inStartedPhaseOfUnitOfWork() {

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -319,10 +319,10 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     /**
      * Either runs the provided {@link Runnable} immediately or adds it to a {@link List} as a resource to the current
      * {@link UnitOfWork} if {@link SimpleQueryBus#inStartedPhaseOfUnitOfWork} returns {@code true}. This is done to
-     * ensure the task is executed in the {@link UnitOfWork.Phase#AFTER_COMMIT} phase if it's called from some message
-     * handling function.
+     * ensure any emitter calls made from a message handling function are executed in the
+     * {@link UnitOfWork.Phase#AFTER_COMMIT} phase.
      * <p>
-     * The latter check requires the current UnitOfWork its Phase to be {@link UnitOfWork.Phase#STARTED}. This is done
+     * The latter check requires the current UnitOfWork's phase to be {@link UnitOfWork.Phase#STARTED}. This is done
      * to allow users to circumvent their {@code queryUpdateTask} being handled in the AFTER_COMMIT phase. They can do
      * this by retrieving the current UnitOfWork and performing any of the {@link QueryUpdateEmitter} calls in a
      * different phase.
@@ -347,11 +347,11 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     }
 
     /**
-     * Return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if its {@link
-     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}.
+     * Return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if the phase is
+     * {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}.
      *
-     * @return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if its {@link
-     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}
+     * @return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if the phase is
+     * {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}.
      */
     private boolean inStartedPhaseOfUnitOfWork() {
         return CurrentUnitOfWork.isStarted() && UnitOfWork.Phase.STARTED.equals(CurrentUnitOfWork.get().phase());

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.interceptors.TransactionManagingInterceptor;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.monitoring.MessageMonitor;
@@ -34,8 +35,22 @@ import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.FluxSink;
 
 import java.lang.reflect.Type;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -61,6 +76,8 @@ import static org.axonframework.common.ObjectUtils.getRemainingOfDeadline;
 public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleQueryBus.class);
+
+    private static final String QUERY_UPDATE_TASKS_RESOURCE_KEY = "/update-tasks";
 
     private final ConcurrentMap<String, CopyOnWriteArrayList<QuerySubscription>> subscriptions = new ConcurrentHashMap<>();
     private final ConcurrentMap<SubscriptionQueryMessage<?, ?, ?>, FluxSinkWrapper<?>> updateHandlers = new ConcurrentHashMap<>();
@@ -254,6 +271,12 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
     @Override
     public <U> void emit(Predicate<SubscriptionQueryMessage<?, ?, U>> filter,
                          SubscriptionQueryUpdateMessage<U> update) {
+        runOnAfterCommitOrNow(() -> doEmit(filter, update));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <U> void doEmit(Predicate<SubscriptionQueryMessage<?, ?, U>> filter,
+                            SubscriptionQueryUpdateMessage<U> update) {
         updateHandlers.keySet()
                       .stream()
                       .filter(sqm -> filter.test((SubscriptionQueryMessage<?, ?, U>) sqm))
@@ -263,6 +286,10 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
 
     @Override
     public void complete(Predicate<SubscriptionQueryMessage<?, ?, ?>> filter) {
+        runOnAfterCommitOrNow(() -> doComplete(filter));
+    }
+
+    private void doComplete(Predicate<SubscriptionQueryMessage<?, ?, ?>> filter) {
         updateHandlers.keySet()
                       .stream()
                       .filter(filter)
@@ -278,11 +305,56 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
 
     @Override
     public void completeExceptionally(Predicate<SubscriptionQueryMessage<?, ?, ?>> filter, Throwable cause) {
+        runOnAfterCommitOrNow(() -> doCompleteExceptionally(filter, cause));
+    }
+
+    private void doCompleteExceptionally(Predicate<SubscriptionQueryMessage<?, ?, ?>> filter, Throwable cause) {
         updateHandlers.keySet()
                       .stream()
                       .filter(filter)
                       .forEach(query -> Optional.ofNullable(updateHandlers.get(query))
                                                 .ifPresent(updateHandler -> emitError(query, cause, updateHandler)));
+    }
+
+    /**
+     * Either runs the provided {@link Runnable} immediately or adds it to a {@link List} as a resource to the current
+     * {@link UnitOfWork} if {@link SimpleQueryBus#inStartedPhaseOfUnitOfWork} returns {@code true}. This is done to
+     * ensure the task is executed in the {@link UnitOfWork.Phase#AFTER_COMMIT} phase if its called from some message
+     * handling function.
+     * <p>
+     * The latter check requires the current UnitOfWork its Phase to be {@link UnitOfWork.Phase#STARTED}. This is done
+     * to allow users to circumvent their {@code queryUpdateTask} being handled in the AFTER_COMMIT phase. They can do
+     * this by retrieving the current UnitOfWork and performing any of the {@link QueryUpdateEmitter} calls in a
+     * different phase.
+     *
+     * @param queryUpdateTask a {@link Runnable} to be ran immediately or as a resource if {@link
+     *                        SimpleQueryBus#inStartedPhaseOfUnitOfWork} returns {@code true}
+     */
+    private void runOnAfterCommitOrNow(Runnable queryUpdateTask) {
+        if (inStartedPhaseOfUnitOfWork()) {
+            UnitOfWork<?> unitOfWork = CurrentUnitOfWork.get();
+            unitOfWork.getOrComputeResource(
+                    this.toString() + QUERY_UPDATE_TASKS_RESOURCE_KEY,
+                    resourceKey -> {
+                        List<Runnable> queryUpdateTasks = new ArrayList<>();
+                        unitOfWork.afterCommit(uow -> queryUpdateTasks.forEach(Runnable::run));
+                        return queryUpdateTasks;
+                    }
+            ).add(queryUpdateTask);
+        } else {
+            queryUpdateTask.run();
+        }
+    }
+
+    /**
+     * Return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if it's {@link
+     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false.
+     *
+     * @return {@code true} if the {@link CurrentUnitOfWork#isStarted()} returns {@code true} and in if it's {@link
+     * UnitOfWork.Phase} is {@link UnitOfWork.Phase#STARTED}, otherwise {@code false}
+     */
+    private boolean inStartedPhaseOfUnitOfWork() {
+        return CurrentUnitOfWork.isStarted() && UnitOfWork.Phase.STARTED.equals(CurrentUnitOfWork.get().phase());
     }
 
     /**
@@ -373,7 +445,8 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
 
     /**
      * Registers an interceptor that is used to intercept Queries before they are passed to their
-     * respective handlers. The interceptor is invoked separately for each handler instance (in a separate unit of work).
+     * respective handlers. The interceptor is invoked separately for each handler instance (in a separate unit of
+     * work).
      *
      * @param interceptor the interceptor to invoke before passing a Query to the handler
      * @return handle to unregister the interceptor
@@ -390,7 +463,8 @@ public class SimpleQueryBus implements QueryBus, QueryUpdateEmitter {
      * @param interceptor the interceptor to invoke when sending a Query
      * @return handle to unregister the interceptor
      */
-    public Registration registerDispatchInterceptor(MessageDispatchInterceptor<? super QueryMessage<?, ?>> interceptor) {
+    public Registration registerDispatchInterceptor(
+            MessageDispatchInterceptor<? super QueryMessage<?, ?>> interceptor) {
         dispatchInterceptors.add(interceptor);
         return () -> dispatchInterceptors.remove(interceptor);
     }


### PR DESCRIPTION
This PR resolves #647.