### PR TITLE
Streamline query error handling

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ErrorCode.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ErrorCode.java
@@ -21,6 +21,7 @@ import org.axonframework.commandhandling.model.AggregateRolledBackException;
 import org.axonframework.commandhandling.model.ConcurrencyException;
 import org.axonframework.common.AxonException;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.queryhandling.QueryExecutionException;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
@@ -44,6 +45,7 @@ public enum ErrorCode {
 
     // Execution errors
     COMMAND_EXECUTION_ERROR("AXONIQ-7000", CommandExecutionException.class),
+    QUERY_EXECUTION_ERROR("AXONIQ-8000", QueryExecutionException.class),
 
     // Internal errors
     DATAFILE_READ_ERROR( "AXONIQ-9000", EventStoreException.class),

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
@@ -16,14 +16,18 @@
 package org.axonframework.axonserver.connector.query;
 
 import io.axoniq.axonserver.grpc.query.QueryResponse;
+import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.util.GrpcMetadata;
 import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
+import org.axonframework.common.AxonException;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.queryhandling.QueryExecutionException;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.Serializer;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -36,13 +40,26 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
     private final QueryResponse queryResponse;
     private final Serializer messageSerializer;
     private final LazyDeserializingObject<R> serializedPayload;
+    private final Throwable exception;
     private final Supplier<MetaData> metadata;
 
     public GrpcBackedResponseMessage(QueryResponse queryResponse, Serializer messageSerializer) {
         this.queryResponse = queryResponse;
         this.messageSerializer = messageSerializer;
         this.metadata = new GrpcMetadata(queryResponse.getMetaDataMap(), messageSerializer);
-        if( queryResponse.hasPayload() && !"empty".equalsIgnoreCase(queryResponse.getPayload().getType())) {
+        if (queryResponse.hasMessage()) {
+            Class<? extends AxonException> exceptionClass = ErrorCode.lookupExceptionClass(queryResponse
+                                                                                                   .getErrorCode());
+            Throwable remoteException = new RemoteQueryException(queryResponse.getErrorCode(),
+                                                                 queryResponse.getMessage());
+            if (QueryExecutionException.class.equals(exceptionClass)) {
+                remoteException = new QueryExecutionException(queryResponse.getMessage().getMessage(), remoteException);
+            }
+            this.exception = remoteException;
+        } else {
+            this.exception = null;
+        }
+        if (queryResponse.hasPayload() && !"empty".equalsIgnoreCase(queryResponse.getPayload().getType())) {
             this.serializedPayload = new LazyDeserializingObject<>(new GrpcSerializedObject(queryResponse.getPayload()),
                                                                    messageSerializer);
         } else {
@@ -50,11 +67,14 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
         }
     }
 
-    private GrpcBackedResponseMessage(QueryResponse queryResponse, Serializer messageSerializer, LazyDeserializingObject<R> serializedPayload, Supplier<MetaData> metadata) {
+    private GrpcBackedResponseMessage(QueryResponse queryResponse, Serializer messageSerializer,
+                                      LazyDeserializingObject<R> serializedPayload, Throwable exception,
+                                      Supplier<MetaData> metadata) {
 
         this.queryResponse = queryResponse;
         this.messageSerializer = messageSerializer;
         this.serializedPayload = serializedPayload;
+        this.exception = exception;
         this.metadata = metadata;
     }
 
@@ -70,19 +90,36 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
 
     @Override
     public R getPayload() {
-        if( serializedPayload == null) return null;
+        if (serializedPayload == null) {
+            return null;
+        }
         return serializedPayload.getObject();
     }
 
     @Override
     public Class<R> getPayloadType() {
-        if( serializedPayload == null) return null;
+        if (serializedPayload == null) {
+            return null;
+        }
         return serializedPayload.getType();
     }
 
     @Override
+    public boolean isExceptional() {
+        return exception != null;
+    }
+
+    @Override
+    public Optional<Throwable> tryGetExceptionResult() {
+        return Optional.ofNullable(exception);
+    }
+
+    @Override
     public GrpcBackedResponseMessage<R> withMetaData(Map<String, ?> metaData) {
-        return new GrpcBackedResponseMessage<>(queryResponse, messageSerializer, serializedPayload,
+        return new GrpcBackedResponseMessage<>(queryResponse,
+                                               messageSerializer,
+                                               serializedPayload,
+                                               exception,
                                                () -> MetaData.from(metaData));
     }
 
@@ -90,5 +127,4 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
     public QueryResponseMessage<R> andMetaData(Map<String, ?> var1) {
         return withMetaData(getMetaData().mergedWith(var1));
     }
-
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
@@ -19,6 +19,7 @@ package org.axonframework.axonserver.connector.query;
 import io.axoniq.axonserver.grpc.query.QueryRequest;
 import io.axoniq.axonserver.grpc.query.QueryResponse;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.QueryMessage;
@@ -79,6 +80,23 @@ public class QuerySerializerTest {
         assertEquals(message.getMetaData(), deserialized.getMetaData());
         assertEquals(message.getPayloadType(), deserialized.getPayloadType());
         assertEquals(message.getPayload(), deserialized.getPayload());
+    }
+
+    @Test
+    public void testSerializeExceptionalResponse() {
+        RuntimeException exception = new RuntimeException("oops");
+        GenericQueryResponseMessage responseMessage = new GenericQueryResponseMessage<>(
+                String.class,
+                exception,
+                MetaData.with("test", "testValue"));
+
+        QueryResponse outbound = testSubject.serializeResponse(responseMessage, "requestIdentifier");
+        QueryResponseMessage deserialize = testSubject.deserializeResponse(outbound);
+
+        assertEquals(responseMessage.getMetaData(), deserialize.getMetaData());
+        assertTrue(deserialize.isExceptional());
+        assertTrue(deserialize.tryGetExceptionResult().isPresent());
+        assertEquals(exception.getMessage(), deserialize.getExceptionResult().getMessage());
     }
 
 }

--- a/core/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/core/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -36,20 +36,14 @@ public interface ResultMessage<R> extends Message<R> {
      *
      * @return {@code true} if execution was unsuccessful, {@code false} otherwise
      */
-    // TODO: 10/11/2018 remove default: https://github.com/AxonFramework/AxonFramework/issues/827
-    default boolean isExceptional() {
-        return Throwable.class.isAssignableFrom(getPayloadType());
-    }
+    boolean isExceptional();
 
     /**
      * Tries to get exception result if present.
      *
      * @return an Optional containing exception result
      */
-    // TODO: 10/11/2018 remove default: https://github.com/AxonFramework/AxonFramework/issues/827
-    default Optional<Throwable> tryGetExceptionResult() {
-        return isExceptional() ? Optional.ofNullable((Throwable) getPayload()) : Optional.empty();
-    }
+    Optional<Throwable> tryGetExceptionResult();
 
     /**
      * Gets exception result. This method is to be called if {@link #isExceptional()} returns {@code true}.

--- a/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/core/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -71,8 +71,17 @@ public class DefaultQueryGateway implements QueryGateway {
 
     @Override
     public <R, Q> CompletableFuture<R> query(String queryName, Q query, ResponseType<R> responseType) {
-        return queryBus.query(processInterceptors(new GenericQueryMessage<>(query, queryName, responseType)))
-                       .thenApply(QueryResponseMessage::getPayload);
+        CompletableFuture<QueryResponseMessage<R>> queryResponse = queryBus
+                .query(processInterceptors(new GenericQueryMessage<>(query, queryName, responseType)));
+        CompletableFuture<R> result = new CompletableFuture<>();
+        queryResponse.thenAccept(queryResponseMessage -> {
+            if (queryResponseMessage.isExceptional()) {
+                result.completeExceptionally(queryResponseMessage.getExceptionResult());
+            } else {
+                result.complete(queryResponseMessage.getPayload());
+            }
+        });
+        return result;
     }
 
     @Override

--- a/core/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
+++ b/core/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
@@ -15,13 +15,15 @@
  */
 package org.axonframework.queryhandling;
 
+import org.axonframework.common.AxonException;
+
 /**
  * Exception indicating that the execution of a Query Handler has resulted in an exception
  *
  * @author Marc Gathier
  * @since 3.1
  */
-public class QueryExecutionException extends RuntimeException {
+public class QueryExecutionException extends AxonException {
 
     private static final long serialVersionUID = 3269266885785226323L;
 

--- a/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -153,6 +153,12 @@ public class SimpleQueryBus implements QueryBus {
                     invocationSuccess = true;
                 } catch (NoHandlerForQueryException e) {
                     // Ignore this Query Handler, as we may have another one which is suitable
+                } catch (Throwable e) {
+                    result.complete(new GenericQueryResponseMessage<>(interceptedQuery.getResponseType()
+                                                                                      .responseMessagePayloadType(),
+                                                                      e));
+                    monitorCallback.reportFailure(e);
+                    return result;
                 }
             }
             if (!invocationSuccess) {
@@ -208,7 +214,17 @@ public class SimpleQueryBus implements QueryBus {
         }
 
         MonoWrapper<QueryResponseMessage<I>> initialResult = MonoWrapper.create(monoSink -> query(query)
-                .thenAccept(monoSink::success)
+                .thenAccept(queryResponseMessage -> {
+                    if (queryResponseMessage.isExceptional()) {
+                        Throwable exceptionResult = queryResponseMessage.getExceptionResult();
+                        logger.error(format("An error happened while trying to report an initial result. Query: %s",
+                                            query),
+                                     exceptionResult);
+                        monoSink.error(exceptionResult);
+                    } else {
+                        monoSink.success(queryResponseMessage);
+                    }
+                })
                 .exceptionally(t -> {
                     logger.error(format("An error happened while trying to report an initial result. Query: %s", query),
                                  t);

--- a/core/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
+++ b/core/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.queryhandling;
 
+import org.axonframework.messaging.Message;
+
 import java.util.Map;
 
 /**
@@ -25,7 +27,7 @@ import java.util.Map;
  * @author Milan Savic
  * @since 3.3
  */
-public interface SubscriptionQueryUpdateMessage<U> extends QueryResponseMessage<U> {
+public interface SubscriptionQueryUpdateMessage<U> extends Message<U> {
 
     @Override
     SubscriptionQueryUpdateMessage<U> withMetaData(Map<String, ?> metaData);

--- a/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -62,6 +62,19 @@ public class DefaultQueryGatewayTest {
         );
     }
 
+    @Test
+    public void testDispatchSingleResultQueryWhenBusReportsAnError() throws Exception {
+        Throwable expected = new Throwable("oops");
+        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(CompletableFuture
+                                                                                       .completedFuture(new GenericQueryResponseMessage<>(
+                                                                                               String.class,
+                                                                                               expected)));
+        CompletableFuture<String> result = testSubject.query("query", String.class);
+        assertTrue(result.isDone());
+        assertTrue(result.isCompletedExceptionally());
+        assertEquals(expected.getMessage(), result.exceptionally(Throwable::getMessage).get());
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     public void testDispatchMultiResultQuery() {

--- a/core/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/core/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -278,12 +278,13 @@ public class SimpleQueryBusTest {
 
         QueryMessage<String, String> testQueryMessage =
                 new GenericQueryMessage<>("query", "query", singleStringResponse);
-        CompletableFuture<String> result = testSubject.query(testQueryMessage)
-                                                      .thenApply(QueryResponseMessage::getPayload);
+        CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQueryMessage);
 
         assertTrue(result.isDone());
-        assertTrue(result.isCompletedExceptionally());
-        assertEquals("Mock", result.exceptionally(e -> e.getCause().getMessage()).get());
+        assertFalse(result.isCompletedExceptionally());
+        QueryResponseMessage<String> queryResponseMessage = result.get();
+        assertTrue(queryResponseMessage.isExceptional());
+        assertEquals("Mock", queryResponseMessage.getExceptionResult().getMessage());
     }
 
     @Test
@@ -326,15 +327,13 @@ public class SimpleQueryBusTest {
         });
 
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("hello", singleStringResponse);
-        CompletableFuture<?> result = testSubject.query(testQueryMessage);
+        CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQueryMessage);
 
-        assertTrue(result.isCompletedExceptionally());
-        try {
-            result.get();
-            fail("Expected exception");
-        } catch (ExecutionException e) {
-            assertEquals(mockException, e.getCause());
-        }
+        assertTrue(result.isDone());
+        assertFalse(result.isCompletedExceptionally());
+        QueryResponseMessage<String> queryResponseMessage = result.get();
+        assertTrue(queryResponseMessage.isExceptional());
+        assertEquals(mockException, queryResponseMessage.getExceptionResult());
     }
 
     @Test


### PR DESCRIPTION
If there is an error in dispatching the query message, it will be reported via CompletableFuture.
If there is an error in handling the query message, it will be reported as a Result Message.
QueryGateway reports all failures using CompletableFuture.

This PR is against `streamline-command-error-handling` since it was branched from it.

Resolves #827 