### PR TITLE
Added connectivity to AxonServer as default behavior of Config API

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2018. AxonIQ
+  ~ Copyright (c) 2010-2018. Axon Framework
+  ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
@@ -56,6 +57,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- OPTIONAL dependency on AXON Framework -->
@@ -91,23 +98,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,8 +16,8 @@
 
 package org.axonframework.axonserver.connector;
 
-import org.axonframework.axonserver.connector.event.util.EventCipher;
 import io.axoniq.axonserver.grpc.control.NodeInfo;
+import org.axonframework.axonserver.connector.event.util.EventCipher;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.lang.management.ManagementFactory;
@@ -31,11 +32,13 @@ import java.util.stream.Collectors;
 @ConfigurationProperties(prefix = "axon.axonserver")
 public class AxonServerConfiguration {
     private static final int DEFAULT_GRPC_PORT = 8124;
+    private static final String DEFAULT_SERVERS = "localhost";
 
     /**
-     * Comma seperated list of AxonDB servers. Each element is hostname or hostname:grpcPort. When no grpcPort is specified, default port 8123 is used.
+     * Comma separated list of AxonDB servers. Each element is hostname or hostname:grpcPort. When no grpcPort is
+     * specified, default port 8123 is used.
      */
-    private String servers = "localhost";
+    private String servers = DEFAULT_SERVERS;
 
     /**
      * clientId as it registers itself to AxonServer, must be unique
@@ -100,6 +103,7 @@ public class AxonServerConfiguration {
     private int processorsNotificationInitialDelay = 5000;
 
     private EventCipher eventCipher = new EventCipher();
+
     /**
      * Timeout (in ms) for keep alive requests
      */
@@ -110,12 +114,13 @@ public class AxonServerConfiguration {
      */
     private long keepAliveTime = 0;
 
-    public AxonServerConfiguration() {
-    }
+    /**
+     * Indicates whether the download advice message should be suppressed, even when default connection properties
+     * (which are generally only used in DEV mode) are used. Defaults to false.
+     */
+    private boolean suppressDownloadMessage = false;
 
-    private AxonServerConfiguration(String routingServers, String componentName) {
-        this.servers = routingServers;
-        this.componentName = componentName;
+    public AxonServerConfiguration() {
     }
 
 
@@ -132,7 +137,7 @@ public class AxonServerConfiguration {
     }
 
     public String getComponentName() {
-        return componentName;
+        return componentName == null ? System.getProperty("axon.application.name", "Unnamed-" + clientName) : componentName;
     }
 
     public void setComponentName(String componentName) {
@@ -141,6 +146,7 @@ public class AxonServerConfiguration {
 
     public void setServers(String routingServers) {
         this.servers = routingServers;
+        suppressDownloadMessage = true;
     }
 
     public String getToken() {
@@ -272,11 +278,20 @@ public class AxonServerConfiguration {
         this.keepAliveTime = keepAliveTime;
     }
 
+    public void setSuppressDownloadMessage(boolean suppressDownloadMessage) {
+        this.suppressDownloadMessage = suppressDownloadMessage;
+    }
+
+    public boolean getSuppressDownloadMessage() {
+        return suppressDownloadMessage;
+    }
+
     @SuppressWarnings("unused")
     public static class Builder {
         private AxonServerConfiguration instance;
-        public Builder(String servers, String componentName) {
-            instance = new AxonServerConfiguration(servers, componentName);
+
+        public Builder() {
+            instance = new AxonServerConfiguration();
             instance.initialNrOfPermits = 100000;
             instance.nrOfNewPermits = 90000;
             instance.newPermitsThreshold = 10000;
@@ -318,9 +333,29 @@ public class AxonServerConfiguration {
         public AxonServerConfiguration build() {
             return instance;
         }
+
+        public Builder servers(String servers) {
+            instance.setServers(servers);
+            return this;
+        }
+
+        public Builder suppressDownloadMessage() {
+            instance.setSuppressDownloadMessage(true);
+            return this;
+        }
+
+        public Builder componentName(String componentName) {
+            instance.setComponentName(componentName);
+            return this;
+        }
     }
 
-    public static Builder newBuilder(String servers, String componentName) {
-        return new Builder( servers, componentName);
+    public static Builder builder() {
+        Builder builder = new Builder();
+        if (Boolean.getBoolean("axon.axonserver.suppressDownloadMessage")) {
+            builder.suppressDownloadMessage();
+        }
+
+        return builder;
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,57 +16,49 @@
 
 package org.axonframework.axonserver.connector;
 
-import org.axonframework.axonserver.connector.util.ContextAddingInterceptor;
-import org.axonframework.axonserver.connector.util.TokenAddingInterceptor;
 import io.axoniq.axonserver.grpc.command.CommandProviderInbound;
 import io.axoniq.axonserver.grpc.command.CommandProviderOutbound;
 import io.axoniq.axonserver.grpc.command.CommandServiceGrpc;
+import io.axoniq.axonserver.grpc.control.*;
 import io.axoniq.axonserver.grpc.query.QueryProviderInbound;
 import io.axoniq.axonserver.grpc.query.QueryProviderOutbound;
 import io.axoniq.axonserver.grpc.query.QueryServiceGrpc;
-import io.axoniq.axonserver.grpc.control.ClientIdentification;
-import io.axoniq.axonserver.grpc.control.NodeInfo;
-import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
-import io.axoniq.axonserver.grpc.control.PlatformInfo;
-import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
-import io.axoniq.axonserver.grpc.control.PlatformServiceGrpc;
-import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
-import io.grpc.ManagedChannel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
+import io.grpc.*;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import io.netty.handler.ssl.SslContext;
+import org.axonframework.axonserver.connector.util.ContextAddingInterceptor;
+import org.axonframework.axonserver.connector.util.TokenAddingInterceptor;
+import org.axonframework.common.AxonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLException;
 import java.io.File;
-import java.util.ArrayDeque;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.net.ssl.SSLException;
 
 /**
  * @author Marc Gathier
  */
-public class PlatformConnectionManager {
-    private final static Logger logger = LoggerFactory.getLogger(PlatformConnectionManager.class);
+public class AxonServerConnectionManager {
+    private final static Logger logger = LoggerFactory.getLogger(AxonServerConnectionManager.class);
 
     private volatile ManagedChannel channel;
     private volatile StreamObserver<PlatformInboundInstruction> inputStream;
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, new AxonThreadFactory("AxonServerConnector") {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = super.newThread(r);
+            thread.setDaemon(true);
+            return thread;
+        }
+    });
     private volatile ScheduledFuture<?> reconnectTask;
     private final List<Runnable> disconnectListeners = new CopyOnWriteArrayList<>();
     private final List<Function<Runnable, Runnable>> reconnectInterceptors = new CopyOnWriteArrayList<>();
@@ -73,14 +66,14 @@ public class PlatformConnectionManager {
     private final AxonServerConfiguration connectInformation;
     private final Map<PlatformOutboundInstruction.RequestCase, Collection<Consumer<PlatformOutboundInstruction>>> handlers = new EnumMap<>(PlatformOutboundInstruction.RequestCase.class);
 
-    public PlatformConnectionManager(AxonServerConfiguration connectInformation) {
+    public AxonServerConnectionManager(AxonServerConfiguration connectInformation) {
         this.connectInformation = connectInformation;
     }
 
     public synchronized Channel getChannel() {
         if( channel == null || channel.isShutdown()) {
             channel = null;
-            logger.info("Connecting {}using SSL...", connectInformation.isSslEnabled()?"":"not ");
+            logger.info("Connecting using {}...", connectInformation.isSslEnabled()?"TLS":"unencrypted connection");
             boolean unavailable = false;
             for(NodeInfo nodeInfo : connectInformation.routingServers()) {
                 ManagedChannel candidate = createChannel( nodeInfo.getHostName(), nodeInfo.getGrpcPort());
@@ -114,11 +107,27 @@ public class PlatformConnectionManager {
                 }
             }
             if( unavailable) {
+                if(!connectInformation.getSuppressDownloadMessage()) {
+                    connectInformation.setSuppressDownloadMessage(true);
+                    writeDownloadMessage();
+                }
                 scheduleReconnect();
-                throw new RuntimeException("No connection to AxonServer available");
+                throw new AxonServerException(ErrorCode.CONNECTION_TO_AXONDB_FAILED, "No connection to AxonServer available");
             }
         }
         return channel;
+    }
+
+    private void writeDownloadMessage() {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("axonserver_download.txt")) {
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = in.read(buffer, 0, 1024)) >= 0) {
+                System.out.write(buffer, 0, read);
+            }
+        } catch (IOException e) {
+            logger.debug("Unable to write download advice. You're on your own now.", e);
+        }
     }
 
     private void shutdown(ManagedChannel managedChannel) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,4 +33,7 @@ public class AxonServerException extends RuntimeException {
         super(errorCode+ " - " +message);
     }
 
+    public AxonServerException(ErrorCode errorCode, String message) {
+        this(errorCode.errorCode(), message);
+    }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector;
+
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
+import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfiguration;
+import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
+import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
+import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
+import org.axonframework.commandhandling.distributed.RoutingStrategy;
+import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.Configurer;
+import org.axonframework.config.ConfigurerModule;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
+import org.axonframework.queryhandling.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configurer module which is auto-loadable by the {@link org.axonframework.config.DefaultConfigurer} that sets
+ * sensible default to use when the AxonServer connector is available on the classpath.
+ *
+ * @author Allard Buijze
+ * @since 4.0
+ */
+public class ServerConnectorConfigurerModule implements ConfigurerModule {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerConnectorConfigurerModule.class);
+
+    @Override
+    public void configureModule(Configurer configurer) {
+        configurer.registerComponent(AxonServerConfiguration.class, c -> new AxonServerConfiguration());
+
+        configurer.registerComponent(AxonServerConnectionManager.class, c -> new AxonServerConnectionManager(c.getComponent(AxonServerConfiguration.class)));
+        configurer.configureEventStore(this::buildEventStore);
+        configurer.configureCommandBus(this::buildCommandBus);
+        configurer.configureQueryBus(this::buildQueryBus);
+        configurer.registerModule(new EventProcessorInfoConfiguration());
+        configurer.registerComponent(TokenStore.class, c -> {
+            logger.warn("BEWARE! Falling back to an in-memory token store. It is highly recommended to configure a " +
+                                "persistent implementation, based on the activity of the handler.");
+            return new InMemoryTokenStore();
+        });
+    }
+
+    private AxonServerEventStore buildEventStore(Configuration c) {
+        return AxonServerEventStore.builder()
+                                   .configuration(c.getComponent(AxonServerConfiguration.class))
+                                   .platformConnectionManager(c.getComponent(AxonServerConnectionManager.class))
+                                   .build();
+    }
+
+    private AxonServerCommandBus buildCommandBus(Configuration c) {
+        AxonServerCommandBus commandBus = new AxonServerCommandBus(c.getComponent(AxonServerConnectionManager.class),
+                                                                   c.getComponent(AxonServerConfiguration.class),
+                                                                   SimpleCommandBus.builder().build(),
+                                                                   c.messageSerializer(),
+                                                                   c.getComponent(RoutingStrategy.class, AnnotationRoutingStrategy::new),
+                                                                   c.getComponent(CommandPriorityCalculator.class,
+                                                                                  () -> new CommandPriorityCalculator() {}));
+        c.onShutdown(commandBus::disconnect);
+        return commandBus;
+    }
+
+    private QueryBus buildQueryBus(Configuration c) {
+        SimpleQueryBus localSegment = SimpleQueryBus.builder()
+                                                    .transactionManager(c.getComponent(TransactionManager.class, NoTransactionManager::instance))
+                                                    .errorHandler(c.getComponent(QueryInvocationErrorHandler.class, () -> LoggingQueryInvocationErrorHandler.builder().build()))
+                                                    .messageMonitor(c.messageMonitor(QueryBus.class, "localQueryBus"))
+                                                    .build();
+        AxonServerQueryBus queryBus = new AxonServerQueryBus(c.getComponent(AxonServerConnectionManager.class),
+                                                             c.getComponent(AxonServerConfiguration.class),
+                                                             c.getComponent(QueryUpdateEmitter.class, localSegment::queryUpdateEmitter),
+                                                             localSegment, c.messageSerializer(), c.serializer(), c.getComponent(QueryPriorityCalculator.class, () -> new QueryPriorityCalculator() {}));
+        c.onShutdown(queryBus::disconnect);
+        return queryBus;
+    }
+
+    @Override
+    public int order() {
+        return Integer.MIN_VALUE;
+    }
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -67,6 +67,9 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
         return AxonServerEventStore.builder()
                                    .configuration(c.getComponent(AxonServerConfiguration.class))
                                    .platformConnectionManager(c.getComponent(AxonServerConnectionManager.class))
+                                   .snapshotSerializer(c.serializer())
+                                   .eventSerializer(c.eventSerializer())
+                                   .upcasterChain(c.upcasterChain())
                                    .build();
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -16,31 +16,22 @@
 
 package org.axonframework.axonserver.connector.command;
 
-import io.axoniq.axonserver.grpc.command.Command;
-import io.axoniq.axonserver.grpc.command.CommandProviderInbound;
-import io.axoniq.axonserver.grpc.command.CommandProviderOutbound;
-import io.axoniq.axonserver.grpc.command.CommandResponse;
-import io.axoniq.axonserver.grpc.command.CommandServiceGrpc;
-import io.axoniq.axonserver.grpc.command.CommandSubscription;
+import io.axoniq.axonserver.grpc.command.*;
 import io.grpc.ClientInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.DispatchInterceptors;
 import org.axonframework.axonserver.connector.ErrorCode;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
 import org.axonframework.axonserver.connector.util.ContextAddingInterceptor;
 import org.axonframework.axonserver.connector.util.ExceptionSerializer;
 import org.axonframework.axonserver.connector.util.FlowControllingStreamObserver;
 import org.axonframework.axonserver.connector.util.TokenAddingInterceptor;
-import org.axonframework.commandhandling.CommandBus;
-import org.axonframework.commandhandling.CommandCallback;
-import org.axonframework.commandhandling.CommandExecutionException;
-import org.axonframework.commandhandling.CommandMessage;
-import org.axonframework.commandhandling.CommandResultMessage;
-import org.axonframework.commandhandling.GenericCommandResultMessage;
+import org.axonframework.commandhandling.*;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
+import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
@@ -51,11 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Comparator;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.stream.IntStream;
 
 import static org.axonframework.axonserver.connector.util.ProcessingInstructionHelper.priority;
@@ -68,7 +55,7 @@ import static org.axonframework.axonserver.connector.util.ProcessingInstructionH
 public class AxonServerCommandBus implements CommandBus {
     private final CommandBus localSegment;
     private final CommandRouterSubscriber commandRouterSubscriber;
-    private final PlatformConnectionManager platformConnectionManager;
+    private final AxonServerConnectionManager axonServerConnectionManager;
     private final RoutingStrategy routingStrategy;
     private final CommandPriorityCalculator priorityCalculator;
     private final CommandSerializer serializer;
@@ -77,23 +64,23 @@ public class AxonServerCommandBus implements CommandBus {
     private final DispatchInterceptors<CommandMessage<?>> dispatchInterceptors = new DispatchInterceptors<>();
     private Logger logger = LoggerFactory.getLogger(AxonServerCommandBus.class);
 
-    public AxonServerCommandBus(PlatformConnectionManager platformConnectionManager, AxonServerConfiguration configuration,
+    public AxonServerCommandBus(AxonServerConnectionManager axonServerConnectionManager, AxonServerConfiguration configuration,
                                 CommandBus localSegment, Serializer serializer, RoutingStrategy routingStrategy) {
-        this( platformConnectionManager, configuration, localSegment, serializer, routingStrategy, new CommandPriorityCalculator(){});
+        this(axonServerConnectionManager, configuration, localSegment, serializer, routingStrategy, new CommandPriorityCalculator(){});
     }
     /**
-     * @param platformConnectionManager creates connection to AxonServer platform
+     * @param axonServerConnectionManager creates connection to AxonServer platform
      * @param configuration contains client and component names used to identify the application in AxonServer
      * @param localSegment handles incoming commands
      * @param serializer serializer/deserializer for command requests and responses
      * @param routingStrategy determines routing key based on command message
      * @param priorityCalculator calculates the request priority based on the content and adds it to the request
      */
-    public AxonServerCommandBus(PlatformConnectionManager platformConnectionManager, AxonServerConfiguration configuration,
+    public AxonServerCommandBus(AxonServerConnectionManager axonServerConnectionManager, AxonServerConfiguration configuration,
                                 CommandBus localSegment, Serializer serializer, RoutingStrategy routingStrategy, CommandPriorityCalculator priorityCalculator) {
         this.localSegment = localSegment;
         this.serializer = new CommandSerializer(serializer, configuration);
-        this.platformConnectionManager = platformConnectionManager;
+        this.axonServerConnectionManager = axonServerConnectionManager;
         this.routingStrategy = routingStrategy;
         this.priorityCalculator = priorityCalculator;
         this.configuration = configuration;
@@ -120,7 +107,7 @@ public class AxonServerCommandBus implements CommandBus {
     public <C, R> void dispatch(CommandMessage<C> commandMessage, CommandCallback<? super C, ? super R> commandCallback) {
         logger.debug("Dispatch with callback: {}", commandMessage.getCommandName());
         CommandMessage<C> command = dispatchInterceptors.intercept(commandMessage);
-            CommandServiceGrpc.newStub(platformConnectionManager.getChannel())
+            CommandServiceGrpc.newStub(axonServerConnectionManager.getChannel())
                               .withInterceptors(interceptors)
                               .dispatch(serializer.serialize(command,
                                                              routingStrategy.getRoutingKey(command),
@@ -185,15 +172,16 @@ public class AxonServerCommandBus implements CommandBus {
     protected class CommandRouterSubscriber {
         private final CopyOnWriteArraySet<String> subscribedCommands = new CopyOnWriteArraySet<>();
         private final PriorityBlockingQueue<Command> commandQueue;
-        private final ExecutorService executor = Executors.newFixedThreadPool(configuration.getCommandThreads());
+        private final ExecutorService executor = Executors.newFixedThreadPool(configuration.getCommandThreads(),
+                                                                              new AxonThreadFactory("AxonServerCommandReceiver"));
         private volatile boolean subscribing;
-
+        private volatile boolean running = true;
 
         private volatile StreamObserver<CommandProviderOutbound> subscriberStreamObserver;
 
         CommandRouterSubscriber() {
-            platformConnectionManager.addReconnectListener(this::resubscribe);
-            platformConnectionManager.addDisconnectListener(this::unsubscribeAll);
+            axonServerConnectionManager.addReconnectListener(this::resubscribe);
+            axonServerConnectionManager.addDisconnectListener(this::unsubscribeAll);
             commandQueue = new PriorityBlockingQueue<>(1000, Comparator.comparingLong(c -> -priority(c.getProcessingInstructionsList())));
             IntStream.range(0, configuration.getCommandThreads()).forEach( i -> executor.submit(this::commandExecutor));
         }
@@ -201,9 +189,9 @@ public class AxonServerCommandBus implements CommandBus {
         private void commandExecutor() {
             logger.debug("Starting command Executor");
             boolean interrupted = false;
-            while(!interrupted) {
+            while(!interrupted && running) {
                 try {
-                    Command command = commandQueue.poll(10, TimeUnit.SECONDS);
+                    Command command = commandQueue.poll(1, TimeUnit.SECONDS);
                     if( command != null) {
                         logger.debug("Received command: {}", command);
                         processCommand(command);
@@ -306,7 +294,7 @@ public class AxonServerCommandBus implements CommandBus {
                     }
                 };
 
-                StreamObserver<CommandProviderOutbound> stream = platformConnectionManager.getCommandStream(commandsFromRoutingServer, interceptors);
+                StreamObserver<CommandProviderOutbound> stream = axonServerConnectionManager.getCommandStream(commandsFromRoutingServer, interceptors);
                 subscriberStreamObserver = new FlowControllingStreamObserver<>(stream,
                         configuration,
                         flowControl -> CommandProviderOutbound.newBuilder().setFlowControl(flowControl).build(),
@@ -374,6 +362,8 @@ public class AxonServerCommandBus implements CommandBus {
         public void disconnect() {
             if( subscriberStreamObserver != null)
                 subscriberStreamObserver.onCompleted();
+            running = false;
+            executor.shutdown();
         }
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,31 +16,18 @@
 
 package org.axonframework.axonserver.connector.event;
 
-import io.axoniq.axonserver.grpc.event.Event;
-import io.axoniq.axonserver.grpc.event.Confirmation;
-import io.axoniq.axonserver.grpc.event.EventStoreGrpc;
-import io.axoniq.axonserver.grpc.event.EventWithToken;
-import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetFirstTokenRequest;
-import io.axoniq.axonserver.grpc.event.GetLastTokenRequest;
-import io.axoniq.axonserver.grpc.event.GetTokenAtRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
-import io.axoniq.axonserver.grpc.event.TrackingToken;
-import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.AxonServerException;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
-import org.axonframework.axonserver.connector.event.util.EventCipher;
-import org.axonframework.axonserver.connector.event.util.GrpcExceptionParser;
-import org.axonframework.axonserver.connector.util.ContextAddingInterceptor;
-import org.axonframework.axonserver.connector.util.TokenAddingInterceptor;
+import io.axoniq.axonserver.grpc.event.*;
 import io.grpc.Channel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.AxonServerException;
+import org.axonframework.axonserver.connector.event.util.EventCipher;
+import org.axonframework.axonserver.connector.event.util.GrpcExceptionParser;
+import org.axonframework.axonserver.connector.util.ContextAddingInterceptor;
+import org.axonframework.axonserver.connector.util.TokenAddingInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +45,7 @@ public class AxonServerEventStoreClient {
     private final TokenAddingInterceptor tokenAddingInterceptor;
     private final ContextAddingInterceptor contextAddingInterceptor;
     private final EventCipher eventCipher;
-    private final PlatformConnectionManager platformConnectionManager;
+    private final AxonServerConnectionManager axonServerConnectionManager;
 
     private boolean shutdown;
 
@@ -65,12 +53,12 @@ public class AxonServerEventStoreClient {
      * Initialize the Event Store Client using given {@code eventStoreConfiguration} and given {@code platformConnectionManager}.
      *
      * @param eventStoreConfiguration The configuration describing the bounded context that this application operates in
-     * @param platformConnectionManager manager for connections to AxonServer platform
+     * @param axonServerConnectionManager manager for connections to AxonServer platform
      */
-    public AxonServerEventStoreClient(AxonServerConfiguration eventStoreConfiguration, PlatformConnectionManager platformConnectionManager) {
+    public AxonServerEventStoreClient(AxonServerConfiguration eventStoreConfiguration, AxonServerConnectionManager axonServerConnectionManager) {
         this.tokenAddingInterceptor = new TokenAddingInterceptor(eventStoreConfiguration.getToken());
         this.eventCipher = eventStoreConfiguration.getEventCipher();
-        this.platformConnectionManager = platformConnectionManager;
+        this.axonServerConnectionManager = axonServerConnectionManager;
         contextAddingInterceptor = new ContextAddingInterceptor(eventStoreConfiguration.getContext());
     }
 
@@ -85,7 +73,7 @@ public class AxonServerEventStoreClient {
 
     private Channel getChannelToEventStore() {
         if (shutdown) return null;
-        return platformConnectionManager.getChannel();
+        return axonServerConnectionManager.getChannel();
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -17,17 +17,11 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import com.google.protobuf.ByteString;
-import io.axoniq.axonserver.grpc.event.Event;
-import io.axoniq.axonserver.grpc.event.EventWithToken;
-import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
+import io.axoniq.axonserver.grpc.event.*;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ErrorCode;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
 import org.axonframework.axonserver.connector.event.AppendEventTransaction;
 import org.axonframework.axonserver.connector.event.AxonServerEventStoreClient;
 import org.axonframework.axonserver.connector.util.FlowControllingStreamObserver;
@@ -38,16 +32,7 @@ import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventsourcing.DomainEventMessage;
 import org.axonframework.eventsourcing.GenericDomainEventMessage;
-import org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.AbstractEventStore;
-import org.axonframework.eventsourcing.eventstore.DomainEventData;
-import org.axonframework.eventsourcing.eventstore.DomainEventStream;
-import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.EventStoreException;
-import org.axonframework.eventsourcing.eventstore.EventUtils;
-import org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken;
-import org.axonframework.eventsourcing.eventstore.TrackedEventData;
-import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
+import org.axonframework.eventsourcing.eventstore.*;
 import org.axonframework.eventsourcing.eventstore.TrackingToken;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.monitoring.MessageMonitor;
@@ -86,7 +71,7 @@ public class AxonServerEventStore extends AbstractEventStore {
      * Instantiate a {@link AxonServerEventStore} based on the fields contained in the {@link Builder}.
      * <p>
      * Will assert that the {@link EventStorageEngine} is set. If not, the {@link AxonServerConfiguration} and
-     * {@link PlatformConnectionManager} should minimally be provided to create an AxonServer specific
+     * {@link AxonServerConnectionManager} should minimally be provided to create an AxonServer specific
      * EventStorageEngine implementation. If either of these {@code null} assertions fail, an
      * {@link AxonConfigurationException} will be thrown.
      *
@@ -102,11 +87,11 @@ public class AxonServerEventStore extends AbstractEventStore {
      * The main goal of this Builder is to instantiate an AxonServer specific {@link EventStorageEngine}. The properties
      * which may be provided through this Builder are thus all used to end up with that EventStorageEngine
      * implementation. An EventStorageEngine may be provided directly however, although we encourage the usage of the
-     * {@link Builder#configuration} and {@link Builder#platformConnectionManager} functions to let it be created.
+     * {@link Builder#configuration} and {@link Builder#axonServerConnectionManager} functions to let it be created.
      * <p>
      * The snapshot {@link Serializer} is defaulted to a {@link XStreamSerializer}, the event Serializer also defaults
      * to a XStreamSerializer and the {@link EventUpcaster} defaults to a {@link NoOpEventUpcaster}.
-     * The {@link AxonServerConfiguration} and {@link PlatformConnectionManager} are <b>hard requirements</b> if no
+     * The {@link AxonServerConfiguration} and {@link AxonServerConnectionManager} are <b>hard requirements</b> if no
      * EventStorageEngine is provided directly.
      *
      * @return a Builder to be able to create a {@link AxonServerEventStore}
@@ -135,17 +120,17 @@ public class AxonServerEventStore extends AbstractEventStore {
      * The main goal of this Builder is to instantiate an AxonServer specific {@link EventStorageEngine}. The properties
      * which may be provided through this Builder are thus all used to end up with that EventStorageEngine
      * implementation. An EventStorageEngine may be provided directly however, although we encourage the usage of the
-     * {@link Builder#configuration} and {@link Builder#platformConnectionManager} functions to let it be created.
+     * {@link Builder#configuration} and {@link Builder#axonServerConnectionManager} functions to let it be created.
      * <p>
      * The snapshot {@link Serializer} is defaulted to a {@link XStreamSerializer}, the event Serializer also defaults
      * to a XStreamSerializer and the {@link EventUpcaster} defaults to a {@link NoOpEventUpcaster}.
-     * The {@link AxonServerConfiguration} and {@link PlatformConnectionManager} are <b>hard requirements</b> if no
+     * The {@link AxonServerConfiguration} and {@link AxonServerConnectionManager} are <b>hard requirements</b> if no
      * EventStorageEngine is provided directly.
      */
     public static class Builder extends AbstractEventStore.Builder {
 
         private AxonServerConfiguration configuration;
-        private PlatformConnectionManager platformConnectionManager;
+        private AxonServerConnectionManager axonServerConnectionManager;
         private Serializer snapshotSerializer = XStreamSerializer.builder().build();
         private Serializer eventSerializer = XStreamSerializer.builder().build();
         private EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
@@ -181,19 +166,19 @@ public class AxonServerEventStore extends AbstractEventStore {
         }
 
         /**
-         * Sets the {@link PlatformConnectionManager} managing the connections to the AxonServer platform.
+         * Sets the {@link AxonServerConnectionManager} managing the connections to the AxonServer platform.
          * <p>
          * This object is used by the AxonServer {@link EventStorageEngine} implementation which this Builder will
          * create if it is not provided. We suggest to use these, instead of the {@link Builder#storageEngine()}
          * function to set the EventStorageEngine.
          *
-         * @param platformConnectionManager the {@link PlatformConnectionManager} managing the connections to the
+         * @param axonServerConnectionManager the {@link AxonServerConnectionManager} managing the connections to the
          *                                  AxonServer platform
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder platformConnectionManager(PlatformConnectionManager platformConnectionManager) {
-            assertNonNull(platformConnectionManager, "PlatformConnectionManager may not be null");
-            this.platformConnectionManager = platformConnectionManager;
+        public Builder platformConnectionManager(AxonServerConnectionManager axonServerConnectionManager) {
+            assertNonNull(axonServerConnectionManager, "PlatformConnectionManager may not be null");
+            this.axonServerConnectionManager = axonServerConnectionManager;
             return this;
         }
 
@@ -262,10 +247,10 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private void buildStorageEngine() {
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");
-            assertNonNull(platformConnectionManager,
+            assertNonNull(axonServerConnectionManager,
                           "The PlatformConnectionManager is a hard requirement and should be provided");
 
-            AxonServerEventStoreClient eventStoreClient = new AxonServerEventStoreClient(configuration, platformConnectionManager);
+            AxonServerEventStoreClient eventStoreClient = new AxonServerEventStoreClient(configuration, axonServerConnectionManager);
             super.storageEngine(AxonIQEventStorageEngine.builder()
                                                         .snapshotSerializer(snapshotSerializer)
                                                         .upcasterChain(upcasterChain)

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventProcessorInfoConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventProcessorInfoConfiguration.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,15 +17,18 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.processor.EventProcessorControlService;
 import org.axonframework.axonserver.connector.processor.EventProcessorController;
 import org.axonframework.axonserver.connector.processor.grpc.GrpcEventProcessorInfoSource;
 import org.axonframework.axonserver.connector.processor.schedule.ScheduledEventProcessorInfoSource;
+import org.axonframework.config.Component;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.ModuleConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
+
+import java.util.function.Function;
 
 /**
  * Module Configuration implementation that defines the components needed to
@@ -35,36 +39,58 @@ import org.axonframework.eventhandling.EventProcessor;
  */
 public class EventProcessorInfoConfiguration implements ModuleConfiguration {
 
-    private final EventProcessorControlService eventProcessorControlService;
+    private final Component<EventProcessingConfiguration> eventProcessingConfiguration;
+    private final Component<AxonServerConnectionManager> connectionManager;
 
-    private final ScheduledEventProcessorInfoSource processorInfoSource;
+    private final Component<AxonServerConfiguration> axonServerConfiguration;
+
+    private final Component<EventProcessorControlService> eventProcessorControlService;
+    private final Component<ScheduledEventProcessorInfoSource> processorInfoSource;
+
+    private Configuration config;
+
+    public EventProcessorInfoConfiguration() {
+        this(Configuration::eventProcessingConfiguration,
+             c -> c.getComponent(AxonServerConnectionManager.class),
+             c -> c.getComponent(AxonServerConfiguration.class));
+    }
 
     public EventProcessorInfoConfiguration(
-            EventProcessingConfiguration eventProcessingConfiguration,
-            PlatformConnectionManager connectionManager,
-            AxonServerConfiguration configuration) {
-        EventProcessorController controller = new EventProcessorController(eventProcessingConfiguration);
-        GrpcEventProcessorInfoSource infoSource = new GrpcEventProcessorInfoSource(eventProcessingConfiguration, connectionManager);
+            Function<Configuration, EventProcessingConfiguration> eventProcessingConfiguration,
+            Function<Configuration, AxonServerConnectionManager> connectionManager,
+            Function<Configuration, AxonServerConfiguration> axonServerConfiguration) {
+        this.eventProcessingConfiguration = new Component<>(() -> config, "eventProcessingConfiguration", eventProcessingConfiguration);
+        this.connectionManager = new Component<>(() -> config, "connectionManager", connectionManager);
+        this.axonServerConfiguration = new Component<>(() -> config, "connectionManager", axonServerConfiguration);
 
-        this.eventProcessorControlService = new EventProcessorControlService(connectionManager, controller);
-        this.processorInfoSource = new ScheduledEventProcessorInfoSource(
-                configuration.getProcessorsNotificationInitialDelay(),
-                configuration.getProcessorsNotificationRate(),
-                infoSource);
+        this.eventProcessorControlService = new Component<>(() -> config, "eventProcessorControlService",
+                                                            c -> new EventProcessorControlService(
+                                                                    this.connectionManager.get(),
+                                                                    new EventProcessorController(
+                                                                            this.eventProcessingConfiguration.get())));
+        this.processorInfoSource = new Component<>(() -> config, "eventProcessorInfoSource", c -> {
+            GrpcEventProcessorInfoSource infoSource = new GrpcEventProcessorInfoSource(this.eventProcessingConfiguration.get(), this.connectionManager.get());
+            return new ScheduledEventProcessorInfoSource(
+                    this.axonServerConfiguration.get().getProcessorsNotificationInitialDelay(),
+                    this.axonServerConfiguration.get().getProcessorsNotificationRate(),
+                    infoSource);
+
+        });
     }
 
     @Override
     public void initialize(Configuration config) {
+        this.config = config;
     }
 
     @Override
     public void start() {
-        processorInfoSource.start();
-        eventProcessorControlService.start();
+        processorInfoSource.get().start();
+        eventProcessorControlService.get().start();
     }
 
     @Override
     public void shutdown() {
-        processorInfoSource.shutdown();
+        processorInfoSource.get().shutdown();
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,9 +16,9 @@
 
 package org.axonframework.axonserver.connector.processor.grpc;
 
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
-import org.axonframework.axonserver.connector.processor.EventProcessorInfoSource;
 import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.processor.EventProcessorInfoSource;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 
@@ -43,11 +44,11 @@ public class GrpcEventProcessorInfoSource implements EventProcessorInfoSource {
     private final Function<EventProcessor, PlatformInboundMessage> mapping;
 
     public GrpcEventProcessorInfoSource(EventProcessingConfiguration eventProcessingConfiguration,
-                                        PlatformConnectionManager platformConnectionManager) {
+                                        AxonServerConnectionManager axonServerConnectionManager) {
         this(new EventProcessors(eventProcessingConfiguration),
-             platformConnectionManager::send,
+             axonServerConnectionManager::send,
              new GrpcEventProcessorMapping());
-        platformConnectionManager.addReconnectListener(lastProcessorsInfo::clear);
+        axonServerConnectionManager.addReconnectListener(lastProcessorsInfo::clear);
     }
 
     GrpcEventProcessorInfoSource(EventProcessors eventProcessors,

--- a/axon-server-connector/src/main/resources/META-INF/services/org.axonframework.config.ConfigurerModule
+++ b/axon-server-connector/src/main/resources/META-INF/services/org.axonframework.config.ConfigurerModule
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2018. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.axonframework.axonserver.connector.ServerConnectorConfigurerModule

--- a/axon-server-connector/src/main/resources/axonserver_download.txt
+++ b/axon-server-connector/src/main/resources/axonserver_download.txt
@@ -1,0 +1,13 @@
+**********************************************
+*                                            *
+*  !!! UNABLE TO CONNECT TO AXON SERVER !!!  *
+*                                            *
+* Are you sure it's running?                 *
+* If you haven't got Axon Server yet, visit  *
+*       https://axoniq.io/downloads          *
+*                                            *
+**********************************************
+
+To suppress this message, you can
+ - explicitly configure an AxonServer location,
+ - start with -Daxon.axonserver.suppressDownloadMessage=true)

--- a/axon-server-connector/src/main/resources/axonserver_download.txt
+++ b/axon-server-connector/src/main/resources/axonserver_download.txt
@@ -10,4 +10,4 @@
 
 To suppress this message, you can
  - explicitly configure an AxonServer location,
- - start with -Daxon.axonserver.suppressDownloadMessage=true)
+ - start with -Daxon.axonserver.suppressDownloadMessage=true

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector;
+
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.DefaultConfigurer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ServerConnectorConfigurerModuleTest {
+
+    @Test
+    public void testAxonServerConfiguredInDefaultConfiguration() {
+        Configuration configuration = DefaultConfigurer.defaultConfiguration()
+                                                       .buildConfiguration();
+
+        assertTrue(configuration.eventStore() instanceof AxonServerEventStore);
+        assertTrue(configuration.commandBus() instanceof AxonServerCommandBus);
+        assertTrue(configuration.queryBus() instanceof AxonServerQueryBus);
+        AxonServerConfiguration axonServerConfiguration = configuration.getComponent(AxonServerConfiguration.class);
+
+        assertEquals("localhost", axonServerConfiguration.getServers());
+        assertNotNull(axonServerConfiguration.getClientName());
+        assertNotNull(axonServerConfiguration.getComponentName());
+        assertTrue(axonServerConfiguration.getComponentName().contains(axonServerConfiguration.getClientName()));
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorRunner.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorRunner.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.TargetAggregateIdentifier;
+import org.axonframework.commandhandling.model.AggregateIdentifier;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.DefaultConfigurer;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Scanner;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
+
+public class ServerConnectorRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerConnectorRunner.class);
+
+    public static void main(String[] args) {
+        Configuration configuration = DefaultConfigurer.defaultConfiguration()
+                                                       .registerComponent(AxonServerConfiguration.class, c -> AxonServerConfiguration.builder().servers("localhost").build())
+                                                       .configureAggregate(MyAggregate.class)
+                                                       .eventProcessing(ep -> ep.registerEventHandler(c -> new MyEventHandler()))
+                                                       .start();
+
+        try {
+            logger.info("Sending command");
+            CompletableFuture<Object> result = configuration.commandGateway().send(new CreateMyAggregateCommand(UUID.randomUUID().toString()));
+            logger.info("Command sent, awaiting response...");
+            result.join();
+            logger.info("Result received. Press enter to shut down");
+            new Scanner(System.in).nextLine();
+        } finally {
+            configuration.shutdown();
+        }
+    }
+
+    public static class MyAggregate {
+
+        @AggregateIdentifier
+        private String id;
+
+        public MyAggregate() {
+        }
+
+
+        @CommandHandler
+        public MyAggregate(CreateMyAggregateCommand command) {
+            apply(new MyAggregateCreatedEvent(command.getId()));
+        }
+
+        @EventSourcingHandler
+        protected void handle(MyAggregateCreatedEvent event) {
+            this.id = event.getId();
+        }
+
+    }
+
+    public static class MyAggregateCreatedEvent {
+        private final String id;
+
+        public MyAggregateCreatedEvent(String id) {
+
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    public static class CreateMyAggregateCommand {
+
+        @TargetAggregateIdentifier
+        private final String id;
+
+        public CreateMyAggregateCommand(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+
+    }
+
+    public static class MyEventHandler {
+
+
+        @EventHandler
+        public void handle(MyAggregateCreatedEvent event) {
+            logger.info("Received event for aggregate: {}", event.getId());
+        }
+
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorRunner.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorRunner.java
@@ -73,10 +73,10 @@ public class ServerConnectorRunner {
         protected void handle(MyAggregateCreatedEvent event) {
             this.id = event.getId();
         }
-
     }
 
     public static class MyAggregateCreatedEvent {
+
         private final String id;
 
         public MyAggregateCreatedEvent(String id) {
@@ -101,17 +101,13 @@ public class ServerConnectorRunner {
         public String getId() {
             return id;
         }
-
-
     }
 
     public static class MyEventHandler {
-
 
         @EventHandler
         public void handle(MyAggregateCreatedEvent event) {
             logger.info("Received event for aggregate: {}", event.getId());
         }
-
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -24,7 +24,7 @@ import io.axoniq.axonserver.grpc.command.CommandProviderInbound;
 import io.axoniq.axonserver.grpc.command.CommandProviderOutbound;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.commandhandling.*;
 import org.axonframework.common.Registration;
 import org.axonframework.serialization.xml.XStreamSerializer;
@@ -65,7 +65,7 @@ public class AxonServerCommandBusTest {
         conf.setNrOfNewPermits(1000);
         localSegment = SimpleCommandBus.builder().build();
         ser = XStreamSerializer.builder().build();
-        testSubject = new AxonServerCommandBus(new PlatformConnectionManager(conf), conf, localSegment, ser,
+        testSubject = new AxonServerCommandBus(new AxonServerConnectionManager(conf), conf, localSegment, ser,
                 command -> "RoutingKey", new CommandPriorityCalculator() {});
         dummyMessagePlatformServer = new DummyMessagePlatformServer(4344);
         dummyMessagePlatformServer.start();
@@ -135,7 +135,7 @@ public class AxonServerCommandBusTest {
 
     @Test
     public void processCommand() {
-        PlatformConnectionManager mockPlatformConnectionManager = mock(PlatformConnectionManager.class);
+        AxonServerConnectionManager mockAxonServerConnectionManager = mock(AxonServerConnectionManager.class);
         AtomicReference<StreamObserver<CommandProviderInbound>> inboundStreamObserverRef = new AtomicReference<>();
         doAnswer(invocationOnMock -> {
             inboundStreamObserverRef.set( invocationOnMock.getArgument(0));
@@ -155,8 +155,8 @@ public class AxonServerCommandBusTest {
 
                 }
             };
-        }).when(mockPlatformConnectionManager).getCommandStream(any(), any());
-        AxonServerCommandBus testSubject2 = new AxonServerCommandBus(mockPlatformConnectionManager, conf, localSegment, ser,
+        }).when(mockAxonServerConnectionManager).getCommandStream(any(), any());
+        AxonServerCommandBus testSubject2 = new AxonServerCommandBus(mockAxonServerConnectionManager, conf, localSegment, ser,
                 command -> "RoutingKey", new CommandPriorityCalculator() {});
         testSubject2.subscribe(String.class.getName(), c -> c.getMetaData().get("test1"));
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2018. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +17,7 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.PlatformConnectionManager;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.event.StubServer;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
@@ -24,14 +25,16 @@ import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class AxonServerEventStoreTest {
 
@@ -42,12 +45,14 @@ public class AxonServerEventStoreTest {
     public void setUp() throws Exception {
         server = new StubServer(6123);
         server.start();
-        AxonServerConfiguration config = AxonServerConfiguration.newBuilder("localhost:6123", "JUNIT")
+        AxonServerConfiguration config = AxonServerConfiguration.builder()
+                                                                .servers("localhost:6123")
+                                                                .componentName("JUNIT")
                                                                 .flowControl(2, 1, 1)
                                                                 .build();
         testSubject = AxonServerEventStore.builder()
                                           .configuration(config)
-                                          .platformConnectionManager(new PlatformConnectionManager(config))
+                                          .platformConnectionManager(new AxonServerConnectionManager(config))
                                           .build();
     }
 

--- a/core/src/main/java/org/axonframework/config/ConfigurerModule.java
+++ b/core/src/main/java/org/axonframework/config/ConfigurerModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,4 +31,17 @@ public interface ConfigurerModule {
      * @param configurer a {@link org.axonframework.config.Configurer} instance to configure this module with
      */
     void configureModule(Configurer configurer);
+
+    /**
+     * Returns the relative order this configurer should be invoked, compared to other intstances.
+     * <p>
+     * Use lower (negative) values for modules providing sensible defaults, and higher values for modules overriding
+     * values potentially previously set.
+     *
+     * @return the order in which this configurer should be invoked
+     */
+    default int order() {
+        return 0;
+    }
+
 }

--- a/core/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
+++ b/core/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
@@ -170,7 +170,7 @@ public interface EventProcessingConfigurer {
     EventProcessingConfigurer registerEventProcessor(String name, EventProcessorBuilder eventProcessorBuilder);
 
     /**
-     * Register a {@link Function} that builds a {@link TokenStore} for the given {@code processingGroup}.
+     * Register a {@link Function} that builds a {@link TokenStore} for the given {@code processorName}.
      *
      * @param processorName     a {@link String} specifying the name of a event processor
      * @param tokenStoreBuilder a {@link Function} that builds a {@link TokenStore}
@@ -178,6 +178,15 @@ public interface EventProcessingConfigurer {
      */
     EventProcessingConfigurer registerTokenStore(String processorName,
                                                  Function<Configuration, TokenStore> tokenStoreBuilder);
+
+    /**
+     * Register a {@link Function} that builds a {@link TokenStore} to use as the default in case no explicit token
+     * store was configured for a processor.
+     *
+     * @param tokenStore a {@link Function} that builds a {@link TokenStore}
+     * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
+     */
+    EventProcessingConfigurer registerTokenStore(Function<Configuration, TokenStore> tokenStore);
 
     /**
      * Defaults Event Processors builders to use {@link org.axonframework.eventhandling.SubscribingEventProcessor}.

--- a/core/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/core/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -427,6 +427,12 @@ public class EventProcessingModule
     }
 
     @Override
+    public EventProcessingConfigurer registerTokenStore(Function<Configuration, TokenStore> tokenStore) {
+        this.defaultTokenStore.update(tokenStore);
+        return this;
+    }
+
+    @Override
     public EventProcessingConfigurer usingSubscribingEventProcessors() {
         this.defaultEventProcessorBuilder = (name, conf, eventHandlerInvoker) ->
                 subscribingEventProcessor(name, conf, eventHandlerInvoker, Configuration::eventBus);

--- a/pom.xml
+++ b/pom.xml
@@ -376,16 +376,6 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.1.11</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>1.1.11</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.1</version>

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -26,17 +26,7 @@ import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.NullLockFactory;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.config.AggregateConfigurer;
-import org.axonframework.config.Configuration;
-import org.axonframework.config.Configurer;
-import org.axonframework.config.ConfigurerModule;
-import org.axonframework.config.DefaultConfigurer;
-import org.axonframework.config.EventProcessingConfiguration;
-import org.axonframework.config.EventProcessingConfigurer;
-import org.axonframework.config.EventProcessingModule;
-import org.axonframework.config.ModuleConfiguration;
-import org.axonframework.config.ProcessingGroup;
-import org.axonframework.config.SagaConfiguration;
+import org.axonframework.config.*;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.ErrorHandler;
 import org.axonframework.eventhandling.EventBus;
@@ -142,7 +132,7 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
         registry.registerBeanDefinition("queryHandlerSubscriber",
                                         genericBeanDefinition(QueryHandlerSubscriber.class).getBeanDefinition());
 
-        Configurer configurer = DefaultConfigurer.defaultConfiguration();
+        Configurer configurer = DefaultConfigurer.defaultConfiguration(false);
 
         RuntimeBeanReference parameterResolver =
                 SpringContextParameterResolverFactoryBuilder.getBeanReference(registry);


### PR DESCRIPTION
When using the Configuration API, and the AxonServer Connector is on the
classpath, it will be used by default, using sensible (dev) settings.

When starting with default settings, the AxonServer Connector will
output a message stating where AxonServer can be downloaded.

This commit also includes a few minor naming changes on the AxonServer
configuration.