### PR TITLE
Saga spring config

### DIFF
--- a/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
@@ -36,6 +36,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.SubscribableMessageSource;
+import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.unitofwork.RollbackConfiguration;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
 import org.axonframework.monitoring.MessageMonitor;
@@ -280,8 +281,13 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
     public EventProcessingConfiguration usingTrackingProcessors(
             Function<Configuration, TrackingEventProcessorConfiguration> processorConfig) {
         registerEventProcessorFactory(
-                (name, config, ehi) ->
-                        trackingEventProcessor(config, name, ehi, processorConfig, Configuration::eventBus));
+                (name, config, ehi) -> {
+                    TrackingEventProcessor trackingEventProcessor =
+                            trackingEventProcessor(config, name, ehi, processorConfig, Configuration::eventBus);
+                    trackingEventProcessor
+                            .registerInterceptor(new CorrelationDataInterceptor<>(config.correlationDataProviders()));
+                    return trackingEventProcessor;
+                });
         return this;
     }
 
@@ -571,7 +577,12 @@ public class EventProcessingConfiguration implements ModuleConfiguration {
 
     private SubscribingEventProcessor defaultEventProcessor(String name, Configuration conf,
                                                             EventHandlerInvoker eventHandlerInvoker) {
-        return subscribingEventProcessor(name, conf, eventHandlerInvoker, Configuration::eventBus);
+        SubscribingEventProcessor eventProcessor = subscribingEventProcessor(name,
+                                                                             conf,
+                                                                             eventHandlerInvoker,
+                                                                             Configuration::eventBus);
+        eventProcessor.registerInterceptor(new CorrelationDataInterceptor<>(conf.correlationDataProviders()));
+        return eventProcessor;
     }
 
     private SubscribingEventProcessor subscribingEventProcessor(String name, Configuration conf,

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -290,8 +290,15 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                     ? sagaAnnotation.configurationBean()
                     : lcFirst(sagaType.getSimpleName()) + "Configuration";
             if (!explicitSagaConfig && !beanFactory.containsBean(configName)) {
-                SagaConfiguration<?> sagaConfiguration =
-                        SagaConfiguration.subscribingSagaManager(sagaType);
+                ProcessingGroup processingGroupAnnotation = beanFactory.findAnnotationOnBean(saga,
+                                                                                             ProcessingGroup.class);
+                SagaConfiguration<?> sagaConfiguration;
+                if (processingGroupAnnotation != null && !"".equals(processingGroupAnnotation.value())) {
+                    sagaConfiguration = SagaConfiguration.subscribingSagaManager(sagaType,
+                                                                                 processingGroupAnnotation.value());
+                } else {
+                    sagaConfiguration = SagaConfiguration.subscribingSagaManager(sagaType);
+                }
                 beanFactory.registerSingleton(configName, sagaConfiguration);
 
                 if (!"".equals(sagaAnnotation.sagaStore())) {

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
@@ -48,7 +48,7 @@ public class EventProcessingConfigurationConfigTest {
 
     @Test
     public void testEventProcessingConfiguration() {
-        assertEquals(2, eventProcessingConfiguration.eventProcessors().size());
+        assertEquals(3, eventProcessingConfiguration.eventProcessors().size());
         assertTrue(eventProcessingConfiguration.eventProcessor("processor2").isPresent());
         assertTrue(eventProcessingConfiguration.eventProcessor("subscribingProcessor").isPresent());
 
@@ -60,6 +60,8 @@ public class EventProcessingConfigurationConfigTest {
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("processor3").get().getName());
         assertEquals("subscribingProcessor",
                      eventProcessingConfiguration.eventProcessorByProcessingGroup("Saga3Processor").get().getName());
+        assertEquals("processor4",
+                     eventProcessingConfiguration.eventProcessorByProcessingGroup("processor4").get().getName());
         List<MessageHandlerInterceptor<? super EventMessage<?>>> interceptors = eventProcessingConfiguration
                 .interceptorsFor("processor3");
         assertEquals(2, interceptors.size());
@@ -75,7 +77,7 @@ public class EventProcessingConfigurationConfigTest {
         public void configure(EventProcessingConfiguration config) {
             config.usingTrackingProcessors();
             config.assignProcessingGroup("processor1", "processor2");
-            config.assignProcessingGroup(group -> group.contains("3") ? "subscribingProcessor" : "processor2");
+            config.assignProcessingGroup(group -> group.contains("3") ? "subscribingProcessor" : group);
             config.registerSubscribingEventProcessor("subscribingProcessor");
             config.registerHandlerInterceptor((configuration, name) -> new LoggingInterceptor<>());
         }
@@ -105,6 +107,18 @@ public class EventProcessingConfigurationConfigTest {
             public void on(String evt) {
                 // nothing to do
             }
+        }
+
+        @Saga
+        @ProcessingGroup("processor4")
+        public static class Saga4 {
+
+        }
+
+        @Saga
+        @ProcessingGroup("processor4")
+        public static class Saga5 {
+
         }
     }
 }

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingConfigurationConfigTest.java
@@ -57,7 +57,7 @@ public class EventProcessingConfigurationConfigTest {
         assertEquals("processor2", processor2.getName());
         List<MessageHandlerInterceptor<? super EventMessage<?>>> interceptorsFor = eventProcessingConfiguration
                 .interceptorsFor("processor2");
-        assertEquals(2, interceptorsFor.size());
+        assertEquals(3, interceptorsFor.size());
         assertTrue(interceptorsFor.stream().anyMatch(i -> i instanceof CorrelationDataInterceptor));
         assertTrue(interceptorsFor.stream().anyMatch(i -> i instanceof LoggingInterceptor));
 


### PR DESCRIPTION
If there is `@ProcessingGroup` annotation on a Saga, pick up the group name and register it within Saga config (this is related to the Spring config).

EventProcessingConfiguration - combine all handler builder functions first and then assign them to processors, old implementation was overriding handler builders that were assigned to the same processor.