### PR TITLE
Call ensureIndexes from constructors instead of @PostConstruct

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventstore/benchmark/mongo/MongoEventStoreBenchMark.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventstore/benchmark/mongo/MongoEventStoreBenchMark.java
@@ -46,7 +46,6 @@ public class MongoEventStoreBenchMark extends AbstractEventStoreBenchmark {
         DefaultMongoTemplate mongoTemplate = new DefaultMongoTemplate(mongoDb);
         mongoTemplate.eventCollection().drop();
         mongoTemplate.snapshotCollection().drop();
-        getStorageEngine().ensureIndexes();
         super.prepareForBenchmark();
     }
 

--- a/mongo/src/main/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
+++ b/mongo/src/main/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
@@ -31,7 +31,6 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.xml.XStreamSerializer;
 
-import javax.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -151,6 +150,7 @@ public class MongoEventStorageEngine extends BatchingEventStorageEngine {
         super(snapshotSerializer, upcasterChain, persistenceExceptionResolver, eventSerializer, batchSize);
         this.template = template;
         this.storageStrategy = storageStrategy;
+        ensureIndexes();
     }
 
     private static boolean isDuplicateKeyException(Exception exception) {
@@ -161,8 +161,7 @@ public class MongoEventStorageEngine extends BatchingEventStorageEngine {
     /**
      * Make sure an index is created on the collection that stores domain events.
      */
-    @PostConstruct
-    public void ensureIndexes() {
+    private void ensureIndexes() {
         storageStrategy.ensureIndexes(template.eventCollection(), template.snapshotCollection());
     }
 

--- a/mongo/src/main/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
+++ b/mongo/src/main/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
@@ -160,8 +160,13 @@ public class MongoEventStorageEngine extends BatchingEventStorageEngine {
 
     /**
      * Make sure an index is created on the collection that stores domain events.
+     *
+     * @deprecated  This method is now called by the constructor instead of the dependency injection framework running
+     *              the @PostConstruct. i.e. You no longer have to call it manually if you don't use a dependency
+     *              injection framework.
      */
-    private void ensureIndexes() {
+    @Deprecated
+    public void ensureIndexes() {
         storageStrategy.ensureIndexes(template.eventCollection(), template.snapshotCollection());
     }
 

--- a/mongo/src/main/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStore.java
+++ b/mongo/src/main/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStore.java
@@ -34,7 +34,6 @@ import org.bson.types.Binary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import java.lang.management.ManagementFactory;
 import java.time.Clock;
 import java.time.Duration;
@@ -96,6 +95,7 @@ public class MongoTokenStore implements TokenStore {
         this.claimTimeout = claimTimeout;
         this.nodeId = nodeId;
         this.contentType = contentType;
+        ensureIndexes();
     }
 
     @Override
@@ -292,8 +292,7 @@ public class MongoTokenStore implements TokenStore {
     /**
      * Creates the indexes required to work with the TokenStore.
      */
-    @PostConstruct
-    public void ensureIndexes() {
+    private void ensureIndexes() {
         mongoTemplate.trackingTokensCollection().createIndex(Indexes.ascending("processorName", "segment"),
                                                              new IndexOptions().unique(true));
     }

--- a/mongo/src/main/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStore.java
+++ b/mongo/src/main/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStore.java
@@ -291,8 +291,13 @@ public class MongoTokenStore implements TokenStore {
 
     /**
      * Creates the indexes required to work with the TokenStore.
+     *
+     * @deprecated  This method is now called by the constructor instead of the dependency injection framework running
+     *              the @PostConstruct. i.e. You no longer have to call it manually if you don't use a dependency
+     *              injection framework.
      */
-    private void ensureIndexes() {
+    @Deprecated
+    public void ensureIndexes() {
         mongoTemplate.trackingTokensCollection().createIndex(Indexes.ascending("processorName", "segment"),
                                                              new IndexOptions().unique(true));
     }

--- a/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
+++ b/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
@@ -95,8 +95,6 @@ public class MongoEventStorageEngineTest extends AbstractMongoEventStorageEngine
         mongoTemplate.snapshotCollection().deleteMany(new BasicDBObject());
         testSubject = context.getBean(MongoEventStorageEngine.class);
         setTestSubject(testSubject);
-
-        testSubject.ensureIndexes();
     }
 
     @Test

--- a/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
+++ b/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
@@ -91,8 +91,6 @@ public class MongoEventStorageEngineTest_DBObjectSerialization extends AbstractM
         mongoTemplate.snapshotCollection().dropIndexes();
         testSubject = context.getBean(MongoEventStorageEngine.class);
         setTestSubject(testSubject);
-
-        testSubject.ensureIndexes();
     }
 
     @Test

--- a/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
+++ b/mongo/src/test/java/org/axonframework/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
@@ -107,7 +107,6 @@ public class MongoEventStorageEngineTest_DocPerCommit extends AbstractMongoEvent
         mongoTemplate.snapshotCollection().dropIndexes();
         testSubject = context.getBean(MongoEventStorageEngine.class);
         setTestSubject(testSubject);
-        testSubject.ensureIndexes();
     }
 
     @Test
@@ -143,6 +142,7 @@ public class MongoEventStorageEngineTest_DocPerCommit extends AbstractMongoEvent
     }
 
     @Test
+    @DirtiesContext
     public void testFetchingEventsReturnsResultsWhenMoreThanBatchSizeCommitsAreAvailable_PartiallyReadingCommit() {
         testSubject.appendEvents(createEvent(0), createEvent(1), createEvent(2));
         testSubject.appendEvents(createEvent(3), createEvent(4), createEvent(5));

--- a/mongo/src/test/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
@@ -100,7 +100,6 @@ public class MongoTokenStoreTest {
                                          claimTimeout,
                                          testOwner,
                                          contentType);
-        tokenStore.ensureIndexes();
         tokenStoreDifferentOwner = new MongoTokenStore(mongoTemplate,
                                                        serializer,
                                                        claimTimeout,


### PR DESCRIPTION
This allows the use of MongoTokenStore in a non-dependency-injected
environment without shifting the burden of initialization onto the
programmer. This is particularly important because of the unintended
event replays which can occur if the @PostConstruct call is not called
manually.

This PR resolves #973