### PR TITLE
Configure `AxonServerCommandBus` Spring (boot) bean to use `localSegment`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -33,10 +33,7 @@
 package org.axonframework.springboot.autoconfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.axonframework.springboot.DistributedCommandBusProperties;
-import org.axonframework.springboot.EventProcessorProperties;
-import org.axonframework.springboot.SerializerProperties;
-import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.distributed.DistributedCommandBus;
@@ -45,11 +42,7 @@ import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingConfigurer;
-import org.axonframework.eventhandling.EventBus;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.SimpleEventBus;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.async.SequencingPolicy;
 import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
@@ -60,21 +53,15 @@ import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.MessageOriginProvider;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
-import org.axonframework.queryhandling.DefaultQueryGateway;
-import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
-import org.axonframework.queryhandling.QueryBus;
-import org.axonframework.queryhandling.QueryGateway;
-import org.axonframework.queryhandling.QueryInvocationErrorHandler;
-import org.axonframework.queryhandling.QueryUpdateEmitter;
-import org.axonframework.queryhandling.SimpleQueryBus;
-import org.axonframework.serialization.AnnotationRevisionResolver;
-import org.axonframework.serialization.ChainingConverter;
-import org.axonframework.serialization.JavaSerializer;
-import org.axonframework.serialization.RevisionResolver;
-import org.axonframework.serialization.Serializer;
+import org.axonframework.queryhandling.*;
+import org.axonframework.serialization.*;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
+import org.axonframework.springboot.DistributedCommandBusProperties;
+import org.axonframework.springboot.EventProcessorProperties;
+import org.axonframework.springboot.SerializerProperties;
+import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -274,7 +261,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
         return sequencingPolicy;
     }
 
-    @ConditionalOnMissingBean(ignored = {DistributedCommandBus.class}, value = CommandBus.class)
+    @ConditionalOnMissingBean(ignored = {DistributedCommandBus.class, AxonServerCommandBus.class}, value = CommandBus.class)
     @Qualifier("localSegment")
     @Bean
     public SimpleCommandBus commandBus(TransactionManager txManager, AxonConfiguration axonConfiguration) {

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -42,9 +42,7 @@ import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfi
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
 import org.axonframework.commandhandling.CommandBus;
-import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
-import org.axonframework.commandhandling.distributed.DistributedCommandBus;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.EventProcessingConfiguration;
@@ -63,7 +61,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 
 /**
@@ -97,17 +94,17 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
         return new AxonServerConnectionManager(routingConfiguration);
     }
 
-    @Bean( destroyMethod = "disconnect")
+    @Bean(destroyMethod = "disconnect")
     @Primary
     @ConditionalOnMissingQualifiedBean(qualifier = "!unqualified", beanClass = CommandBus.class)
     public AxonServerCommandBus axonServerCommandBus(TransactionManager txManager,
-                                           AxonConfiguration axonConfiguration,
-                                           AxonServerConfiguration axonServerConfiguration,
-                                           Serializer serializer,
-                                           AxonServerConnectionManager axonServerConnectionManager,
-                                           RoutingStrategy routingStrategy,
-                                           CommandPriorityCalculator priorityCalculator,
-                                           @Qualifier("localSegment") CommandBus localSegment) {
+                                                     AxonConfiguration axonConfiguration,
+                                                     AxonServerConfiguration axonServerConfiguration,
+                                                     Serializer serializer,
+                                                     AxonServerConnectionManager axonServerConnectionManager,
+                                                     RoutingStrategy routingStrategy,
+                                                     CommandPriorityCalculator priorityCalculator,
+                                                     @Qualifier("localSegment") CommandBus localSegment) {
 
         return new AxonServerCommandBus(axonServerConnectionManager,
                 axonServerConfiguration,

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -124,7 +124,6 @@ public class AxonServerAutoConfigurationTest {
     @Test
     public void testNonAxonServerCommandBusConfiguration() {
         this.contextRunner
-                //.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                 .run((context) -> {
                     assertThat(context).getBeanNames(CommandBus.class).hasSize(1);
                     assertThat(context).getBean(CommandBus.class).isExactlyInstanceOf(SimpleCommandBus.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -16,19 +16,29 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 @ContextConfiguration
@@ -37,8 +47,29 @@ import static org.junit.Assert.*;
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonServerAutoConfigurationTest {
 
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    AxonAutoConfiguration.class,
+                    EventProcessingAutoConfiguration.class,
+                    InfraConfiguration.class,
+                    JdbcAutoConfiguration.class,
+                    JpaAutoConfiguration.class,
+                    JpaEventStoreAutoConfiguration.class,
+                    MetricsAutoConfiguration.class,
+                    NoOpTransactionAutoConfiguration.class,
+                    ObjectMapperAutoConfiguration.class,
+                    TransactionAutoConfiguration.class
+            ));
+
     @Autowired
     private QueryBus queryBus;
+
+    @Autowired
+    private CommandBus commandBus;
+
+    @Autowired
+    @Qualifier("localSegment")
+    private CommandBus localSegment;
 
     @Autowired
     private QueryUpdateEmitter updateEmitter;
@@ -47,5 +78,70 @@ public class AxonServerAutoConfigurationTest {
     public void testAxonServerQueryBusConfiguration() {
         assertTrue(queryBus instanceof AxonServerQueryBus);
         assertSame(updateEmitter, queryBus.queryUpdateEmitter());
+    }
+
+    @Test
+    public void testAxonServerCommandBusBeanTypesConfiguration() {
+        assertTrue(commandBus instanceof AxonServerCommandBus);
+        assertTrue(localSegment instanceof SimpleCommandBus);
+    }
+
+    @Test
+    public void testAxonServerDefaultCommandBusConfiguration() {
+        this.contextRunner
+                .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                .run((context) -> {
+                    assertThat(context).getBeanNames(CommandBus.class).hasSize(2);
+                    assertThat(context).getBean("axonServerCommandBus").isExactlyInstanceOf(AxonServerCommandBus.class);
+                    assertThat(context).getBean("commandBus").isExactlyInstanceOf(SimpleCommandBus.class);
+                });
+    }
+
+    @Test
+    public void testAxonServerUserDefinedCommandBusConfiguration() {
+        this.contextRunner
+                .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                .withUserConfiguration(ExplicitUserCommandBusConfiguration.class)
+                .run((context) -> {
+                    assertThat(context).getBeanNames(CommandBus.class).hasSize(1);
+                    assertThat(context).getBean(CommandBus.class).isExactlyInstanceOf(DisruptorCommandBus.class);
+
+                });
+    }
+
+    @Test
+    public void testAxonServerUserDefinedLocalSegmentConfiguration() {
+        this.contextRunner
+                .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                .withUserConfiguration(ExplicitUserLocalSegmentConfiguration.class)
+                .run((context) -> {
+                    assertThat(context).getBeanNames(CommandBus.class).hasSize(2);
+                    assertThat(context).getBean("axonServerCommandBus").isExactlyInstanceOf(AxonServerCommandBus.class);
+                    assertThat(context).getBean("commandBus").isExactlyInstanceOf(SimpleCommandBus.class);
+                });
+    }
+
+    @Test
+    public void testNonAxonServerCommandBusConfiguration() {
+        this.contextRunner
+                //.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                .run((context) -> {
+                    assertThat(context).getBeanNames(CommandBus.class).hasSize(1);
+                    assertThat(context).getBean(CommandBus.class).isExactlyInstanceOf(SimpleCommandBus.class);
+                });
+    }
+
+    public static class ExplicitUserCommandBusConfiguration {
+        @Bean
+        public DisruptorCommandBus commandBus() {
+            return DisruptorCommandBus.builder().build();
+        }
+    }
+
+    public static class ExplicitUserLocalSegmentConfiguration {
+        @Qualifier("localSegment")
+        public DisruptorCommandBus commandBus() {
+            return DisruptorCommandBus.builder().build();
+        }
     }
 }


### PR DESCRIPTION
Conditionally load `AxonServerCommandBus` if there is no **unqualified `CommandBus`** in the Spring context already

**The idea:**

If there is a bean of type `CommandBus` **qualified with `localSegmet`**, it will be used by `AxonServerCommandBus`.

If there is a bean of type `CommandBus` **NOT qualified with any name**, `AxonServerCommandBus` will not be loaded to context at all (in favor of specific `CommandBus` that user defined).