### PR TITLE
[#749] QuartzEventScheduler must use serializer to serialize events

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -23,7 +23,6 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.axonframework.serialization.Serializer;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -60,11 +59,6 @@ public class FireEventJob implements Job {
      * The key used to locate the optional TransactionManager in the scheduler context.
      */
     public static final String TRANSACTION_MANAGER_KEY = TransactionManager.class.getName();
-
-    /**
-     * The key used to locate the {@link Serializer} in the scheduler context.
-     */
-    public static final String JOB_DATA_SERIALIZER = Serializer.class.getName();
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -23,12 +23,7 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.quartz.Job;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.SchedulerContext;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +33,8 @@ import org.slf4j.LoggerFactory;
  * scheduler context.
  *
  * @author Allard Buijze
- * @see EventJobDataBinder
  * @since 0.7
+ * @see EventJobDataBinder
  */
 public class FireEventJob implements Job {
 
@@ -75,8 +70,7 @@ public class FireEventJob implements Job {
             EventMessage<?> eventMessage = createMessage(event);
 
             EventBus eventBus = (EventBus) context.getScheduler().getContext().get(EVENT_BUS_KEY);
-            TransactionManager txManager =
-                    (TransactionManager) context.getScheduler().getContext().get(TRANSACTION_MANAGER_KEY);
+            TransactionManager txManager = (TransactionManager) context.getScheduler().getContext().get(TRANSACTION_MANAGER_KEY);
 
             UnitOfWork<EventMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(null);
             if (txManager != null) {

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -23,7 +23,13 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.quartz.*;
+import org.axonframework.serialization.Serializer;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +39,8 @@ import org.slf4j.LoggerFactory;
  * scheduler context.
  *
  * @author Allard Buijze
- * @since 0.7
  * @see EventJobDataBinder
+ * @since 0.7
  */
 public class FireEventJob implements Job {
 
@@ -55,6 +61,11 @@ public class FireEventJob implements Job {
      */
     public static final String TRANSACTION_MANAGER_KEY = TransactionManager.class.getName();
 
+    /**
+     * The key used to locate the {@link Serializer} in the scheduler context.
+     */
+    public static final String JOB_DATA_SERIALIZER = Serializer.class.getName();
+
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         logger.debug("Starting job to publish a scheduled event");
@@ -70,7 +81,8 @@ public class FireEventJob implements Job {
             EventMessage<?> eventMessage = createMessage(event);
 
             EventBus eventBus = (EventBus) context.getScheduler().getContext().get(EVENT_BUS_KEY);
-            TransactionManager txManager = (TransactionManager) context.getScheduler().getContext().get(TRANSACTION_MANAGER_KEY);
+            TransactionManager txManager =
+                    (TransactionManager) context.getScheduler().getContext().get(TRANSACTION_MANAGER_KEY);
 
             UnitOfWork<EventMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(null);
             if (txManager != null) {
@@ -80,7 +92,7 @@ public class FireEventJob implements Job {
 
             if (logger.isInfoEnabled()) {
                 logger.info("Job successfully executed. Scheduled Event [{}] has been published.",
-                             eventMessage.getPayloadType().getSimpleName());
+                            eventMessage.getPayloadType().getSimpleName());
             }
         } catch (Exception e) {
             logger.error("Exception occurred while publishing scheduled event [{}]", jobDetail.getDescription(), e);

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -80,7 +80,7 @@ public class FireEventJob implements Job {
 
             if (logger.isInfoEnabled()) {
                 logger.info("Job successfully executed. Scheduled Event [{}] has been published.",
-                            eventMessage.getPayloadType().getSimpleName());
+                             eventMessage.getPayloadType().getSimpleName());
             }
         } catch (Exception e) {
             logger.error("Exception occurred while publishing scheduled event [{}]", jobDetail.getDescription(), e);

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -281,11 +281,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
          * Approach one only exists for backwards compatibility and should be removed in subsequent major releases.
          * <p>
          * {@inheritDoc}
-         *
-         * @deprecated the if-block should be removed on the next major release | it is only maintained for backwards
-         * compatibility
          */
-        @Deprecated
         @Override
         public Object fromJobData(JobDataMap jobDataMap) {
             if (jobDataMap.containsKey(SERIALIZED_MESSAGE_PAYLOAD)) {
@@ -295,6 +291,15 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
                                                  retrieveDeadlineTimestamp(jobDataMap));
             }
 
+            return fromJobDataMap(jobDataMap);
+        }
+
+        /**
+         * @deprecated this private function is in place for backwards compatibility only. Ideally, the event message is
+         * retrieved based on the serialized keys.
+         */
+        @Deprecated
+        private Object fromJobDataMap(JobDataMap jobDataMap) {
             return jobDataMap.get(EVENT_KEY);
         }
 

--- a/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -288,14 +288,14 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         @Deprecated
         @Override
         public Object fromJobData(JobDataMap jobDataMap) {
-            if (jobDataMap.containsKey(EVENT_KEY)) {
-                return jobDataMap.get(EVENT_KEY);
+            if (jobDataMap.containsKey(SERIALIZED_MESSAGE_PAYLOAD)) {
+                return new GenericEventMessage<>((String) jobDataMap.get(MESSAGE_ID),
+                                                 deserializePayload(jobDataMap),
+                                                 deserializeMetaData(jobDataMap),
+                                                 retrieveDeadlineTimestamp(jobDataMap));
             }
 
-            return new GenericEventMessage<>((String) jobDataMap.get(MESSAGE_ID),
-                                             deserializePayload(jobDataMap),
-                                             deserializeMetaData(jobDataMap),
-                                             retrieveDeadlineTimestamp(jobDataMap));
+            return jobDataMap.get(EVENT_KEY);
         }
 
         private Object deserializePayload(JobDataMap jobDataMap) {

--- a/core/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -1,0 +1,133 @@
+package org.axonframework.eventhandling.scheduling.quartz;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.JavaSerializer;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import org.quartz.JobDataMap;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.axonframework.messaging.Headers.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class DirectEventJobDataBinderTest {
+
+    private static final String TEST_EVENT_PAYLOAD = "event-payload";
+
+    private QuartzEventScheduler.DirectEventJobDataBinder testSubject;
+
+    private final Serializer serializer;
+    private final Function<Class, String> expectedSerializedClassType;
+    private final Predicate<Object> revisionMatcher;
+
+    private final EventMessage<String> testEventMessage;
+    private final MetaData testMetaData;
+
+    @SuppressWarnings("unused") // Test name used to give sensible name to parameterized test
+    public DirectEventJobDataBinderTest(String testName,
+                                        Serializer serializer,
+                                        Function<Class, String> expectedSerializedClassType,
+                                        Predicate<Object> revisionMatcher) {
+        this.serializer = spy(serializer);
+        this.expectedSerializedClassType = expectedSerializedClassType;
+        this.revisionMatcher = revisionMatcher;
+
+        EventMessage<String> testEventMessage = GenericEventMessage.asEventMessage(TEST_EVENT_PAYLOAD);
+        testMetaData = MetaData.with("some-key", "some-value");
+        this.testEventMessage = testEventMessage.withMetaData(testMetaData);
+
+        testSubject = new QuartzEventScheduler.DirectEventJobDataBinder(this.serializer);
+    }
+
+    @Parameterized.Parameters(name = "Using {0}")
+    public static Collection serializerImplementationAndAssertionSpecifics() {
+        return Arrays.asList(new Object[][]{
+                {
+                        "JavaSerializer",
+                        new JavaSerializer(),
+                        (Function<Class, String>) Class::getName,
+                        (Predicate<Object>) Objects::nonNull},
+                {
+                        "XStreamSerializer",
+                        new XStreamSerializer(),
+                        (Function<Class, String>) clazz -> clazz.getSimpleName().toLowerCase(),
+                        (Predicate<Object>) Objects::isNull
+                },
+                {
+                        "JacksonSerializer",
+                        new JacksonSerializer(),
+                        (Function<Class, String>) Class::getName,
+                        (Predicate<Object>) Objects::isNull
+                }
+        });
+    }
+
+    @Test
+    public void testEventMessageToJobData() {
+        JobDataMap result = testSubject.toJobData(testEventMessage);
+
+        assertEquals(testEventMessage.getIdentifier(), result.get(MESSAGE_ID));
+        assertEquals(testEventMessage.getTimestamp().toEpochMilli(), result.get(MESSAGE_TIMESTAMP));
+        String expectedPayloadType = expectedSerializedClassType.apply(testEventMessage.getPayloadType());
+        assertEquals(expectedPayloadType, result.get(MESSAGE_TYPE));
+        Object resultRevision = result.get(MESSAGE_REVISION);
+        assertTrue(revisionMatcher.test(resultRevision));
+
+        assertNotNull(result.get(SERIALIZED_MESSAGE_PAYLOAD));
+        assertNotNull(result.get(MESSAGE_METADATA));
+
+        verify(serializer).serialize(TEST_EVENT_PAYLOAD, byte[].class);
+        verify(serializer).serialize(testMetaData, byte[].class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEventMessageFromJobData() {
+        JobDataMap testJobDataMap = testSubject.toJobData(testEventMessage);
+
+        Object result = testSubject.fromJobData(testJobDataMap);
+
+        assertTrue(result instanceof EventMessage);
+
+        EventMessage<String> resultEventMessage = (EventMessage<String>) result;
+
+        assertEquals(testEventMessage.getIdentifier(), resultEventMessage.getIdentifier());
+        assertEquals(testEventMessage.getTimestamp(), resultEventMessage.getTimestamp());
+        assertEquals(testEventMessage.getPayload(), resultEventMessage.getPayload());
+        assertEquals(testEventMessage.getPayloadType(), resultEventMessage.getPayloadType());
+        assertEquals(testEventMessage.getMetaData(), resultEventMessage.getMetaData());
+
+        verify(serializer, times(2)).deserialize(
+                (SimpleSerializedObject<?>) argThat(this::assertEventMessageSerializedObject)
+        );
+    }
+
+    private boolean assertEventMessageSerializedObject(SimpleSerializedObject<?> serializedObject) {
+        String expectedSerializedPayloadType = expectedSerializedClassType.apply(TEST_EVENT_PAYLOAD.getClass());
+
+        SerializedType type = serializedObject.getType();
+        String serializedTypeName = type.getName();
+        boolean isSerializedMetaData = serializedTypeName.equals(MetaData.class.getName());
+
+        return serializedObject.getData() != null &&
+                serializedObject.getContentType().equals(byte[].class) &&
+                (serializedTypeName.equals(expectedSerializedPayloadType) || isSerializedMetaData) &&
+                (isSerializedMetaData || revisionMatcher.test(type.getRevision()));
+    }
+}

--- a/core/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerTest.java
+++ b/core/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerTest.java
@@ -22,6 +22,7 @@ import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.saga.Saga;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
@@ -82,7 +83,7 @@ public class QuartzEventSchedulerTest {
         }).when(eventBus).publish(isA(EventMessage.class));
         Saga mockSaga = mock(Saga.class);
         when(mockSaga.getSagaIdentifier()).thenReturn(UUID.randomUUID().toString());
-        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), new StubEvent());
+        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), buildTestEvent());
         assertTrue(token.toString().contains("Quartz"));
         assertTrue(token.toString().contains(GROUP_ID));
         latch.await(1, TimeUnit.SECONDS);
@@ -104,7 +105,7 @@ public class QuartzEventSchedulerTest {
         }).when(mockTransaction).commit();
         Saga mockSaga = mock(Saga.class);
         when(mockSaga.getSagaIdentifier()).thenReturn(UUID.randomUUID().toString());
-        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), new StubEvent());
+        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), buildTestEvent());
         assertTrue(token.toString().contains("Quartz"));
         assertTrue(token.toString().contains(GROUP_ID));
         latch.await(1, TimeUnit.SECONDS);
@@ -130,7 +131,7 @@ public class QuartzEventSchedulerTest {
         testSubject.initialize();
         Saga mockSaga = mock(Saga.class);
         when(mockSaga.getSagaIdentifier()).thenReturn(UUID.randomUUID().toString());
-        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), new StubEvent());
+        ScheduleToken token = testSubject.schedule(Duration.ofMillis(30), buildTestEvent());
         assertTrue(token.toString().contains("Quartz"));
         assertTrue(token.toString().contains(GROUP_ID));
         latch.await(1, TimeUnit.SECONDS);
@@ -147,7 +148,7 @@ public class QuartzEventSchedulerTest {
     public void testCancelJob() throws SchedulerException {
         Saga mockSaga = mock(Saga.class);
         when(mockSaga.getSagaIdentifier()).thenReturn(UUID.randomUUID().toString());
-        ScheduleToken token = testSubject.schedule(Duration.ofMillis(1000), new StubEvent());
+        ScheduleToken token = testSubject.schedule(Duration.ofMillis(1000), buildTestEvent());
         assertEquals(1, scheduler.getJobKeys(GroupMatcher.groupEquals(GROUP_ID)).size());
         testSubject.cancelSchedule(token);
         assertEquals(0, scheduler.getJobKeys(GroupMatcher.groupEquals(GROUP_ID)).size());
@@ -155,7 +156,7 @@ public class QuartzEventSchedulerTest {
         verify(eventBus, never()).publish(isA(EventMessage.class));
     }
 
-    private class StubEvent {
-
+    private EventMessage<Object> buildTestEvent() {
+        return new GenericEventMessage<>(new Object());
     }
 }


### PR DESCRIPTION
This PR introduces an adjustment to the `QuartzEventScheduler`, which makes it so that scheduled events will use a configurable `Serializer` to store a serialized version of the `EventMessage` in the Quartz `JobDataMap` instead of the `EventMessage` directly.
The old format made it so that Java serialization was performed, which is not inline with how the framework de-/serializes messages overall.

This PR resolves #749 