### PR TITLE
[#995] Implement split-and-merge in Axon Server Client

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,7 +125,7 @@
             </extension>
         </extensions>
         <plugins>
-            <!-- Copy public .proto from the axoniq-eventstore-client-proto artifact to target/proto -->
+            <!-- Copy public .proto from the axon-server-api artifact to target/proto -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,13 @@
 
 package org.axonframework.axonserver.connector.processor;
 
-import io.axoniq.axonserver.grpc.control.*;
+import io.axoniq.axonserver.grpc.control.MergeEventProcessorSegment;
+import io.axoniq.axonserver.grpc.control.PauseEventProcessor;
+import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
+import io.axoniq.axonserver.grpc.control.ReleaseEventProcessorSegment;
+import io.axoniq.axonserver.grpc.control.RequestEventProcessorInfo;
+import io.axoniq.axonserver.grpc.control.SplitEventProcessorSegment;
+import io.axoniq.axonserver.grpc.control.StartEventProcessor;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.processor.grpc.GrpcEventProcessorMapping;
 import org.axonframework.axonserver.connector.processor.grpc.PlatformInboundMessage;
@@ -28,23 +34,33 @@ import java.util.function.Function;
 
 import static io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction.RequestCase.*;
 
-
 /**
- * Service that listens to {@link PlatformOutboundInstruction}s to control {@link EventProcessor}s when requested by AxonServer.
+ * Service that listens to {@link PlatformOutboundInstruction}s to control {@link EventProcessor}s when for example
+ * requested by Axon Server. Will delegate the calls to the {@link AxonServerConnectionManager} and/or {@link
+ * EventProcessorController} for further processing.
  *
  * @author Sara Pellegrini
  * @since 4.0
  */
 public class EventProcessorControlService {
 
-    private final Logger logger = LoggerFactory.getLogger(EventProcessorControlService.class);
+    private static final Logger logger = LoggerFactory.getLogger(EventProcessorControlService.class);
 
     private final AxonServerConnectionManager axonServerConnectionManager;
-
     private final EventProcessorController eventProcessorController;
-
     private final Function<EventProcessor, PlatformInboundMessage> mapping;
 
+    /**
+     * Initialize a {@link EventProcessorControlService} which adds {@link java.util.function.Consumer}s to the given
+     * {@link AxonServerConnectionManager} on {@link PlatformOutboundInstruction}s. These Consumers typically leverage
+     * the {@link EventProcessorController} to issue operations to the {@link EventProcessor}s contained in this
+     * application.
+     *
+     * @param axonServerConnectionManager a {@link AxonServerConnectionManager} used to add operations when
+     *                                    {@link PlatformOutboundInstruction} have been received
+     * @param eventProcessorController    the {@link EventProcessorController} used to perform operations on the
+     *                                    {@link EventProcessor}s
+     */
     public EventProcessorControlService(AxonServerConnectionManager axonServerConnectionManager,
                                         EventProcessorController eventProcessorController) {
         this.axonServerConnectionManager = axonServerConnectionManager;
@@ -52,40 +68,59 @@ public class EventProcessorControlService {
         this.mapping = new GrpcEventProcessorMapping();
     }
 
-    public void start(){
+    /**
+     * Add {@link java.util.function.Consumer}s to the {@link AxonServerConnectionManager} for several
+     * {@link PlatformOutboundInstruction}s.
+     */
+    @SuppressWarnings("Duplicates")
+    public void start() {
         this.axonServerConnectionManager.onOutboundInstruction(PAUSE_EVENT_PROCESSOR, this::pauseProcessor);
         this.axonServerConnectionManager.onOutboundInstruction(START_EVENT_PROCESSOR, this::startProcessor);
         this.axonServerConnectionManager.onOutboundInstruction(RELEASE_SEGMENT, this::releaseSegment);
-        this.axonServerConnectionManager.onOutboundInstruction(REQUEST_EVENT_PROCESSOR_INFO, this::getEventProcessorInfo);
+        this.axonServerConnectionManager.onOutboundInstruction(
+                REQUEST_EVENT_PROCESSOR_INFO, this::getEventProcessorInfo
+        );
+        this.axonServerConnectionManager.onOutboundInstruction(SPLIT_EVENT_PROCESSOR_SEGMENT, this::splitSegment);
+        this.axonServerConnectionManager.onOutboundInstruction(MERGE_EVENT_PROCESSOR_SEGMENT, this::mergeSegment);
     }
 
-    public void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
+    private void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
         PauseEventProcessor pauseEventProcessor = platformOutboundInstruction.getPauseEventProcessor();
         String processorName = pauseEventProcessor.getProcessorName();
         eventProcessorController.pauseProcessor(processorName);
     }
 
-    public void startProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
+    private void startProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
         StartEventProcessor startEventProcessor = platformOutboundInstruction.getStartEventProcessor();
         String processorName = startEventProcessor.getProcessorName();
         eventProcessorController.startProcessor(processorName);
     }
 
-    public void releaseSegment(PlatformOutboundInstruction platformOutboundInstruction) {
+    private void releaseSegment(PlatformOutboundInstruction platformOutboundInstruction) {
         ReleaseEventProcessorSegment releaseSegment = platformOutboundInstruction.getReleaseSegment();
         String processorName = releaseSegment.getProcessorName();
         int segmentIdentifier = releaseSegment.getSegmentIdentifier();
         eventProcessorController.releaseSegment(processorName, segmentIdentifier);
     }
 
-    public void getEventProcessorInfo(PlatformOutboundInstruction platformOutboundInstruction){
+    private void getEventProcessorInfo(PlatformOutboundInstruction platformOutboundInstruction) {
+        RequestEventProcessorInfo requestInfo = platformOutboundInstruction.getRequestEventProcessorInfo();
+        String processorName = requestInfo.getProcessorName();
         try {
-            RequestEventProcessorInfo request = platformOutboundInstruction.getRequestEventProcessorInfo();
-            EventProcessor processor = eventProcessorController.getEventProcessor(request.getProcessorName());
+            EventProcessor processor = eventProcessorController.getEventProcessor(processorName);
             axonServerConnectionManager.send(mapping.apply(processor).instruction());
         } catch (Exception e) {
-            logger.debug("Problem getting the information about Event Processor",e);
+            logger.debug("Problem getting the information about Event Processor [{}]", processorName, e);
         }
     }
 
+    private void splitSegment(PlatformOutboundInstruction platformOutboundInstruction) {
+        SplitEventProcessorSegment splitSegment = platformOutboundInstruction.getSplitEventProcessorSegment();
+        eventProcessorController.splitSegment(splitSegment.getProcessorName(), splitSegment.getSegmentIdentifier());
+    }
+
+    private void mergeSegment(PlatformOutboundInstruction platformOutboundInstruction) {
+        MergeEventProcessorSegment mergeSegment = platformOutboundInstruction.getMergeEventProcessorSegment();
+        eventProcessorController.mergeSegment(mergeSegment.getProcessorName(), mergeSegment.getSegmentIdentifier());
+    }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorController.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorController.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,60 +17,132 @@
 package org.axonframework.axonserver.connector.processor;
 
 import org.axonframework.config.EventProcessingConfiguration;
-import org.axonframework.config.EventProcessingModule;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Consumer;
 
 /**
- * Controller for {@link EventProcessor}s.
+ * Controller used to delegate operations to the {@link EventProcessor}s contained in an application.
  *
  * @author Sara Pellegrini
  * @since 4.0
  */
 public class EventProcessorController {
 
+    private static final Logger logger = LoggerFactory.getLogger(EventProcessorController.class);
+
     private final EventProcessingConfiguration eventProcessingConfiguration;
-
     private final Deque<Consumer<String>> pauseHandlers = new ArrayDeque<>();
-
     private final Deque<Consumer<String>> startHandlers = new ArrayDeque<>();
 
+    /**
+     * Instantiate a controller to perform operations on the {@link EventProcessor} instances contained in this
+     * application. This controller should provide functionality to trigger all the APIs available on the EventProcessor
+     * interface and it's implementations.
+     *
+     * @param eventProcessingConfiguration the {@link EventProcessingConfiguration} from which the existing
+     *                                     {@link EventProcessor}s will be retrieved
+     */
     public EventProcessorController(EventProcessingConfiguration eventProcessingConfiguration) {
         this.eventProcessingConfiguration = eventProcessingConfiguration;
     }
 
-    public EventProcessor getEventProcessor(String processorName){
-        return this.eventProcessingConfiguration
-                .eventProcessor(processorName)
-                .orElseThrow(() -> new RuntimeException("Processor not found"));
+    EventProcessor getEventProcessor(String processorName) {
+        return eventProcessingConfiguration.eventProcessor(processorName)
+                                           .orElseThrow(() -> new RuntimeException(
+                                                   "Processor [" + processorName + "] not found"
+                                           ));
     }
 
-    public void pauseProcessor(String processor){
-        getEventProcessor(processor).shutDown();
-        this.pauseHandlers.forEach(consumer -> consumer.accept(processor));
+    void pauseProcessor(String processorName) {
+        getEventProcessor(processorName).shutDown();
+        this.pauseHandlers.forEach(consumer -> consumer.accept(processorName));
     }
 
-    public void startProcessor(String processor){
-        getEventProcessor(processor).start();
-        this.startHandlers.forEach(consumer -> consumer.accept(processor));
+    void startProcessor(String processorName) {
+        getEventProcessor(processorName).start();
+        this.startHandlers.forEach(consumer -> consumer.accept(processorName));
     }
 
-    public void releaseSegment(String processor, int segmentId){
-        EventProcessor eventProcessor = getEventProcessor(processor);
-        if (eventProcessor instanceof TrackingEventProcessor){
-            ((TrackingEventProcessor) eventProcessor).releaseSegment(segmentId);
+    void releaseSegment(String processorName, int segmentId) {
+        EventProcessor eventProcessor = getEventProcessor(processorName);
+        if (!(eventProcessor instanceof TrackingEventProcessor)) {
+            logger.info("Release segment requested for processor [{}] which is not a Tracking Event Processor");
+            return;
         }
+        ((TrackingEventProcessor) eventProcessor).releaseSegment(segmentId);
     }
 
-    public void onPause(Consumer<String> consumer){
-        this.pauseHandlers.add(consumer);
+    void splitSegment(String processorName, int segmentId) {
+        EventProcessor eventProcessor = getEventProcessor(processorName);
+        if (!(eventProcessor instanceof TrackingEventProcessor)) {
+            logger.info("Split segment requested for processor [{}] which is not a Tracking Event Processor");
+            return;
+        }
+
+        ((TrackingEventProcessor) eventProcessor).splitSegment(segmentId).whenComplete(
+                (result, throwable) -> {
+                    if (throwable != null) {
+                        logger.error("Failed to split segment [{}] for processor [{}]",
+                                     segmentId, processorName, throwable);
+                        return;
+                    }
+
+                    if (result) {
+                        logger.info("Successfully split segment [{}] of processor [{}]", segmentId, processorName);
+                    } else {
+                        logger.warn("Was not able to split segment [{}] for processor [{}]", segmentId, processorName);
+                    }
+                }
+        );
     }
 
-    public void onStart(Consumer<String> consumer){
-        this.startHandlers.add(consumer);
+    void mergeSegment(String processorName, int segmentId) {
+        EventProcessor eventProcessor = getEventProcessor(processorName);
+        if (!(eventProcessor instanceof TrackingEventProcessor)) {
+            logger.info("Merge segment requested for processor [{}] which is not a Tracking Event Processor");
+            return;
+        }
+
+        ((TrackingEventProcessor) eventProcessor).mergeSegment(segmentId).whenComplete(
+                (result, throwable) -> {
+                    if (throwable != null) {
+                        logger.error("Failed to merge segment [{}] for processor [{}]",
+                                     segmentId, processorName, throwable);
+                        return;
+                    }
+
+                    if (result) {
+                        logger.info("Successfully merged segment [{}] of processor [{}]", segmentId, processorName);
+                    } else {
+                        logger.warn("Was not able to merge segment [{}] for processor [{}]", segmentId, processorName);
+                    }
+                }
+        );
+    }
+
+    /**
+     * Add a {@link Consumer} to be called when an {@link EventProcessor} is paused through the
+     * {@link EventProcessor#shutDown()} method.
+     *
+     * @param pauseHandler the {@link Consumer} to be called when an {@link EventProcessor} is paused
+     */
+    public void onPause(Consumer<String> pauseHandler) {
+        this.pauseHandlers.add(pauseHandler);
+    }
+
+    /**
+     * Add a {@link Consumer} to be called when an {@link EventProcessor} is started through the
+     * {@link EventProcessor#start()} ()} method.
+     *
+     * @param startHandler the {@link Consumer} to be called when an {@link EventProcessor} is started
+     */
+    public void onStart(Consumer<String> startHandler) {
+        this.startHandlers.add(startHandler);
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorController.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorController.java
@@ -78,52 +78,46 @@ public class EventProcessorController {
         ((TrackingEventProcessor) eventProcessor).releaseSegment(segmentId);
     }
 
-    void splitSegment(String processorName, int segmentId) {
+    boolean splitSegment(String processorName, int segmentId) {
         EventProcessor eventProcessor = getEventProcessor(processorName);
         if (!(eventProcessor instanceof TrackingEventProcessor)) {
             logger.info("Split segment requested for processor [{}] which is not a Tracking Event Processor");
-            return;
+            return false;
         }
 
-        ((TrackingEventProcessor) eventProcessor).splitSegment(segmentId).whenComplete(
-                (result, throwable) -> {
-                    if (throwable != null) {
-                        logger.error("Failed to split segment [{}] for processor [{}]",
-                                     segmentId, processorName, throwable);
-                        return;
-                    }
-
+        return ((TrackingEventProcessor) eventProcessor)
+                .splitSegment(segmentId)
+                .thenApply(result -> {
                     if (result) {
-                        logger.info("Successfully split segment [{}] of processor [{}]", segmentId, processorName);
+                        logger.info("Successfully split segment [{}] of processor [{}]",
+                                    segmentId, processorName);
                     } else {
-                        logger.warn("Was not able to split segment [{}] for processor [{}]", segmentId, processorName);
+                        logger.warn("Was not able to split segment [{}] for processor [{}]",
+                                    segmentId, processorName);
                     }
-                }
-        );
+                    return result;
+                }).join();
     }
 
-    void mergeSegment(String processorName, int segmentId) {
+    boolean mergeSegment(String processorName, int segmentId) {
         EventProcessor eventProcessor = getEventProcessor(processorName);
         if (!(eventProcessor instanceof TrackingEventProcessor)) {
             logger.info("Merge segment requested for processor [{}] which is not a Tracking Event Processor");
-            return;
+            return false;
         }
 
-        ((TrackingEventProcessor) eventProcessor).mergeSegment(segmentId).whenComplete(
-                (result, throwable) -> {
-                    if (throwable != null) {
-                        logger.error("Failed to merge segment [{}] for processor [{}]",
-                                     segmentId, processorName, throwable);
-                        return;
-                    }
-
+        return ((TrackingEventProcessor) eventProcessor)
+                .mergeSegment(segmentId)
+                .thenApply(result -> {
                     if (result) {
-                        logger.info("Successfully merged segment [{}] of processor [{}]", segmentId, processorName);
+                        logger.info("Successfully merged segment [{}] of processor [{}]",
+                                    segmentId, processorName);
                     } else {
-                        logger.warn("Was not able to merge segment [{}] for processor [{}]", segmentId, processorName);
+                        logger.warn("Was not able to merge segment [{}] for processor [{}]",
+                                    segmentId, processorName);
                     }
-                }
-        );
+                    return result;
+                }).join();
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/EventProcessors.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/EventProcessors.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +31,7 @@ public class EventProcessors implements Iterable<EventProcessor> {
 
     private final EventProcessingConfiguration eventProcessingConfiguration;
 
-    public EventProcessors(EventProcessingConfiguration eventProcessingConfiguration) {
+    EventProcessors(EventProcessingConfiguration eventProcessingConfiguration) {
         this.eventProcessingConfiguration = eventProcessingConfiguration;
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSource.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSource.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,50 +31,61 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Implementation of {@link EventProcessorInfoSource} that send {@link EventProcessor}'s status to AxonServer using GRPC messages.
+ * Implementation of {@link EventProcessorInfoSource} that send {@link EventProcessor}'s status to Axon Server using
+ * gRPC messages.
  *
  * @author Sara Pellegrini
  * @since 4.0
  */
 public class GrpcEventProcessorInfoSource implements EventProcessorInfoSource {
+
     private static final Logger logger = LoggerFactory.getLogger(GrpcEventProcessorInfoSource.class);
 
-    private final Map<String, PlatformInboundInstruction> lastProcessorsInfo = new HashMap<>();
-
     private final EventProcessors eventProcessors;
+    private final Consumer<PlatformInboundInstruction> platformInstructionSender;
+    private final Function<EventProcessor, PlatformInboundMessage> platformInboundMessageMapper;
+    private final Map<String, PlatformInboundInstruction> lastProcessorsInfo;
 
-    private final Consumer<PlatformInboundInstruction> send;
-
-    private final Function<EventProcessor, PlatformInboundMessage> mapping;
-
+    /**
+     * Instantiate a {@link EventProcessorInfoSource} which can send {@link EventProcessor} status info to Axon Server.
+     * It uses the given {@link EventProcessingConfiguration} to retrieve all the EventProcessor instances and the
+     * provided {@link AxonServerConnectionManager} to send message to Axon Server.
+     *
+     * @param eventProcessingConfiguration the {@link EventProcessingConfiguration} from which the existing
+     *                                     {@link EventProcessor} instances are retrieved
+     * @param axonServerConnectionManager  the {@link AxonServerConnectionManager} used to send message to Axon Server
+     */
     public GrpcEventProcessorInfoSource(EventProcessingConfiguration eventProcessingConfiguration,
                                         AxonServerConnectionManager axonServerConnectionManager) {
-        this(new EventProcessors(eventProcessingConfiguration),
-             axonServerConnectionManager::send,
-             new GrpcEventProcessorMapping());
+        this(
+                new EventProcessors(eventProcessingConfiguration),
+                axonServerConnectionManager::send,
+                new GrpcEventProcessorMapping()
+        );
         axonServerConnectionManager.addReconnectListener(lastProcessorsInfo::clear);
     }
 
     GrpcEventProcessorInfoSource(EventProcessors eventProcessors,
-                                        Consumer<PlatformInboundInstruction> send,
-                                        Function<EventProcessor, PlatformInboundMessage> mapping) {
+                                 Consumer<PlatformInboundInstruction> platformInstructionSender,
+                                 Function<EventProcessor, PlatformInboundMessage> platformInboundMessageMapper) {
         this.eventProcessors = eventProcessors;
-        this.send = send;
-        this.mapping = mapping;
+        this.platformInstructionSender = platformInstructionSender;
+        this.platformInboundMessageMapper = platformInboundMessageMapper;
+        this.lastProcessorsInfo = new HashMap<>();
     }
 
     @Override
     public void notifyInformation() {
         try {
             eventProcessors.forEach(processor -> {
-                PlatformInboundInstruction instruction = mapping.apply(processor).instruction();
+                PlatformInboundInstruction instruction = platformInboundMessageMapper.apply(processor).instruction();
                 if (!instruction.equals(lastProcessorsInfo.get(processor.getName()))) {
-                    send.accept(instruction);
+                    platformInstructionSender.accept(instruction);
                 }
                 lastProcessorsInfo.put(processor.getName(), instruction);
             });
-        } catch (Exception | OutOfDirectMemoryError ex) {
-            logger.warn("Sending processor status failed: {}", ex.getMessage());
+        } catch (Exception | OutOfDirectMemoryError e) {
+            logger.warn("Sending processor status failed: {}", e.getMessage());
         }
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorMapping.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorMapping.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +23,8 @@ import org.axonframework.eventhandling.TrackingEventProcessor;
 import java.util.function.Function;
 
 /**
- * Mapping that translates an {@link EventProcessor} to GRPC {@link PlatformInboundMessage} representing the status of the {@link EventProcessor}.
+ * Mapping that translates an {@link EventProcessor} to gRPC {@link PlatformInboundMessage} representing the status of
+ * the {@link EventProcessor}.
  *
  * @author Sara Pellegrini
  * @since 4.0
@@ -31,10 +33,11 @@ public class GrpcEventProcessorMapping implements Function<EventProcessor, Platf
 
     @Override
     public PlatformInboundMessage apply(EventProcessor processor) {
-        if (processor instanceof TrackingEventProcessor)
+        if (processor instanceof TrackingEventProcessor) {
             return new TrackingEventProcessorInfoMessage((TrackingEventProcessor) processor);
-        if (processor instanceof SubscribingEventProcessor)
+        } else if (processor instanceof SubscribingEventProcessor) {
             return new SubscribingEventProcessorInfoMessage((SubscribingEventProcessor) processor);
+        }
         throw new RuntimeException("Unknown instance of Event Processor detected.");
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/PlatformInboundMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/PlatformInboundMessage.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,6 +27,10 @@ import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
 @FunctionalInterface
 public interface PlatformInboundMessage {
 
+    /**
+     * Supply a {@link PlatformInboundInstruction}.
+     *
+     * @return a {@link PlatformInboundInstruction}
+     */
     PlatformInboundInstruction instruction();
-
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/SubscribingEventProcessorInfoMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/SubscribingEventProcessorInfoMessage.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,21 +28,29 @@ import org.axonframework.eventhandling.SubscribingEventProcessor;
  */
 public class SubscribingEventProcessorInfoMessage implements PlatformInboundMessage {
 
-    private final SubscribingEventProcessor processor;
+    private static final String EVENT_PROCESSOR_MODE = "Subscribing";
 
-    public SubscribingEventProcessorInfoMessage(SubscribingEventProcessor processor) {
-        this.processor = processor;
+    private final SubscribingEventProcessor eventProcessor;
+
+    /**
+     * Instantiate a {@link PlatformInboundInstruction} representing the status of the given
+     * {@link SubscribingEventProcessor}
+     *
+     * @param eventProcessor a {@link SubscribingEventProcessor} for which the status will be mapped to a
+     *                       {@link PlatformInboundInstruction}
+     */
+    SubscribingEventProcessorInfoMessage(SubscribingEventProcessor eventProcessor) {
+        this.eventProcessor = eventProcessor;
     }
 
     @Override
     public PlatformInboundInstruction instruction() {
-        EventProcessorInfo msg = EventProcessorInfo.newBuilder()
-                                                   .setProcessorName(processor.getName())
-                                                   .setMode("Subscribing")
-                                                   .build();
-        return PlatformInboundInstruction
-                .newBuilder()
-                .setEventProcessorInfo(msg)
-                .build();
+        EventProcessorInfo eventProcessorInfo = EventProcessorInfo.newBuilder()
+                                                                  .setProcessorName(eventProcessor.getName())
+                                                                  .setMode(EVENT_PROCESSOR_MODE)
+                                                                  .build();
+        return PlatformInboundInstruction.newBuilder()
+                                         .setEventProcessorInfo(eventProcessorInfo)
+                                         .build();
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessage.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,41 +35,51 @@ import static java.util.stream.Collectors.toList;
  */
 public class TrackingEventProcessorInfoMessage implements PlatformInboundMessage {
 
-    private final TrackingEventProcessor processor;
+    private static final String EVENT_PROCESSOR_MODE = "Tracking";
 
-    public TrackingEventProcessorInfoMessage(TrackingEventProcessor processor) {
-        this.processor = processor;
+    private final TrackingEventProcessor eventProcessor;
+
+    /**
+     * Instantiate a {@link PlatformInboundInstruction} representing the status of the given
+     * {@link TrackingEventProcessor}
+     *
+     * @param eventProcessor a {@link TrackingEventProcessor} for which the status will be mapped to a
+     *                       {@link PlatformInboundInstruction}
+     */
+    TrackingEventProcessorInfoMessage(TrackingEventProcessor eventProcessor) {
+        this.eventProcessor = eventProcessor;
     }
 
     @Override
     public PlatformInboundInstruction instruction() {
-        Map<Integer, EventTrackerStatus> statusMap = processor.processingStatus();
+        List<EventTrackerInfo> trackerInfo = eventProcessor.processingStatus()
+                                                           .entrySet()
+                                                           .stream()
+                                                           .map(this::buildTrackerInfo)
+                                                           .collect(toList());
 
+        EventProcessorInfo eventProcessorInfo =
+                EventProcessorInfo.newBuilder()
+                                  .setProcessorName(eventProcessor.getName())
+                                  .setMode(EVENT_PROCESSOR_MODE)
+                                  .setActiveThreads(eventProcessor.activeProcessorThreads())
+                                  .setAvailableThreads(eventProcessor.availableProcessorThreads())
+                                  .setRunning(eventProcessor.isRunning())
+                                  .setError(eventProcessor.isError())
+                                  .addAllEventTrackersInfo(trackerInfo)
+                                  .build();
 
-        List<EventTrackerInfo> trackers = statusMap
-                .entrySet()
-                .stream()
-                .map(e -> EventTrackerInfo.newBuilder()
-                                          .setSegmentId(e.getKey())
-                                          .setCaughtUp(e.getValue().isCaughtUp())
-                                          .setReplaying(e.getValue().isReplaying())
-                                          .setOnePartOf(e.getValue().getSegment().getMask()+1)
+        return PlatformInboundInstruction.newBuilder()
+                                         .setEventProcessorInfo(eventProcessorInfo)
+                                         .build();
+    }
 
-                     .build())
-                .collect(toList());
-
-        EventProcessorInfo msg = EventProcessorInfo.newBuilder()
-                                                   .setProcessorName(processor.getName())
-                                                   .setMode("Tracking")
-                                                   .setActiveThreads(processor.activeProcessorThreads())
-                                                   .setAvailableThreads(processor.availableProcessorThreads())
-                                                   .setRunning(processor.isRunning())
-                                                   .setError(processor.isError())
-                                                   .addAllEventTrackersInfo(trackers)
-                                                   .build();
-        return PlatformInboundInstruction
-                .newBuilder()
-                .setEventProcessorInfo(msg)
-                .build();
+    private EventTrackerInfo buildTrackerInfo(Map.Entry<Integer, EventTrackerStatus> e) {
+        return EventTrackerInfo.newBuilder()
+                               .setSegmentId(e.getKey())
+                               .setCaughtUp(e.getValue().isCaughtUp())
+                               .setReplaying(e.getValue().isReplaying())
+                               .setOnePartOf(e.getValue().getSegment().getMask() + 1)
+                               .build();
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.processor;
+
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.junit.*;
+
+import java.util.function.Consumer;
+
+import static io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction.RequestCase.*;
+import static org.mockito.Mockito.*;
+
+public class EventProcessorControlServiceTest {
+
+    private final AxonServerConnectionManager axonServerConnectionManager = mock(AxonServerConnectionManager.class);
+    private final EventProcessorController eventProcessorController = mock(EventProcessorController.class);
+
+    private final EventProcessorControlService testSubject =
+            new EventProcessorControlService(axonServerConnectionManager, eventProcessorController);
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testStartAddOutboundInstructionToTheAxonServerConnectionManager() {
+        testSubject.start();
+
+        verify(axonServerConnectionManager).onOutboundInstruction(eq(PAUSE_EVENT_PROCESSOR), any(Consumer.class));
+        verify(axonServerConnectionManager).onOutboundInstruction(eq(START_EVENT_PROCESSOR), any(Consumer.class));
+        verify(axonServerConnectionManager).onOutboundInstruction(eq(RELEASE_SEGMENT), any(Consumer.class));
+        verify(axonServerConnectionManager).onOutboundInstruction(
+                eq(REQUEST_EVENT_PROCESSOR_INFO), any(Consumer.class)
+        );
+        verify(axonServerConnectionManager).onOutboundInstruction(
+                eq(SPLIT_EVENT_PROCESSOR_SEGMENT), any(Consumer.class)
+        );
+        verify(axonServerConnectionManager).onOutboundInstruction(
+                eq(MERGE_EVENT_PROCESSOR_SEGMENT), any(Consumer.class)
+        );
+        verifyNoMoreInteractions(axonServerConnectionManager);
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.processor;
+
+import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.SubscribingEventProcessor;
+import org.axonframework.eventhandling.TrackingEventProcessor;
+import org.junit.*;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class EventProcessorControllerTest {
+
+    private static final String TRACKING_PROCESSOR_NAME = "some-event-processor-name";
+    private static final String SUBSCRIBING_PROCESSOR_NAME = "some-other-processor";
+    private static final int SEGMENT_ID = 0;
+
+    private final EventProcessingConfiguration eventProcessingConfiguration = mock(EventProcessingConfiguration.class);
+
+    private final EventProcessorController testSubject = new EventProcessorController(eventProcessingConfiguration);
+
+    private final TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
+    private final SubscribingEventProcessor testSubscribingProcessor = mock(SubscribingEventProcessor.class);
+
+    @Before
+    public void setUp() {
+        when(eventProcessingConfiguration.eventProcessor(TRACKING_PROCESSOR_NAME))
+                .thenReturn(Optional.of(testTrackingProcessor));
+        when(eventProcessingConfiguration.eventProcessor(SUBSCRIBING_PROCESSOR_NAME))
+                .thenReturn(Optional.of(testSubscribingProcessor));
+
+        when(testTrackingProcessor.splitSegment(SEGMENT_ID)).thenReturn(CompletableFuture.completedFuture(true));
+        when(testTrackingProcessor.mergeSegment(SEGMENT_ID)).thenReturn(CompletableFuture.completedFuture(true));
+    }
+
+    @Test
+    public void testGetEventProcessorReturnsAnEventProcessor() {
+        EventProcessor result = testSubject.getEventProcessor(TRACKING_PROCESSOR_NAME);
+
+        assertEquals(testTrackingProcessor, result);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetEventProcessorThrowsRuntimeExceptionForNonExistingProcessor() {
+        testSubject.getEventProcessor("non-existing-processor");
+    }
+
+    @Test
+    public void testPauseProcessorCallsShutdownOnAnEventProcessor() {
+        testSubject.pauseProcessor(TRACKING_PROCESSOR_NAME);
+
+        verify(testTrackingProcessor).shutDown();
+    }
+
+    @Test
+    public void testStartProcessorCallsStartOnAnEventProcessor() {
+        testSubject.startProcessor(TRACKING_PROCESSOR_NAME);
+
+        verify(testTrackingProcessor).start();
+    }
+
+    @Test
+    public void testReleaseSegmentCallsReleaseSegmentOnAnEventProcessor() {
+        testSubject.releaseSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verify(testTrackingProcessor).releaseSegment(SEGMENT_ID);
+    }
+
+    @Test
+    public void testReleaseSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+        testSubject.releaseSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verifyZeroInteractions(testSubscribingProcessor);
+    }
+
+    @Test
+    public void testSplitSegmentCallSplitOnAnEventProcessor() {
+        testSubject.splitSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verify(testTrackingProcessor).splitSegment(SEGMENT_ID);
+    }
+
+    @Test
+    public void testSplitSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+        testSubject.splitSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verifyZeroInteractions(testSubscribingProcessor);
+    }
+
+    @Test
+    public void testMergeSegmentCallMergeOnAnEventProcessor() {
+        testSubject.mergeSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verify(testTrackingProcessor).mergeSegment(SEGMENT_ID);
+    }
+
+    @Test
+    public void testMergeSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+        testSubject.mergeSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
+
+        verifyZeroInteractions(testSubscribingProcessor);
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
@@ -94,29 +94,57 @@ public class EventProcessorControllerTest {
 
     @Test
     public void testSplitSegmentCallSplitOnAnEventProcessor() {
-        testSubject.splitSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
+        boolean result = testSubject.splitSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
 
         verify(testTrackingProcessor).splitSegment(SEGMENT_ID);
+        assertTrue(result);
     }
 
     @Test
     public void testSplitSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
-        testSubject.splitSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
+        boolean result = testSubject.splitSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
 
         verifyZeroInteractions(testSubscribingProcessor);
+        assertFalse(result);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSplitSegmentThrowsAnExceptionIfSplittingFails() {
+        String testEventProcessorName = "failing-event-processor";
+        TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
+
+        when(eventProcessingConfiguration.eventProcessor(testEventProcessorName))
+                .thenReturn(Optional.of(testTrackingProcessor));
+        when(testTrackingProcessor.splitSegment(SEGMENT_ID)).thenThrow(new IllegalStateException("some-exception"));
+
+        testSubject.splitSegment(testEventProcessorName, SEGMENT_ID);
     }
 
     @Test
     public void testMergeSegmentCallMergeOnAnEventProcessor() {
-        testSubject.mergeSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
+        boolean result = testSubject.mergeSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
 
         verify(testTrackingProcessor).mergeSegment(SEGMENT_ID);
+        assertTrue(result);
     }
 
     @Test
     public void testMergeSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
-        testSubject.mergeSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
+        boolean result = testSubject.mergeSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
 
         verifyZeroInteractions(testSubscribingProcessor);
+        assertFalse(result);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMergeSegmentThrowsAnExceptionIfMergingFails() {
+        String testEventProcessorName = "failing-event-processor";
+        TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
+
+        when(eventProcessingConfiguration.eventProcessor(testEventProcessorName))
+                .thenReturn(Optional.of(testTrackingProcessor));
+        when(testTrackingProcessor.mergeSegment(SEGMENT_ID)).thenThrow(new IllegalStateException("some-exception"));
+
+        testSubject.mergeSegment(testEventProcessorName, SEGMENT_ID);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -137,7 +137,7 @@
         <jackson.version>2.9.8</jackson.version>
         <grpc.version>1.16.1</grpc.version>
         <netty.tcnative.version>2.0.8.Final</netty.tcnative.version>
-        <axonserver.api.version>4.0</axonserver.api.version>
+        <axonserver.api.version>4.1-SNAPSHOT</axonserver.api.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR introduces the functionality to receive a split or merge `PlatformOutboundInstruction` from, for example, Axon Server.

To support this, the `EventProcessorControlService` has now included the `SPLIT_EVENT_PROCESSOR_SEGMENT` and `MERGE_EVENT_PROCESSOR_SEGMENT` operations to the `AxonServerConnectionManager`, which will add a `Consumer` which issues a split/merge against the `EventProcessorController`.

The `EventProcessorController` in turn will try to retrieve the right `EventProcessor` and hit the `mergeSegment(int)`/`splitSegment(int)` methods.

Additionally, I've performed some clean up operations, leading to re-indents of the file, added javadoc,  modifier adjustments and some new test cases.

This PR relies on the Axon Server API addition of split and merge, which will be introduced [here](https://github.com/AxonIQ/axon-server-api/pull/7).

This PR resolves issue #995 