### PR TITLE
Add getter for the messageSource

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -419,7 +419,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
      * Returns the {@link StreamableMessageSource} this processor is using
      * @return {@link StreamableMessageSource}
      */
-    public StreamableMessageSource<TrackedEventMessage<?>> getMessageSource() {
+    public StreamableMessageSource<? extends TrackedEventMessage<?>> getMessageSource() {
         return messageSource;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -416,6 +416,14 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
     }
 
     /**
+     * Returns the {@link StreamableMessageSource} this processor is using
+     * @return {@link StreamableMessageSource}
+     */
+    public StreamableMessageSource<TrackedEventMessage<?>> getMessageSource() {
+        return messageSource;
+    }
+
+    /**
      * Shut down the processor.
      */
     @Override


### PR DESCRIPTION
Hi,

In our application we want to have monitoring in order to see where a tracking event processor is comparing to the head of the stream.  
In order to accomplish this in a 'generic' way we need access to the messageSource.  Currently we have worked around this using reflection but this is far from ideal.  A getter would be mush more useful.

`StreamableMessageSource messageSource = (StreamableMessageSource) FieldUtils.readField(trackingEventProcessor, "messageSource", true);
TrackingToken headToken = messageSource.createHeadToken();`