### PR TITLE
JacksonSerializer caching of classForType method

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -26,17 +26,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.AnnotationRevisionResolver;
-import org.axonframework.serialization.ChainingConverter;
-import org.axonframework.serialization.Converter;
-import org.axonframework.serialization.RevisionResolver;
-import org.axonframework.serialization.SerializationException;
-import org.axonframework.serialization.SerializedObject;
-import org.axonframework.serialization.SerializedType;
-import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.SimpleSerializedObject;
-import org.axonframework.serialization.SimpleSerializedType;
-import org.axonframework.serialization.UnknownSerializedType;
+import org.axonframework.serialization.*;
 
 import java.io.IOException;
 import java.util.Map;
@@ -78,7 +68,7 @@ public class JacksonSerializer implements Serializer {
         this.classLoader = builder.classLoader;
 
         this.objectMapper.registerModule(
-            new SimpleModule("Axon-Jackson Module").addDeserializer(MetaData.class, new MetaDataDeserializer())
+                new SimpleModule("Axon-Jackson Module").addDeserializer(MetaData.class, new MetaDataDeserializer())
         );
         this.objectMapper.registerModule(new JavaTimeModule());
         if (converter instanceof ChainingConverter) {
@@ -121,13 +111,13 @@ public class JacksonSerializer implements Serializer {
             if (String.class.equals(expectedRepresentation)) {
                 //noinspection unchecked
                 return new SimpleSerializedObject<>((T) getWriter().writeValueAsString(object), expectedRepresentation,
-                    typeForClass(ObjectUtils.nullSafeTypeOf(object)));
+                                                    typeForClass(ObjectUtils.nullSafeTypeOf(object)));
             }
 
             byte[] serializedBytes = getWriter().writeValueAsBytes(object);
             T serializedContent = converter.convert(serializedBytes, expectedRepresentation);
             return new SimpleSerializedObject<>(serializedContent, expectedRepresentation,
-                typeForClass(ObjectUtils.nullSafeTypeOf(object)));
+                                                typeForClass(ObjectUtils.nullSafeTypeOf(object)));
         } catch (JsonProcessingException e) {
             throw new SerializationException("Unable to serialize object", e);
         }
@@ -166,7 +156,7 @@ public class JacksonSerializer implements Serializer {
     @Override
     public <T> boolean canSerializeTo(Class<T> expectedRepresentation) {
         return JsonNode.class.equals(expectedRepresentation) || String.class.equals(expectedRepresentation) ||
-            converter.canConvert(byte[].class, expectedRepresentation);
+                converter.canConvert(byte[].class, expectedRepresentation);
     }
 
     @Override
@@ -181,7 +171,7 @@ public class JacksonSerializer implements Serializer {
             }
             if (JsonNode.class.equals(serializedObject.getContentType())) {
                 return getReader(type)
-                    .readValue((JsonNode) serializedObject.getData());
+                        .readValue((JsonNode) serializedObject.getData());
             }
             SerializedObject<byte[]> byteSerialized = converter.convert(serializedObject, byte[].class);
             return getReader(type).readValue(byteSerialized.getData());

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -48,7 +48,7 @@ public class JacksonSerializer implements Serializer {
     private final Converter converter;
     private final ObjectMapper objectMapper;
     private final ClassLoader classLoader;
-    private final Map<String, Class> classForType = new ConcurrentHashMap<>();
+    private final Map<String, Class> classForTypeCache = new ConcurrentHashMap<>();
 
     /**
      * Instantiate a {@link JacksonSerializer} based on the fields contained in the {@link Builder}.
@@ -185,7 +185,7 @@ public class JacksonSerializer implements Serializer {
         if (SimpleSerializedType.emptyType().equals(type)) {
             return Void.class;
         }
-        return classForType.computeIfAbsent(resolveClassName(type), key -> {
+        return classForTypeCache.computeIfAbsent(resolveClassName(type), key -> {
             try {
                 return classLoader.loadClass(key);
             } catch (ClassNotFoundException e) {


### PR DESCRIPTION
https://github.com/AxonFramework/AxonFramework/issues/928

Hi,

During some profiling we have noticed that the JacksonSerializer does following call each time it deserializes an event:
return classLoader.loadClass(resolveClassName(type));

This is located in following method:
org.axonframework.serialization.json.JacksonSerializer#classForType

In a simple service the time and memory needed to load the class seems to be the biggest performance blocker. Moreover, going multi-threaded would not solve much because the loadClass method is synchronized.

Given that the result of this call will not change during the lifetime of the execution of an application I was wondering if it is beneficial to store an in-memory map of this result in order to not have to load the class for each event.

I think this would improve performance.