### PR TITLE
[#1008] Provide functionality to set the 'Token Claim Interval' for TrackingEventProcessors through a Spring Configuration file

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -191,7 +191,6 @@ public class EventProcessorProperties {
             return tokenClaimInterval;
         }
 
-
         /**
          * Sets the time to wait after a failed attempt to claim any token, before making another attempt.
          * Defaults to 5000 milliseconds.

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -93,11 +93,15 @@ public class EventProcessorProperties {
 
         /**
          * Indicates the time to wait after a failed attempt to claim any token, before making another attempt.
+         *
+         * Defaults to 5000 milliseconds.
          */
         private long tokenClaimInterval = 5000;
 
         /**
          * The time unit of the token claim interval.
+         *
+         * Defaults to MILLISECONDS.
          */
         private TimeUnit tokenClaimIntervalTimeUnit = TimeUnit.MILLISECONDS;
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -177,18 +177,37 @@ public class EventProcessorProperties {
             this.initialSegmentCount = initialSegmentCount;
         }
 
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * @return the tokenClaimInterval
+         */
         public long getTokenClaimInterval() {
             return tokenClaimInterval;
         }
 
+
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         *
+         * @param tokenClaimInterval the token claim interval
+         */
         public void setTokenClaimInterval(long tokenClaimInterval) {
             this.tokenClaimInterval = tokenClaimInterval;
         }
 
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * @return the tokenClaimIntervalTimeUnit
+         */
         public TimeUnit getTokenClaimIntervalTimeUnit() {
             return tokenClaimIntervalTimeUnit;
         }
 
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         *
+         * @param tokenClaimIntervalTimeUnit the token claim interval time unit
+         */
         public void setTokenClaimIntervalTimeUnit(TimeUnit tokenClaimIntervalTimeUnit) {
             this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;
         }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -92,12 +92,12 @@ public class EventProcessorProperties {
         private int initialSegmentCount = 1;
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * Indicates the time to wait after a failed attempt to claim any token, before making another attempt.
          */
         private long tokenClaimInterval = 5000;
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * The time unit of the token claim interval.
          */
         private TimeUnit tokenClaimIntervalTimeUnit = TimeUnit.MILLISECONDS;
 
@@ -178,8 +178,10 @@ public class EventProcessorProperties {
         }
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
-         * @return the tokenClaimInterval
+         * Returns the interval between attempts to claim the token.
+         * Defaults to 5000 milliseconds.
+         *
+         * @return interval between attempts to claim the token.
          */
         public long getTokenClaimInterval() {
             return tokenClaimInterval;
@@ -187,26 +189,29 @@ public class EventProcessorProperties {
 
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * Sets the time to wait after a failed attempt to claim any token, before making another attempt.
+         * Defaults to 5000 milliseconds.
          *
-         * @param tokenClaimInterval the token claim interval
+         * @param tokenClaimInterval the interval between attempts to claim the token.
          */
         public void setTokenClaimInterval(long tokenClaimInterval) {
             this.tokenClaimInterval = tokenClaimInterval;
         }
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
-         * @return the tokenClaimIntervalTimeUnit
+         * Returns the time unit used to define the token claim interval. Defaults to MILLISECONDS.
+         *
+         * @return the time unit used to defined the token claim interval.
          */
         public TimeUnit getTokenClaimIntervalTimeUnit() {
             return tokenClaimIntervalTimeUnit;
         }
 
         /**
-         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         * Sets the time unit used to defined the token claim interval. It must be a valid value of {@link TimeUnit}.
+         * Defaults to MILLISECONDS.
          *
-         * @param tokenClaimIntervalTimeUnit the token claim interval time unit
+         * @param tokenClaimIntervalTimeUnit the time unit used to defined the token claim interval.
          */
         public void setTokenClaimIntervalTimeUnit(TimeUnit tokenClaimIntervalTimeUnit) {
             this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -92,14 +92,14 @@ public class EventProcessorProperties {
         private int initialSegmentCount = 1;
 
         /**
-         * Indicates the time to wait after a failed attempt to claim any token, before making another attempt.
+         * The interval between attempts to claim tokens by a {@link org.axonframework.eventhandling.TrackingEventProcessor}.
          *
          * Defaults to 5000 milliseconds.
          */
         private long tokenClaimInterval = 5000;
 
         /**
-         * The time unit of the token claim interval.
+         * The time unit of tokens claim interval.
          *
          * Defaults to MILLISECONDS.
          */
@@ -182,10 +182,10 @@ public class EventProcessorProperties {
         }
 
         /**
-         * Returns the interval between attempts to claim the token.
+         * Returns the interval between attempts to claim tokens by a {@link org.axonframework.eventhandling.TrackingEventProcessor}.
          * Defaults to 5000 milliseconds.
          *
-         * @return interval between attempts to claim the token.
+         * @return the interval between attempts to claim tokens by a {@link org.axonframework.eventhandling.TrackingEventProcessor}.
          */
         public long getTokenClaimInterval() {
             return tokenClaimInterval;
@@ -195,26 +195,26 @@ public class EventProcessorProperties {
          * Sets the time to wait after a failed attempt to claim any token, before making another attempt.
          * Defaults to 5000 milliseconds.
          *
-         * @param tokenClaimInterval the interval between attempts to claim the token.
+         * @param tokenClaimInterval the interval between attempts to claim tokens by a {@link org.axonframework.eventhandling.TrackingEventProcessor}.
          */
         public void setTokenClaimInterval(long tokenClaimInterval) {
             this.tokenClaimInterval = tokenClaimInterval;
         }
 
         /**
-         * Returns the time unit used to define the token claim interval. Defaults to MILLISECONDS.
+         * Returns the time unit used to define tokens claim interval. Defaults to MILLISECONDS.
          *
-         * @return the time unit used to defined the token claim interval.
+         * @return the time unit used to defined tokens claim interval.
          */
         public TimeUnit getTokenClaimIntervalTimeUnit() {
             return tokenClaimIntervalTimeUnit;
         }
 
         /**
-         * Sets the time unit used to defined the token claim interval. It must be a valid value of {@link TimeUnit}.
+         * Sets the time unit used to defined tokens claim interval. It must be a valid value of {@link TimeUnit}.
          * Defaults to MILLISECONDS.
          *
-         * @param tokenClaimIntervalTimeUnit the time unit used to defined the token claim interval.
+         * @param tokenClaimIntervalTimeUnit the time unit used to defined tokens claim interval.
          */
         public void setTokenClaimIntervalTimeUnit(TimeUnit tokenClaimIntervalTimeUnit) {
             this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -32,10 +32,12 @@
 
 package org.axonframework.springboot;
 
+import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Properties describing the settings for Event Processors.
@@ -88,6 +90,16 @@ public class EventProcessorProperties {
          * Indicates the number of segments that should be created when the processor starts for the first time.
          */
         private int initialSegmentCount = 1;
+
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         */
+        private long tokenClaimInterval = 5000;
+
+        /**
+         * See {@link TrackingEventProcessorConfiguration#andTokenClaimInterval(long, java.util.concurrent.TimeUnit)}
+         */
+        private TimeUnit tokenClaimIntervalTimeUnit = TimeUnit.MILLISECONDS;
 
         /**
          * The maximum number of threads the processor should process events with. Defaults to the number of initial
@@ -163,6 +175,22 @@ public class EventProcessorProperties {
          */
         public void setInitialSegmentCount(int initialSegmentCount) {
             this.initialSegmentCount = initialSegmentCount;
+        }
+
+        public long getTokenClaimInterval() {
+            return tokenClaimInterval;
+        }
+
+        public void setTokenClaimInterval(long tokenClaimInterval) {
+            this.tokenClaimInterval = tokenClaimInterval;
+        }
+
+        public TimeUnit getTokenClaimIntervalTimeUnit() {
+            return tokenClaimIntervalTimeUnit;
+        }
+
+        public void setTokenClaimIntervalTimeUnit(TimeUnit tokenClaimIntervalTimeUnit) {
+            this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;
         }
 
         /**

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -223,7 +223,8 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
                 TrackingEventProcessorConfiguration config = TrackingEventProcessorConfiguration
                         .forParallelProcessing(v.getThreadCount())
                         .andBatchSize(v.getBatchSize())
-                        .andInitialSegmentsCount(v.getInitialSegmentCount());
+                        .andInitialSegmentsCount(v.getInitialSegmentCount())
+                        .andTokenClaimInterval(v.getTokenClaimInterval(), v.getTokenClaimIntervalTimeUnit());
                 Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> messageSource = resolveMessageSource(applicationContext, v);
                 eventProcessingConfigurer.registerTrackingEventProcessor(k, messageSource, c -> config);
             } else {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
@@ -97,7 +97,6 @@ public class EventProcessorConfigurationTest {
         long tokenClaimInterval = ReflectionUtils.getFieldValue(TrackingEventProcessor.class.getDeclaredField("tokenClaimInterval"), eventProcessor);
         assertEquals("It must be possible to override token claim interval via Spring Configuration",
                 tokenClaimInterval, 60000000L);
-
     }
 
     @Configuration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.common.ReflectionUtils.ensureAccessible;
 import static org.junit.Assert.*;
@@ -69,17 +70,34 @@ public class EventProcessorConfigurationTest {
     @Test
     public void testPublishSomeEvents() throws Exception {
         Map<String, EventProcessor> processors = eventProcessingConfiguration.eventProcessors();
-        assertEquals(2, processors.size());
-        assertEquals(TrackingEventProcessor.class, processors.get("first").getClass());
+        assertEquals(3, processors.size());
+        EventProcessor eventProcessor = processors.get("first");
+        assertNotNull(eventProcessor);
+        assertEquals(TrackingEventProcessor.class, eventProcessor.getClass());
+        long tokenClaimInterval = ReflectionUtils.getFieldValue(TrackingEventProcessor.class.getDeclaredField("tokenClaimInterval"), eventProcessor);
+        assertEquals("Must be 5000 ms by default", tokenClaimInterval, 5000L);
         MultiEventHandlerInvoker invoker = (MultiEventHandlerInvoker) ensureAccessible(
                 AbstractEventProcessor.class.getDeclaredMethod("eventHandlerInvoker")
-        ).invoke(processors.get("first"));
+        ).invoke(eventProcessor);
         SimpleEventHandlerInvoker simpleEventHandlerInvoker = (SimpleEventHandlerInvoker) invoker.delegates().get(0);
         SequencingPolicy policy = ReflectionUtils.getFieldValue(
                 SimpleEventHandlerInvoker.class.getDeclaredField("sequencingPolicy"), simpleEventHandlerInvoker
         );
 
         assertEquals(expectedPolicy, policy);
+    }
+
+    @Test
+    public void verifyTokenClaimIntervalCanBeSetViaSpringConfiguration() throws Exception {
+        Map<String, EventProcessor> processors = eventProcessingConfiguration.eventProcessors();
+        assertEquals(3, processors.size());
+        EventProcessor eventProcessor = processors.get("non_default_token_claim_interval");
+        assertNotNull(eventProcessor);
+        assertEquals(TrackingEventProcessor.class, eventProcessor.getClass());
+        long tokenClaimInterval = ReflectionUtils.getFieldValue(TrackingEventProcessor.class.getDeclaredField("tokenClaimInterval"), eventProcessor);
+        assertEquals("It must be possible to override token claim interval via Spring Configuration",
+                tokenClaimInterval, 60000000L);
+
     }
 
     @Configuration
@@ -126,6 +144,18 @@ public class EventProcessorConfigurationTest {
             public void handle(String event) {
                 countDownLatch2.countDown();
             }
+        }
+
+        @SuppressWarnings("unused")
+        @Component
+        @ProcessingGroup("non_default_token_claim_interval")
+        public static class NonDefaultTokenClaimIntervalHandler {
+
+            @EventHandler
+            public void handle(String event) {
+
+            }
+
         }
     }
 }

--- a/spring-boot-autoconfigure/src/test/resources/test-processors.application.properties
+++ b/spring-boot-autoconfigure/src/test/resources/test-processors.application.properties
@@ -16,3 +16,8 @@
 
 axon.eventhandling.processors.first.mode=tracking
 axon.eventhandling.processors.first.sequencingPolicy=customPolicy
+
+axon.eventhandling.processors.non_default_token_claim_interval.mode=tracking
+axon.eventhandling.processors.non_default_token_claim_interval.tokenClaimInterval=1000
+axon.eventhandling.processors.non_default_token_claim_interval.tokenClaimIntervalTimeUnit=MINUTES
+


### PR DESCRIPTION
This PR resolves #1008