### PR TITLE
Tests for KafkaAutoConfiguration

### DIFF
--- a/kafka/src/main/java/org/axonframework/kafka/eventhandling/consumer/DefaultConsumerFactory.java
+++ b/kafka/src/main/java/org/axonframework/kafka/eventhandling/consumer/DefaultConsumerFactory.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.axonframework.common.Assert;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,6 +45,16 @@ public class DefaultConsumerFactory<K, V> implements ConsumerFactory<K, V> {
     @Override
     public Consumer<K, V> createConsumer() {
         return new KafkaConsumer<>(this.configs);
+    }
+
+    /**
+     * Return an unmodifiable reference to the configuration map for this factory.
+     * Useful for cloning to make a similar factory.
+     *
+     * @return the configs.
+     */
+    public Map<String, Object> configurationProperties() {
+        return Collections.unmodifiableMap(this.configs);
     }
 
 }

--- a/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -126,7 +126,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
     /**
      * TransactionalId prefix for all producer instances.
      *
-     * @return the confirmation mode.
+     * @return the transactionalIdPrefix.
      */
     public String transactionIdPrefix() {
         return transactionIdPrefix;

--- a/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -124,7 +124,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
     }
 
     /**
-     * TransactionalId prefix for all producer instances.
+     * TransactionalIdPrefix for all producer instances.
      *
      * @return the transactionalIdPrefix.
      */

--- a/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -114,6 +114,25 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
     }
 
     /**
+     * Return an unmodifiable reference to the configuration map for this factory.
+     * Useful for cloning to make a similar factory.
+     *
+     * @return the configs.
+     */
+    public Map<String, Object> configurationProperties() {
+        return Collections.unmodifiableMap(configs);
+    }
+
+    /**
+     * TransactionalId prefix for all producer instances.
+     *
+     * @return the confirmation mode.
+     */
+    public String transactionIdPrefix() {
+        return transactionIdPrefix;
+    }
+
+    /**
      * Closes all producer instances.
      */
     @Override

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/KafkaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/KafkaAutoConfiguration.java
@@ -80,8 +80,15 @@ public class KafkaAutoConfiguration {
     }
 
     @ConditionalOnMissingBean
+    @Bean
+    public KafkaMessageConverter<String, byte[]> kafkaMessageConverter(
+            @Qualifier("eventSerializer") Serializer eventSerializer) {
+        return new DefaultKafkaMessageConverter(eventSerializer);
+    }
+
+    @ConditionalOnMissingBean
     @Bean(initMethod = "start", destroyMethod = "shutDown")
-    @ConditionalOnBean(ProducerFactory.class)
+    @ConditionalOnBean({ProducerFactory.class, KafkaMessageConverter.class})
     public KafkaPublisher<String, byte[]> kafkaPublisher(ProducerFactory<String, byte[]> kafkaProducerFactory,
                                                          EventBus eventBus,
                                                          KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
@@ -97,7 +104,7 @@ public class KafkaAutoConfiguration {
     }
 
     @ConditionalOnMissingBean
-    @ConditionalOnBean(ConsumerFactory.class)
+    @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class})
     @Bean(destroyMethod = "shutdown")
     public Fetcher kafkaFetcher(ConsumerFactory<String, byte[]> kafkaConsumerFactory,
                                 KafkaMessageConverter<String, byte[]> kafkaMessageConverter) {
@@ -115,12 +122,5 @@ public class KafkaAutoConfiguration {
     @ConditionalOnBean(ConsumerFactory.class)
     public KafkaMessageSource kafkaMessageSource(Fetcher kafkaFetcher) {
         return new KafkaMessageSource(kafkaFetcher);
-    }
-
-    @ConditionalOnMissingBean
-    @Bean
-    public KafkaMessageConverter<String, byte[]> kafkaMessageConverter(
-            @Qualifier("eventSerializer") Serializer eventSerializer) {
-        return new DefaultKafkaMessageConverter(eventSerializer);
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/KafkaProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/KafkaProperties.java
@@ -70,7 +70,8 @@ public class KafkaProperties {
     private String defaultTopic;
 
     /**
-     * Additional properties used to configure the client.
+     * Additional properties, common to producers and consumers, used to configure the
+     * client.
      */
     private Map<String, String> properties = new HashMap<String, String>();
 
@@ -276,6 +277,11 @@ public class KafkaProperties {
          */
         private Integer maxPollRecords;
 
+        /**
+         * Additional consumer-specific properties used to configure the client.
+         */
+        private final Map<String, String> properties = new HashMap<>();
+
         public Ssl getSsl() {
             return this.ssl;
         }
@@ -376,6 +382,10 @@ public class KafkaProperties {
             this.maxPollRecords = maxPollRecords;
         }
 
+        public Map<String, String> getProperties() {
+            return this.properties;
+        }
+
         public Map<String, Object> buildProperties() {
             Map<String, Object> properties = new HashMap<String, Object>();
             if (this.autoCommitInterval != null) {
@@ -443,6 +453,7 @@ public class KafkaProperties {
                 properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
                                this.maxPollRecords);
             }
+            properties.putAll(this.properties);
             return properties;
         }
     }
@@ -538,6 +549,11 @@ public class KafkaProperties {
          */
         private Integer retries;
 
+        /**
+         * Additional producer-specific properties used to configure the client.
+         */
+        private final Map<String, String> properties = new HashMap<>();
+
         public Ssl getSsl() {
             return this.ssl;
         }
@@ -622,6 +638,10 @@ public class KafkaProperties {
             this.retries = retries;
         }
 
+        public Map<String, String> getProperties() {
+            return this.properties;
+        }
+
         public Map<String, Object> buildProperties() {
             Map<String, Object> properties = new HashMap<String, Object>();
             if (this.acks != null) {
@@ -675,6 +695,7 @@ public class KafkaProperties {
                 properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                                this.valueSerializer);
             }
+            properties.putAll(this.properties);
             return properties;
         }
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/KafkaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/KafkaAutoConfigurationTests.java
@@ -286,7 +286,7 @@ public class KafkaAutoConfigurationTests {
         }
 
         @Bean
-        AxonConfiguration axonConfiguration() {
+        public AxonConfiguration axonConfiguration() {
             AxonConfiguration mock = mock(AxonConfiguration.class);
             when(mock.messageMonitor(any(), any())).thenReturn((MessageMonitor) NoOpMessageMonitor.instance());
             return mock;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/KafkaAutoConfigurationTests.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/KafkaAutoConfigurationTests.java
@@ -14,7 +14,49 @@
  * limitations under the License.
  */
 
+
 package org.axonframework.boot;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.axonframework.boot.autoconfig.KafkaAutoConfiguration;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.kafka.eventhandling.KafkaMessageConverter;
+import org.axonframework.kafka.eventhandling.consumer.ConsumerFactory;
+import org.axonframework.kafka.eventhandling.consumer.DefaultConsumerFactory;
+import org.axonframework.kafka.eventhandling.consumer.Fetcher;
+import org.axonframework.kafka.eventhandling.consumer.KafkaMessageSource;
+import org.axonframework.kafka.eventhandling.producer.ConfirmationMode;
+import org.axonframework.kafka.eventhandling.producer.DefaultProducerFactory;
+import org.axonframework.kafka.eventhandling.producer.KafkaPublisher;
+import org.axonframework.kafka.eventhandling.producer.ProducerFactory;
+import org.axonframework.monitoring.MessageMonitor;
+import org.axonframework.monitoring.NoOpMessageMonitor;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.spring.config.AxonConfiguration;
+import org.junit.*;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link org.axonframework.boot.autoconfig.KafkaAutoConfiguration}.
@@ -22,4 +64,232 @@ package org.axonframework.boot;
  * @author Nakul Mishra
  */
 public class KafkaAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class));
+
+    @Test
+    public void minimalRequiredProperties() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                          .withPropertyValues("axon.kafka.default-topic=testTopic",
+                                              "axon.kafka.producer.transaction-id-prefix=foo",
+                                              "axon.kafka.consumer.group-id=bar")
+                          .run((context) -> {
+                              DefaultProducerFactory producerFactory = ((DefaultProducerFactory<?, ?>) context
+                                      .getBean(DefaultProducerFactory.class));
+
+                              Map<String, Object> producerConfigs = ((DefaultProducerFactory<?, ?>) context
+                                      .getBean(DefaultProducerFactory.class)).configurationProperties();
+
+                              Map<String, Object> consumerConfigs = ((DefaultConsumerFactory<?, ?>) context
+                                      .getBean(DefaultConsumerFactory.class))
+                                      .configurationProperties();
+
+                              // required beans
+                              assertThat(context.getBeanNamesForType(ProducerFactory.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(ConsumerFactory.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(KafkaPublisher.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(Fetcher.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(KafkaMessageSource.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
+
+                              assertThat(consumerConfigs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))
+                                      .isEqualTo(Collections.singletonList("localhost:9092"));
+
+                              //producer
+                              assertThat(producerFactory.confirmationMode()).isEqualTo(ConfirmationMode.TRANSACTIONAL);
+                              assertThat(producerFactory.transactionIdPrefix()).isEqualTo("foo");
+                              assertThat(producerConfigs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(
+                                      StringSerializer.class);
+                              assertThat(producerConfigs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)).isEqualTo(
+                                      ByteArraySerializer.class);
+
+                              // consumer
+                              assertThat(consumerConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.GROUP_ID_CONFIG))
+                                      .isEqualTo("bar");
+                              assertThat(consumerConfigs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)).isNull();
+                              assertThat(consumerConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(StringDeserializer.class);
+                              assertThat(
+                                      consumerConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(ByteArrayDeserializer.class);
+                          });
+    }
+
+    @Test
+    public void consumerProperties() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                          .withPropertyValues("axon.kafka.default-topic=testTopic",
+                                              "axon.kafka.consumer.group-id=bar",
+                                              //override
+                                              "axon.kafka.bootstrap-servers=foo:1234",
+                                              "axon.kafka.properties.foo=bar",
+                                              "axon.kafka.default-topic=testTopic",
+                                              "axon.kafka.properties.baz=qux",
+                                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
+                                              "axon.kafka.ssl.key-password=p1",
+                                              "axon.kafka.ssl.keystore-location=classpath:ksLoc",
+                                              "axon.kafka.ssl.keystore-password=p2",
+                                              "axon.kafka.ssl.truststore-location=classpath:tsLoc",
+                                              "axon.kafka.ssl.truststore-password=p3",
+                                              "axon.kafka.consumer.auto-commit-interval=123",
+                                              "axon.kafka.consumer.max-poll-records=42",
+                                              "axon.kafka.consumer.auto-offset-reset=earliest",
+                                              "axon.kafka.consumer.client-id=ccid",
+                                              "axon.kafka.consumer.enable-auto-commit=false",
+                                              "axon.kafka.consumer.fetch-max-wait=456",
+                                              "axon.kafka.consumer.properties.fiz.buz=fix.fox",
+                                              "axon.kafka.consumer.fetch-min-size=789",
+                                              "axon.kafka.consumer.group-id=bar",
+                                              "axon.kafka.consumer.heartbeat-interval=234",
+                                              "axon.kafka.consumer.key-deserializer = org.apache.kafka.common.serialization.LongDeserializer",
+                                              "axon.kafka.consumer.value-deserializer = org.apache.kafka.common.serialization.IntegerDeserializer")
+                          .run((context) -> {
+                              DefaultConsumerFactory<?, ?> consumerFactory = context
+                                      .getBean(DefaultConsumerFactory.class);
+                              Map<String, Object> configs = consumerFactory
+                                      .configurationProperties();
+
+                              //required beans
+                              assertThat(context.getBeanNamesForType(ConsumerFactory.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(Fetcher.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(KafkaMessageSource.class)).hasSize(1);
+                              assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
+
+                              assertThat(configs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))
+                                      .isEqualTo(Collections.singletonList("foo:1234"));
+                              assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG))
+                                      .isEqualTo("p1");
+                              assertThat(
+                                      (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+                                      .endsWith(File.separator + "ksLoc");
+                              assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG))
+                                      .isEqualTo("p2");
+                              assertThat((String) configs
+                                      .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
+                                      .endsWith(File.separator + "tsLoc");
+                              assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG))
+                                      .isEqualTo("p3");
+                              // consumer
+                              assertThat(configs.get(ConsumerConfig.CLIENT_ID_CONFIG))
+                                      .isEqualTo("ccid");
+                              assertThat(configs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
+                                      .isEqualTo(Boolean.FALSE);
+                              assertThat(configs.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG))
+                                      .isEqualTo(123);
+                              assertThat(configs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
+                                      .isEqualTo("earliest");
+                              assertThat(configs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG))
+                                      .isEqualTo(456);
+                              assertThat(configs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG))
+                                      .isEqualTo(789);
+                              assertThat(configs.get(ConsumerConfig.GROUP_ID_CONFIG))
+                                      .isEqualTo("bar");
+                              assertThat(configs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG))
+                                      .isEqualTo(234);
+                              assertThat(configs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(LongDeserializer.class);
+                              assertThat(
+                                      configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(IntegerDeserializer.class);
+                              assertThat(configs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))
+                                      .isEqualTo(42);
+                              assertThat(configs.get("foo")).isEqualTo("bar");
+                              assertThat(configs.get("baz")).isEqualTo("qux");
+                              assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
+                              assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+                          });
+    }
+
+
+    @Test
+    public void producerProperties() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                          .withPropertyValues("axon.kafka.clientId=cid",
+                                              "axon.kafka.default-topic=testTopic",
+                                              "axon.kafka.producer.transaction-id-prefix=foo",
+                                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
+                                              "axon.kafka.producer.acks=all",
+                                              "axon.kafka.producer.batch-size=20",
+                                              "axon.kafka.producer.bootstrap-servers=bar:1234",
+                                              // test
+                                              // override
+                                              "axon.kafka.producer.buffer-memory=12345",
+                                              "axon.kafka.producer.compression-type=gzip",
+                                              "axon.kafka.producer.key-serializer=org.apache.kafka.common.serialization.LongSerializer",
+                                              "axon.kafka.producer.retries=2",
+                                              "axon.kafka.producer.properties.fiz.buz=fix.fox",
+                                              "axon.kafka.producer.ssl.key-password=p4",
+                                              "axon.kafka.producer.ssl.keystore-location=classpath:ksLocP",
+                                              "axon.kafka.producer.ssl.keystore-password=p5",
+                                              "axon.kafka.producer.ssl.truststore-location=classpath:tsLocP",
+                                              "axon.kafka.producer.ssl.truststore-password=p6",
+                                              "axon.kafka.producer.value-serializer=org.apache.kafka.common.serialization.IntegerSerializer")
+                          .run((context) -> {
+                              DefaultProducerFactory<?, ?> producerFactory = context
+                                      .getBean(DefaultProducerFactory.class);
+                              Map<String, Object> configs = producerFactory
+                                      .configurationProperties();
+                              // common
+                              assertThat(configs.get(ProducerConfig.CLIENT_ID_CONFIG))
+                                      .isEqualTo("cid");
+                              // producer
+                              assertThat(configs.get(ProducerConfig.ACKS_CONFIG)).isEqualTo("all");
+                              assertThat(configs.get(ProducerConfig.BATCH_SIZE_CONFIG))
+                                      .isEqualTo(20);
+                              assertThat(configs.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
+                                      .isEqualTo(Collections.singletonList("bar:1234")); // override
+                              assertThat(configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG))
+                                      .isEqualTo(12345L);
+                              assertThat(configs.get(ProducerConfig.COMPRESSION_TYPE_CONFIG))
+                                      .isEqualTo("gzip");
+                              assertThat(configs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(LongSerializer.class);
+                              assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG))
+                                      .isEqualTo("p4");
+                              assertThat(
+                                      (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+                                      .endsWith(File.separator + "ksLocP");
+                              assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG))
+                                      .isEqualTo("p5");
+                              assertThat((String) configs
+                                      .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
+                                      .endsWith(File.separator + "tsLocP");
+                              assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG))
+                                      .isEqualTo("p6");
+                              assertThat(configs.get(ProducerConfig.RETRIES_CONFIG)).isEqualTo(2);
+                              assertThat(configs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
+                                      .isEqualTo(IntegerSerializer.class);
+                              assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
+                              assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+                          });
+    }
+
+    @Configuration
+    protected static class TestConfiguration {
+
+        @Bean
+        public Serializer eventSerializer() {
+            return new XStreamSerializer();
+        }
+
+        @Bean
+        public EventBus eventBus() {
+            return mock(EventBus.class);
+        }
+
+        @Bean
+        AxonConfiguration axonConfiguration() {
+            AxonConfiguration mock = mock(AxonConfiguration.class);
+            when(mock.messageMonitor(any(), any())).thenReturn((MessageMonitor) NoOpMessageMonitor.instance());
+            return mock;
+        }
+    }
 }

--- a/spring-boot-autoconfigure/src/test/resources/ksLoc
+++ b/spring-boot-autoconfigure/src/test/resources/ksLoc
@@ -1,0 +1,1 @@
+Test file for Kafka.

--- a/spring-boot-autoconfigure/src/test/resources/ksLocP
+++ b/spring-boot-autoconfigure/src/test/resources/ksLocP
@@ -1,0 +1,1 @@
+Test file for Kafka.

--- a/spring-boot-autoconfigure/src/test/resources/tsLoc
+++ b/spring-boot-autoconfigure/src/test/resources/tsLoc
@@ -1,0 +1,1 @@
+Test file for Kafka.

--- a/spring-boot-autoconfigure/src/test/resources/tsLocP
+++ b/spring-boot-autoconfigure/src/test/resources/tsLocP
@@ -1,0 +1,1 @@
+Test file for Kafka.


### PR DESCRIPTION
- Fixes #710 
- Fixes #717
- Added support for consumer and producer specific properties.