### PR TITLE
[#881]  Add possibility to register default TrackingEventProcessorConfiguration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk11
 
 before_install:
-  - docker run -d -p 1521:1521 -e ORACLE_ALLOW_REMOTE=true wnameless/oracle-xe-11g
+  - docker run -d -p 1521:1521 gautamsaggar/oracle11g:v2 || echo "WARNING - Unable to start Oracle 11g"
   - docker ps
   - mysql -e 'CREATE DATABASE axon;'
 

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -428,13 +428,7 @@ public class EventProcessingModule
     @Override
     public EventProcessingConfigurer registerTrackingEventProcessor(String name,
                                                                     Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source) {
-        return registerTrackingEventProcessor(
-                name,
-                source,
-                c -> c.getComponent(
-                        TrackingEventProcessorConfiguration.class, defaultTrackingEventProcessorConfiguration::get
-                )
-        );
+        return registerTrackingEventProcessor(name, source, c -> defaultTrackingEventProcessorConfiguration.get());
     }
 
     @Override
@@ -623,9 +617,7 @@ public class EventProcessingModule
             return trackingEventProcessor(
                     name,
                     eventHandlerInvoker,
-                    conf.getComponent(
-                            TrackingEventProcessorConfiguration.class, defaultTrackingEventProcessorConfiguration::get
-                    ),
+                    defaultTrackingEventProcessorConfiguration.get(),
                     (StreamableMessageSource) conf.eventBus()
             );
         } else {

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,22 @@ package org.axonframework.config;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.DirectEventProcessingStrategy;
+import org.axonframework.eventhandling.ErrorHandler;
+import org.axonframework.eventhandling.EventHandlerInvoker;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
+import org.axonframework.eventhandling.LoggingErrorHandler;
+import org.axonframework.eventhandling.MultiEventHandlerInvoker;
+import org.axonframework.eventhandling.PropagatingErrorHandler;
+import org.axonframework.eventhandling.SimpleEventHandlerInvoker;
+import org.axonframework.eventhandling.SubscribingEventProcessor;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingEventProcessor;
+import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventhandling.async.SequencingPolicy;
 import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
-import org.axonframework.modelling.saga.repository.SagaStore;
-import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.Message;
@@ -33,9 +44,17 @@ import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.unitofwork.RollbackConfiguration;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
+import org.axonframework.modelling.saga.repository.SagaStore;
+import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.axonframework.monitoring.MessageMonitor;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -74,6 +93,7 @@ public class EventProcessingModule
     private final Map<String, Component<TokenStore>> tokenStore = new HashMap<>();
     private final Map<String, Component<RollbackConfiguration>> rollbackConfigurations = new HashMap<>();
     private final Map<String, Component<TransactionManager>> transactionManagers = new HashMap<>();
+    private final Map<String, Component<TrackingEventProcessorConfiguration>> trackingEventProcessorConfigurations = new HashMap<>();
     // Set up the default selector that determines the processing group by inspecting the @ProcessingGroup annotation;
     // if no annotation is present, the package name is used
     private Function<Class<?>, String> typeFallback = c -> c.getSimpleName() + "Processor";
@@ -128,6 +148,15 @@ public class EventProcessingModule
             "transactionManager",
             c -> c.getComponent(TransactionManager.class, NoTransactionManager::instance)
     );
+    private final Component<TrackingEventProcessorConfiguration> defaultTrackingEventProcessorConfiguration =
+            new Component<>(
+                    () -> configuration,
+                    "trackingEventProcessorConfiguration",
+                    c -> c.getComponent(
+                            TrackingEventProcessorConfiguration.class,
+                            TrackingEventProcessorConfiguration::forSingleThreadedProcessing
+                    )
+            );
     private EventProcessorBuilder defaultEventProcessorBuilder = this::defaultEventProcessor;
     private Function<String, String> defaultProcessingGroupAssignment = Function.identity();
 
@@ -398,9 +427,24 @@ public class EventProcessingModule
 
     @Override
     public EventProcessingConfigurer registerTrackingEventProcessor(String name,
+                                                                    Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source) {
+        return registerTrackingEventProcessor(
+                name,
+                source,
+                c -> c.getComponent(
+                        TrackingEventProcessorConfiguration.class, defaultTrackingEventProcessorConfiguration::get
+                )
+        );
+    }
+
+    @Override
+    public EventProcessingConfigurer registerTrackingEventProcessor(String name,
                                                                     Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source,
                                                                     Function<Configuration, TrackingEventProcessorConfiguration> processorConfiguration) {
-        registerEventProcessor(name, (n, c, ehi) -> trackingEventProcessor(n, ehi, processorConfiguration.apply(c), source.apply(c)));
+        registerEventProcessor(
+                name,
+                (n, c, ehi) -> trackingEventProcessor(n, ehi, processorConfiguration.apply(c), source.apply(c))
+        );
         return this;
     }
 
@@ -564,22 +608,33 @@ public class EventProcessingModule
         return this;
     }
 
+    @Override
+    public EventProcessingConfigurer registerTrackingEventProcessorConfiguration(
+            Function<Configuration, TrackingEventProcessorConfiguration> trackingEventProcessorConfigurationBuilder) {
+        this.defaultTrackingEventProcessorConfiguration.update(trackingEventProcessorConfigurationBuilder);
+        return this;
+    }
+
     @SuppressWarnings("unchecked")
-    private EventProcessor defaultEventProcessor(String name, Configuration conf,
+    private EventProcessor defaultEventProcessor(String name,
+                                                 Configuration conf,
                                                  EventHandlerInvoker eventHandlerInvoker) {
         if (conf.eventBus() instanceof StreamableMessageSource) {
-            return trackingEventProcessor(name,
-                                          eventHandlerInvoker,
-                                          conf.getComponent(
-                                                  TrackingEventProcessorConfiguration.class,
-                                                  TrackingEventProcessorConfiguration::forSingleThreadedProcessing),
-                                          (StreamableMessageSource) conf.eventBus());
+            return trackingEventProcessor(
+                    name,
+                    eventHandlerInvoker,
+                    conf.getComponent(
+                            TrackingEventProcessorConfiguration.class, defaultTrackingEventProcessorConfiguration::get
+                    ),
+                    (StreamableMessageSource) conf.eventBus()
+            );
         } else {
             return subscribingEventProcessor(name, conf, eventHandlerInvoker, Configuration::eventBus);
         }
     }
 
-    private SubscribingEventProcessor subscribingEventProcessor(String name, Configuration conf,
+    private SubscribingEventProcessor subscribingEventProcessor(String name,
+                                                                Configuration conf,
                                                                 EventHandlerInvoker eventHandlerInvoker,
                                                                 Function<Configuration, SubscribableMessageSource<? extends EventMessage<?>>> messageSource) {
         return SubscribingEventProcessor.builder()


### PR DESCRIPTION
This PR adds the `registerTrackingEventProcessorConfiguration(Function<Configuration, TrackingEventProcessorConfiguration>)` function to set the default `TrackingEventProcessorConfiguration` to use for any `TrackingEventProcessor` of no specific one is provided through the regular `registerTrackingEventProcessor()` functions.

This PR resolves issue #881