### PR TITLE
Allow registration of sagafixture start recording callbacks

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -16,11 +16,13 @@
 
 package org.axonframework.test.saga;
 
+import com.sun.tools.javadoc.resources.javadoc;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.modelling.saga.Saga;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.aggregate.ResultValidator;
 import org.axonframework.test.matchers.FieldFilter;
@@ -154,8 +156,12 @@ public interface FixtureConfiguration {
     /**
      * Registers a callback to be invoked when the fixture execution starts recording. This happens right before
      * invocation of the 'when' step (stimulus) of the fixture.
+     * <p/>
+     * Use this to manage Saga dependencies which are not an Axon first class citizen, but do require monitoring of
+     * their interactions. For example, register the callback to set a mock in recording mode.
      *
      * @param onStartRecordingCallback callback to invoke
+     * @return the current FixtureConfiguration, for fluent interfacing
      */
     FixtureConfiguration registerStartRecordingCallback(Runnable onStartRecordingCallback);
 

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -152,6 +152,14 @@ public interface FixtureConfiguration {
             MessageHandlerInterceptor<DeadlineMessage<?>> deadlineHandlerInterceptor);
 
     /**
+     * Registers a callback to be invoked when the fixture execution starts recording. This happens right before
+     * invocation of the 'when' step (stimulus) of the fixture.
+     *
+     * @param onStartRecordingCallback callback to invoke
+     */
+    FixtureConfiguration registerStartRecordingCallback(Runnable onStartRecordingCallback);
+
+    /**
      * Sets the instance that defines the behavior of the Command Bus when a command is dispatched with a callback.
      *
      * @param callbackBehavior The instance deciding to how the callback should be invoked.

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -16,13 +16,11 @@
 
 package org.axonframework.test.saga;
 
-import com.sun.tools.javadoc.resources.javadoc;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.annotation.HandlerDefinition;
-import org.axonframework.modelling.saga.Saga;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.aggregate.ResultValidator;
 import org.axonframework.test.matchers.FieldFilter;

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -78,6 +78,15 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
         onStartRecordingCallbacks = new CopyOnWriteArrayList<>();
     }
 
+    /**
+     * Registers a callback to be invoked when the fixture execution starts recording. This happens right before
+     * invocation of the 'when' step (stimulus) of the fixture.
+     * <p/>
+     * Use this to manage Saga dependencies which are not an Axon first class citizen, but do require monitoring of
+     * their interactions. For example, register the callback to set a mock in recording mode.
+     *
+     * @param onStartRecordingCallback callback to invoke
+     */
     public void registerStartRecordingCallback(Runnable onStartRecordingCallback) {
         Assert.notNull(onStartRecordingCallback, () -> "onStartRecordingCallback may not be null");
         onStartRecordingCallbacks.add(onStartRecordingCallback);

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -344,6 +344,12 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
         return this;
     }
 
+    @Override
+    public FixtureConfiguration registerStartRecordingCallback(Runnable onStartRecordingCallback) {
+        this.fixtureExecutionResult.registerStartRecordingCallback(onStartRecordingCallback);
+        return this;
+    }
+
     private AggregateEventPublisherImpl getPublisherFor(String aggregateIdentifier) {
         if (!aggregatePublishers.containsKey(aggregateIdentifier)) {
             aggregatePublishers.put(aggregateIdentifier, new AggregateEventPublisherImpl(aggregateIdentifier));

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.axonframework.test.matchers.Matchers.*;
 import static org.junit.Assert.*;
@@ -337,6 +338,15 @@ public class FixtureExecutionResultImplTest {
         sagaStore.insertSaga(StubSaga.class, "test2", new StubSaga(), Collections.emptySet());
 
         testSubject.expectActiveSagas(1);
+    }
+
+    @Test
+    public void testStartRecordingCallback() {
+        AtomicInteger startRecordingCallbackInvocations = new AtomicInteger();
+        testSubject.registerStartRecordingCallback(startRecordingCallbackInvocations::incrementAndGet);
+        testSubject.startRecording();
+
+        assertThat(startRecordingCallbackInvocations.get(), equalTo(1));
     }
 
     private static class SimpleCommand {

--- a/test/src/test/java/org/axonframework/test/saga/SagaTestFixtureTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/SagaTestFixtureTest.java
@@ -1,0 +1,69 @@
+package org.axonframework.test.saga;
+
+import org.axonframework.modelling.saga.SagaEventHandler;
+import org.axonframework.modelling.saga.StartSaga;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.time.Duration.ofSeconds;
+import static java.time.Instant.now;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+
+public class SagaTestFixtureTest {
+
+    private SagaTestFixture<MyTestSaga> fixture;
+    private AtomicInteger startRecordingCount;
+
+    @Before
+    public void before() {
+        fixture = new SagaTestFixture<>(MyTestSaga.class);
+        startRecordingCount = new AtomicInteger();
+        fixture.registerStartRecordingCallback(startRecordingCount::getAndIncrement);
+    }
+
+    @Test
+    public void startRecordingCallbackIsInvokedOnWhenPublishingAnEvent() throws Exception {
+        fixture.givenAPublished(new MyTestSaga.MyEvent());
+        assertThat(startRecordingCount.get(), equalTo(0));
+
+        fixture.whenPublishingA(new MyTestSaga.MyEvent());
+        assertThat(startRecordingCount.get(), equalTo(1));
+    }
+
+    @Test
+    public void startRecordingCallbackIsInvokedOnWhenTimeAdvances() throws Exception {
+        fixture.givenAPublished(new MyTestSaga.MyEvent());
+        assertThat(startRecordingCount.get(), equalTo(0));
+
+        fixture.whenTimeAdvancesTo(now());
+        assertThat(startRecordingCount.get(), equalTo(1));
+    }
+
+    @Test
+    public void startRecordingCallbackIsInvokedOnWhenTimeElapses() throws Exception {
+        fixture.givenAPublished(new MyTestSaga.MyEvent());
+        assertThat(startRecordingCount.get(), equalTo(0));
+
+        fixture.whenTimeElapses(ofSeconds(5));
+        assertThat(startRecordingCount.get(), equalTo(1));
+    }
+
+    public static class MyTestSaga {
+
+        @StartSaga
+        @SagaEventHandler(associationProperty = "id")
+        public void handle(MyEvent e) {
+            // don't care
+        }
+
+        public static class MyEvent {
+
+            public String getId() {
+                return "42";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note:
This PR is similar to #898, but made against (at time of writing) most recent master of 4.x+.

This change enables SagaFixture to register callbacks to be notified when the
recording of fixture execution results starts.

This is particularly helpful to testing scenarios where a Saga collaborator
resource(s) is injected which is not a well known Axon collaborator (such as
e.g. CommandGateway), but is interested in having its interactions verified,
local to a specific Saga message handling.