### PR TITLE
make org.axonframework.eventhandling.AbstractEventProcessor#eventHandlerInvoker public

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
@@ -165,7 +165,7 @@ public abstract class AbstractEventProcessor implements EventProcessor {
      *
      * @return the invoker assigned to this processor
      */
-    protected EventHandlerInvoker eventHandlerInvoker() {
+    public EventHandlerInvoker eventHandlerInvoker() {
         return eventHandlerInvoker;
     }
 


### PR DESCRIPTION
In our application we have built a system to handle errors more gracefully.
It is some kind of deadletter queue for events from a tracking event processor.

In order to replay those events I need access to the eventHandlerInvoker. Unfortunately the getter is protected. This pull request is to make it public.