### PR TITLE
Enhance QueryGateway API - Subscription Query with one ResultType for initial and update respones

### DIFF
--- a/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -15,6 +15,8 @@
  */
 package org.axonframework.queryhandling;
 
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.queryhandling.responsetypes.ResponseType;
 
@@ -62,21 +64,21 @@ public class DefaultQueryGateway implements QueryGateway {
         return queryBus.scatterGather(processInterceptors(queryMessage), timeout, timeUnit)
                        .map(QueryResponseMessage::getPayload);
     }
-
-    @Override
-    public <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(String queryName, Q query,
-                                                                     ResponseType<I> initialResponseType,
-                                                                     ResponseType<U> updateResponseType,
-                                                                     SubscriptionQueryBackpressure backpressure,
-                                                                     int updateBufferSize) {
-        SubscriptionQueryMessage<Q, I, U> subscriptionQueryMessage =
-                new GenericSubscriptionQueryMessage<>(query, queryName, initialResponseType, updateResponseType);
-        SubscriptionQueryResult<QueryResponseMessage<I>, SubscriptionQueryUpdateMessage<U>> result = queryBus
-                .subscriptionQuery(processInterceptors(subscriptionQueryMessage), backpressure, updateBufferSize);
-        return new DefaultSubscriptionQueryResult<>(result.initialResult().map(QueryResponseMessage::getPayload),
-                                                    result.updates().map(SubscriptionQueryUpdateMessage::getPayload),
-                                                    result);
-    }
+//
+//    @Override
+//    public <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(String queryName, Q query,
+//                                                                     ResponseType<I> initialResponseType,
+//                                                                     ResponseType<U> updateResponseType,
+//                                                                     SubscriptionQueryBackpressure backpressure,
+//                                                                     int updateBufferSize) {
+//        SubscriptionQueryMessage<Q, I, U> subscriptionQueryMessage =
+//                new GenericSubscriptionQueryMessage<>(query, queryName, initialResponseType, updateResponseType);
+//        SubscriptionQueryResult<QueryResponseMessage<I>, SubscriptionQueryUpdateMessage<U>> result = queryBus
+//                .subscriptionQuery(processInterceptors(subscriptionQueryMessage), backpressure, updateBufferSize);
+//        return new DefaultSubscriptionQueryResult<>(result.initialResult().map(QueryResponseMessage::getPayload),
+//                                                    result.updates().map(SubscriptionQueryUpdateMessage::getPayload),
+//                                                    result);
+//    }
 
     @Override
     public <Q, I, U> SubscriptionQueryBuilder<Q, I, U> createSubscriptionQuery() {

--- a/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -78,6 +78,11 @@ public class DefaultQueryGateway implements QueryGateway {
                                                     result);
     }
 
+    @Override
+    public <Q, I, U> SubscriptionQueryBuilder<Q, I, U> createSubscriptionQuery() {
+        return new SubscriptionQueryBuilder<>(queryBus, dispatchInterceptors);
+    }
+
     @SuppressWarnings("unchecked")
     private <Q, R, T extends QueryMessage<Q, R>> T processInterceptors(T query) {
         T intercepted = query;

--- a/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -303,6 +303,9 @@ public interface QueryGateway {
                                                               SubscriptionQueryBackpressure backpressure,
                                                               int updateBufferSize);
 
+
+    <Q, I, U >SubscriptionQueryBuilder<Q,I,U> createSubscriptionQuery();
+
     /**
      * Sends given query to the query bus and expects a result of type resultClass. Execution may be asynchronous.
      *

--- a/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -162,6 +162,48 @@ public interface QueryGateway {
      * incremental updates (received at the moment the query is sent, until it is cancelled by the caller or closed by
      * the emitting side).
      *
+     * Expects initial and incremental responses to have the same responseType.
+     *
+     * @param query               The {@code query} to be sent
+     * @param responseType The response type used for this query
+     * @param <Q>                 The type of the query
+     * @param <R>                 The type of the initial and incremental response
+     * @return registration which can be used to cancel receiving updates
+     * @see QueryGateway#subscriptionQuery(String, Object, Class)
+     */
+    default <Q, R> SubscriptionQueryResult<R, R> subscriptionQuery(Q query, Class<R> responseType) {
+        return subscriptionQuery(query.getClass().getName(),
+                                 query,
+                                 responseType);
+    }
+
+    /**
+     * Sends given {@code query} over the {@link QueryBus} and returns result containing initial response and
+     * incremental updates (received at the moment the query is sent, until it is cancelled by the caller or closed by
+     * the emitting side).
+     *
+     * Expects initial and incremental responses to have the same responseType.
+     *
+     * @param queryName           A {@link String} describing query to be executed
+     * @param query               The {@code query} to be sent
+     * @param responseType The response type used for this query
+     * @param <Q>                 The type of the query
+     * @param <R>                 The type of the initial and incremental response
+     * @return registration which can be used to cancel receiving updates
+     * @see QueryGateway#subscriptionQuery(Object, Class, Class)
+     */
+    default <Q, R> SubscriptionQueryResult<R, R> subscriptionQuery(String queryName, Q query, Class<R> responseType) {
+        return subscriptionQuery(queryName,
+                                 query,
+                                 responseType,
+                                 responseType);
+    }
+
+    /**
+     * Sends given {@code query} over the {@link QueryBus} and returns result containing initial response and
+     * incremental updates (received at the moment the query is sent, until it is cancelled by the caller or closed by
+     * the emitting side).
+     *
      * @param queryName           A {@link String} describing query to be executed
      * @param query               The {@code query} to be sent
      * @param initialResponseType The initial response type used for this query

--- a/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -149,6 +149,7 @@ public interface QueryGateway {
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */
+    @Deprecated
     default <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(Q query, Class<I> initialResponseType,
                                                                       Class<U> updateResponseType) {
         return subscriptionQuery(query.getClass().getName(),
@@ -296,12 +297,21 @@ public interface QueryGateway {
      * @return registration which can be used to cancel receiving updates
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
+     * @see #createSubscriptionQuery()
      */
-    <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(String queryName, Q query,
+   default  <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(String queryName, Q query,
                                                               ResponseType<I> initialResponseType,
                                                               ResponseType<U> updateResponseType,
                                                               SubscriptionQueryBackpressure backpressure,
-                                                              int updateBufferSize);
+                                                              int updateBufferSize) {
+       return createSubscriptionQuery()
+           .queryName(queryName)
+           .query(query)
+           .initialResponseType(initialResponseType)
+           .updateResponseType(updateResponseType)
+           .backpressure(backpressure)
+           .bufferSize(updateBufferSize).subscribe();
+   }
 
 
     <Q, I, U >SubscriptionQueryBuilder<Q,I,U> createSubscriptionQuery();

--- a/core/src/main/java/org/axonframework/queryhandling/SubscriptionQueryBuilder.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SubscriptionQueryBuilder.java
@@ -1,0 +1,155 @@
+package org.axonframework.queryhandling;
+
+import java.util.Arrays;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.queryhandling.responsetypes.ResponseType;
+import org.axonframework.queryhandling.responsetypes.ResponseTypes;
+import reactor.util.concurrent.Queues;
+
+/**
+ * Usage:
+ *
+ * <code>
+ *   queryGateway.createSubscriptionQuery()
+ *   .query(new Query("foo"))
+ *   .responseType(Result.class)
+ *   .subscribe();
+ * </code>
+ *
+ * @param <Q>
+ * @param <I>
+ * @param <U>
+ */
+public class SubscriptionQueryBuilder<Q, I, U> {
+
+  private final QueryBus queryBus;
+  private final MessageDispatchInterceptor<? super QueryMessage<?, ?>>[] dispatchInterceptors;
+
+   SubscriptionQueryBuilder(QueryBus queryBus,
+      MessageDispatchInterceptor<? super QueryMessage<?, ?>>[] dispatchInterceptors) {
+    this.queryBus = queryBus;
+    this.dispatchInterceptors = dispatchInterceptors;
+  }
+
+
+  private String queryName;
+  private Q query;
+
+  private ResponseType<I> initialResponseType;
+  private ResponseType<U> updateResponseType;
+
+  private SubscriptionQueryBackpressure backpressure = SubscriptionQueryBackpressure
+      .defaultBackpressure();
+  private int bufferSize = Queues.SMALL_BUFFER_SIZE;
+
+
+  public <X> SubscriptionQueryBuilder<X, I, U> query(X query) {
+    SubscriptionQueryBuilder<X, I,U> b = new SubscriptionQueryBuilder<>(queryBus, dispatchInterceptors);
+    b.query = query;
+    b.initialResponseType = this.initialResponseType;
+    b.updateResponseType=this.updateResponseType;
+    return b;
+  }
+
+  private <XQ, XI,XU>SubscriptionQueryBuilder<XQ, XI,XU> copy() {
+    SubscriptionQueryBuilder<XQ, XI,XU> b =  new SubscriptionQueryBuilder<>(queryBus, dispatchInterceptors);
+    b.queryName = this.queryName;
+    b.backpressure = this.backpressure;
+    b.bufferSize = this.bufferSize;
+
+    return b;
+  }
+
+  public SubscriptionQueryBuilder<Q,I,U> queryName(String queryName) {
+    this.queryName = queryName;
+    return this;
+  }
+  public SubscriptionQueryBuilder<Q,I,U> backpressure(SubscriptionQueryBackpressure backpressure) {
+    this.backpressure = backpressure;
+    return this;
+  }
+  public SubscriptionQueryBuilder<Q,I,U> bufferSize(int bufferSize) {
+    this.bufferSize = bufferSize;
+    return this;
+  }
+
+  public <X> SubscriptionQueryBuilder<Q,X,X> responseType(Class<X> responseType) {
+    return this.responseType(ResponseTypes.instanceOf(responseType));
+  }
+
+  public <X> SubscriptionQueryBuilder<Q,X,X> responseType(ResponseType<X> responseType) {
+    SubscriptionQueryBuilder<Q, X,X> b = this.copy();
+    b.query = this.query;
+    b.initialResponseType = responseType;
+    b.updateResponseType = responseType;
+
+    return b;
+  }
+
+  public <X> SubscriptionQueryBuilder<Q, X, U> initialResponseType(Class<X> responseType ) {
+    return this.initialResponseType(ResponseTypes.instanceOf(responseType));
+  }
+
+  public <X> SubscriptionQueryBuilder<Q, X, U> initialResponseType(ResponseType<X> responseType ) {
+    SubscriptionQueryBuilder<Q, X,U> b = this.copy();
+    b.query = this.query;
+    b.initialResponseType = responseType;
+    b.updateResponseType = this.updateResponseType;
+
+    return b;
+  }
+
+  public <X> SubscriptionQueryBuilder<Q, I, X> updateResponseType(Class<X>responseType ) {
+    return this.updateResponseType(ResponseTypes.instanceOf(responseType));
+  }
+
+  public <X> SubscriptionQueryBuilder<Q, I, X> updateResponseType(ResponseType<X>responseType ) {
+    SubscriptionQueryBuilder<Q, I,X> b = this.copy();
+    b.query = this.query;
+    b.initialResponseType = this.initialResponseType;
+    b.updateResponseType = responseType;
+
+    return b;
+  }
+
+//  @Override
+//  public <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(String queryName, Q query,
+//      ResponseType<I> initialResponseType,
+//      ResponseType<U> updateResponseType,
+//      SubscriptionQueryBackpressure backpressure,
+//      int updateBufferSize) {
+
+
+  @Override
+  public String toString() {
+    return "SubscriptionBuilder{" +
+        "queryBus=" + queryBus +
+        ", dispatchInterceptors=" + Arrays.toString(dispatchInterceptors) +
+        ", queryName='" + queryName + '\'' +
+        ", query=" + query +
+        ", initialResponseType=" + initialResponseType +
+        ", updateResponseType=" + updateResponseType +
+        ", backpressure=" + backpressure +
+        ", bufferSize=" + bufferSize +
+        '}';
+  }
+
+  public SubscriptionQueryResult<I, U> subscribe() {
+    SubscriptionQueryMessage<Q, I, U> subscriptionQueryMessage =
+        new GenericSubscriptionQueryMessage<Q,I,U>(query, queryName, initialResponseType, updateResponseType);
+    SubscriptionQueryResult<QueryResponseMessage<I>, SubscriptionQueryUpdateMessage<U>> result = queryBus
+        .subscriptionQuery(processInterceptors(subscriptionQueryMessage), backpressure, bufferSize);
+    return new DefaultSubscriptionQueryResult<>(result.initialResult().map(QueryResponseMessage::getPayload),
+        result.updates().map(SubscriptionQueryUpdateMessage::getPayload),
+        result);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <Q, R, T extends QueryMessage<Q, R>> T processInterceptors(T query) {
+    T intercepted = query;
+    for (MessageDispatchInterceptor<? super QueryMessage<?, ?>> interceptor : dispatchInterceptors) {
+      intercepted = (T) interceptor.handle(intercepted);
+    }
+    return intercepted;
+  }
+}

--- a/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -85,6 +85,21 @@ public class DefaultQueryGatewayTest {
                                                    x -> "query".equals(x.getPayload())), any(), anyInt());
     }
 
+
+    @Test
+    public void testDispatchSubscriptionQueryBuilder() {
+        when(mockBus.subscriptionQuery(any(), any(), anyInt()))
+            .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
+
+        testSubject.createSubscriptionQuery().queryName("query")
+            .initialResponseType(ResponseTypes.instanceOf(String.class))
+            .updateResponseType(ResponseTypes.instanceOf(String.class))
+            .subscribe();
+        verify(mockBus)
+            .subscriptionQuery(argThat((ArgumentMatcher<SubscriptionQueryMessage<String, String, String>>)
+                x -> "query".equals(x.getPayload())), any(), anyInt());
+    }
+
     @SuppressWarnings("unused")
     private <Q, R> QueryMessage<Q, R> anyMessage(Class<Q> queryType, Class<R> responseType) {
         return any();

--- a/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -16,21 +16,27 @@
 
 package org.axonframework.queryhandling;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.queryhandling.responsetypes.ResponseTypes;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink.OverflowStrategy;
 import reactor.core.publisher.Mono;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 public class DefaultQueryGatewayTest {
 

--- a/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink.OverflowStrategy;
 import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
@@ -86,19 +87,6 @@ public class DefaultQueryGatewayTest {
     }
 
 
-    @Test
-    public void testDispatchSubscriptionQueryBuilder() {
-        when(mockBus.subscriptionQuery(any(), any(), anyInt()))
-            .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
-
-        testSubject.createSubscriptionQuery().queryName("query")
-            .initialResponseType(ResponseTypes.instanceOf(String.class))
-            .updateResponseType(ResponseTypes.instanceOf(String.class))
-            .subscribe();
-        verify(mockBus)
-            .subscriptionQuery(argThat((ArgumentMatcher<SubscriptionQueryMessage<String, String, String>>)
-                x -> "query".equals(x.getPayload())), any(), anyInt());
-    }
 
     @SuppressWarnings("unused")
     private <Q, R> QueryMessage<Q, R> anyMessage(Class<Q> queryType, Class<R> responseType) {

--- a/core/src/test/java/org/axonframework/queryhandling/SubscriptionQueryBuilderTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/SubscriptionQueryBuilderTest.java
@@ -1,0 +1,69 @@
+package org.axonframework.queryhandling;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.Serializable;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.SubscriptionQueryBuilder;
+import org.axonframework.queryhandling.SubscriptionQueryBackpressure;
+import org.axonframework.queryhandling.responsetypes.ResponseTypes;
+import org.junit.Test;
+import reactor.core.publisher.FluxSink.OverflowStrategy;
+
+public class SubscriptionQueryBuilderTest {
+
+  public static class QueryType implements Serializable {
+
+    private final String name;
+
+    public QueryType(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+  public static class InitialResponse implements Serializable {
+
+    private final String name;
+
+    public InitialResponse(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+  public static class UpdateResponse implements Serializable {
+
+    private final String name;
+
+    public UpdateResponse(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+
+  private final QueryBus queryBus = mock(QueryBus.class);
+  private final MessageDispatchInterceptor[] dispatchInterceptors = new MessageDispatchInterceptor[0];
+
+
+  @Test
+  public void name() {
+    SubscriptionQueryBuilder<QueryType, InitialResponse, UpdateResponse> builder = new SubscriptionQueryBuilder<>(queryBus, dispatchInterceptors)
+        .query(new QueryType("foo"))
+        .queryName("someQueryName")
+        .initialResponseType(ResponseTypes.instanceOf(InitialResponse.class))
+        .updateResponseType(ResponseTypes.instanceOf(UpdateResponse.class))
+        .bufferSize(10)
+        .backpressure(new SubscriptionQueryBackpressure(OverflowStrategy.BUFFER));
+
+    System.out.println(builder.toString());
+  }
+}


### PR DESCRIPTION
This PR resolves #665