### PR TITLE
#687 EventProcessingConfiguration

### DIFF
--- a/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
@@ -473,7 +473,7 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      * @param interceptorBuilder The builder function that provides an interceptor for each available processor
      * @return this EventHandlingConfiguration instance for further configuration
      *
-     * @deprecated use {@link EventProcessingConfiguration#registerHandlerInterceptor(String, Function)} instead
+     * @deprecated use {@link EventProcessingConfiguration#registerHandlerInterceptor(BiFunction)} instead
      */
     @Deprecated
     public EventHandlingConfiguration registerHandlerInterceptor(

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
@@ -19,6 +19,7 @@ package org.axonframework.spring.config;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.spring.stereotype.Saga;
 import org.junit.*;
 import org.junit.runner.*;
@@ -41,7 +42,7 @@ public class EventProcessingConfigurationConfigTest {
     private EventProcessingConfiguration eventProcessingConfiguration;
 
     @Test
-    public void testProcessorConfiguration() {
+    public void testEventProcessingConfiguration() {
         assertEquals(2, eventProcessingConfiguration.eventProcessors().size());
         assertTrue(eventProcessingConfiguration.eventProcessor("processor2").isPresent());
         assertTrue(eventProcessingConfiguration.eventProcessor("subscribingProcessor").isPresent());
@@ -54,6 +55,7 @@ public class EventProcessingConfigurationConfigTest {
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("processor3").get().getName());
         assertEquals("subscribingProcessor",
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("Saga3Processor").get().getName());
+        assertEquals(2, eventProcessingConfiguration.interceptorsFor("processor3").size());
     }
 
     @EnableAxon
@@ -66,6 +68,7 @@ public class EventProcessingConfigurationConfigTest {
             config.assignProcessingGroup("processor1", "processor2");
             config.assignProcessingGroup(group -> group.contains("3") ? "subscribingProcessor" : "processor2");
             config.registerSubscribingEventProcessor("subscribingProcessor");
+            config.registerHandlerInterceptor((configuration, name) -> new CorrelationDataInterceptor<>());
         }
 
         @Saga


### PR DESCRIPTION
This issue introduces the `registerHandlerInterceptor(BiFunction)` in the `EventProcessingConfiguration`.
The same method exists in the `EventHandlerConfiguration`, but is deprecated since `v3.3`. Not alternative method was introduced yet in the `EventProcessingConfiguration`.

- Added the method 
- Adjusted the `interceptorsFor` method to also pass the default handler interceptors
- Adjusted the `EventProcessingConfigurationTest`
- Added comments