### PR TITLE
Fix for #714

### DIFF
--- a/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
@@ -313,10 +313,9 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
         if (configuration != null) {
             eventProcessor(processorName).ifPresent(eventProcessor -> eventProcessor
                     .registerInterceptor(interceptorBuilder.apply(configuration)));
-        } else {
-            handlerInterceptorsBuilders.computeIfAbsent(processorName, k -> new ArrayList<>())
-                                       .add(interceptorBuilder);
         }
+        handlerInterceptorsBuilders.computeIfAbsent(processorName, k -> new ArrayList<>())
+                                   .add(interceptorBuilder);
         return this;
     }
 
@@ -459,8 +458,8 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
      * Obtains Event Processor by name. This method is to be called after Event Processor Registry is initialized.
      *
      * @param name The name of the event processor
+     * @param <T>  The type of processor expected
      * @return optional whether event processor with given name exists
-     * @param <T> The type of processor expected
      */
     @SuppressWarnings("unchecked")
     public <T extends EventProcessor> Optional<T> eventProcessor(String name) {

--- a/spring/src/test/java/org/axonframework/spring/config/EventHandlingConfigurationWithInterceptorsTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventHandlingConfigurationWithInterceptorsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config;
+
+import org.axonframework.config.EventHandlingConfiguration;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.InterceptorChain;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.annotation.MetaDataValue;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.junit.*;
+import org.junit.runner.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test ensures that any handler interceptor registered via {@link EventHandlingConfiguration} is registered with
+ * {@link org.axonframework.config.EventProcessingConfiguration}.
+ *
+ * @author Milan Savic
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+public class EventHandlingConfigurationWithInterceptorsTest {
+
+    @Autowired
+    private EventBus eventBus;
+    @Autowired
+    private Context.MyEventHandler myEventHandler;
+
+    @Test
+    public void testInterceptorRegistration() {
+        eventBus.publish(GenericEventMessage.asEventMessage("myEvent"));
+        assertEquals("myMetaDataValue", myEventHandler.getMetaDataValue());
+    }
+
+    @EnableAxon
+    @Configuration
+    public static class Context {
+
+        @Autowired
+        public void configure(EventHandlingConfiguration eventHandlingConfiguration, MyInterceptor myInterceptor) {
+            eventHandlingConfiguration.registerHandlerInterceptor((a, b) -> myInterceptor);
+        }
+
+        @Component
+        public class MyInterceptor implements MessageHandlerInterceptor<EventMessage<?>> {
+
+            @Override
+            public Object handle(UnitOfWork<? extends EventMessage<?>> unitOfWork, InterceptorChain interceptorChain)
+                    throws Exception {
+                unitOfWork.transformMessage(event -> event
+                        .andMetaData(Collections.singletonMap("myMetaDataKey", "myMetaDataValue")));
+                return interceptorChain.proceed();
+            }
+        }
+
+        @Component
+        public class MyEventHandler {
+
+            private String metaDataValue;
+
+            String getMetaDataValue() {
+                return metaDataValue;
+            }
+
+            @EventHandler
+            public void on(String event, @MetaDataValue("myMetaDataKey") String metaDataValue) {
+                this.metaDataValue = metaDataValue;
+            }
+        }
+    }
+}

--- a/spring/src/test/java/org/axonframework/spring/config/EventHandlingConfigurationWithInterceptorsTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventHandlingConfigurationWithInterceptorsTest.java
@@ -82,7 +82,7 @@ public class EventHandlingConfigurationWithInterceptorsTest {
 
             private String metaDataValue;
 
-            String getMetaDataValue() {
+            public String getMetaDataValue() {
                 return metaDataValue;
             }
 

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
@@ -19,6 +19,9 @@ package org.axonframework.spring.config;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.interceptors.LoggingInterceptor;
 import org.axonframework.spring.stereotype.Saga;
 import org.junit.*;
@@ -27,6 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -55,7 +60,11 @@ public class EventProcessingConfigurationConfigTest {
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("processor3").get().getName());
         assertEquals("subscribingProcessor",
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("Saga3Processor").get().getName());
-        assertEquals(1, eventProcessingConfiguration.interceptorsFor("processor3").size());
+        List<MessageHandlerInterceptor<? super EventMessage<?>>> interceptors = eventProcessingConfiguration
+                .interceptorsFor("processor3");
+        assertEquals(2, interceptors.size());
+        assertTrue(interceptors.stream().anyMatch(i -> i instanceof CorrelationDataInterceptor));
+        assertTrue(interceptors.stream().anyMatch(i -> i instanceof LoggingInterceptor));
     }
 
     @EnableAxon


### PR DESCRIPTION
Add handler interceptors to builders within EventProcessingConfiguration. Reason for this is if we reinitialize the configuration, interceptor gets registered with the EventProcessor.

This PR resolve #714.