### PR TITLE
Fix some bugs with ConfigurationScopeAwareProvider

### DIFF
--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -26,8 +26,9 @@ import org.axonframework.messaging.ScopeDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Implementation of the {@link ScopeAwareProvider} which will retrieve a {@link List} of {@link ScopeAware} components
@@ -67,18 +68,16 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
     }
 
     private List<Repository> retrieveAggregateRepositories() {
-        return configuration.getModules().stream()
-                            .filter(module -> module instanceof AggregateConfiguration)
-                            .map(module -> (AggregateConfiguration) module)
-                            .map((Function<AggregateConfiguration, Repository>) AggregateConfiguration::repository)
-                            .collect(Collectors.toList());
+        return configuration.findModules(AggregateConfiguration.class)
+                .stream()
+                .map((Function<AggregateConfiguration, Repository>) AggregateConfiguration::repository)
+                .collect(toList());
     }
 
     private List<AbstractSagaManager> retrieveSagaManagers() {
-        return configuration.getModules().stream()
-                            .filter(module -> module instanceof SagaConfiguration)
-                            .map(module -> (SagaConfiguration) module)
-                            .map((Function<SagaConfiguration, AnnotatedSagaManager>) SagaConfiguration::getSagaManager)
-                            .collect(Collectors.toList());
+        return configuration.findModules(SagaConfiguration.class)
+                .stream()
+                .map((Function<SagaConfiguration, AnnotatedSagaManager>) SagaConfiguration::getSagaManager)
+                .collect(toList());
     }
 }

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -18,7 +18,6 @@ package org.axonframework.config;
 
 import org.axonframework.commandhandling.model.Repository;
 import org.axonframework.eventhandling.saga.AbstractSagaManager;
-import org.axonframework.eventhandling.saga.AnnotatedSagaManager;
 import org.axonframework.messaging.ScopeAware;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
@@ -80,7 +79,7 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
     private List<AbstractSagaManager> retrieveSagaManagers() {
         return configuration.findModules(SagaConfiguration.class)
                 .stream()
-                .map((Function<SagaConfiguration, AnnotatedSagaManager>) SagaConfiguration::getSagaManager)
+                .map((Function<SagaConfiguration, AbstractSagaManager>) SagaConfiguration::getSagaManager)
                 .collect(toList());
     }
 }

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -33,9 +33,10 @@ import static java.util.stream.Collectors.toList;
 /**
  * Implementation of the {@link ScopeAwareProvider} which will retrieve a {@link List} of {@link ScopeAware} components
  * in a lazy manner. It does this by pulling these components from the provided {@link Configuration} as soon as
- * #provideScopeAwareStream(ScopeDescriptor) has been called.
+ * {@link #provideScopeAwareStream(ScopeDescriptor)} is called.
  *
  * @author Steven van Beelen
+ * @author Rob van der Linden Vooren
  * @since 3.3
  */
 public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -41,8 +42,9 @@ import static java.util.stream.Collectors.toList;
  */
 public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
 
+    private final Configuration configuration;
+
     private List<ScopeAware> scopeAwareComponents;
-    private Configuration configuration;
 
     /**
      * Instantiate a lazy {@link ScopeAwareProvider} with the given {@code configuration} parameter.
@@ -50,22 +52,22 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
      * @param configuration a {@link Configuration} used to retrieve {@link ScopeAware} components from
      */
     public ConfigurationScopeAwareProvider(Configuration configuration) {
-        scopeAwareComponents = new ArrayList<>();
-        this.configuration = configuration;
+        this.configuration = requireNonNull(configuration);
     }
 
     @Override
     public Stream<ScopeAware> provideScopeAwareStream(ScopeDescriptor scopeDescriptor) {
-        if (scopeAwareComponents.isEmpty()) {
-            lookupScopeAwareComponents();
+        if (scopeAwareComponents == null) {
+            scopeAwareComponents = retrieveScopeAwareComponents();
         }
-
         return scopeAwareComponents.stream();
     }
 
-    private void lookupScopeAwareComponents() {
-        scopeAwareComponents.addAll(retrieveAggregateRepositories());
-        scopeAwareComponents.addAll(retrieveSagaManagers());
+    private List<ScopeAware> retrieveScopeAwareComponents() {
+        List<ScopeAware> components = new ArrayList<>();
+        components.addAll(retrieveAggregateRepositories());
+        components.addAll(retrieveSagaManagers());
+        return components;
     }
 
     private List<Repository> retrieveAggregateRepositories() {

--- a/core/src/main/java/org/axonframework/config/SagaConfiguration.java
+++ b/core/src/main/java/org/axonframework/config/SagaConfiguration.java
@@ -33,6 +33,7 @@ import org.axonframework.eventhandling.SubscribingEventProcessor;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.eventhandling.saga.AbstractSagaManager;
 import org.axonframework.eventhandling.saga.AnnotatedSagaManager;
 import org.axonframework.eventhandling.saga.SagaRepository;
 import org.axonframework.eventhandling.saga.repository.AnnotatedSagaRepository;
@@ -603,7 +604,7 @@ public class SagaConfiguration<S> implements ModuleConfiguration {
      *
      * @throws IllegalStateException when this configuration hasn't been initialized yet
      */
-    public AnnotatedSagaManager<S> getSagaManager() {
+    public AbstractSagaManager<S> getSagaManager() {
         Assert.state(config != null, () -> "Configuration is not initialized yet");
         return sagaManager.get();
     }

--- a/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -1,0 +1,86 @@
+package org.axonframework.config;
+
+import org.axonframework.commandhandling.model.AggregateScopeDescriptor;
+import org.axonframework.commandhandling.model.Repository;
+import org.axonframework.eventhandling.saga.AnnotatedSagaManager;
+import org.axonframework.eventhandling.saga.SagaScopeDescriptor;
+import org.axonframework.messaging.ScopeAware;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Random;
+
+import static java.util.Arrays.asList;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link ConfigurationScopeAwareProvider}.
+ *
+ * @author Rob van der Linden Vooren
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationScopeAwareProviderTest {
+
+    @Mock
+    private Configuration config;
+
+    @Mock
+    private AggregateConfiguration aggregateConfiguration;
+
+    @Mock
+    private Repository aggregateRepository;
+
+    @Mock
+    private SagaConfiguration sagaConfiguration;
+
+    @Mock
+    private AnnotatedSagaManager sagaManager;
+
+    private ConfigurationScopeAwareProvider scopeAwareProvider;
+
+    @Before
+    public void setUp() {
+        scopeAwareProvider = new ConfigurationScopeAwareProvider(config);
+    }
+
+    @Test
+    public void providesScopeAwareAggregatesFromModuleConfiguration() {
+        when(config.getModules()).thenReturn(asList(aggregateConfiguration));
+        when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
+
+        List<ScopeAware> scopeAwares = scopeAwareProvider
+                .provideScopeAwareStream(randomScopeDescriptor())
+                .collect(toList());
+
+        assertThat(scopeAwares, equalTo(asList(aggregateRepository)));
+    }
+
+    @Test
+    public void providesScopeAwareSagasFromModuleConfiguration() {
+        when(config.getModules()).thenReturn(asList(sagaConfiguration));
+        when(sagaConfiguration.getSagaManager()).thenReturn(sagaManager);
+
+        List<ScopeAware> scopeAwares = scopeAwareProvider
+                .provideScopeAwareStream(randomScopeDescriptor())
+                .collect(toList());
+
+        assertThat(scopeAwares, equalTo(asList(sagaManager)));
+    }
+
+    private static ScopeDescriptor randomScopeDescriptor() {
+        String id = randomUUID().toString();
+        if (new Random().nextBoolean()) {
+            return new AggregateScopeDescriptor("Aggregate", id);
+        }
+        return new SagaScopeDescriptor("Saga", id);
+    }
+}

--- a/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -20,6 +20,8 @@ import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -31,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class ConfigurationScopeAwareProviderTest {
 
     @Mock
-    private Configuration config;
+    private Configuration configuration;
 
     @Mock
     private AggregateConfiguration aggregateConfiguration;
@@ -49,33 +51,56 @@ public class ConfigurationScopeAwareProviderTest {
 
     @Before
     public void setUp() {
-        scopeAwareProvider = new ConfigurationScopeAwareProvider(config);
+        scopeAwareProvider = new ConfigurationScopeAwareProvider(configuration);
     }
 
     @Test
     public void providesScopeAwareAggregatesFromModuleConfiguration() {
-        when(config.findModules(AggregateConfiguration.class)).thenCallRealMethod();
-        when(config.getModules()).thenReturn(asList(new WrappingModuleConfiguration(aggregateConfiguration)));
+        when(configuration.findModules(AggregateConfiguration.class)).thenCallRealMethod();
+        when(configuration.getModules()).thenReturn(asList(new WrappingModuleConfiguration(aggregateConfiguration)));
         when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
 
-        List<ScopeAware> scopeAwares = scopeAwareProvider
-                .provideScopeAwareStream(anyScopeDescriptor())
+        List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
                 .collect(toList());
 
-        assertThat(scopeAwares, equalTo(asList(aggregateRepository)));
+        assertThat(components, equalTo(asList(aggregateRepository)));
     }
 
     @Test
     public void providesScopeAwareSagasFromModuleConfiguration() {
-        when(config.findModules(SagaConfiguration.class)).thenCallRealMethod();
-        when(config.getModules()).thenReturn(asList(new WrappingModuleConfiguration(sagaConfiguration)));
+        when(configuration.findModules(SagaConfiguration.class)).thenCallRealMethod();
+        when(configuration.getModules()).thenReturn(asList(new WrappingModuleConfiguration(sagaConfiguration)));
         when(sagaConfiguration.getSagaManager()).thenReturn(sagaManager);
 
-        List<ScopeAware> scopeAwares = scopeAwareProvider
-                .provideScopeAwareStream(anyScopeDescriptor())
+        List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
                 .collect(toList());
 
-        assertThat(scopeAwares, equalTo(asList(sagaManager)));
+        assertThat(components, equalTo(asList(sagaManager)));
+    }
+
+    @Test
+    public void lazilyInitializes() {
+        new ConfigurationScopeAwareProvider(configuration);
+
+        verifyZeroInteractions(configuration);
+    }
+
+    @Test
+    public void cachesScopeAwareComponentsOnceProvisioned() {
+        when(configuration.findModules(AggregateConfiguration.class)).thenCallRealMethod();
+        when(configuration.getModules()).thenReturn(asList(new WrappingModuleConfiguration(aggregateConfiguration)));
+        when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
+
+        // provision once
+        List<ScopeAware> first = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
+                .collect(toList());
+        reset(configuration, aggregateConfiguration);
+
+        // provision twice
+        List<ScopeAware> second = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor()).collect(toList());
+        verifyZeroInteractions(configuration);
+        verifyZeroInteractions(aggregateConfiguration);
+        assertThat(second, equalTo(first));
     }
 
     private static ScopeDescriptor anyScopeDescriptor() {


### PR DESCRIPTION
This PR addresses a bug we encountered when using the with `ConfigurationScopeAwareProvider` with Axon's Spring autoconfiguration.

This bug occurred because`ConfigurationScopeAwareProvider` did not detect `LazyRetrievedModuleConfiguration` to be a `ModuleConfiguration` which wraps the actual `SagaManagerConfiguration`. As a consequence, deadline messages are not being sent to relevant Saga instances as a result of failing to lookup `SagaManager`s configured by the `SpringAutoConfigurer`.

Similar behavior was expected (and addresses by this PR) with Aggregates (also a ScopeAwareComponent), for similar reasons.

In addition to for-mentioned bugfix, this PR addresses a non-observed but possible bug where concurrent initialization of the `ConfigurationScopeAwareProvider` could yield in duplicate instances of the same `ScopeAwareComponent` being cached in the lookup. As a consequence, a single deadline message could be delivered to the same `ScopeAwareComponent` as many times as it was registered, unintendedly.

Also, I can imagine this should not be merged against `master` directly but onto the current development branch (3.3.x)? You may be able to cherry pick quite easily. :)

@smcvb could you have a look?

(rewrote description)
