### PR TITLE
[#735] Constructor overloading for threadfactory in EmbeddedEventStore

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -108,9 +108,37 @@ public class EmbeddedEventStore extends AbstractEventStore {
      */
     public EmbeddedEventStore(EventStorageEngine storageEngine, MessageMonitor<? super EventMessage<?>> monitor,
                               int cachedEvents, long fetchDelay, long cleanupDelay, TimeUnit timeUnit) {
+        this(storageEngine, monitor, 10000, 1000L, 10000L, TimeUnit.MILLISECONDS,
+            new AxonThreadFactory(THREAD_GROUP));
+    }
+
+    /**
+     * Initializes an {@link EmbeddedEventStore} with given {@code storageEngine} and {@code monitor} and custom
+     * settings.
+     *
+     * @param storageEngine the storage engine to use
+     * @param monitor       the metrics monitor that tracks how many events are ingested by the event store
+     * @param cachedEvents  the maximum number of events in the cache that is shared between the streams of tracking
+     *                      event processors
+     * @param fetchDelay    the time to wait before fetching new events from the backing storage engine while tracking
+     *                      after a previous stream was fetched and read. Note that this only applies to situations in
+     *                      which no events from the current application have meanwhile been committed. If the current
+     *                      application commits events then those events are fetched without delay.
+     * @param cleanupDelay  the delay between two clean ups of lagging event processors. An event processor is lagging
+     *                      behind and removed from the set of processors that track cached events if the oldest event
+     *                      in the cache is newer than the last processed event of the event processor. Once removed the
+     *                      processor will be independently fetching directly from the event storage engine until it has
+     *                      caught up again. Event processors will not notice this change during tracking (i.e. the
+     *                      stream is not closed when an event processor falls behind and is removed).
+     * @param timeUnit      time unit for fetch and clean up delay
+     * @param threadFactory the factory to create threads with
+     */
+    public EmbeddedEventStore(EventStorageEngine storageEngine, MessageMonitor<? super EventMessage<?>> monitor,
+                              int cachedEvents, long fetchDelay, long cleanupDelay, TimeUnit timeUnit,
+                              ThreadFactory threadFactory) {
         super(storageEngine, monitor);
-        threadFactory = new AxonThreadFactory(THREAD_GROUP);
-        cleanupService = Executors.newScheduledThreadPool(1, threadFactory);
+        this.threadFactory = threadFactory;
+        cleanupService = Executors.newScheduledThreadPool(1, this.threadFactory);
         producer = new EventProducer(timeUnit.toNanos(fetchDelay), cachedEvents);
         cleanupDelayMillis = timeUnit.toMillis(cleanupDelay);
     }

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.MockException;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Stream;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -59,17 +61,19 @@ public class EmbeddedEventStoreTest {
 
     private EmbeddedEventStore testSubject;
     private EventStorageEngine storageEngine;
+    private ThreadFactory threadFactory;
 
     @Before
     public void setUp() {
         storageEngine = spy(new InMemoryEventStorageEngine());
+        threadFactory = spy(new AxonThreadFactory(new ThreadGroup(EmbeddedEventStore.class.getSimpleName())));
         newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY);
     }
 
     private void newTestSubject(int cachedEvents, long fetchDelay, long cleanupDelay) {
         Optional.ofNullable(testSubject).ifPresent(EmbeddedEventStore::shutDown);
         testSubject = new EmbeddedEventStore(storageEngine, NoOpMessageMonitor.INSTANCE, cachedEvents, fetchDelay,
-                                             cleanupDelay, MILLISECONDS);
+                                             cleanupDelay, MILLISECONDS, threadFactory);
     }
 
     @After
@@ -285,6 +289,20 @@ public class EmbeddedEventStoreTest {
         unitOfWork.rollback();
 
         Assert.assertEquals(2, testSubject.readEvents(AGGREGATE).asStream().count());
+    }
+
+    @Test(timeout = 5000)
+    public void testCustomThreadFactoryIsUsed() throws Exception {
+        CountDownLatch lock = new CountDownLatch(1);
+        TrackingEventStream stream = testSubject.openStream(null);
+        Thread t = new Thread(() -> stream.asStream().findFirst().ifPresent(event -> lock.countDown()));
+        t.start();
+        assertFalse(lock.await(100, MILLISECONDS));
+        testSubject.publish(createEvent());
+        t.join();
+        assertEquals(0, lock.getCount());
+
+        verify(threadFactory, atLeastOnce()).newThread(any(Runnable.class));
     }
 
     private static class SynchronizedBooleanAnswer implements Answer<Boolean> {

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -66,7 +66,7 @@ public class EmbeddedEventStoreTest {
     @Before
     public void setUp() {
         storageEngine = spy(new InMemoryEventStorageEngine());
-        threadFactory = spy(new AxonThreadFactory(new ThreadGroup(EmbeddedEventStore.class.getSimpleName())));
+        threadFactory = spy(new AxonThreadFactory(EmbeddedEventStore.class.getSimpleName()));
         newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY);
     }
 


### PR DESCRIPTION
Implemented an overloaded version of the `EmbeddedEventStore` constructor, to allow the usage of a custom `ThreadFactory`.

This PR resolves #735.