### PR TITLE
Bugfix of Exception Text in JdbcEventStorageEngine

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -310,7 +310,7 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
                 () -> executeQuery(getConnection(),
                                    connection -> connection.prepareStatement(sql),
                                    resultSet -> nextAndExtract(resultSet, 1, Long.class),
-                                   e -> new EventStoreException("Failed to get head token")));
+                                   e -> new EventStoreException("Failed to get tail token")));
         return Optional.ofNullable(index)
                        .map(seq -> GapAwareTrackingToken.newInstance(seq, Collections.emptySet()))
                        .orElse(null);


### PR DESCRIPTION
(meant was "tail token" not "head token")