### PR TITLE
Fix generics on Matchers.exactSequenceOf()

### DIFF
--- a/test/src/main/java/org/axonframework/test/matchers/Matchers.java
+++ b/test/src/main/java/org/axonframework/test/matchers/Matchers.java
@@ -112,7 +112,7 @@ public abstract class Matchers {
      */
     @SafeVarargs
     @Factory
-    public static <T> Matcher<List<T>> exactSequenceOf(Matcher<? super T>... matchers) {
+    public static <T> Matcher<List<T>> exactSequenceOf(Matcher<T>... matchers) {
         return new ExactSequenceMatcher<>(matchers);
     }
 


### PR DESCRIPTION
Noticed this issue when migrating from Axon 2.x to 3.x.

Cfr: issue #269 and https://groups.google.com/forum/?nomobile=true#!searchin/axonframework/exactSequenceOf%7Csort:date/axonframework/kr8AMCqh3io/d3ESeFMqBwAJ