### PR TITLE
Fix GlobalSequenceTrackingToken.covers for Axon 4.0.x

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -497,8 +497,8 @@ public class TrackingEventProcessorTest {
         testSubject.resetTokens();
         testSubject.start();
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(8, handled.size()));
-        assertEquals(handled.subList(0, 3), handled.subList(4, 7));
-        assertEquals(handled.subList(4, 7), handledInRedelivery);
+        assertEquals(handled.subList(0, 4), handled.subList(4, 8));
+        assertEquals(handled.subList(4, 8), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
@@ -528,8 +528,8 @@ public class TrackingEventProcessorTest {
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(6, handled.size()));
         assertFalse(handledInRedelivery.contains(handled.get(0)));
         assertFalse(handledInRedelivery.contains(handled.get(1)));
-        assertEquals(handled.subList(2, 3), handled.subList(4, 5));
-        assertEquals(handled.subList(4, 5), handledInRedelivery);
+        assertEquals(handled.subList(2, 4), handled.subList(4, 6));
+        assertEquals(handled.subList(4, 6), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
@@ -576,8 +576,8 @@ public class TrackingEventProcessorTest {
         testSubject.resetTokens();
         testSubject.start();
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(4, handled.size()));
-        assertEquals(handled.subList(0, 1), handled.subList(2, 3));
-        assertEquals(handled.subList(2, 3), handledInRedelivery);
+        assertEquals(handled.subList(0, 2), handled.subList(2, 4));
+        assertEquals(handled.subList(2, 4), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));

--- a/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
@@ -100,7 +100,7 @@ public class GlobalSequenceTrackingToken implements TrackingToken, Comparable<Gl
         Assert.isTrue(other instanceof GlobalSequenceTrackingToken, () -> "Incompatible token type provided.");
         GlobalSequenceTrackingToken otherToken = (GlobalSequenceTrackingToken) other;
 
-        return otherToken.globalIndex < this.globalIndex;
+        return otherToken.globalIndex <= this.globalIndex;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
@@ -16,9 +16,9 @@
 
 package org.axonframework.eventhandling;
 
-import org.junit.Test;
+import static junit.framework.TestCase.*;
 
-import static junit.framework.TestCase.assertSame;
+import org.junit.Test;
 
 public class GlobalSequenceTrackingTokenTest {
 
@@ -30,5 +30,25 @@ public class GlobalSequenceTrackingTokenTest {
         assertSame(token2, token1.upperBound(token2));
         assertSame(token2, token2.upperBound(token1));
         assertSame(token2, token2.upperBound(token2));
+    }
+
+    @Test
+    public void testLowerBound() {
+        GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
+        GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
+
+        assertSame(token1, token1.lowerBound(token2));
+        assertSame(token1, token2.lowerBound(token1));
+        assertSame(token2, token2.lowerBound(token2));
+    }
+
+    @Test
+    public void testCovers() {
+        GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
+        GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
+
+        assertFalse(token1.covers(token2));
+        assertTrue(token2.covers(token1));
+        assertTrue(token2.covers(token2));
     }
 }


### PR DESCRIPTION
Hi,

As requested by @smcvb, this is a pull request of my earlier fix (see https://github.com/AxonFramework/AxonFramework/pull/930) but for 4.0.x instead of master.

Regards,
Jens De Wit