### PR TITLE
[#915] Make Event Consumption optimization adjustable

### DIFF
--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -194,18 +194,15 @@ public class EmbeddedEventStore extends AbstractEventStore {
         producer = new EventProducer(timeUnit.toNanos(fetchDelay), cachedEvents);
         cleanupDelayMillis = timeUnit.toMillis(cleanupDelay);
         this.optimizeEventConsumption = getOrDefault(
-                optimizeEventConsumption,
-                EmbeddedEventStore::fetchEventConsumptionSystemPropertyOrDefault
+                optimizeEventConsumption, EmbeddedEventStore::fetchEventConsumptionSystemPropertyOrDefault
         );
     }
 
     private static boolean fetchEventConsumptionSystemPropertyOrDefault() {
-        try {
-            return Boolean.valueOf(System.getProperty(OPTIMIZE_EVENT_CONSUMPTION_SYSTEM_PROPERTY));
-        } catch (Exception e) {
-            // Ignore exception of instantiating this field based on a system property; default to true
-            return OPTIMIZE_EVENT_CONSUMPTION;
-        }
+        String optimizeEventConsumptionSystemProperty = System.getProperty(OPTIMIZE_EVENT_CONSUMPTION_SYSTEM_PROPERTY);
+        return optimizeEventConsumptionSystemProperty == null
+                ? OPTIMIZE_EVENT_CONSUMPTION // Default to optimize event consumption of no property has been set
+                : Boolean.TRUE.toString().equalsIgnoreCase(optimizeEventConsumptionSystemProperty);
     }
 
     /**

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -239,7 +239,7 @@ public class EmbeddedEventStore extends AbstractEventStore {
     public TrackingEventStream openStream(TrackingToken trackingToken) {
         Node node = findNode(trackingToken);
         EventConsumer eventConsumer;
-        if (node != null) {
+        if (node != null && optimizeEventConsumption) {
             eventConsumer = new EventConsumer(node);
             tailingConsumers.add(eventConsumer);
         } else {
@@ -419,7 +419,7 @@ public class EmbeddedEventStore extends AbstractEventStore {
         }
 
         private TrackedEventMessage<?> peek(int timeout, TimeUnit timeUnit) throws InterruptedException {
-            boolean allowSwitchToTailingConsumer = true;
+            boolean allowSwitchToTailingConsumer = optimizeEventConsumption;
             if (tailingConsumers.contains(this)) {
                 if (!behindGlobalCache()) {
                     return peekGlobalStream(timeout, timeUnit);

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -155,7 +155,10 @@ public class EmbeddedEventStore extends AbstractEventStore {
     public EmbeddedEventStore(EventStorageEngine storageEngine, MessageMonitor<? super EventMessage<?>> monitor,
                               int cachedEvents, long fetchDelay, long cleanupDelay, TimeUnit timeUnit,
                               ThreadFactory threadFactory) {
-        this(storageEngine, monitor, cachedEvents, fetchDelay, cleanupDelay, timeUnit, threadFactory, null);
+        this(
+                storageEngine, monitor, cachedEvents, fetchDelay, cleanupDelay, timeUnit, threadFactory,
+                fetchEventConsumptionSystemPropertyOrDefault()
+        );
     }
 
     /**
@@ -191,15 +194,13 @@ public class EmbeddedEventStore extends AbstractEventStore {
      */
     public EmbeddedEventStore(EventStorageEngine storageEngine, MessageMonitor<? super EventMessage<?>> monitor,
                               int cachedEvents, long fetchDelay, long cleanupDelay, TimeUnit timeUnit,
-                              ThreadFactory threadFactory, Boolean optimizeEventConsumption) {
+                              ThreadFactory threadFactory, boolean optimizeEventConsumption) {
         super(storageEngine, monitor);
         this.threadFactory = threadFactory;
         cleanupService = Executors.newScheduledThreadPool(1, this.threadFactory);
         producer = new EventProducer(timeUnit.toNanos(fetchDelay), cachedEvents);
         cleanupDelayMillis = timeUnit.toMillis(cleanupDelay);
-        this.optimizeEventConsumption = getOrDefault(
-                optimizeEventConsumption, EmbeddedEventStore::fetchEventConsumptionSystemPropertyOrDefault
-        );
+        this.optimizeEventConsumption = optimizeEventConsumption;
     }
 
     private static boolean fetchEventConsumptionSystemPropertyOrDefault() {

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -42,7 +42,6 @@ import java.util.stream.Stream;
 import javax.annotation.PreDestroy;
 
 import static java.util.stream.Collectors.toList;
-import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
  * Implementation of an {@link EventStore} that stores and fetches events using an {@link EventStorageEngine}. If
@@ -53,6 +52,11 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * events. This cache is shared between the streams of various event processors. So, assuming an event processor
  * processes events fast enough and is not far behind the head of the event log it will not need a private connection
  * to the underlying data store. The size of the cache (in number of events) is configurable.
+ * This 'event consumption optimization' might in some scenarios not be desirable, as it will spin up additional threads
+ * and perform some locking operations. Hence it is switchable by using the
+ * {@link #EmbeddedEventStore(EventStorageEngine, MessageMonitor, int, long, long, TimeUnit, ThreadFactory, boolean)}
+ * constructor and provided a {@code false} for the last parameter. Additionally, this can also be turned off by
+ * providing a system property with key {@code optimize-event-consumption}.
  * <p>
  * The embedded event store automatically fetches new events from the store if there is at least one registered tracking
  * event processor present. It will do so after new events are committed to the store, as well as periodically as

--- a/core/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/core/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.eventstore.inmemory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventsourcing.DomainEventMessage;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken;
@@ -30,13 +31,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.axonframework.eventsourcing.eventstore.EventUtils.asTrackedEventMessage;
 
@@ -72,10 +76,7 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
      */
     @Override
     public Stream<? extends TrackedEventMessage<?>> readEvents(TrackingToken trackingToken, boolean mayBlock) {
-        if (trackingToken == null) {
-            return events.values().stream();
-        }
-        return events.tailMap(trackingToken, false).values().stream();
+        return StreamSupport.stream(new MapEntrySpliterator(events, trackingToken), false);
     }
 
     @Override
@@ -133,5 +134,32 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
     protected GlobalSequenceTrackingToken nextTrackingToken() {
         return events.isEmpty() ? new GlobalSequenceTrackingToken(0) :
                 ((GlobalSequenceTrackingToken) events.lastKey()).next();
+    }
+
+    private static class MapEntrySpliterator extends Spliterators.AbstractSpliterator<TrackedEventMessage<?>> {
+
+        private final NavigableMap<TrackingToken, TrackedEventMessage<?>> source;
+        private volatile TrackingToken lastToken;
+
+        public MapEntrySpliterator(NavigableMap<TrackingToken, TrackedEventMessage<?>> source, TrackingToken trackingToken) {
+            super(Long.MAX_VALUE, Spliterator.ORDERED);
+            this.source = source;
+            this.lastToken = trackingToken;
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super TrackedEventMessage<?>> action) {
+            Map.Entry<TrackingToken, TrackedEventMessage<?>> next;
+            if (lastToken != null) {
+                next = source.higherEntry(lastToken);
+            } else {
+                next = source.firstEntry();
+            }
+            if (next != null) {
+                lastToken = next.getKey();
+                action.accept(next.getValue());
+            }
+            return next != null;
+        }
     }
 }

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -27,12 +27,9 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.monitoring.NoOpMessageMonitor;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+import org.junit.*;
+import org.mockito.invocation.*;
+import org.mockito.stubbing.*;
 
 import java.util.Iterator;
 import java.util.List;
@@ -58,6 +55,7 @@ public class EmbeddedEventStoreTest {
     private static final int CACHED_EVENTS = 10;
     private static final long FETCH_DELAY = 1000;
     private static final long CLEANUP_DELAY = 10000;
+    private static final boolean OPTIMIZE_EVENT_CONSUMPTION = true;
 
     private EmbeddedEventStore testSubject;
     private EventStorageEngine storageEngine;
@@ -67,13 +65,16 @@ public class EmbeddedEventStoreTest {
     public void setUp() {
         storageEngine = spy(new InMemoryEventStorageEngine());
         threadFactory = spy(new AxonThreadFactory(EmbeddedEventStore.class.getSimpleName()));
-        newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY);
+        newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY, OPTIMIZE_EVENT_CONSUMPTION);
     }
 
-    private void newTestSubject(int cachedEvents, long fetchDelay, long cleanupDelay) {
+    private void newTestSubject(int cachedEvents,
+                                long fetchDelay,
+                                long cleanupDelay,
+                                boolean optimizeEventConsumption) {
         Optional.ofNullable(testSubject).ifPresent(EmbeddedEventStore::shutDown);
         testSubject = new EmbeddedEventStore(storageEngine, NoOpMessageMonitor.INSTANCE, cachedEvents, fetchDelay,
-                                             cleanupDelay, MILLISECONDS, threadFactory);
+                                             cleanupDelay, MILLISECONDS, threadFactory, optimizeEventConsumption);
     }
 
     @After
@@ -167,7 +168,7 @@ public class EmbeddedEventStoreTest {
 
     @Test(timeout = 5000)
     public void testPeriodicPollingWhenEventStorageIsUpdatedIndependently() throws Exception {
-        newTestSubject(CACHED_EVENTS, 20, CLEANUP_DELAY);
+        newTestSubject(CACHED_EVENTS, 20, CLEANUP_DELAY, OPTIMIZE_EVENT_CONSUMPTION);
         TrackingEventStream stream = testSubject.openStream(null);
         CountDownLatch lock = new CountDownLatch(1);
         Thread t = new Thread(() -> stream.asStream().findFirst().ifPresent(event -> lock.countDown()));
@@ -180,7 +181,7 @@ public class EmbeddedEventStoreTest {
 
     @Test(timeout = 5000)
     public void testConsumerStopsTailingWhenItFallsBehindTheCache() throws Exception {
-        newTestSubject(CACHED_EVENTS, FETCH_DELAY, 20);
+        newTestSubject(CACHED_EVENTS, FETCH_DELAY, 20, OPTIMIZE_EVENT_CONSUMPTION);
         TrackingEventStream stream = testSubject.openStream(null);
         assertFalse(stream.hasNextAvailable()); //now we should be tailing
         testSubject.publish(createEvents(CACHED_EVENTS)); //triggers event producer to open a stream
@@ -217,7 +218,7 @@ public class EmbeddedEventStoreTest {
     /* Reproduces issue reported in https://github.com/AxonFramework/AxonFramework/issues/485 */
     @Test
     public void testStreamEventsShouldNotReturnDuplicateTokens() throws InterruptedException {
-        newTestSubject(0, 1000, 1000);
+        newTestSubject(0, 1000, 1000, OPTIMIZE_EVENT_CONSUMPTION);
         Stream mockStream = mock(Stream.class);
         Iterator mockIterator = mock(Iterator.class);
         when(mockStream.iterator()).thenReturn(mockIterator);
@@ -303,6 +304,66 @@ public class EmbeddedEventStoreTest {
         assertEquals(0, lock.getCount());
 
         verify(threadFactory, atLeastOnce()).newThread(any(Runnable.class));
+    }
+
+    @Test
+    public void testOpenStreamReadsEventsFromAnEventProducedByVerifyThreadFactoryOperation() throws InterruptedException {
+        TrackingEventStream eventStream = testSubject.openStream(null);
+
+        assertFalse(eventStream.hasNextAvailable()); // There are no events published yet, so stream will tail
+        testSubject.publish(createEvents(5));// Publish some events which should be returned to the stream by a producer
+
+        Thread.sleep(100); // Give the Event Producer thread time to fill the cache
+        assertTrue(eventStream.hasNextAvailable()); // Stream should contain events again, from the producer
+
+        // Consume events until the end
+        while (eventStream.hasNextAvailable()) {
+            eventStream.nextAvailable();
+        }
+
+        assertFalse(eventStream.hasNextAvailable()); // Should have reached the end, hence returned false
+
+        verify(threadFactory, atLeastOnce()).newThread(any(Runnable.class)); // Verify a producer thread was created
+    }
+
+    @Test
+    public void testTailingConsumptionThreadIsNeverCreatedIfEventConsumptionOptimizationIsSwitchedOff()
+            throws InterruptedException {
+        boolean doNotOptimizeEventConsumption = false;
+        //noinspection ConstantConditions
+        newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY, doNotOptimizeEventConsumption);
+
+        TrackingEventStream eventStream = testSubject.openStream(null);
+        testSubject.publish(createEvents(5));
+
+        // Consume some events
+        while (eventStream.hasNextAvailable()) {
+            eventStream.nextAvailable();
+        }
+
+        // No tailing-consumer Producer thread has ever been created
+        verifyZeroInteractions(threadFactory);
+    }
+
+    @Test
+    public void testEventStreamKeepsReturningEventsIfEventConsumptionOptimizationIsSwitchedOff()
+            throws InterruptedException {
+        boolean doNotOptimizeEventConsumption = false;
+        //noinspection ConstantConditions
+        newTestSubject(CACHED_EVENTS, FETCH_DELAY, CLEANUP_DELAY, doNotOptimizeEventConsumption);
+
+        TrackingEventStream eventStream = testSubject.openStream(null);
+
+        assertFalse(eventStream.hasNextAvailable()); // There are no events published yet, so should be false
+
+        testSubject.publish(createEvents(5)); // Publish some events which should be returned to the stream
+
+        assertTrue(eventStream.hasNextAvailable()); // There are new events, so should be true
+        // Consume until the end
+        while (eventStream.hasNextAvailable()) {
+            eventStream.nextAvailable();
+        }
+        assertFalse(eventStream.hasNextAvailable()); // Should have no events anymore
     }
 
     private static class SynchronizedBooleanAnswer implements Answer<Boolean> {

--- a/core/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
+++ b/core/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
@@ -13,19 +13,34 @@
 
 package org.axonframework.eventsourcing.eventstore.inmemory;
 
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngineTest;
 import org.junit.Before;
+import org.junit.Test;
 
-import java.sql.SQLException;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Rene de Waele
  */
 public class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
 
+    private InMemoryEventStorageEngine testSubject;
+
     @Before
     public void setUp() {
-        setTestSubject(new InMemoryEventStorageEngine());
+        testSubject = new InMemoryEventStorageEngine();
+        setTestSubject(testSubject);
     }
 
+    @Test
+    public void testPublishedEventsEmittedToExistingStreams() {
+        Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
+        testSubject.appendEvents(GenericEventMessage.asEventMessage("test"));
+
+        assertTrue(stream.findFirst().isPresent());
+    }
 }


### PR DESCRIPTION
This PR introduces a `boolean` field which enables or disable 'event consumption optimization' in the `EmbeddedEventStore`. The `EmbeddedEventStore` has logic in place to let several Event Consumer read events from the same event-stream-tailing consumer. There might however be scenario that this optimization is not desirable, hence opening it up to be switched off is desirable. 

The default approach to this is `true` as that's what the `EmbeddedEventStore` used to do initial.
To adjust the `optimizeEventConsumption` field, one could either create the `EmbeddedEventStore` themselves and provide this field through the constructor. If something like Spring (Boot) is used to instantiate the Axon application, this might not be desirable. To that end, we've opened up the option to provide a System property under the key `optimize-event-consumption`.