### PR TITLE
[#756] SpringHttpCommandBusConnector should support async execution

### DIFF
--- a/distributed-commandbus-jgroups/src/test/java/org/axonframework/jgroups/commandhandling/JgroupsConnectorTest_Gossip.java
+++ b/distributed-commandbus-jgroups/src/test/java/org/axonframework/jgroups/commandhandling/JgroupsConnectorTest_Gossip.java
@@ -143,7 +143,7 @@ public class JgroupsConnectorTest_Gossip {
     }
 
     private void waitForConnectorSync() throws InterruptedException {
-        long deadline = System.currentTimeMillis() + 10000;
+        long deadline = System.currentTimeMillis() + 20000;
         while ((connector1.getConsistentHash().getMembers().isEmpty())
                 || !connector1.getConsistentHash().equals(connector2.getConsistentHash())) {
             // don't have a member for String yet, which means we must wait a little longer

--- a/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnector.java
+++ b/distributed-commandbus-springcloud/src/main/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnector.java
@@ -43,11 +43,20 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+/**
+ * A {@link CommandBusConnector} implementation based on Spring Rest characteristics. Serves as a {@link RestController}
+ * to receive Command Messages for its node, but also contains a {@link RestOperations} component to send Command
+ * Messages to other nodes. Will use a {@code localCommandBus} of type {@link CommandBus} to publish any received
+ * Command Messages to its local instance. Messages are de-/serialized using a {@link Serializer}.
+ *
+ * @author Steven van Beelen
+ * @since 3.0
+ */
 @RestController
 @RequestMapping("/spring-command-bus-connector")
 public class SpringHttpCommandBusConnector implements CommandBusConnector {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SpringHttpCommandBusConnector.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpringHttpCommandBusConnector.class);
 
     private static final boolean EXPECT_REPLY = true;
     private static final boolean DO_NOT_EXPECT_REPLY = false;
@@ -58,12 +67,37 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
     private final Serializer serializer;
     private final Executor executor;
 
+    /**
+     * Initialize a {@link SpringHttpCommandBusConnector} using the provided local {@link CommandBus},
+     * {@link RestOperations} and {@link Serializer}. The {@code localCommandBus} is used to publish received commands
+     * which to the local segment. The given RestOperations provides the connectivity between other nodes to send
+     * commands, and the Serializer is used to serialize the command messages when they are sent between nodes.
+     * The {@link Executor} used to make the sending of commands asynchronous is defaulted to a
+     * {@link DirectExecutor#INSTANCE}.
+     *
+     * @param localCommandBus the {@link CommandBus} to publish received commands which to the local segment
+     * @param restOperations  the {@link RestOperations} used to send commands to other nodes
+     * @param serializer      the {@link Serializer} used to serialize command messages when they are sent between nodes
+     */
     public SpringHttpCommandBusConnector(CommandBus localCommandBus,
                                          RestOperations restOperations,
                                          Serializer serializer) {
         this(localCommandBus, restOperations, serializer, DirectExecutor.INSTANCE);
     }
 
+    /**
+     * Initialize a {@link SpringHttpCommandBusConnector} using the provided local {@link CommandBus},
+     * {@link RestOperations}, {@link Serializer} and {@link Executor}. The {@code localCommandBus} is used to publish
+     * received commands which to the local segment. The given RestOperations provides the connectivity between other
+     * nodes to send commands, and the Serializer is used to serialize the command messages when they are sent between
+     * nodes. The provided Executor is used to unblock then sending of a command with the RestOperations.
+     *
+     * @param localCommandBus the {@link CommandBus} to publish received commands which to the local segment
+     * @param restOperations  the {@link RestOperations} used to send commands to other nodes
+     * @param serializer      the {@link Serializer} used to serialize command messages when they are sent between nodes
+     * @param executor        the {@link Executor} used to make the sending of commands using the @link RestOperations}
+     *                        asynchronous
+     */
     public SpringHttpCommandBusConnector(CommandBus localCommandBus,
                                          RestOperations restOperations,
                                          Serializer serializer,
@@ -130,10 +164,8 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         } else {
             String errorMessage = String.format("No Connection Endpoint found in Member [%s] for protocol [%s] " +
                                                         "to send the command message [%s] to",
-                                                destination,
-                                                URI.class,
-                                                commandMessage);
-            LOGGER.error(errorMessage);
+                                                destination, URI.class, commandMessage);
+            logger.error(errorMessage);
             throw new IllegalArgumentException(errorMessage);
         }
     }
@@ -142,7 +174,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         try {
             return new URI(scheme, userInfo, host, port, path + COMMAND_BUS_CONNECTOR_PATH, null, null);
         } catch (URISyntaxException e) {
-            LOGGER.error("Failed to build URI for [{}{}{}], with user info [{}] and path [{}]",
+            logger.error("Failed to build URI for [{}{}{}], with user info [{}] and path [{}]",
                          scheme, host, port, userInfo, COMMAND_BUS_CONNECTOR_PATH, e);
             throw new IllegalArgumentException(e);
         }
@@ -163,7 +195,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
                 localCommandBus.dispatch(commandMessage, replyFutureCallback);
                 return replyFutureCallback;
             } catch (Exception e) {
-                LOGGER.error("Could not dispatch command", e);
+                logger.error("Could not dispatch command", e);
                 return CompletableFuture.completedFuture(createReply(commandMessage, false, e));
             }
         } else {
@@ -171,7 +203,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
                 localCommandBus.dispatch(commandMessage);
                 return CompletableFuture.completedFuture("");
             } catch (Exception e) {
-                LOGGER.error("Could not dispatch command", e);
+                logger.error("Could not dispatch command", e);
                 return CompletableFuture.completedFuture(createReply(commandMessage, false, e));
             }
         }
@@ -181,7 +213,7 @@ public class SpringHttpCommandBusConnector implements CommandBusConnector {
         try {
             return new SpringHttpReplyMessage<>(commandMessage.getIdentifier(), success, result, serializer);
         } catch (Exception e) {
-            LOGGER.warn("Could not serialize command reply [{}]. Sending back NULL.", result, e);
+            logger.warn("Could not serialize command reply [{}]. Sending back NULL.", result, e);
             return new SpringHttpReplyMessage(commandMessage.getIdentifier(), success, null, serializer);
         }
     }

--- a/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
+++ b/distributed-commandbus-springcloud/src/test/java/org/axonframework/springcloud/commandhandling/SpringHttpCommandBusConnectorTest.java
@@ -114,8 +114,6 @@ public class SpringHttpCommandBusConnectorTest {
         when(serializer.deserialize(new SerializedMetaData<>(SERIALIZED_COMMAND_METADATA, byte[].class)))
                 .thenReturn(COMMAND_MESSAGE.getMetaData());
         when(serializer.getConverter()).thenReturn(new ChainingConverter());
-
-//        testSubject = new SpringHttpCommandBusConnector(localCommandBus, restTemplate, serializer);
     }
 
     @Test


### PR DESCRIPTION
Made the sending of commands through the `RestOperations` in the  `SpringHttpCommandBusConnector` use an `Executor` to make those calls async.
Additionally, added missing javadoc to the `SpringHttpCommandBusConnector`.