### PR TITLE
[#1014]  Misleading method names in AggregateTestFixture

### DIFF
--- a/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
@@ -82,7 +82,7 @@ public class PessimisticLockFactoryTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 7500)
     public void testDeadlockDetected_TwoDifferentLockInstances() throws InterruptedException {
         final PessimisticLockFactory lock1 = PessimisticLockFactory.builder().build();
         final PessimisticLockFactory lock2 = PessimisticLockFactory.builder().build();

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -16,12 +16,24 @@
 
 package org.axonframework.test.aggregate;
 
-import org.axonframework.commandhandling.*;
+import org.axonframework.commandhandling.AnnotationCommandHandlerAdapter;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.common.Assert;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.deadline.DeadlineMessage;
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.TrackingEventStream;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcedAggregate;
 import org.axonframework.eventsourcing.EventSourcingRepository;
@@ -29,13 +41,29 @@ import org.axonframework.eventsourcing.GenericAggregateFactory;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
-import org.axonframework.messaging.*;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
-import org.axonframework.messaging.annotation.*;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
+import org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.axonframework.modelling.command.*;
+import org.axonframework.modelling.command.Aggregate;
+import org.axonframework.modelling.command.AggregateAnnotationCommandHandler;
+import org.axonframework.modelling.command.AggregateNotFoundException;
+import org.axonframework.modelling.command.AggregateScopeDescriptor;
+import org.axonframework.modelling.command.CommandTargetResolver;
+import org.axonframework.modelling.command.ConflictingAggregateVersionException;
+import org.axonframework.modelling.command.Repository;
+import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregate;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
@@ -54,7 +82,16 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -282,9 +319,14 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                 payload = ((Message) event).getPayload();
                 metaData = ((Message) event).getMetaData();
             }
-            this.givenEvents.add(new GenericDomainEventMessage<>(aggregateType.getSimpleName(), aggregateIdentifier,
-                                                                 sequenceNumber++, new GenericMessage<>(payload, metaData),
-                                                                 deadlineManager.getCurrentDateTime()));
+            GenericDomainEventMessage<Object> eventMessage = new GenericDomainEventMessage<>(
+                    aggregateType.getSimpleName(),
+                    aggregateIdentifier,
+                    sequenceNumber++,
+                    new GenericMessage<>(payload, metaData),
+                    deadlineManager.getCurrentDateTime()
+            );
+            this.givenEvents.add(eventMessage);
         }
         return this;
     }
@@ -310,7 +352,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         finalizeConfiguration();
         for (Object command : commands) {
             ExecutionExceptionAwareCallback callback = new ExecutionExceptionAwareCallback();
-            executeAtSimulatedTime(() -> commandBus.dispatch(GenericCommandMessage.asCommandMessage(command), callback));
+            CommandMessage<Object> commandMessage = GenericCommandMessage.asCommandMessage(command);
+            executeAtSimulatedTime(() -> commandBus.dispatch(commandMessage, callback));
             callback.assertSuccessful();
             givenEvents.addAll(storedEvents);
             storedEvents.clear();
@@ -347,13 +390,23 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public ResultValidator andThenTimeElapses(Duration elapsedTime) {
+        return whenThenTimeElapses(elapsedTime);
+    }
+
+    @Override
+    public ResultValidator whenThenTimeElapses(Duration elapsedTime) {
         deadlineManager.advanceTimeBy(elapsedTime, this::handleDeadline);
         return buildResultValidator();
     }
 
     @Override
-    public ResultValidator andThenTimeAdvancesTo(Instant newDateTime) {
-        deadlineManager.advanceTimeTo(newDateTime, this::handleDeadline);
+    public ResultValidator andThenTimeAdvancesTo(Instant newPointInTime) {
+        return whenThenTimeAdvancesTo(newPointInTime);
+    }
+
+    @Override
+    public ResultValidator whenThenTimeAdvancesTo(Instant newPointInTime) {
+        deadlineManager.advanceTimeTo(newPointInTime, this::handleDeadline);
         return buildResultValidator();
     }
 
@@ -371,7 +424,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                                                                            () -> repository.getAggregate(),
                                                                            deadlineManager);
 
-        executeAtSimulatedTime(() -> commandBus.dispatch(GenericCommandMessage.asCommandMessage(command).andMetaData(metaData), resultValidator));
+        CommandMessage<Object> commandMessage = GenericCommandMessage.asCommandMessage(command).andMetaData(metaData);
+        executeAtSimulatedTime(() -> commandBus.dispatch(commandMessage, resultValidator));
 
         if (!repository.rolledBack) {
             Aggregate<T> workingAggregate = repository.aggregate;

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -389,19 +389,9 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     @Override
-    public ResultValidator andThenTimeElapses(Duration elapsedTime) {
-        return whenThenTimeElapses(elapsedTime);
-    }
-
-    @Override
     public ResultValidator whenThenTimeElapses(Duration elapsedTime) {
         deadlineManager.advanceTimeBy(elapsedTime, this::handleDeadline);
         return buildResultValidator();
-    }
-
-    @Override
-    public ResultValidator andThenTimeAdvancesTo(Instant newPointInTime) {
-        return whenThenTimeAdvancesTo(newPointInTime);
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -131,7 +131,9 @@ public interface TestExecutor<T> {
      * return type
      */
     @Deprecated
-    ResultValidator andThenTimeElapses(Duration elapsedTime);
+    default ResultValidator andThenTimeElapses(Duration elapsedTime) {
+        return whenThenTimeElapses(elapsedTime);
+    }
 
     /**
      * Simulates the time elapsing in the current given state using a {@link Duration} as the unit of time. This can be
@@ -156,7 +158,9 @@ public interface TestExecutor<T> {
      * return type
      */
     @Deprecated
-    ResultValidator andThenTimeAdvancesTo(Instant newPointInTime);
+    default ResultValidator andThenTimeAdvancesTo(Instant newPointInTime) {
+        return whenThenTimeAdvancesTo(newPointInTime);
+    }
 
     /**
      * Simulates the time advancing in the current given state using an {@link Instant} as the unit of time. This can be

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -16,10 +16,10 @@
 
 package org.axonframework.test.aggregate;
 
-import java.time.Duration;
-import java.time.Instant;
 import org.axonframework.messaging.Message;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -119,20 +119,52 @@ public interface TestExecutor<T> {
     Instant currentTime();
 
     /**
-     * Simulates time shifts in the current given state. This can be useful when the time between given events is of
-     * importance.
+     * Simulates the time elapsing in the current given state using a {@link Duration} as the unit of time. This can be
+     * useful when the time between given events is of importance, for example when leveraging the
+     * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
      *
-     * @param elapsedTime The amount of time that will elapse
-     * @return a ResultValidator that can be used to validate the resulting actions of the command execution
+     * @param elapsedTime a {@link Duration} specifying the amount of time that will elapse
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
+     *
+     * @deprecated in favor of {@link #whenThenTimeElapses(Duration)}. This function incorrectly suggests you can
+     * proceed with other operations after calling it, which is made impossible due to the {@link ResultValidator}
+     * return type
      */
+    @Deprecated
     ResultValidator andThenTimeElapses(Duration elapsedTime);
 
     /**
-     * Simulates time shifts in the current given state. This can be useful when the time between given events is of
-     * importance.
+     * Simulates the time elapsing in the current given state using a {@link Duration} as the unit of time. This can be
+     * useful when the time between given events is of importance, for example when leveraging the
+     * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
      *
-     * @param newDateTime The time to advance the clock to
-     * @return a ResultValidator that can be used to validate the resulting actions of the command execution
+     * @param elapsedTime a {@link Duration} specifying the amount of time that will elapse
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
      */
-    ResultValidator andThenTimeAdvancesTo(Instant newDateTime);
+    ResultValidator whenThenTimeElapses(Duration elapsedTime);
+
+    /**
+     * Simulates the time advancing in the current given state using an {@link Instant} as the unit of time. This can be
+     * useful when the time between given events is of importance, for example when leveraging the
+     * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
+     *
+     * @param newPointInTime an {@link Instant} specifying the amount of time to advance the clock to
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
+     *
+     * @deprecated in favor of {@link #whenThenTimeAdvancesTo(Instant)}. This function incorrectly suggests you can
+     * proceed with other operations after calling it, which is made impossible due to the {@link ResultValidator}
+     * return type
+     */
+    @Deprecated
+    ResultValidator andThenTimeAdvancesTo(Instant newPointInTime);
+
+    /**
+     * Simulates the time advancing in the current given state using an {@link Instant} as the unit of time. This can be
+     * useful when the time between given events is of importance, for example when leveraging the
+     * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
+     *
+     * @param newPointInTime an {@link Instant} specifying the amount of time to advance the clock to
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
+     */
+    ResultValidator whenThenTimeAdvancesTo(Instant newPointInTime);
 }


### PR DESCRIPTION
Introduce a `whenThenTimeElapses()` and `whenThenTimeAdvancesTo()` function, to replace the misleadingly named `andThenTimeElapses()` and `andThenTimeAdvancesTo()` functions. 
All four return the result, thus ending the possibility to chain further. A method starting with `and...()` however suggest you can do more afterwards, which isn't the case with these methods.
Next to adding these new functions, the old ones are deprecated and the javadoc has been updated accordingly.

This PR resolves #1014