### PR TITLE
Exception results are not properly sent to AxonServer

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExceptionSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExceptionSerializer.java
@@ -2,6 +2,8 @@ package org.axonframework.axonserver.connector.util;
 
 import io.axoniq.axonserver.grpc.ErrorMessage;
 
+import static org.axonframework.common.ObjectUtils.getOrDefault;
+
 /**
  * Author: marc
  */
@@ -9,7 +11,7 @@ public class ExceptionSerializer {
     public static ErrorMessage serialize(String client, Throwable t) {
         if( t.getCause() != null)
             t = t.getCause();
-        ErrorMessage.Builder builder = ErrorMessage.newBuilder().setLocation(client).setMessage(
+        ErrorMessage.Builder builder = ErrorMessage.newBuilder().setLocation(getOrDefault(client, "")).setMessage(
                 t.getMessage() == null ? t.getClass().getName() : t.getMessage());
         builder.addDetails(t.getMessage() == null ? t.getClass().getName() : t.getMessage());
         while(t.getCause() != null) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ExceptionSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ExceptionSerializerTest.java
@@ -1,0 +1,27 @@
+package org.axonframework.axonserver.connector.util;
+
+import io.axoniq.axonserver.grpc.ErrorMessage;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Author: marc
+ */
+public class ExceptionSerializerTest {
+    @Test
+    public void serializeNullClient() {
+        ErrorMessage result = ExceptionSerializer.serialize(null,
+                                                            new RuntimeException(
+                                                                    "Something went wrong"));
+        assertEquals("", result.getLocation());
+    }
+
+    @Test
+    public void serializeNonNullClient() {
+        ErrorMessage result = ExceptionSerializer.serialize("Client",
+                                                            new RuntimeException(
+                                                                    "Something went wrong"));
+        assertEquals("Client", result.getLocation());
+    }
+}


### PR DESCRIPTION
When an exception occurs in a Command or Query Handler, this exception is not properly serialized into a protobuf message. As a result, senders aren't notified of the exception and receive a timeout.