### PR TITLE
Fixing the documentation on AnnotationDriven

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/AnnotationDriven.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AnnotationDriven.java
@@ -17,15 +17,15 @@
 package org.axonframework.spring.config;
 
 import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.queryhandling.QueryHandler;
 import org.springframework.context.annotation.Import;
 
 import java.lang.annotation.*;
 
 /**
  * Annotation for {@link org.springframework.context.annotation.Configuration @Configuration} that will automatically
- * subscribe {@link CommandHandler @CommandHandler} and {@link EventHandler @EventHandler} annotated beans with the
- * CommandBus and EventBus, respectively.
+ * subscribe {@link CommandHandler @CommandHandler} and {@link QueryHandler @QueryHandler} annotated beans with the
+ * CommandBus and QueryBus, respectively.
  *
  * @author Allard Buijze
  * @since 2.3


### PR DESCRIPTION
Fixing the documentation on AnnotationDriven, as the AnnotationDrivenRegistrar doesn't register eventhandlers with the eventbus but rather registers queryhandlers with the querybus.