### PR TITLE
Configure `AxonServerCommandBus` Spring (boot) bean to use `localSegment` - correction

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -96,7 +96,7 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
 
     @Bean(destroyMethod = "disconnect")
     @Primary
-    @ConditionalOnMissingQualifiedBean(qualifier = "!unqualified", beanClass = CommandBus.class)
+    @ConditionalOnMissingQualifiedBean(qualifier = "!localSegment", beanClass = CommandBus.class)
     public AxonServerCommandBus axonServerCommandBus(TransactionManager txManager,
                                                      AxonConfiguration axonConfiguration,
                                                      AxonServerConfiguration axonServerConfiguration,

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -117,7 +117,18 @@ public class AxonServerAutoConfigurationTest {
                 .run((context) -> {
                     assertThat(context).getBeanNames(CommandBus.class).hasSize(2);
                     assertThat(context).getBean("axonServerCommandBus").isExactlyInstanceOf(AxonServerCommandBus.class);
-                    assertThat(context).getBean("commandBus").isExactlyInstanceOf(SimpleCommandBus.class);
+                    assertThat(context).getBean("commandBus").isExactlyInstanceOf(DisruptorCommandBus.class);
+                });
+    }
+
+    @Test
+    public void testAxonServerWrongUserDefinedLocalSegmentConfiguration() {
+        this.contextRunner
+                .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                .withUserConfiguration(ExplicitWrongUserLocalSegmentConfiguration.class)
+                .run((context) -> {
+                    assertThat(context).getBeanNames(CommandBus.class).hasSize(1);
+                    assertThat(context).getBean(CommandBus.class).isExactlyInstanceOf(DisruptorCommandBus.class);
                 });
     }
 
@@ -138,7 +149,16 @@ public class AxonServerAutoConfigurationTest {
     }
 
     public static class ExplicitUserLocalSegmentConfiguration {
+        @Bean
         @Qualifier("localSegment")
+        public DisruptorCommandBus commandBus() {
+            return DisruptorCommandBus.builder().build();
+        }
+    }
+
+    public static class ExplicitWrongUserLocalSegmentConfiguration {
+        @Bean
+        @Qualifier("wrongSegment")
         public DisruptorCommandBus commandBus() {
             return DisruptorCommandBus.builder().build();
         }


### PR DESCRIPTION
Correction of https://github.com/AxonFramework/AxonFramework/pull/980 (test was green, but incorrect)

Conditionally load `AxonServerCommandBus`
- if there is no **`CommandBus`**  that is not qualified or qualified with  the name that is different then `localSegment`