### PR TITLE
[#911]  JdbcEventStorageEngine should cope with potential Aggregate Event Stream gaps

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -43,7 +43,7 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
 
     private static final int DEFAULT_BATCH_SIZE = 100;
 
-    protected final int batchSize;
+    private final int batchSize;
 
     /**
      * Initializes an EventStorageEngine with given {@code serializer}, {@code upcasterChain}, {@code
@@ -137,9 +137,9 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
                                                                             long firstSequenceNumber, int batchSize);
 
     /**
-     * Return a {@code boolean} specifying whether {@link #readEventData(String, long)} should proceed fetching events
-     * for an aggregate until an empty batch is returned. Defaults to {@code false}, as Aggregate event batches
-     * typically do not have gaps in them.
+     * Specifies whether the {@link #readEventData(String, long)} should proceed fetching events for an aggregate until
+     * an empty batch is returned. Defaults to {@code false}, as Aggregate event batches typically do not have gaps in
+     * them.
      *
      * @return a {@code boolean} specifying whether {@link #readEventData(String, long)} should proceed fetching events
      * for an aggregate until an empty batch is returned

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -42,7 +42,8 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
 public abstract class BatchingEventStorageEngine extends AbstractEventStorageEngine {
 
     private static final int DEFAULT_BATCH_SIZE = 100;
-    private final int batchSize;
+
+    protected final int batchSize;
 
     /**
      * Initializes an EventStorageEngine with given {@code serializer}, {@code upcasterChain}, {@code
@@ -170,13 +171,14 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
         private final Function<T, List<? extends T>> fetchFunction;
         private final int batchSize;
         private final boolean fetchUntilEmpty;
+
         private Iterator<? extends T> iterator;
         private T lastItem;
         private int sizeOfLastBatch;
 
-        protected EventStreamSpliterator(Function<T, List<? extends T>> fetchFunction,
-                                         int batchSize,
-                                         boolean fetchUntilEmpty) {
+        public EventStreamSpliterator(Function<T, List<? extends T>> fetchFunction,
+                                      int batchSize,
+                                      boolean fetchUntilEmpty) {
             super(Long.MAX_VALUE, NONNULL | ORDERED | DISTINCT | CONCURRENT);
             this.fetchFunction = fetchFunction;
             this.batchSize = batchSize;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -165,7 +165,7 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
         return batchSize;
     }
 
-    private static class EventStreamSpliterator<T> extends Spliterators.AbstractSpliterator<T> {
+    protected static class EventStreamSpliterator<T> extends Spliterators.AbstractSpliterator<T> {
 
         private final Function<T, List<? extends T>> fetchFunction;
         private final int batchSize;
@@ -174,8 +174,9 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
         private T lastItem;
         private int sizeOfLastBatch;
 
-        private EventStreamSpliterator(Function<T, List<? extends T>> fetchFunction, int batchSize,
-                                       boolean fetchUntilEmpty) {
+        protected EventStreamSpliterator(Function<T, List<? extends T>> fetchFunction,
+                                         int batchSize,
+                                         boolean fetchUntilEmpty) {
             super(Long.MAX_VALUE, NONNULL | ORDERED | DISTINCT | CONCURRENT);
             this.fetchFunction = fetchFunction;
             this.batchSize = batchSize;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -97,8 +97,7 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
      */
     public BatchingEventStorageEngine(Serializer snapshotSerializer, EventUpcaster upcasterChain,
                                       PersistenceExceptionResolver persistenceExceptionResolver,
-                                      Serializer eventSerializer, Predicate<? super DomainEventData<?>> snapshotFilter,
-                                      Integer batchSize) {
+                                      Serializer eventSerializer, Predicate<? super DomainEventData<?>> snapshotFilter, Integer batchSize) {
         super(snapshotSerializer, upcasterChain, persistenceExceptionResolver, eventSerializer, snapshotFilter);
         this.batchSize = getOrDefault(batchSize, DEFAULT_BATCH_SIZE);
     }

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -47,6 +47,8 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.lang.String.format;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
@@ -411,6 +413,15 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
                                 format("Failed to read events for aggregate [%s]", aggregateIdentifier), e
                         )
                 ));
+    }
+
+    @Override
+    protected Stream<? extends DomainEventData<?>> readEventData(String identifier, long firstSequenceNumber) {
+        EventStreamSpliterator<? extends DomainEventData<?>> spliterator = new EventStreamSpliterator<>(
+                lastItem -> fetchDomainEvents(identifier,
+                                              lastItem == null ? firstSequenceNumber : lastItem.getSequenceNumber() + 1,
+                                              batchSize), batchSize, true);
+        return StreamSupport.stream(spliterator, false);
     }
 
     @Override

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -47,8 +47,6 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static java.lang.String.format;
 import static org.axonframework.common.DateTimeUtils.formatInstant;

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -416,12 +416,8 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     @Override
-    protected Stream<? extends DomainEventData<?>> readEventData(String identifier, long firstSequenceNumber) {
-        EventStreamSpliterator<? extends DomainEventData<?>> spliterator = new EventStreamSpliterator<>(
-                lastItem -> fetchDomainEvents(identifier,
-                                              lastItem == null ? firstSequenceNumber : lastItem.getSequenceNumber() + 1,
-                                              batchSize), batchSize, true);
-        return StreamSupport.stream(spliterator, false);
+    protected boolean fetchForAggregateUntilEmpty() {
+        return true;
     }
 
     @Override

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
@@ -216,7 +216,7 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
     }
 
     @Test
-    public void testReadEventDataForAggregateReturnsTheCompleteStream() {
+    public void testReadEventsForAggregateReturnsTheCompleteStream() {
         testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
                                    defaultPersistenceExceptionResolver,
                                    new EventSchema(),
@@ -232,7 +232,8 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
 
         testSubject.appendEvents(testEventOne, testEventTwo, testEventThree, testEventFour, testEventFive);
 
-        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+        List<? extends DomainEventMessage<?>> result = testSubject.readEvents(AGGREGATE, 0L).asStream()
+                                                                  .collect(toList());
 
         assertEquals(5, result.size());
         assertEquals(0, result.get(0).getSequenceNumber());
@@ -243,7 +244,7 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
     }
 
     @Test
-    public void testReadEventDataForAggregateWithGapsReturnsTheCompleteStream() {
+    public void testReadEventsForAggregateWithGapsReturnsTheCompleteStream() {
         testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
                                    defaultPersistenceExceptionResolver,
                                    new EventSchema(),
@@ -259,7 +260,8 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
 
         testSubject.appendEvents(testEventOne, testEventTwo, testEventFour, testEventFive);
 
-        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+        List<? extends DomainEventMessage<?>> result = testSubject.readEvents(AGGREGATE, 0L).asStream()
+                                                                  .collect(toList());
 
         assertEquals(4, result.size());
         assertEquals(0, result.get(0).getSequenceNumber());
@@ -269,7 +271,7 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
     }
 
     @Test
-    public void testReadEventDataForAggregateWithEventsExceedingOneBatchReturnsTheCompleteStream() {
+    public void testReadEventsForAggregateWithEventsExceedingOneBatchReturnsTheCompleteStream() {
         // Set batch size to 5, so that the number of events exceeds at least one batch
         int batchSize = 5;
         testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
@@ -293,7 +295,8 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
                 testEventEight
         );
 
-        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+        List<? extends DomainEventMessage<?>> result = testSubject.readEvents(AGGREGATE, 0L).asStream()
+                                                                  .collect(toList());
 
         assertEquals(8, result.size());
         assertEquals(0, result.get(0).getSequenceNumber());
@@ -307,7 +310,7 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
     }
 
     @Test
-    public void testReadEventDataForAggregateWithEventsExceedingOneBatchAndGapsReturnsTheCompleteStream() {
+    public void testReadEventsForAggregateWithEventsExceedingOneBatchAndGapsReturnsTheCompleteStream() {
         // Set batch size to 5, so that the number of events exceeds at least one batch
         int batchSize = 5;
         testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
@@ -331,7 +334,8 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
                 testEventEight
         );
 
-        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+        List<? extends DomainEventMessage<?>> result = testSubject.readEvents(AGGREGATE, 0L).asStream()
+                                                                  .collect(toList());
 
         assertEquals(7, result.size());
         assertEquals(0, result.get(0).getSequenceNumber());

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
@@ -19,14 +19,20 @@ package org.axonframework.eventsourcing.eventstore.jdbc;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.axonframework.eventsourcing.eventstore.*;
+import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngineTest;
+import org.axonframework.eventsourcing.eventstore.DomainEventData;
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
+import org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken;
+import org.axonframework.eventsourcing.eventstore.TrackedEventData;
+import org.axonframework.eventsourcing.eventstore.TrackingEventStream;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.hsqldb.jdbc.JDBCDataSource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.springframework.test.annotation.DirtiesContext;
 
 import java.sql.Connection;
@@ -46,8 +52,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.AGGREGATE;
 import static org.axonframework.eventsourcing.eventstore.EventStoreTestUtils.createEvent;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Rene de Waele
@@ -208,6 +213,134 @@ public class JdbcEventStorageEngineTest extends BatchingEventStorageEngineTest {
 
         testSubject.storeSnapshot(createEvent(1));
         assertFalse(testSubject.readSnapshot(AGGREGATE).isPresent());
+    }
+
+    @Test
+    public void testReadEventDataForAggregateReturnsTheCompleteStream() {
+        testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
+                                   defaultPersistenceExceptionResolver,
+                                   new EventSchema(),
+                                   byte[].class,
+                                   HsqlEventTableFactory.INSTANCE,
+                                   10);
+
+        DomainEventMessage<String> testEventOne = createEvent(0);
+        DomainEventMessage<String> testEventTwo = createEvent(1);
+        DomainEventMessage<String> testEventThree = createEvent(2);
+        DomainEventMessage<String> testEventFour = createEvent(3);
+        DomainEventMessage<String> testEventFive = createEvent(4);
+
+        testSubject.appendEvents(testEventOne, testEventTwo, testEventThree, testEventFour, testEventFive);
+
+        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+
+        assertEquals(5, result.size());
+        assertEquals(0, result.get(0).getSequenceNumber());
+        assertEquals(1, result.get(1).getSequenceNumber());
+        assertEquals(2, result.get(2).getSequenceNumber());
+        assertEquals(3, result.get(3).getSequenceNumber());
+        assertEquals(4, result.get(4).getSequenceNumber());
+    }
+
+    @Test
+    public void testReadEventDataForAggregateWithGapsReturnsTheCompleteStream() {
+        testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
+                                   defaultPersistenceExceptionResolver,
+                                   new EventSchema(),
+                                   byte[].class,
+                                   HsqlEventTableFactory.INSTANCE,
+                                   10);
+
+        DomainEventMessage<String> testEventOne = createEvent(0);
+        DomainEventMessage<String> testEventTwo = createEvent(1);
+        // Event with sequence number 2 is missing -> the gap
+        DomainEventMessage<String> testEventFour = createEvent(3);
+        DomainEventMessage<String> testEventFive = createEvent(4);
+
+        testSubject.appendEvents(testEventOne, testEventTwo, testEventFour, testEventFive);
+
+        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+
+        assertEquals(4, result.size());
+        assertEquals(0, result.get(0).getSequenceNumber());
+        assertEquals(1, result.get(1).getSequenceNumber());
+        assertEquals(3, result.get(2).getSequenceNumber());
+        assertEquals(4, result.get(3).getSequenceNumber());
+    }
+
+    @Test
+    public void testReadEventDataForAggregateWithEventsExceedingOneBatchReturnsTheCompleteStream() {
+        // Set batch size to 5, so that the number of events exceeds at least one batch
+        int batchSize = 5;
+        testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
+                                   defaultPersistenceExceptionResolver,
+                                   new EventSchema(),
+                                   byte[].class,
+                                   HsqlEventTableFactory.INSTANCE,
+                                   batchSize);
+
+        DomainEventMessage<String> testEventOne = createEvent(0);
+        DomainEventMessage<String> testEventTwo = createEvent(1);
+        DomainEventMessage<String> testEventThree = createEvent(2);
+        DomainEventMessage<String> testEventFour = createEvent(3);
+        DomainEventMessage<String> testEventFive = createEvent(4);
+        DomainEventMessage<String> testEventSix = createEvent(5);
+        DomainEventMessage<String> testEventSeven = createEvent(6);
+        DomainEventMessage<String> testEventEight = createEvent(7);
+
+        testSubject.appendEvents(
+                testEventOne, testEventTwo, testEventThree, testEventFour, testEventFive, testEventSix, testEventSeven,
+                testEventEight
+        );
+
+        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+
+        assertEquals(8, result.size());
+        assertEquals(0, result.get(0).getSequenceNumber());
+        assertEquals(1, result.get(1).getSequenceNumber());
+        assertEquals(2, result.get(2).getSequenceNumber());
+        assertEquals(3, result.get(3).getSequenceNumber());
+        assertEquals(4, result.get(4).getSequenceNumber());
+        assertEquals(5, result.get(5).getSequenceNumber());
+        assertEquals(6, result.get(6).getSequenceNumber());
+        assertEquals(7, result.get(7).getSequenceNumber());
+    }
+
+    @Test
+    public void testReadEventDataForAggregateWithEventsExceedingOneBatchAndGapsReturnsTheCompleteStream() {
+        // Set batch size to 5, so that the number of events exceeds at least one batch
+        int batchSize = 5;
+        testSubject = createEngine(NoOpEventUpcaster.INSTANCE,
+                                   defaultPersistenceExceptionResolver,
+                                   new EventSchema(),
+                                   byte[].class,
+                                   HsqlEventTableFactory.INSTANCE,
+                                   batchSize);
+
+        DomainEventMessage<String> testEventOne = createEvent(0);
+        DomainEventMessage<String> testEventTwo = createEvent(1);
+        // Event with sequence number 2 is missing -> the gap
+        DomainEventMessage<String> testEventFour = createEvent(3);
+        DomainEventMessage<String> testEventFive = createEvent(4);
+        DomainEventMessage<String> testEventSix = createEvent(5);
+        DomainEventMessage<String> testEventSeven = createEvent(6);
+        DomainEventMessage<String> testEventEight = createEvent(7);
+
+        testSubject.appendEvents(
+                testEventOne, testEventTwo, testEventFour, testEventFive, testEventSix, testEventSeven,
+                testEventEight
+        );
+
+        List<? extends DomainEventData<?>> result = testSubject.readEventData(AGGREGATE, 0L).collect(toList());
+
+        assertEquals(7, result.size());
+        assertEquals(0, result.get(0).getSequenceNumber());
+        assertEquals(1, result.get(1).getSequenceNumber());
+        assertEquals(3, result.get(2).getSequenceNumber());
+        assertEquals(4, result.get(3).getSequenceNumber());
+        assertEquals(5, result.get(4).getSequenceNumber());
+        assertEquals(6, result.get(5).getSequenceNumber());
+        assertEquals(7, result.get(6).getSequenceNumber());
     }
 
     @Override


### PR DESCRIPTION
This PR introduces a fix so that the `JdbcEventStorageEngine` will enforce further retrieval of events from the database, even if the retrieved batch contained gaps.
It does so by overriding the `BatchingEventStorageEngine.readEventData(String, long)` function and using the `EventStreamSpliterator` (which was made protected) with `fetchUntilEmpty` set to false.
Doing so will ensure that the `EventStreamSpliterator` notices it should fetch another batch of events, which enables this functionality to retrieve all the events for a given Aggregate regardless of any gaps in the Aggregate's event stream.

This PR resolves #911.