### PR TITLE
Improved matching of generics in AnnotationHandlerBeanPostProcessors

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonHandlerConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonHandlerConfigurationTest.java
@@ -1,0 +1,56 @@
+package org.axonframework.boot;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.SupportedCommandNamesAware;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.QueryHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebClientAutoConfiguration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(classes = AxonAutoConfigurationTest.Context.class)
+@EnableAutoConfiguration(exclude = {JmxAutoConfiguration.class, WebClientAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class, DataSourceAutoConfiguration.class})
+@RunWith(SpringRunner.class)
+public class AxonHandlerConfigurationTest {
+
+    @Autowired
+    private QueryGateway queryGateway;
+
+    @Autowired
+    private CommandGateway commandGateway;
+
+    @Test
+    public void testMessageRoutedToCorrectMethod() throws Exception {
+        assertEquals("Command: info", commandGateway.send("info").get());
+        assertEquals("Query: info", queryGateway.query("info", String.class).get());
+    }
+
+    @SuppressWarnings("unused")
+    @Component
+    public static class CommandAndQueryHandler {
+
+        @CommandHandler
+        public String handle(String command) {
+            return "Command: " + command;
+        }
+
+        @QueryHandler
+        public String query(String query) {
+            return "Query: " + query;
+        }
+
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -18,6 +18,7 @@ package org.axonframework.spring.config;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ReflectionUtils;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.HandlerDefinition;
@@ -36,6 +37,9 @@ import org.springframework.util.ClassUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.stream.StreamSupport;
+
+import static java.lang.reflect.Modifier.isAbstract;
 
 /**
  * Abstract bean post processor that finds candidates for proxying. Typically used to wrap annotated beans with their
@@ -91,7 +95,7 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
 
                 T adapter = initializeAdapterFor(proxyInvokingBean, parameterResolverFactory, handlerDefinition);
                 return createAdapterProxy(proxyInvokingBean, adapter, getAdapterInterfaces(), false,
-                                                   classLoader);
+                                          classLoader);
             } catch (Exception e) {
                 throw new AxonConfigurationException("Unable to wrap annotated handler.", e);
             }
@@ -265,7 +269,7 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
         public Object invoke(MethodInvocation invocation) throws Exception {
             Class<?> declaringClass = invocation.getMethod().getDeclaringClass();
             try {
-                if (declaringClass.isAssignableFrom(adapterInterface)) {
+                if (declaringClass.isAssignableFrom(adapterInterface) && genericParametersMatch(invocation, adapter)) {
                     return invocation.getMethod().invoke(adapter, invocation.getArguments());
                 }
                 return invocation.proceed();
@@ -276,6 +280,31 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
                     throw (Error) e;
                 }
                 throw new InvocationTargetException(e);
+            }
+        }
+
+        private boolean genericParametersMatch(MethodInvocation invocation, Object adapter) {
+            try {
+                Method proxyMethod = invocation.getMethod();
+                Method methodOnAdapter = adapter.getClass().getMethod(proxyMethod.getName(), proxyMethod.getParameterTypes());
+                if (methodOnAdapter.isSynthetic()) {
+                    return StreamSupport.stream(ReflectionUtils.methodsOf(adapter.getClass()).spliterator(), false)
+                                        .filter(m -> !m.isSynthetic())
+                                        .filter(m -> !isAbstract(m.getModifiers()))
+                                        .filter(m -> invocation.getMethod().getName().equals(m.getName()))
+                                        .filter(m -> m.getParameterCount() == invocation.getArguments().length)
+                                        .anyMatch(m -> {
+                                            for (int i = 0; i < m.getParameterTypes().length; i++) {
+                                                if (!m.getParameterTypes()[i].isInstance(invocation.getArguments()[i])) {
+                                                    return false;
+                                                }
+                                            }
+                                            return true;
+                                        });
+                }
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
             }
         }
 


### PR DESCRIPTION
When a class would declare both `@CommandHandler` and `@QueryHandler`
annotated method, it would be proxied twice with only generics as the
main difference. This improvement ensures that the proxies method will
call the correct adapter, taking generics into account as well. It does
so by attempting to find a non-synthetic and non-abstract method with
parameters matching the invocation. If such method is found, the
corresponding adapter is invoked.

Resolves #670