### PR TITLE
EventSourcingRepository with custom Lockfactory combined with AggregateModel

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -246,7 +246,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
      * {@code snapshotTriggerDefinition}
      *
      * @param aggregateModel            The meta model describing the aggregate's structure
-     * @param lockFactory               The lock
+     * @param lockFactory               The locking strategy to apply to this repository
      * @param aggregateFactory          The factory for new aggregate instances
      * @param eventStore                The event store that holds the event streams for this repository
      * @param snapshotTriggerDefinition The definition describing when to trigger a snapshot

--- a/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -241,6 +241,31 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
     }
 
     /**
+     * Initializes a repository with a locking strategy underpinned by the given {@code lockFactory}, uses the given
+     * {@code aggregateFactory} to create new aggregate instances and triggering snapshots using the given
+     * {@code snapshotTriggerDefinition}
+     *
+     * @param aggregateModel            The meta model describing the aggregate's structure
+     * @param lockFactory               The lock
+     * @param aggregateFactory          The factory for new aggregate instances
+     * @param eventStore                The event store that holds the event streams for this repository
+     * @param snapshotTriggerDefinition The definition describing when to trigger a snapshot
+     * @param repositoryProvider        Provides repositories for specific aggregate types
+     * @see LockingRepository#LockingRepository(Class, LockFactory)
+     */
+    public EventSourcingRepository(AggregateModel<T> aggregateModel, LockFactory lockFactory,
+                                   AggregateFactory<T> aggregateFactory, EventStore eventStore,
+                                   SnapshotTriggerDefinition snapshotTriggerDefinition,
+                                   RepositoryProvider repositoryProvider) {
+        super(aggregateModel, lockFactory);
+        Assert.notNull(eventStore, () -> "eventStore may not be null");
+        this.aggregateFactory = aggregateFactory;
+        this.eventStore = eventStore;
+        this.snapshotTriggerDefinition = snapshotTriggerDefinition;
+        this.repositoryProvider = repositoryProvider;
+    }
+
+    /**
      * Initializes a repository with the default locking strategy, using the given {@code aggregateFactory} to
      * create new aggregate instances.
      *


### PR DESCRIPTION
Adding additional constructor as to allow one to use the EventSourcingRepository with a custom lockfactory in combination with an (preconstructed) AggregateModel.