### PR TITLE
Fix resolving of ScopeAwareProvider components in Spring autoconfigured context

### DIFF
--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -26,8 +26,9 @@ import org.axonframework.messaging.ScopeDescriptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Implementation of the {@link ScopeAwareProvider} which will retrieve a {@link List} of {@link ScopeAware} components
@@ -67,18 +68,14 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
     }
 
     private List<Repository> retrieveAggregateRepositories() {
-        return configuration.getModules().stream()
-                            .filter(module -> module instanceof AggregateConfiguration)
-                            .map(module -> (AggregateConfiguration) module)
+        return configuration.findModules(AggregateConfiguration.class).stream()
                             .map((Function<AggregateConfiguration, Repository>) AggregateConfiguration::repository)
-                            .collect(Collectors.toList());
+                            .collect(toList());
     }
 
     private List<AbstractSagaManager> retrieveSagaManagers() {
-        return configuration.getModules().stream()
-                            .filter(module -> module instanceof SagaConfiguration)
-                            .map(module -> (SagaConfiguration) module)
+        return configuration.findModules(SagaConfiguration.class).stream()
                             .map((Function<SagaConfiguration, AnnotatedSagaManager>) SagaConfiguration::getSagaManager)
-                            .collect(Collectors.toList());
+                            .collect(toList());
     }
 }

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -17,6 +17,7 @@
 package org.axonframework.config;
 
 import org.axonframework.commandhandling.model.Repository;
+import org.axonframework.common.Assert;
 import org.axonframework.eventhandling.saga.AbstractSagaManager;
 import org.axonframework.eventhandling.saga.AnnotatedSagaManager;
 import org.axonframework.messaging.ScopeAware;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -50,9 +50,10 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
      * Instantiate a lazy {@link ScopeAwareProvider} with the given {@code configuration} parameter.
      *
      * @param configuration a {@link Configuration} used to retrieve {@link ScopeAware} components from
+     * @throws IllegalArgumentException when {@code configuration} is {@code null}
      */
     public ConfigurationScopeAwareProvider(Configuration configuration) {
-        this.configuration = requireNonNull(configuration);
+        this.configuration = Assert.nonNull(configuration, () -> "configuration may not be null");
     }
 
     @Override

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -33,9 +33,10 @@ import static java.util.stream.Collectors.toList;
 /**
  * Implementation of the {@link ScopeAwareProvider} which will retrieve a {@link List} of {@link ScopeAware} components
  * in a lazy manner. It does this by pulling these components from the provided {@link Configuration} as soon as
- * #provideScopeAwareStream(ScopeDescriptor) has been called.
+ * {@link #provideScopeAwareStream(ScopeDescriptor)} is called.
  *
  * @author Steven van Beelen
+ * @author Rob van der Linden Vooren
  * @since 3.3
  */
 public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {

--- a/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -41,8 +42,9 @@ import static java.util.stream.Collectors.toList;
  */
 public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
 
+    private final Configuration configuration;
+
     private List<ScopeAware> scopeAwareComponents;
-    private Configuration configuration;
 
     /**
      * Instantiate a lazy {@link ScopeAwareProvider} with the given {@code configuration} parameter.
@@ -50,22 +52,22 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
      * @param configuration a {@link Configuration} used to retrieve {@link ScopeAware} components from
      */
     public ConfigurationScopeAwareProvider(Configuration configuration) {
-        scopeAwareComponents = new ArrayList<>();
-        this.configuration = configuration;
+        this.configuration = requireNonNull(configuration);
     }
 
     @Override
     public Stream<ScopeAware> provideScopeAwareStream(ScopeDescriptor scopeDescriptor) {
-        if (scopeAwareComponents.isEmpty()) {
-            lookupScopeAwareComponents();
+        if (scopeAwareComponents == null) {
+            scopeAwareComponents = retrieveScopeAwareComponents();
         }
-
         return scopeAwareComponents.stream();
     }
 
-    private void lookupScopeAwareComponents() {
-        scopeAwareComponents.addAll(retrieveAggregateRepositories());
-        scopeAwareComponents.addAll(retrieveSagaManagers());
+    private List<ScopeAware> retrieveScopeAwareComponents() {
+        List<ScopeAware> components = new ArrayList<>();
+        components.addAll(retrieveAggregateRepositories());
+        components.addAll(retrieveSagaManagers());
+        return components;
     }
 
     private List<Repository> retrieveAggregateRepositories() {

--- a/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -1,0 +1,77 @@
+package org.axonframework.config;
+
+import org.axonframework.commandhandling.model.Repository;
+import org.axonframework.eventhandling.saga.AnnotatedSagaManager;
+import org.axonframework.messaging.ScopeAware;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.junit.*;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link ConfigurationScopeAwareProvider}.
+ *
+ * @author Rob van der Linden Vooren
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationScopeAwareProviderTest {
+
+    @Mock
+    private Configuration config;
+
+    @Mock
+    private AggregateConfiguration aggregateConfiguration;
+
+    @Mock
+    private Repository aggregateRepository;
+
+    @Mock
+    private SagaConfiguration sagaConfiguration;
+
+    @Mock
+    private AnnotatedSagaManager sagaManager;
+
+    private ConfigurationScopeAwareProvider scopeAwareProvider;
+
+    @Before
+    public void setUp() {
+        scopeAwareProvider = new ConfigurationScopeAwareProvider(config);
+    }
+
+    @Test
+    public void providesScopeAwareAggregatesFromModuleConfiguration() {
+        when(config.getModules()).thenReturn(asList(aggregateConfiguration));
+        when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
+
+        List<ScopeAware> scopeAwares = scopeAwareProvider
+                .provideScopeAwareStream(anyScopeDescriptor())
+                .collect(toList());
+
+        assertThat(scopeAwares, equalTo(asList(aggregateRepository)));
+    }
+
+    @Test
+    public void providesScopeAwareSagasFromModuleConfiguration() {
+        when(config.getModules()).thenReturn(asList(sagaConfiguration));
+        when(sagaConfiguration.getSagaManager()).thenReturn(sagaManager);
+
+        List<ScopeAware> scopeAwares = scopeAwareProvider
+                .provideScopeAwareStream(anyScopeDescriptor())
+                .collect(toList());
+
+        assertThat(scopeAwares, equalTo(asList(sagaManager)));
+    }
+
+    private static ScopeDescriptor anyScopeDescriptor() {
+        return (ScopeDescriptor) () -> "test-scope";
+    }
+}

--- a/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -54,7 +54,7 @@ public class ConfigurationScopeAwareProviderTest {
         when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
 
         List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
-                .collect(toList());
+                                                        .collect(toList());
 
         assertThat(components, equalTo(asList(aggregateRepository)));
     }
@@ -66,7 +66,7 @@ public class ConfigurationScopeAwareProviderTest {
         when(sagaConfiguration.getSagaManager()).thenReturn(sagaManager);
 
         List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
-                .collect(toList());
+                                                        .collect(toList());
 
         assertThat(components, equalTo(asList(sagaManager)));
     }
@@ -86,7 +86,7 @@ public class ConfigurationScopeAwareProviderTest {
 
         // provision once
         List<ScopeAware> first = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
-                .collect(toList());
+                                                   .collect(toList());
         reset(configuration, aggregateConfiguration);
 
         // provision twice
@@ -111,14 +111,23 @@ public class ConfigurationScopeAwareProviderTest {
             this.delegate = delegate;
         }
 
+        /**
+         * No-op.
+         */
         @Override
         public void initialize(Configuration config) {
         }
 
+        /**
+         * No-op.
+         */
         @Override
         public void start() {
         }
 
+        /**
+         * No-op.
+         */
         @Override
         public void shutdown() {
         }

--- a/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/core/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -49,7 +49,8 @@ public class ConfigurationScopeAwareProviderTest {
 
     @Test
     public void providesScopeAwareAggregatesFromModuleConfiguration() {
-        when(config.getModules()).thenReturn(asList(aggregateConfiguration));
+        when(config.findModules(AggregateConfiguration.class)).thenCallRealMethod();
+        when(config.getModules()).thenReturn(asList(new WrappingModuleConfiguration(aggregateConfiguration)));
         when(aggregateConfiguration.repository()).thenReturn(aggregateRepository);
 
         List<ScopeAware> scopeAwares = scopeAwareProvider
@@ -61,7 +62,8 @@ public class ConfigurationScopeAwareProviderTest {
 
     @Test
     public void providesScopeAwareSagasFromModuleConfiguration() {
-        when(config.getModules()).thenReturn(asList(sagaConfiguration));
+        when(config.findModules(SagaConfiguration.class)).thenCallRealMethod();
+        when(config.getModules()).thenReturn(asList(new WrappingModuleConfiguration(sagaConfiguration)));
         when(sagaConfiguration.getSagaManager()).thenReturn(sagaManager);
 
         List<ScopeAware> scopeAwares = scopeAwareProvider
@@ -73,5 +75,34 @@ public class ConfigurationScopeAwareProviderTest {
 
     private static ScopeDescriptor anyScopeDescriptor() {
         return (ScopeDescriptor) () -> "test-scope";
+    }
+
+    /**
+     * Test variant of a {@link #unwrap() wrapping} configuration.
+     */
+    private static class WrappingModuleConfiguration implements ModuleConfiguration {
+
+        private final ModuleConfiguration delegate;
+
+        WrappingModuleConfiguration(ModuleConfiguration delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void initialize(Configuration config) {
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void shutdown() {
+        }
+
+        @Override
+        public ModuleConfiguration unwrap() {
+            return delegate == null ? this : delegate;
+        }
     }
 }


### PR DESCRIPTION
This PR addresses a bug we encountered when using the with `ConfigurationScopeAwareProvider` with Axon's Spring autoconfiguration.

This bug occurred because `ConfigurationScopeAwareProvider` did not detect `LazyRetrievedModuleConfiguration` to be a `ModuleConfiguration` which wraps the actual `SagaManagerConfiguration`. As a consequence, deadline messages are not being sent to relevant Saga instances as a result of failing to lookup `SagaManager`s configured by the `SpringAutoConfigurer`.

Similar behavior was expected (and addresses by this PR) with Aggregates (also a `ScopeAwareComponent`), for similar reasons.

In addition to aforementioned bugfix, this PR addresses a non-observed but possible bug where concurrent initialization of the `ConfigurationScopeAwareProvider` could yield in duplicate instances of the same `ScopeAwareComponent` being cached in the lookup. As a consequence, a single deadline message could be delivered to the same `ScopeAwareComponent` as many times as it was registered due concurrent access, unintendedly.

@smcvb could you have a look? (again, thanks in advance)
- rewrote description
- PR against axon-3.3.x latest (at time of writing)
