### PR TITLE
JPQL "IN" expression corrected to work with EclipseLink

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -241,7 +241,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
                         "SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, "
                                 + "e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData " +
                                 "FROM " + domainEventEntryEntityName() + " e " +
-                                "WHERE e.globalIndex > :token OR e.globalIndex IN (:gaps) ORDER BY e.globalIndex ASC",
+                                "WHERE e.globalIndex > :token OR e.globalIndex IN :gaps ORDER BY e.globalIndex ASC",
                         Object[].class
                 ).setParameter("gaps", previousToken.getGaps());
             }


### PR DESCRIPTION
After changing JPA implementation from Hibernate to EclipseLink, TrackingEventProcessor fails due to incorrect JPQL query with exception:

```
2018-07-19 11:16:35.036 ERROR 566 --- [dedEventStore-0] o.a.e.eventstore.EmbeddedEventStore      : Failed to read events from the underlying event storage

java.lang.IllegalArgumentException: You have attempted to set a value of type class java.util.Collections$UnmodifiableSortedSet for parameter gaps with expected type of long from query string SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData FROM DomainEventEntry e WHERE e.globalIndex > :token OR e.globalIndex IN (:gaps) ORDER BY e.globalIndex ASC.
        at org.eclipse.persistence.internal.jpa.QueryImpl.setParameterInternal(QueryImpl.java:944) ~[org.eclipse.persistence.jpa-2.7.2.jar:na]
        at org.eclipse.persistence.internal.jpa.EJBQueryImpl.setParameter(EJBQueryImpl.java:607) ~[org.eclipse.persistence.jpa-2.7.2.jar:na]
        at org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine.lambda$fetchTrackedEvents$1(JpaEventStorageEngine.java:244) ~[axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.common.transaction.TransactionManager.fetchInTransaction(TransactionManager.java:67) ~[axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine.fetchTrackedEvents(JpaEventStorageEngine.java:228) ~[axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine.lambda$readEventData$1(BatchingEventStorageEngine.java:123) ~[axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine$EventStreamSpliterator.tryAdvance(BatchingEventStorageEngine.java:161) ~[axon-core-3.1.1.jar:3.1.1]
        at java.util.Spliterator.forEachRemaining(Spliterator.java:326) ~[na:1.8.0_65]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_65]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_65]
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[na:1.8.0_65]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[na:1.8.0_65]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_65]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418) ~[na:1.8.0_65]
        at org.axonframework.eventsourcing.eventstore.EmbeddedEventStore$EventProducer.fetchData(EmbeddedEventStore.java:237) [axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.EmbeddedEventStore$EventProducer.run(EmbeddedEventStore.java:203) [axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.EmbeddedEventStore$EventProducer.access$2000(EmbeddedEventStore.java:182) [axon-core-3.1.1.jar:3.1.1]
        at org.axonframework.eventsourcing.eventstore.EmbeddedEventStore.lambda$ensureProducerStarted$0(EmbeddedEventStore.java:132) [axon-core-3.1.1.jar:3.1.1]
        at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_65]
```

After removing parenthesis from query code seems to be working in both Hibernate and EclipseLink.