### PR TITLE
#687 EventProcessingConfiguration registerHandlerInterceptor(BiFunction) - 3.3.5

### DIFF
--- a/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventHandlingConfiguration.java
@@ -430,7 +430,8 @@ public class EventHandlingConfiguration implements ModuleConfiguration {
      *
      * @param interceptorBuilder The builder function that provides an interceptor for each available processor
      * @return this EventHandlingConfiguration instance for further configuration
-     * @deprecated use {@link EventProcessingConfiguration#registerHandlerInterceptor(String, Function)} instead
+     *
+     * @deprecated use {@link EventProcessingConfiguration#registerHandlerInterceptor(BiFunction)} instead
      */
     @Deprecated
     public EventHandlingConfiguration registerHandlerInterceptor(

--- a/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
@@ -44,7 +44,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -65,6 +67,7 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
     private Function<String, String> defaultProcessingGroupAssignment = Function.identity();
     private final Map<String, EventProcessorBuilder> eventProcessorBuilders = new HashMap<>();
     private final Map<String, Component<EventProcessor>> eventProcessors = new HashMap<>();
+    private final List<BiFunction<Configuration, String, MessageHandlerInterceptor<? super EventMessage<?>>>> defaultHandlerInterceptors = new ArrayList<>();
     private final Map<String, List<Function<Configuration, MessageHandlerInterceptor<? super EventMessage<?>>>>> handlerInterceptorsBuilders = new HashMap<>();
     private final Map<String, Function<Configuration, ErrorHandler>> errorHandlers = new HashMap<>();
     private final Map<String, Function<Configuration, RollbackConfiguration>> rollbackConfigurations = new HashMap<>();
@@ -321,6 +324,23 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
     }
 
     /**
+     * Register the given {@code interceptorBuilder} to build an Message Handling Interceptor for Event Processors
+     * created in this configuration.
+     * <p>
+     * The {@code interceptorBuilder} is invoked once for each processor created, and may return {@code null}, in which
+     * case the return value is ignored.
+     * <p>
+     *
+     * @param interceptorBuilder The builder function that provides an interceptor for each available processor
+     * @return this EventHandlingConfiguration instance for further configuration
+     */
+    public EventProcessingConfiguration registerHandlerInterceptor(
+            BiFunction<Configuration, String, MessageHandlerInterceptor<? super EventMessage<?>>> interceptorBuilder) {
+        defaultHandlerInterceptors.add(interceptorBuilder);
+        return this;
+    }
+
+    /**
      * Returns a list of interceptors for a processor with given {@code processorName}.
      *
      * @param processorName The name of the processor
@@ -328,10 +348,21 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
      */
     public List<MessageHandlerInterceptor<? super EventMessage<?>>> interceptorsFor(String processorName) {
         Assert.state(configuration != null, () -> "Configuration is not initialized yet");
-        return handlerInterceptorsBuilders.getOrDefault(processorName, new ArrayList<>())
-                                          .stream()
-                                          .map(hi -> hi.apply(configuration))
-                                          .collect(Collectors.toList());
+
+        List<MessageHandlerInterceptor<? super EventMessage<?>>> interceptors = new ArrayList<>();
+
+        defaultHandlerInterceptors.stream()
+                                  .map(f -> f.apply(configuration, processorName))
+                                  .filter(Objects::nonNull)
+                                  .forEach(interceptors::add);
+
+        handlerInterceptorsBuilders.getOrDefault(processorName, new ArrayList<>())
+                                   .stream()
+                                   .map(hi -> hi.apply(configuration))
+                                   .filter(Objects::nonNull)
+                                   .forEach(interceptors::add);
+
+        return interceptors;
     }
 
 

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
@@ -19,6 +19,7 @@ package org.axonframework.spring.config;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.messaging.interceptors.LoggingInterceptor;
 import org.axonframework.spring.stereotype.Saga;
 import org.junit.*;
 import org.junit.runner.*;
@@ -41,7 +42,7 @@ public class EventProcessingConfigurationConfigTest {
     private EventProcessingConfiguration eventProcessingConfiguration;
 
     @Test
-    public void testProcessorConfiguration() {
+    public void testEventProcessingConfiguration() {
         assertEquals(2, eventProcessingConfiguration.eventProcessors().size());
         assertTrue(eventProcessingConfiguration.eventProcessor("processor2").isPresent());
         assertTrue(eventProcessingConfiguration.eventProcessor("subscribingProcessor").isPresent());
@@ -54,6 +55,7 @@ public class EventProcessingConfigurationConfigTest {
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("processor3").get().getName());
         assertEquals("subscribingProcessor",
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("Saga3Processor").get().getName());
+        assertEquals(1, eventProcessingConfiguration.interceptorsFor("processor3").size());
     }
 
     @EnableAxon
@@ -66,6 +68,7 @@ public class EventProcessingConfigurationConfigTest {
             config.assignProcessingGroup("processor1", "processor2");
             config.assignProcessingGroup(group -> group.contains("3") ? "subscribingProcessor" : "processor2");
             config.registerSubscribingEventProcessor("subscribingProcessor");
+            config.registerHandlerInterceptor((configuration, name) -> new LoggingInterceptor<>());
         }
 
         @Saga


### PR DESCRIPTION
#687 This issue introduces the registerHandlerInterceptor(BiFunction) in the EventProcessingConfiguration.
The same method exists in the EventHandlerConfiguration, but is deprecated since v3.3. Not alternative method was introduced yet in the EventProcessingConfiguration.

- Added the method in the EventProcessingConfiguration
- Adjusted the interceptorsFor method to also pass the default handler interceptors
- Adjusted the EventProcessingConfigurationTest
- Added comments

This is the PR for the 3.3.x branch
PR for the master branch is here #709 