### PR TITLE
Bugfix 807 backport

### DIFF
--- a/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/core/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -208,11 +208,17 @@ public abstract class AbstractXStreamSerializer implements Serializer {
     @SuppressWarnings("unchecked")
     @Override
     public <S, T> T deserialize(SerializedObject<S> serializedObject) {
+        if (SerializedType.emptyType().equals(serializedObject.getType())) {
+            return null;
+        }
         return (T) doDeserialize(serializedObject, xStream);
     }
 
     @Override
     public Class classForType(SerializedType type) {
+        if (SerializedType.emptyType().equals(type)) {
+            return Void.class;
+        }
         try {
             return xStream.getMapper().realClass(type.getName());
         } catch (CannotResolveClassException e) {

--- a/core/src/main/java/org/axonframework/serialization/JavaSerializer.java
+++ b/core/src/main/java/org/axonframework/serialization/JavaSerializer.java
@@ -89,6 +89,9 @@ public class JavaSerializer implements Serializer {
     @SuppressWarnings("unchecked")
     @Override
     public <S, T> T deserialize(SerializedObject<S> serializedObject) {
+        if (SerializedType.emptyType().equals(serializedObject.getType())) {
+            return null;
+        }
         SerializedObject<InputStream> converted =
                 converter.convert(serializedObject, InputStream.class);
         ObjectInputStream ois = null;
@@ -104,6 +107,9 @@ public class JavaSerializer implements Serializer {
 
     @Override
     public Class classForType(SerializedType type) {
+        if (SerializedType.emptyType().equals(type)) {
+            return Void.class;
+        }
         try {
             return Class.forName(type.getName());
         } catch (ClassNotFoundException e) {

--- a/core/src/main/java/org/axonframework/serialization/SerializedType.java
+++ b/core/src/main/java/org/axonframework/serialization/SerializedType.java
@@ -25,6 +25,16 @@ package org.axonframework.serialization;
 public interface SerializedType {
 
     /**
+     * Returns the type that represents an empty message, of undefined type. The type of such message is "empty" and
+     * always has a {@code null} revision.
+     *
+     * @return the type representing an empty message
+     */
+    static SerializedType emptyType() {
+        return SimpleSerializedType.emptyType();
+    }
+
+    /**
      * Returns the name of the serialized type. This may be the class name of the serialized object, or an alias for
      * that name.
      *

--- a/core/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/core/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -25,17 +25,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.AnnotationRevisionResolver;
-import org.axonframework.serialization.ChainingConverter;
-import org.axonframework.serialization.Converter;
-import org.axonframework.serialization.RevisionResolver;
-import org.axonframework.serialization.SerializationException;
-import org.axonframework.serialization.SerializedObject;
-import org.axonframework.serialization.SerializedType;
-import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.SimpleSerializedObject;
-import org.axonframework.serialization.SimpleSerializedType;
-import org.axonframework.serialization.UnknownSerializedTypeException;
+import org.axonframework.serialization.*;
 
 import java.io.IOException;
 
@@ -203,6 +193,9 @@ public class JacksonSerializer implements Serializer {
 
     @Override
     public <S, T> T deserialize(SerializedObject<S> serializedObject) {
+        if (SerializedType.emptyType().equals(serializedObject.getType())) {
+            return null;
+        }
         try {
             if (JsonNode.class.equals(serializedObject.getContentType())) {
                 return getReader(classForType(serializedObject.getType()))

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
@@ -43,6 +43,7 @@ import java.util.stream.LongStream;
 
 import static java.util.stream.Collectors.toList;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.AGGREGATE;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.createEvent;
 import static org.junit.Assert.assertFalse;
@@ -156,7 +157,7 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
     public void testEventsWithUnknownPayloadTypeAreSkipped() throws SQLException, InterruptedException {
         String expectedPayloadOne = "Payload3";
         String expectedPayloadTwo = "Payload4";
-        List<String> expected = Arrays.asList(expectedPayloadOne, expectedPayloadTwo);
+        List<String> expected = Arrays.asList(null, null, expectedPayloadOne, expectedPayloadTwo);
 
         int testBatchSize = 2;
         testSubject = createEngine(
@@ -182,6 +183,8 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
 
         TrackingEventStream eventStoreResult = testEventStore.openStream(null);
         assertTrue(eventStoreResult.hasNextAvailable());
+        assertNull(eventStoreResult.nextAvailable().getPayload());
+        assertNull(eventStoreResult.nextAvailable().getPayload());
         assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().getPayload());
         assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().getPayload());
     }

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
@@ -52,6 +52,7 @@ import java.util.stream.LongStream;
 
 import static java.util.stream.Collectors.toList;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -239,7 +240,7 @@ public class JpaEventStorageEngineTest extends BatchingEventStorageEngineTest {
     public void testEventsWithUnknownPayloadTypeAreSkipped() throws InterruptedException {
         String expectedPayloadOne = "Payload3";
         String expectedPayloadTwo = "Payload4";
-        List<String> expected = Arrays.asList(expectedPayloadOne, expectedPayloadTwo);
+        List<String> expected = Arrays.asList(null, null, expectedPayloadOne, expectedPayloadTwo);
 
         int testBatchSize = 2;
         testSubject = createEngine(NoOpEventUpcaster.INSTANCE, defaultPersistenceExceptionResolver, testBatchSize);
@@ -261,6 +262,8 @@ public class JpaEventStorageEngineTest extends BatchingEventStorageEngineTest {
         TrackingEventStream eventStoreResult = testEventStore.openStream(null);
 
         assertTrue(eventStoreResult.hasNextAvailable());
+        assertNull(eventStoreResult.nextAvailable().getPayload());
+        assertNull(eventStoreResult.nextAvailable().getPayload());
         assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().getPayload());
         assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().getPayload());
         assertFalse(eventStoreResult.hasNextAvailable());

--- a/core/src/test/java/org/axonframework/serialization/JavaSerializerTest.java
+++ b/core/src/test/java/org/axonframework/serialization/JavaSerializerTest.java
@@ -81,6 +81,12 @@ public class JavaSerializerTest {
         assertNull(testSubject.deserialize(serializedNullString));
     }
 
+    @Test
+    public void testDeserializeEmptyBytes() {
+        assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
+        assertNull(testSubject.deserialize(new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())));
+    }
+
     private static class MySerializableObject implements Serializable {
 
         private static final long serialVersionUID = 2166108932776672373L;

--- a/core/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/core/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -177,6 +177,12 @@ public class JacksonSerializerTest {
         assertNull(testSubject.deserialize(serializedNullString));
     }
 
+    @Test
+    public void testDeserializeEmptyBytes() {
+        assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
+        assertNull(testSubject.deserialize(new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())));
+    }
+
     public static class ComplexObject {
         private final String value1;
         private final String value2;

--- a/core/src/test/java/org/axonframework/serialization/xml/XStreamSerializerTest.java
+++ b/core/src/test/java/org/axonframework/serialization/xml/XStreamSerializerTest.java
@@ -17,9 +17,7 @@
 package org.axonframework.serialization.xml;
 
 import org.axonframework.eventsourcing.StubDomainEvent;
-import org.axonframework.serialization.Revision;
-import org.axonframework.serialization.SerializedObject;
-import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,6 +66,12 @@ public class XStreamSerializerTest {
         SerializedObject<org.dom4j.Document> serializedEvent = testSubject.serialize(testEvent, org.dom4j.Document.class);
         Object actualResult = testSubject.deserialize(serializedEvent);
         assertEquals(testEvent, actualResult);
+    }
+
+    @Test
+    public void testDeserializeEmptyBytes() {
+        assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
+        assertNull(testSubject.deserialize(new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())));
     }
 
     @Test


### PR DESCRIPTION
Backport of a fix done in the 4.0 release to 3.4.x.
The main difference is that a `null` payload is returned for unknown events, instead of an UnknownSerializedType. This only happens in cases where unknown types are explicitly skipped.