### PR TITLE
[#857] Javadoc issues in AxonFramework core

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
@@ -16,12 +16,8 @@
 
 package org.axonframework.axonserver.connector.event;
 
-import io.grpc.Channel;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
-import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.Confirmation;
+import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventStoreGrpc;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
@@ -35,6 +31,10 @@ import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
 import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
 import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
 import io.axoniq.axonserver.grpc.event.TrackingToken;
+import io.grpc.Channel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.AxonServerException;
@@ -130,9 +130,10 @@ public class AxonServerEventStoreClient {
     }
 
     /**
+     * Provide a list of events by using a {@link StreamObserver} for type {@link GetEventsRequest}.
      *
-     * @param responseStreamObserver: observer for messages from server
-     * @return stream observer to send request messages to server
+     * @param responseStreamObserver a {@link StreamObserver} for messages from the server
+     * @return the {@link StreamObserver} to send request messages to server with
      */
     public StreamObserver<GetEventsRequest> listEvents(StreamObserver<EventWithToken> responseStreamObserver) {
         StreamObserver<EventWithToken> wrappedStreamObserver = new StreamObserver<EventWithToken>() {

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -38,16 +38,13 @@ import static org.axonframework.common.ReflectionUtils.*;
  * that commands with the same identifier, thus dealt with by the same target, are dispatched to the same node in
  * a {@link DistributedCommandBus}.
  * <p>
- * An example would be the {@link org.axonframework.commandhandling.TargetAggregateIdentifier}, which is annotated with
- * RoutingKey. See {@link org.axonframework.commandhandling.AnnotationCommandTargetResolver} for more details on this
- * approach.
+ * An example would be the TargetAggregateIdentifier annotation, which is meta-annotated with RoutingKey. See the
+ * AnnotationCommandTargetResolver for more details on this approach.
  * <p/>
  * This class requires the returned routing keys to implement a proper {@link Object#toString()} method. An inconsistent
  * toString() method may result in different members using different routing keys for the same identifier.
  *
  * @author Allard Buijze
- * @see org.axonframework.commandhandling.TargetAggregateIdentifier
- * @see org.axonframework.commandhandling.AnnotationCommandTargetResolver
  * @see DistributedCommandBus
  * @since 2.0
  */

--- a/messaging/src/main/java/org/axonframework/deadline/AbstractDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/AbstractDeadlineManager.java
@@ -28,10 +28,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Abstract implementation of the {@link DeadlineManager} to be implemented by concrete solutions for the
- * DeadlineManager. Provides functionality to perform a call to the DeadlineManager in the
- * {@link UnitOfWork.Phase#PREPARE_COMMIT} phase. This #runOnPrepareCommitOrNow(Runnable) functionality is required, as
- * the DeadlineManager schedules a {@link org.axonframework.messaging.Message} which needs to happen on order with the
- * other messages published throughout the system.
+ * DeadlineManager. Provides functionality to perform a call to the DeadlineManager in the a {@link UnitOfWork} it's
+ * 'prepare commit' phase. This #runOnPrepareCommitOrNow(Runnable) functionality is required, as the DeadlineManager
+ * schedules a Message which needs to happen on order with the other messages published throughout the system.
  *
  * @author Steven van Beelen
  * @since 3.3
@@ -42,7 +41,7 @@ public abstract class AbstractDeadlineManager implements DeadlineManager {
     private final List<MessageHandlerInterceptor<? super DeadlineMessage<?>>> handlerInterceptors = new CopyOnWriteArrayList<>();
 
     /**
-     * Run a given {@code deadlineCall} immediately, or schedule it for the {@link UnitOfWork.Phase#PREPARE_COMMIT}
+     * Run a given {@code deadlineCall} immediately, or schedule it for the {@link UnitOfWork} it's 'prepare commit'
      * phase if a UnitOfWork is active. This is required as the DeadlineManager schedule message which we want to happen
      * on order with other message being handled.
      *

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -476,14 +476,13 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
     }
 
     /**
-     * Starts the {@link TrackingSegmentWorker workers} for a number of segments. When only the
-     * {@link Segment#ROOT_SEGMENT root } segment {@link TokenStore#fetchSegments(String) exists} in the  TokenStore,
-     * it will be split in multiple segments as configured by the
-     * {@link TrackingEventProcessorConfiguration#andInitialSegmentsCount(int)}, otherwise the existing segments in
-     * the TokenStore will be used.
+     * Starts workers for a number of segments. When only the {@link Segment#ROOT_SEGMENT root } segment
+     * {@link TokenStore#fetchSegments(String) exists} in the  TokenStore, it will be split in multiple segments as
+     * configured by the {@link TrackingEventProcessorConfiguration#andInitialSegmentsCount(int)}, otherwise the
+     * existing segments in the TokenStore will be used.
      * <p/>
-     * An attempt will be made to instantiate a {@link TrackingSegmentWorker} for each segment. This will succeed when
-     * the number of threads matches the requested segments. The number of active threads can be configured with
+     * An attempt will be made to instantiate a worker for each segment. This will succeed when the number of threads
+     * matches the requested segments. The number of active threads can be configured with
      * {@link TrackingEventProcessorConfiguration#forParallelProcessing(int)}. When insufficient threads are available
      * to serve the number of segments, it will result in some segments not being processed.
      */

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -85,9 +85,9 @@ public class JdbcTokenStore implements TokenStore {
      * Instantiate a Builder to be able to create a {@link JdbcTokenStore}.
      * <p>
      * The {@code schema} is defaulted to an {@link TokenSchema}, the {@code claimTimeout} to a 10 seconds duration,
-     * the {@code nodeId} is defaulted to the {@link ManagementFactory#getRuntimeMXBean#getName} output and the
-     * {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and {@link Serializer} are
-     * a <b>hard requirements</b> and as such should be provided.
+     * {@code nodeId} is defaulted to the name of the managed bean for the runtime system of the Java virtual machine
+     * and the {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and
+     * {@link Serializer} are <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link JdbcTokenStore}
      */
@@ -443,9 +443,9 @@ public class JdbcTokenStore implements TokenStore {
      * Builder class to instantiate a {@link JdbcTokenStore}.
      * <p>
      * The {@code schema} is defaulted to an {@link TokenSchema}, the {@code claimTimeout} to a 10 seconds duration,
-     * {@code nodeId} is defaulted to the {@link ManagementFactory#getRuntimeMXBean#getName} output and the
-     * {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and {@link Serializer} are
-     * <b>hard requirements</b> and as such should be provided.
+     * {@code nodeId} is defaulted to the name of the managed bean for the runtime system of the Java virtual machine
+     * and the {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and
+     * {@link Serializer} are <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
@@ -508,8 +508,8 @@ public class JdbcTokenStore implements TokenStore {
         }
 
         /**
-         * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to
-         * {@link ManagementFactory#getRuntimeMXBean#getName} output as the node id.
+         * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to the name of the managed bean for
+         * the runtime system of the Java virtual machine
          *
          * @param nodeId the id as a {@link String} to identify ownership of the tokens
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -74,9 +74,9 @@ public class JpaTokenStore implements TokenStore {
     /**
      * Instantiate a Builder to be able to create a {@link JpaTokenStore}.
      * <p>
-     * The {@code claimTimeout} to a 10 seconds duration, and the {@code nodeId} is defaulted to the
-     * {@link ManagementFactory#getRuntimeMXBean#getName} output. The {@link EntityManagerProvider} and
-     * {@link Serializer} are a <b>hard requirements</b> and as such should be provided.
+     * The {@code claimTimeout} to a 10 seconds duration, and {@code nodeId} is defaulted to the name of the managed
+     * bean for the runtime system of the Java virtual machine. The {@link EntityManagerProvider} and {@link Serializer}
+     * are a <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link JpaTokenStore}
      */
@@ -200,9 +200,9 @@ public class JpaTokenStore implements TokenStore {
     /**
      * Builder class to instantiate a {@link JpaTokenStore}.
      * <p>
-     * The {@code claimTimeout} to a 10 seconds duration, and the {@code nodeId} is defaulted to the
-     * {@link ManagementFactory#getRuntimeMXBean#getName} output. The {@link EntityManagerProvider} and
-     * {@link Serializer} are a <b>hard requirements</b> and as such should be provided.
+     * The {@code claimTimeout} to a 10 seconds duration, and {@code nodeId} is defaulted to the name of the managed
+     * bean for the runtime system of the Java virtual machine. The {@link EntityManagerProvider} and {@link Serializer}
+     * are a <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
@@ -252,8 +252,8 @@ public class JpaTokenStore implements TokenStore {
         }
 
         /**
-         * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to
-         * {@link ManagementFactory#getRuntimeMXBean#getName} output as the node id.
+         * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to the name of the managed bean for
+         * the runtime system of the Java virtual machine
          *
          * @param nodeId the id as a {@link String} to identify ownership of the tokens
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/main/java/org/axonframework/messaging/Scope.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Scope.java
@@ -25,13 +25,9 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 
 /**
- * Describes functionality off processes which can be 'in scope', like the
- * {@link org.axonframework.commandhandling.model.AggregateLifecycle} or
- * {@link org.axonframework.eventhandling.saga.SagaLifecycle}.
+ * Describes functionality off processes which can be 'in scope', like an Aggregate or Saga.
  *
  * @author Steven van Beelen
- * @see org.axonframework.commandhandling.model.AggregateLifecycle
- * @see org.axonframework.eventhandling.saga.SagaLifecycle
  * @since 3.3
  */
 public abstract class Scope {

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryBackpressure.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryBackpressure.java
@@ -19,8 +19,8 @@ package org.axonframework.queryhandling;
 import reactor.core.publisher.FluxSink;
 
 /**
- * Backpressure mechanism used for subscription queries. Uses underlying {@link FluxSink.OverflowStrategy} to express
- * the type of backpressure.
+ * Backpressure mechanism used for subscription queries. Uses underlying FluxSink.OverflowStrategy from Project Reactor
+ * to express the type of back pressure.
  *
  * @author Milan Savic
  * @since 3.3
@@ -39,9 +39,9 @@ public class SubscriptionQueryBackpressure {
     }
 
     /**
-     * Creates default backpressure - {@link FluxSink.OverflowStrategy#ERROR}.
+     * Creates default backpressure, using Project Reactor's FluxSink.OverflowStrategy ERROR strategy.
      *
-     * @return initialized backpressure - {@link FluxSink.OverflowStrategy#ERROR}
+     * @return initialized backpressure, using Project Reactor's FluxSink.OverflowStrategy ERROR strategy
      */
     public static SubscriptionQueryBackpressure defaultBackpressure() {
         return new SubscriptionQueryBackpressure(FluxSink.OverflowStrategy.ERROR);

--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -256,7 +256,7 @@ public abstract class AbstractXStreamSerializer implements Serializer {
      * <p>
      * Upon instantiation, several defaults aliases are added to the XStream instance, for example for the
      * {@link GenericDomainEventMessage}, the {@link GenericCommandMessage} and the {@link MetaData} objects among
-     * others. Additionally, a {@link MetaDataConverter} is registered too. Lastly, if the provided Converter instance
+     * others. Additionally, a MetaData Converter is registered too. Lastly, if the provided Converter instance
      * is of type ChainingConverter, then the {@link AbstractXStreamSerializer#registerConverters(ChainingConverter)}
      * function will be called. Depending on the AbstractXStreamSerializer, this will add a number of Converter
      * instances to the chain.

--- a/messaging/src/main/java/org/axonframework/serialization/UnknownSerializedType.java
+++ b/messaging/src/main/java/org/axonframework/serialization/UnknownSerializedType.java
@@ -59,7 +59,7 @@ public class UnknownSerializedType {
      * To verify whether a format is supported, use {@link #supportsFormat(Class)}.
      *
      * @param desiredFormat the format in which the data is desired
-     * @param <T></T>       the format in which the data is desired
+     * @param <T>           the format in which the data is desired
      * @return the data in the desired format
      */
     public <T> T readData(Class<T> desiredFormat) {

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -53,7 +53,7 @@ public class JacksonSerializer implements Serializer {
      * Upon instantiation, the ObjectMapper will get two modules registered to it by default, (1) the
      * {@link MetaDataDeserializer} and the (2) {@link JavaTimeModule}. Lastly, if the provided converter is of type
      * ChainingConverter, the {@link JacksonSerializer#registerConverters} is performed to automatically add the
-     * {@link JsonNodeToByteArrayConverter) and {@link ByteArrayToJsonNodeConverter).
+     * {@link JsonNodeToByteArrayConverter} and {@link ByteArrayToJsonNodeConverter}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link JacksonSerializer} instance
      */
@@ -78,12 +78,12 @@ public class JacksonSerializer implements Serializer {
      * <p>
      * The {@link RevisionResolver} is defaulted to an {@link AnnotationRevisionResolver}, the {@link Converter} to a
      * {@link ChainingConverter}, the {@link ObjectMapper} defaults to a {@link ObjectMapper#ObjectMapper()} result and
-     * the {@link ClassLoader} to the result of an {@link Object#getClass()#getClassLoader()} call.
+     * the {@link ClassLoader} to the ClassLoader of {@code this} class.
      * <p>
      * Upon instantiation, the ObjectMapper will get two modules registered to it by default, (1) the
      * {@link MetaDataDeserializer} and the (2) {@link JavaTimeModule}. Lastly, if the provided converter is of type
      * ChainingConverter, the {@link JacksonSerializer#registerConverters} is performed to automatically add the
-     * {@link JsonNodeToByteArrayConverter) and {@link ByteArrayToJsonNodeConverter).
+     * {@link JsonNodeToByteArrayConverter} and {@link ByteArrayToJsonNodeConverter}.
      *
      * @return a Builder to be able to create a {@link JacksonSerializer}
      */
@@ -224,12 +224,12 @@ public class JacksonSerializer implements Serializer {
      * <p>
      * The {@link RevisionResolver} is defaulted to an {@link AnnotationRevisionResolver}, the {@link Converter} to a
      * {@link ChainingConverter}, the {@link ObjectMapper} defaults to a {@link ObjectMapper#ObjectMapper()} result and
-     * the {@link ClassLoader} to the result of an {@link Object#getClass()#getClassLoader()} call.
+     * the {@link ClassLoader} to the ClassLoader of {@code this} class.
      * <p>
      * Upon instantiation, the ObjectMapper will get two modules registered to it by default, (1) the
      * {@link MetaDataDeserializer} and the (2) {@link JavaTimeModule}. Lastly, if the provided converter is of type
      * ChainingConverter, the {@link JacksonSerializer#registerConverters} is performed to automatically add the
-     * {@link JsonNodeToByteArrayConverter) and {@link ByteArrayToJsonNodeConverter).
+     * {@link JsonNodeToByteArrayConverter} and {@link ByteArrayToJsonNodeConverter}.
      */
     public static class Builder {
 
@@ -281,8 +281,7 @@ public class JacksonSerializer implements Serializer {
         }
 
         /**
-         * Sets the {@link ClassLoader} used to load classes with when deserializing. Defaults to the result of an
-         * {@link Object#getClass()#getClassLoader()} call.
+         * Sets the {@link ClassLoader} used to load classes with when deserializing. Defaults to the ClassLoader of {@code this} class.
          *
          * @param classLoader the {@link ClassLoader} used to load classes with when deserializing
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/SingleEntryMultiUpcaster.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/SingleEntryMultiUpcaster.java
@@ -39,8 +39,8 @@ public abstract class SingleEntryMultiUpcaster<T> implements Upcaster<T> {
     }
 
     /**
-     * Checks if this upcaster can upcast the given {@code intermediateRepresentation}.
-     * If the upcaster cannot upcast the representation the {@link #doUpcast(T)} is not invoked.
+     * Checks if this upcaster can upcast the given {@code intermediateRepresentation}. If the upcaster cannot upcast
+     * the representation the {@link #doUpcast(Object)} is not invoked.
      *
      * @param intermediateRepresentation the intermediate object representation to upcast
      * @return {@code true} if the representation can be upcast, {@code false} otherwise
@@ -48,11 +48,11 @@ public abstract class SingleEntryMultiUpcaster<T> implements Upcaster<T> {
     protected abstract boolean canUpcast(T intermediateRepresentation);
 
     /**
-     * Upcasts the given {@code intermediateRepresentation}.
-     * This method is only invoked if {@link #canUpcast(T)} returned {@code true} for the given representation.
+     * Upcasts the given {@code intermediateRepresentation}. This method is only invoked if {@link #canUpcast(Object)}
+     * returned {@code true} for the given representation.
      * <p>
-     * Note that the returned representation should not be {@code null}.
-     * To remove an intermediateRepresentation add a filter to the input stream.
+     * Note that the returned representation should not be {@code null}. To remove an intermediateRepresentation add a
+     * filter to the input stream.
      *
      * @param intermediateRepresentation the representation of the object to upcast
      * @return the upcasted representations as a {@code Stream} with generic type {@code T}

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -68,7 +68,7 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
      * <p>
      * Upon instantiation, several defaults aliases are added to the XStream instance, for example for the
      * {@link GenericDomainEventMessage}, the {@link org.axonframework.commandhandling.GenericCommandMessage} and the
-     * {@link org.axonframework.messaging.MetaData} objects among others. Additionally, a {@link MetaDataConverter} is
+     * {@link org.axonframework.messaging.MetaData} objects among others. Additionally, a MetaData Converter is
      * registered too. Lastly, if the provided Converter instance is of type ChainingConverter, then the
      * {@link XStreamSerializer#registerConverters(ChainingConverter)} function will be called. This will register the
      * {@link Dom4JToByteArrayConverter}, {@link InputStreamToDom4jConverter}, {@link XomToStringConverter} and
@@ -120,7 +120,7 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
      * Upon instantiation, several defaults aliases are added to the XStream instance, for example for the
      * {@link GenericDomainEventMessage}, the
      * {@link org.axonframework.commandhandling.GenericCommandMessage} and the
-     * {@link org.axonframework.messaging.MetaData} objects among others. Additionally, a {@link MetaDataConverter} is
+     * {@link org.axonframework.messaging.MetaData} objects among others. Additionally, a MetaData Converter is
      * registered too. Lastly, if the provided Converter instance is of type ChainingConverter, then the
      * {@link XStreamSerializer#registerConverters(ChainingConverter)} function will be called. This will register the
      * {@link Dom4JToByteArrayConverter}, {@link InputStreamToDom4jConverter}, {@link XomToStringConverter} and

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SimpleResourceInjector.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SimpleResourceInjector.java
@@ -23,14 +23,13 @@ import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 /**
- * A resource injector that checks for {@link javax.inject.Inject} annotated fields and setter methods to inject
- * resources. If a field is annotated with {@link javax.inject.Inject}, a Resource of the type of that field is injected
- * into it, if present. If a method is annotated with {@link javax.inject.Inject}, the method is invoked with a Resource
- * of the type of the first parameter, if present.
+ * A resource injector that checks for @Inject annotated fields and setter methods to inject resources. If a field is
+ * annotated with @Inject, a Resource of the type of that field is injected into it, if present. If
+ * a method is annotated with @Inject, the method is invoked with a Resource of the type of the first parameter, if
+ * present.
  *
  * @author Allard Buijze
  * @since 1.1
- * @see javax.inject.Inject
  */
 public class SimpleResourceInjector extends AbstractResourceInjector {
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -64,7 +64,7 @@ public class CachingSagaStore<T> implements SagaStore<T> {
     /**
      * Instantiate a Builder to be able to create a {@link CachingSagaStore}.
      * <p>
-     * The {@code delegateSagaStore} of type {@link SagaStore, the {@code associationsCache} and {@code sagaCache}
+     * The {@code delegateSagaStore} of type {@link SagaStore}, the {@code associationsCache} and {@code sagaCache}
      * (both of type {@link Cache}) are <b>hard requirements</b> and as such should be provided.
      *
      * @param <T> a generic specifying the Saga type contained in this
@@ -160,11 +160,10 @@ public class CachingSagaStore<T> implements SagaStore<T> {
     /**
      * Builder class to instantiate a {@link CachingSagaStore}.
      * <p>
-     * The {@code delegateSagaStore} of type {@link SagaStore, the {@code associationsCache} and {@code sagaCache}
+     * The {@code delegateSagaStore} of type {@link SagaStore}, the {@code associationsCache} and {@code sagaCache}
      * (both of type {@link Cache}) are <b>hard requirements</b> and as such should be provided.
      *
-     * @param <T> a generic specifying the Saga type contained in this
-     *            {@link SagaRepository } implementation
+     * @param <T> a generic specifying the Saga type contained in this {@link SagaRepository} implementation
      */
     public static class Builder<T> {
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -342,7 +342,7 @@ public class JpaSagaStore implements SagaStore<Object> {
     /**
      * Intended for clients to override. Defaults to {@link SerializedSaga#getClass() SerialzedSaga.class}
      *
-     * @return
+     * @return the serialized object type of the Saga this {@link SagaStore} stores
      */
     protected Class<? extends SimpleSerializedObject<?>> serializedObjectType() {
         return SerializedSaga.class;

--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,25 @@
                 </executions>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <!-- These parameters are in preparation for resolution of this issue: -->
+                    <!-- https://bugs.openjdk.java.net/browse/JDK-8068562 -->
+                    <tags>
+                        <tag>
+                            <name>apiNote</name>
+                            <placement>a</placement>
+                            <head>API Note:</head>
+                        </tag>
+                        <tag>
+                            <name>implSpec</name>
+                            <placement>a</placement>
+                            <head>Implementation Requirements:</head>
+                        </tag>
+                        <tag>
+                            <name>implNote</name>
+                            <placement>a</placement>
+                            <head>Implementation Note:</head>
+                        </tag>
+                    </tags>
                 </configuration>
             </plugin>
             <plugin>

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
@@ -128,7 +128,8 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
 
     /**
      * Sets the {@link EventJobDataBinder} instance which reads / writes the event message to publish to the
-     * {@link JobDataMap}. Defaults to {@link QuartzEventScheduler.DirectEventJobDataBinder}.
+     * {@link JobDataMap}. Defaults to
+     * {@link org.axonframework.eventhandling.scheduling.quartz.QuartzEventScheduler.DirectEventJobDataBinder}.
      *
      * @param eventJobDataBinder to use
      */

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.test.saga;
 
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
@@ -96,8 +97,8 @@ public interface FixtureConfiguration {
 
     /**
      * Registers the given {@code fieldFilter}, which is used to define which Fields are used when comparing
-     * objects. The {@link ResultValidator#expectEvents(Object...)} and {@link ResultValidator#expectReturnValue(Object)},
-     * for example, use this filter.
+     * objects. The {@link ResultValidator#expectEvents(Object...)} and
+     * {@link ResultValidator#expectResultMessage(CommandResultMessage)}, for example, use this filter.
      * <p/>
      * When multiple filters are registered, a Field must be accepted by all registered filters in order to be
      * accepted.


### PR DESCRIPTION
Fix several javadoc build issues we had according to running `mvn clean package javadoc:aggregate-jar -DskipTests=true`.
Additionally, add the 'custom tags' apiNote, implSpec and implNote.
They're slated for Java 8, but still not part of the javadoc build.
Hence we need to introduce them ourselves.

This PR resolves issues #857 