### PR TITLE
Use AxonThreadFactory instead of default

### DIFF
--- a/core/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
+++ b/core/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
@@ -17,6 +17,7 @@
 package org.axonframework.commandhandling;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.messaging.MessageHandler;
@@ -50,7 +51,7 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
      * Initialize the AsynchronousCommandBus, using a Cached Thread Pool.
      */
     public AsynchronousCommandBus() {
-        this(Executors.newCachedThreadPool());
+        this(Executors.newCachedThreadPool(new AxonThreadFactory(AsynchronousCommandBus.class.getSimpleName())));
     }
 
     /**

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/java/SimpleEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/java/SimpleEventSchedulerFactoryBean.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.spring.eventhandling.scheduling.java;
 
+import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.scheduling.java.SimpleEventScheduler;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
@@ -72,7 +73,7 @@ public class SimpleEventSchedulerFactoryBean implements FactoryBean<SimpleEventS
     @Override
     public void afterPropertiesSet() {
         if (executorService == null) {
-            executorService = Executors.newSingleThreadScheduledExecutor();
+            executorService = Executors.newSingleThreadScheduledExecutor(new AxonThreadFactory(SimpleEventSchedulerFactoryBean.class.getSimpleName()));
             executorServiceToShutDown = executorService;
         }
         if (eventBus == null) {


### PR DESCRIPTION
Use AxonThreadFactory instead of default so thread pools and thread created by axon have non-default names (e.g.: useful for troubleshooting stuck threads).

This is based on another PR, #790.