### PR TITLE
Add default bean with SimpleDeadlineManager

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/autoconfig/AxonAutoConfiguration.java
@@ -28,8 +28,11 @@ import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.Configuration;
+import org.axonframework.config.ConfigurationScopeAwareProvider;
 import org.axonframework.config.EventHandlingConfiguration;
 import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.deadline.DeadlineManager;
+import org.axonframework.deadline.SimpleDeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.SimpleEventBus;
@@ -277,6 +280,15 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
         return new SimpleQueryBus(axonConfiguration.messageMonitor(QueryBus.class, "queryBus"),
                                   transactionManager,
                                   eh);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DeadlineManager deadlineManager(AxonConfiguration axonConfiguration,
+                                           TransactionManager transactionManager) {
+        return new SimpleDeadlineManager(
+                new ConfigurationScopeAwareProvider(axonConfiguration),
+                transactionManager);
     }
 
     @Override

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.SagaConfiguration;
+import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.saga.SagaEventHandler;
@@ -95,6 +96,7 @@ public class AxonAutoConfigurationTest {
         assertNotNull(applicationContext.getBean(EventStore.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
+        assertNotNull(applicationContext.getBean(DeadlineManager.class));
         assertEquals(MultiParameterResolverFactory.class, applicationContext.getBean(ParameterResolverFactory.class).getClass());
         assertEquals(1, applicationContext.getBeansOfType(EventStorageEngine.class).size());
         assertEquals(0, applicationContext.getBeansOfType(TokenStore.class).size());

--- a/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
@@ -23,6 +23,7 @@ import org.axonframework.commandhandling.model.Repository;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.ModuleConfiguration;
+import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.saga.ResourceInjector;
 import org.axonframework.messaging.Message;
@@ -167,6 +168,11 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Override
     public HandlerDefinition handlerDefinition(Class<?> inspectedType) {
         return config.handlerDefinition(inspectedType);
+    }
+
+    @Override
+    public DeadlineManager deadlineManager() {
+        return config.deadlineManager();
     }
 
     @Override


### PR DESCRIPTION
Adds SimpleDeadlineManager to be the default bean when applying AxonAutoConfiguration.

