### PR TITLE
[#689] Don't catch event handling exception in MultiEventHandlerInvoker

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
+++ b/core/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
@@ -74,12 +74,10 @@ public class MultiEventHandlerInvoker implements EventHandlerInvoker {
 
     @Override
     public void handle(EventMessage<?> message, Segment segment) throws Exception {
-        delegates.stream().filter(i -> i.canHandle(message, segment)).forEach(i -> {
-            try {
+        for (EventHandlerInvoker i : delegates) {
+            if (i.canHandle(message, segment)) {
                 i.handle(message, segment);
-            } catch (Exception e) {
-                // do nothing, each handler invoker should invoke its own ListenerInvocationErrorHandler
             }
-        });
+        }
     }
 }

--- a/core/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
@@ -1,0 +1,63 @@
+package org.axonframework.eventhandling;
+
+import org.junit.*;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class MultiEventHandlerInvokerTest {
+
+    private MultiEventHandlerInvoker testSubject;
+
+    private EventHandlerInvoker mockedEventHandlerInvokerOne = mock(EventHandlerInvoker.class);
+    private EventHandlerInvoker mockedEventHandlerInvokerTwo = mock(EventHandlerInvoker.class);
+
+    private EventMessage<String> testEventMessage;
+    private Segment testSegment;
+
+    @Before
+    public void setUp() {
+        testEventMessage = GenericEventMessage.asEventMessage("some-event");
+        testSegment = new Segment(1, 1);
+
+        when(mockedEventHandlerInvokerOne.canHandle(testEventMessage, testSegment)).thenReturn(true);
+        when(mockedEventHandlerInvokerTwo.canHandle(testEventMessage, testSegment)).thenReturn(true);
+
+        testSubject = new MultiEventHandlerInvoker(mockedEventHandlerInvokerOne, mockedEventHandlerInvokerTwo);
+    }
+
+    @Test
+    public void testDelegatesReturnsSetDelegates() {
+        List<EventHandlerInvoker> result = testSubject.delegates();
+
+        assertTrue(result.contains(mockedEventHandlerInvokerOne));
+        assertTrue(result.contains(mockedEventHandlerInvokerTwo));
+    }
+
+    @Test
+    public void testCanHandleCallsCanHandleOnTheFirstDelegateToReturn() {
+        testSubject.canHandle(testEventMessage, testSegment);
+
+        verify(mockedEventHandlerInvokerOne).canHandle(testEventMessage, testSegment);
+        verifyZeroInteractions(mockedEventHandlerInvokerTwo);
+    }
+
+    @Test
+    public void testHandleCallsCanHandleAndHandleOfAllDelegates() throws Exception {
+        testSubject.handle(testEventMessage, testSegment);
+
+        verify(mockedEventHandlerInvokerOne).canHandle(testEventMessage, testSegment);
+        verify(mockedEventHandlerInvokerOne).handle(testEventMessage, testSegment);
+        verify(mockedEventHandlerInvokerTwo).canHandle(testEventMessage, testSegment);
+        verify(mockedEventHandlerInvokerTwo).handle(testEventMessage, testSegment);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testHandleThrowsExceptionIfDelegatesThrowAnException() throws Exception {
+        doThrow(new RuntimeException()).when(mockedEventHandlerInvokerTwo).handle(testEventMessage, testSegment);
+
+        testSubject.handle(testEventMessage, testSegment);
+    }
+}


### PR DESCRIPTION
This PR adjusts the `MultiEventHandlerInvoker` to not catch a thrown exception from it's delegates on the `handle(EventMessage<?>, Segment)` function, but leave it as is.

This PR resolves #689