### PR TITLE
Issue725 expect events always fails for event messages

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -96,7 +96,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectEvents(EventMessage... expectedEvents) {
-        this.expectEvents((Object[]) (Stream.of(expectedEvents).map(Message::getPayload).toArray()));
+        this.expectEvents(Stream.of(expectedEvents).map(Message::getPayload).toArray());
 
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (EventMessage expectedEvent : expectedEvents) {

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.axonframework.test.matchers.Matchers.messageWithPayload;
 import static org.hamcrest.CoreMatchers.*;
@@ -95,7 +96,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectEvents(EventMessage... expectedEvents) {
-        this.expectEvents((Object[]) expectedEvents);
+        this.expectEvents((Object[]) (Stream.of(expectedEvents).map(Message::getPayload).toArray()));
 
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (EventMessage expectedEvent : expectedEvents) {

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -35,4 +35,12 @@ public class ResultValidatorImplTest {
 
         validator.expectEvents(expected);
     }
+
+    @Test
+    public void shouldSuccesfullyCompareEqualMetadata() {
+        EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("key1", "value1"));
+
+        validator.expectEvents(expected);
+    }
+
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -24,11 +24,6 @@ public class ResultValidatorImplTest {
         validator.expectEvents(expected);
     }
 
-    private List<EventMessage<?>> actualEvents() {
-        return singletonList(asEventMessage(new MyEvent("aggregateId", 123))
-                                     .andMetaData(singletonMap("key1", "value1")));
-    }
-
     @Test(expected = AxonAssertionError.class)
     public void shouldCompareKeysForEquality() {
         EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("KEY1", "value1"));
@@ -41,6 +36,11 @@ public class ResultValidatorImplTest {
         EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("key1", "value1"));
 
         validator.expectEvents(expected);
+    }
+
+    private List<EventMessage<?>> actualEvents() {
+        return singletonList(asEventMessage(new MyEvent("aggregateId", 123))
+                .andMetaData(singletonMap("key1", "value1")));
     }
 
 }


### PR DESCRIPTION
This PR resolves #725 

Introduces Test and Fix for the bug where calling expectEvents() with EventMessage... on ResultValidatorImpl would always result in a failed test, whether they are valid or not.