### PR TITLE
[#968] The IntervalRetryScheduler builder should provide sensible defaults

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
@@ -27,8 +27,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.common.BuilderUtils.assertThat;
+import static org.axonframework.common.BuilderUtils.*;
 
 /**
  * RetryScheduler implementation that retries commands at regular intervals when they fail because of an exception that
@@ -134,8 +133,8 @@ public class IntervalRetryScheduler implements RetryScheduler {
      */
     public static class Builder {
 
-        private int retryInterval;
-        private int maxRetryCount;
+        private int retryInterval = 100;
+        private int maxRetryCount = 1;
         private ScheduledExecutorService retryExecutor;
 
         /**
@@ -158,7 +157,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder maxRetryCount(int maxRetryCount) {
-            assertPositive(maxRetryCount, "The maxRetryCount must be a positive number");
+            assertStrictPositive(maxRetryCount, "The maxRetryCount must be a positive number");
             this.maxRetryCount = maxRetryCount;
             return this;
         }
@@ -192,12 +191,9 @@ public class IntervalRetryScheduler implements RetryScheduler {
          */
         protected void validate() throws AxonConfigurationException {
             assertPositive(retryInterval, "The retryInterval is a hard requirement and should be provided");
-            assertPositive(maxRetryCount, "The maxRetryCount is a hard requirement and should be provided");
+            assertStrictPositive(maxRetryCount, "The maxRetryCount is a hard requirement and should be provided");
             assertNonNull(retryExecutor, "The ScheduledExecutorService is a hard requirement and should be provided");
         }
 
-        private void assertPositive(int integer, String exceptionDescription) {
-            assertThat(integer, number -> number >= 0, exceptionDescription);
-        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
@@ -40,6 +40,9 @@ public class IntervalRetryScheduler implements RetryScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(IntervalRetryScheduler.class);
 
+    private static final int DEFAULT_RETRY_INTERVAL = 100;
+    private static final int DEFAULT_MAX_RETRIES = 1;
+
     private final int retryInterval;
     private final int maxRetryCount;
     private final ScheduledExecutorService retryExecutor;
@@ -133,8 +136,8 @@ public class IntervalRetryScheduler implements RetryScheduler {
      */
     public static class Builder {
 
-        private int retryInterval = 100;
-        private int maxRetryCount = 1;
+        private int retryInterval = DEFAULT_RETRY_INTERVAL;
+        private int maxRetryCount = DEFAULT_MAX_RETRIES;
         private ScheduledExecutorService retryExecutor;
 
         /**

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/IntervalRetryScheduler.java
@@ -66,6 +66,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
     /**
      * Instantiate a Builder to be able to create a {@link IntervalRetryScheduler}.
      * <p>
+     * The default for {@code retryInterval} is set to 100ms, while {@code maxRetryCount} gets a single retry.
      * The {@code retryInterval}, {@code maxRetryCount} and {@link ScheduledExecutorService} are
      * <b>hard requirements</b> and as such should be provided.
      *
@@ -110,7 +111,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
      * occur
      * again.
      *
-     * @param failure The exception that occurred while processing a command
+     * @param failure the exception that occurred while processing a command
      * @return {@code true} if the exception is clearly non-transient and the command should <em>not</em> be
      * retried, or {@code false} when the command has a chance of succeeding if it retried.
      */
@@ -131,6 +132,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
     /**
      * Builder class to instantiate a {@link IntervalRetryScheduler}.
      * <p>
+     * The default for {@code retryInterval} is set to 100ms, while {@code maxRetryCount} gets a single retry.
      * The {@code retryInterval}, {@code maxRetryCount} and {@link ScheduledExecutorService} are
      * <b>hard requirements</b> and as such should be provided.
      */
@@ -141,7 +143,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
         private ScheduledExecutorService retryExecutor;
 
         /**
-         * Sets the retry interval in milliseconds at which to schedule a retry.
+         * Sets the retry interval in milliseconds at which to schedule a retry, defaulted to 100ms.
          *
          * @param retryInterval an {@code int} specifying the retry interval in milliseconds at which to schedule a
          *                      retry
@@ -154,7 +156,7 @@ public class IntervalRetryScheduler implements RetryScheduler {
         }
 
         /**
-         * Sets the maximum number of retries allowed for a single command.
+         * Sets the maximum number of retries allowed for a single command, defaulted to 1.
          *
          * @param maxRetryCount an {@code int} specifying the maximum number of retries allowed for a single command
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
@@ -38,7 +38,7 @@ public abstract class BuilderUtils {
      *
      * @param value            a {@code T} specifying the value to assert
      * @param assertion        a {@link Predicate} to test {@code value} against
-     * @param exceptionMessage a {@link Supplier} of the exception {@code X} if {@code assertion} evaluates to false
+     * @param exceptionMessage The message for the exception.
      * @param <T>              a generic specifying the type of the {@code value}, which is the input for the
      *                         {@code assertion}
      * @throws AxonConfigurationException if the {@code value} asserts to {@code false} by the {@code assertion}
@@ -54,11 +54,34 @@ public abstract class BuilderUtils {
      * containing the provided {@code exceptionMessage}.
      *
      * @param value a {@code T} specifying the value to assert
+     * @param exceptionMessage The message for the exception.
      * @param <T>   a generic specifying the type of the {@code value}, which is the input for the
      *              {@code assertion}
      * @throws AxonConfigurationException if the {@code value} equals {@code null}
      */
     public static <T> void assertNonNull(T value, String exceptionMessage) throws AxonConfigurationException {
         assertThat(value, Objects::nonNull, exceptionMessage);
+    }
+
+    /**
+     * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an
+     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     *
+     * @param integer The value to assert
+     * @param exceptionMessage The message for the exception.
+     */
+    public static void assertPositive(int integer, String exceptionMessage) {
+        assertThat(integer, number -> number >= 0, exceptionMessage);
+    }
+
+    /**
+     * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an
+     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     *
+     * @param integer The value to assert
+     * @param exceptionMessage The message for the exception.
+     */
+    public static void assertStrictPositive(int integer, String exceptionMessage) {
+        assertThat(integer, number -> number > 0, exceptionMessage);
     }
 }

--- a/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
@@ -67,8 +67,8 @@ public abstract class BuilderUtils {
      * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an
      * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
-     * @param integer The value to assert
-     * @param exceptionMessage The message for the exception.
+     * @param integer the value to assert
+     * @param exceptionMessage the message for the exception
      */
     public static void assertPositive(int integer, String exceptionMessage) {
         assertThat(integer, number -> number >= 0, exceptionMessage);
@@ -78,8 +78,8 @@ public abstract class BuilderUtils {
      * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an
      * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
-     * @param integer The value to assert
-     * @param exceptionMessage The message for the exception.
+     * @param integer the value to assert
+     * @param exceptionMessage the message for the exception.
      */
     public static void assertStrictPositive(int integer, String exceptionMessage) {
         assertThat(integer, number -> number > 0, exceptionMessage);


### PR DESCRIPTION
This PR resolves #968.