### PR TITLE
Improve logging of the event listener type in LoggingErrorHandler

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/LoggingErrorHandler.java
+++ b/core/src/main/java/org/axonframework/eventhandling/LoggingErrorHandler.java
@@ -13,6 +13,7 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.eventhandling.saga.AnnotatedSaga;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +45,22 @@ public class LoggingErrorHandler implements ListenerInvocationErrorHandler {
 
     @Override
     public void onError(Exception exception, EventMessage<?> event, EventListener eventListener) {
-        Class<?> eventListenerType = eventListener instanceof EventListenerProxy ? ((EventListenerProxy) eventListener).getTargetType() : eventListener.getClass();
+        Class<?> eventListenerType = getEventListenerType(eventListener);
         logger.error("EventListener [{}] failed to handle event [{}] ({}). " +
                              "Continuing processing with next listener",
                      eventListenerType.getSimpleName(),
                      event.getIdentifier(),
                      event.getPayloadType().getName(),
                      exception);
+    }
+
+    private Class<?> getEventListenerType(EventListener eventListener) {
+        if (eventListener instanceof EventListenerProxy) {
+            return ((EventListenerProxy) eventListener).getTargetType();
+        } else if (eventListener instanceof AnnotatedSaga) {
+            return ((AnnotatedSaga) eventListener).root().getClass();
+        } else {
+            return eventListener.getClass();
+        }
     }
 }


### PR DESCRIPTION
**Current behavior**  
When an error in a Saga is logged, it shows `AnnotatedSaga` as the EventListener name.

**New behavior**  
The name of the Saga will be logged. E.g. if the name of the class of the Saga is `FoobarSaga` then `FoobarSaga` will be logged.