### PR TITLE
SpringCloudHttpBackupCommandRouter: Suppress exception stack traces when logging info messages

### DIFF
--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringCloudHttpBackupCommandRouter.java
@@ -250,12 +250,13 @@ public class SpringCloudHttpBackupCommandRouter extends SpringCloudCommandRouter
             return responseEntity.hasBody() ? Optional.of(responseEntity.getBody()) : Optional.empty();
         } catch (HttpClientErrorException e) {
             logger.info("Blacklisting Service [" + serviceInstance.getServiceId() + "], "
-                                + "as requesting message routing information from it resulted in an exception.", e);
+                + "as requesting message routing information from it resulted in an exception.",
+                logger.isDebugEnabled() ? e : null);
             return Optional.empty();
         } catch (Exception e) {
             logger.info("Failed to receive message routing information from Service ["
                                 + serviceInstance.getServiceId() + "] due to an exception. "
-                                + "Will temporarily set this instance to deny all incoming messages", e);
+                                + "Will temporarily set this instance to deny all incoming messages", logger.isDebugEnabled()?e:null);
             return Optional.of(unreachableService);
         }
     }


### PR DESCRIPTION
 for instances that are not available, unless debug level is enabled in which case include stacktrace.

This occurs whenever any service is registered with eureka registry but does not have distributed command bus enabled. All other services will log ugly exceptions (which in my opinion is warnings seeing that they're logged under INFO), prompting sysadmins to investigate "error" unnecessarily.

PR addresses concern by suppressing exception stack trace and only showing it if logger's level is set to DEBUG. 