### PR TITLE
Fix running tests with jacoco on JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.1</version>
+                        <version>0.8.3</version>
 
                         <executions>
                             <execution>


### PR DESCRIPTION
Running `mvn -Pcoverage clean test` on JDK 11 results in 
`Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?`

The version update fixes the problem.


