### PR TITLE
Ignore merge segment request if there is only a single segment present

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -1075,6 +1075,19 @@ public class TrackingEventProcessorTest {
         assertFalse("Expected merge to be rejected", actual.join());
     }
 
+    @Test(timeout = 10000)
+    public void testMergeWithSingleSegmentRejected() throws InterruptedException {
+        int numberOfSegments = 1;
+        initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(numberOfSegments));
+
+        testSubject.start();
+        waitForActiveThreads(1);
+
+        CompletableFuture<Boolean> actual = testSubject.mergeSegment(0);
+
+        assertFalse("Expected merge to be rejected", actual.join());
+    }
+
     private void waitForStatus(String description, long time, TimeUnit unit, Predicate<Map<Integer, EventTrackerStatus>> status) throws InterruptedException {
         long deadline = System.currentTimeMillis() + unit.toMillis(time);
         while (!status.test(testSubject.processingStatus())) {


### PR DESCRIPTION
The `TrackingEventProcessor#mergeSegment(int)` operation shouldn't be allowed to occur if there's just a single segment present for the given `TrackingEventProcessor`.
To that end, this pull request checks whether the 'segment to merge with' it's `segmentId` is identical to the `segmentId` used to call the `mergeSegment` function, by leveraging the `Segment#mergeableSegmentId()` function.

If this returns `true`, a `CompletableFuture.completedFuture(false)` will be returned.