### PR TITLE
Adding back off support to PessimisticLockFactory

### DIFF
--- a/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -109,7 +109,7 @@ public class PessimisticLockFactory implements LockFactory {
 
         private final String identifier;
         private final PubliclyOwnedReentrantLock lock;
-        private boolean isClosed = false;
+        private volatile boolean isClosed = false;
 
         private DisposableLock(String identifier) {
             this.identifier = identifier;

--- a/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -31,18 +31,19 @@ import static java.util.Collections.synchronizedMap;
 
 /**
  * Implementation of a {@link LockFactory} that uses a pessimistic locking strategy. Calls to
- * {@link #obtainLock} will block until a lock could be obtained or back off based on the {@link BackoffParameters}
- * by throwing an exception. The later will cause the command to fail, but will allow the Thread to be released. If a
- * lock is obtained by a thread, that thread has guaranteed unique access.
+ * {@link #obtainLock} will block until a lock could be obtained or back off limit is reached, based on the 
+ * {@link BackoffParameters}, by throwing an exception. The latter will cause the command to fail, but will allow 
+ * the calling thread to be freed. If a lock is obtained by a thread, that thread has guaranteed unique access.
  * <p/>
  * Each thread can hold the same lock multiple times. The lock will only be released for other threads when the lock
  * has been released as many times as it was obtained.
  * <p/>
  * This lock can be used to ensure thread safe access to a number of objects, such as Aggregates and Sagas.
  *
- * Back off properties with respect to acquiring locks can be configured though the {@link BackoffParameters}.
+ * Back off properties with respect to acquiring locks can be configured through the {@link BackoffParameters}.
  *
  * @author Allard Buijze
+ * @author Michael Bischoff
  * @since 1.3
  */
 public class PessimisticLockFactory implements LockFactory {
@@ -60,11 +61,14 @@ public class PessimisticLockFactory implements LockFactory {
      *
      * @apiNote Since the previous versions didn't support any backoff properties, this no-arg constructor creates a
      * {@link PessimisticLockFactory} with no backoff properties. This is however a poor default (the system will
-     * very likely converge to a state where it no longer handles any commands any lock is held indefinitely.) In the
+     * very likely converge to a state where it no longer handles any commands if any lock is held indefinitely.) In the
      * next major version of Axon sane defaults should be chosen and thus behavior will change. Should your setup rely
      * on the no-backoff behavior then you are advised to call {@link #PessimisticLockFactory(BackoffParameters)} with
      * explicitly specified {@link BackoffParameters}.
+     *
+     * @Deprecated use {@link #PessimisticLockFactory(BackoffParameters)} instead
      */
+    @Deprecated
     public PessimisticLockFactory() {
         this(new BackoffParameters(-1, -1, 100));
     }
@@ -137,7 +141,7 @@ public class PessimisticLockFactory implements LockFactory {
      *
      * acquireAttempts
      *  This used to specify the maxium number of attempts to obtain a lock before we back off
-     *  (throwing a {@link LockAcquisitionFailedException}). A value of '-1' means unlimited attempts.
+     *  (throwing a {@link LockAcquisitionFailedException} if it does). A value of '-1' means unlimited attempts.
      *
      * maximumQueued
      *  Maximum number of queued threads we allow to try and obtain a lock, if another thread tries to obtain the lock

--- a/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/core/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -216,10 +216,8 @@ public class PessimisticLockFactory implements LockFactory {
                     do {
                         attempts--;
                         checkForDeadlock();
-                        if(backoffParameters.hasAcquireAttemptLimit()) {
-                            if(attempts < 1) {
-                                throw new LockAcquisitionFailedException("Failed to acquire lock for aggregate identifier " + identifier);
-                            }
+                        if(backoffParameters.hasAcquireAttemptLimit() && attempts < 1) {
+                            throw new LockAcquisitionFailedException("Failed to acquire lock for aggregate identifier " + identifier);
                         }
                     } while (!lock.tryLock(backoffParameters.spinTime, TimeUnit.MILLISECONDS));
                 }

--- a/core/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
+++ b/core/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
@@ -192,19 +192,19 @@ public class PessimisticLockFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBackoffParametersConstructor_aquireAttempts() {
+    public void testBackoffParametersConstructorAquireAttempts() {
         int illegalValue = 0;
         new PessimisticLockFactory.BackoffParameters(illegalValue, 100, 100);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBackoffParametersConstructor_maximumQueued() {
+    public void testBackoffParametersConstructorMaximumQueued() {
         int illegalValue = 0;
         new PessimisticLockFactory.BackoffParameters(10, illegalValue, 100);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBackoffParametersConstructor_spinTime() {
+    public void testBackoffParametersConstructorSpinTime() {
         int illegalValue = -1;
         new PessimisticLockFactory.BackoffParameters(10, 100, illegalValue);
     }

--- a/core/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
+++ b/core/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
@@ -191,6 +191,24 @@ public class PessimisticLockFactoryTest {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testBackoffParametersConstructor_aquireAttempts() {
+        int illegalValue = 0;
+        new PessimisticLockFactory.BackoffParameters(illegalValue, 100, 100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBackoffParametersConstructor_maximumQueued() {
+        int illegalValue = 0;
+        new PessimisticLockFactory.BackoffParameters(10, illegalValue, 100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBackoffParametersConstructor_spinTime() {
+        int illegalValue = -1;
+        new PessimisticLockFactory.BackoffParameters(10, 100, illegalValue);
+    }
+
     private void createThreadObtainLockAndWaitForState(PessimisticLockFactory lockFactory, Thread.State state, CountDownLatch rendezvous, AtomicReference<Exception> exceptionInThread, String id) {
         Thread thread = new Thread(() -> {
             try(Lock ignored = lockFactory.obtainLock(id)) {


### PR DESCRIPTION
Adding back off support to PessimisticLockFactory to avoid unresponsiveness under load.

Backing off from trying to obtain a lock allows the system to signal, to client firing commands, that it failed to do so in a reasonable amount of time, allowing the client to respond / degrade gracefully. (perhaps by throttling, rescheduling or dropping commands)

Also should an specific aggregate(or saga) (type or instance) contain bad logic, then backing off allows the system to still process commands targeting other aggregates(or sagas). If one waits indefinitely then eventually all worker threads will be waiting to obtain the lock causing the pool to dry up. At that point the system no longer processes commands, making it unavailable.