### PR TITLE
Add position to trackingToken

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
@@ -228,4 +228,9 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
     public String toString() {
         return "GapAwareTrackingToken{" + "index=" + index + ", gaps=" + gaps + '}';
     }
+
+    @Override
+    public long position() {
+        return index;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.LongStream;
@@ -230,7 +231,7 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
     }
 
     @Override
-    public long position() {
-        return index;
+    public OptionalLong position() {
+        return OptionalLong.of(index);
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
@@ -22,6 +22,7 @@ import org.axonframework.common.Assert;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.OptionalLong;
 
 /**
  * Tracking token based on the global sequence number of an event.
@@ -133,7 +134,7 @@ public class GlobalSequenceTrackingToken implements TrackingToken, Comparable<Gl
     }
 
     @Override
-    public long position() {
-        return globalIndex;
+    public OptionalLong position() {
+        return OptionalLong.of(globalIndex);
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GlobalSequenceTrackingToken.java
@@ -131,4 +131,9 @@ public class GlobalSequenceTrackingToken implements TrackingToken, Comparable<Gl
     public int compareTo(GlobalSequenceTrackingToken o) {
         return Long.compare(globalIndex, o.globalIndex);
     }
+
+    @Override
+    public long position() {
+        return globalIndex;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -242,4 +242,12 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
                 ", tokenAtReset=" + tokenAtReset +
                 '}';
     }
+
+    @Override
+    public long position() {
+        if(currentToken != null){
+            return currentToken.position();
+        }
+        return -1L;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.Message;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Token keeping track of the position before a reset was triggered. This allows for downstream components to detect
@@ -244,10 +245,10 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
     }
 
     @Override
-    public long position() {
+    public OptionalLong position() {
         if(currentToken != null){
             return currentToken.position();
         }
-        return -1L;
+        return OptionalLong.empty();
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
@@ -56,4 +56,12 @@ public interface TrackingToken {
      */
     boolean covers(TrackingToken other);
 
+    /**
+     * Return the position this token represents
+     * @return the position this token represents
+     */
+    default long position() {
+        return -1l;
+    }
+
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling;
 
+import java.util.OptionalLong;
+
 /**
  * Tag interface identifying a token that is used to identify the position of an event in an event stream. Event
  * processors use this token to keep track of the events they have processed and still need to process.
@@ -57,11 +59,13 @@ public interface TrackingToken {
     boolean covers(TrackingToken other);
 
     /**
-     * Return the position this token represents
-     * @return the position this token represents
+     * Return the estimated relative position this token represents.
+     * In case no estimation can be given an {@code OptionalLong.empty()} will be returned.
+     *
+     * @return the estimated relative position of this token
      */
-    default long position() {
-        return -1L;
+    default OptionalLong position() {
+        return OptionalLong.empty();
     }
 
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
@@ -61,7 +61,7 @@ public interface TrackingToken {
      * @return the position this token represents
      */
     default long position() {
-        return -1l;
+        return -1L;
     }
 
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
@@ -217,7 +217,7 @@ public class GapAwareTrackingTokenTest {
     public void testPosition() {
         GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
 
-        assertEquals(15L, token.position());
+        assertEquals(15L, token.position().getAsLong());
     }
 
     private TreeSet<Long> asTreeSet(Long... elements) {

--- a/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
@@ -213,6 +213,13 @@ public class GapAwareTrackingTokenTest {
         assertTrue(token1.withGapsTruncatedAt(10).covers(token1));
     }
 
+    @Test
+    public void testPosition() {
+        GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
+
+        assertEquals(15L, token.position());
+    }
+
     private TreeSet<Long> asTreeSet(Long... elements) {
         return new TreeSet<>(asList(elements));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
@@ -57,6 +57,6 @@ public class GlobalSequenceTrackingTokenTest {
     public void testPosition() {
         GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(1L);
 
-        assertEquals(1L, token.position());
+        assertEquals(1L, token.position().getAsLong());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
@@ -52,4 +52,11 @@ public class GlobalSequenceTrackingTokenTest {
         assertTrue(token2.covers(token2));
         assertTrue(token2.covers(null));
     }
+
+    @Test
+    public void testPosition() {
+        GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(1L);
+
+        assertEquals(1L, token.position());
+    }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
@@ -144,6 +144,12 @@ public class MergedTrackingTokenTest {
         assertEquals(token(3), merged.unwrap(GlobalSequenceTrackingToken.class).orElse(null));
     }
 
+    @Test
+    public void testPosition_isNotPresent() {
+        MergedTrackingToken merged = new MergedTrackingToken(mock(TrackingToken.class), token(3));
+        assertFalse(merged.position().isPresent());
+    }
+
     private GlobalSequenceTrackingToken token(int sequence) {
         return new GlobalSequenceTrackingToken(sequence);
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
@@ -145,7 +145,7 @@ public class MergedTrackingTokenTest {
     }
 
     @Test
-    public void testPosition_isNotPresent() {
+    public void testPositionIsNotPresent() {
         MergedTrackingToken merged = new MergedTrackingToken(mock(TrackingToken.class), token(3));
         assertFalse(merged.position().isPresent());
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -64,7 +64,7 @@ public class ReplayTokenTest {
 
     @Test
     public void testPosition() {
-        TrackingToken replayToken = ReplayToken.createReplayToken(innerToken, GapAwareTrackingToken.newInstance(10, Collections.singleton(9L)));
-        assertEquals(10, replayToken.position());
+        TrackingToken replayToken = ReplayToken.createReplayToken(innerToken, GapAwareTrackingToken.newInstance(11L, Collections.singleton(9L)));
+        assertEquals(11L, replayToken.position());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -65,6 +65,12 @@ public class ReplayTokenTest {
     @Test
     public void testPosition() {
         TrackingToken replayToken = ReplayToken.createReplayToken(innerToken, GapAwareTrackingToken.newInstance(11L, Collections.singleton(9L)));
-        assertEquals(11L, replayToken.position());
+        assertEquals(11L, replayToken.position().getAsLong());
+    }
+
+    @Test
+    public void testPosition_isNotPresent() {
+        TrackingToken replayToken = ReplayToken.createReplayToken(innerToken);
+        assertFalse(replayToken.position().isPresent());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -69,7 +69,7 @@ public class ReplayTokenTest {
     }
 
     @Test
-    public void testPosition_isNotPresent() {
+    public void testPositionIsNotPresent() {
         TrackingToken replayToken = ReplayToken.createReplayToken(innerToken);
         assertFalse(replayToken.position().isPresent());
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -61,4 +61,10 @@ public class ReplayTokenTest {
                                                           .readValue(serializedReplayToken);
         assertEquals(replayToken, deserializedReplayToken);
     }
+
+    @Test
+    public void testPosition() {
+        TrackingToken replayToken = ReplayToken.createReplayToken(innerToken, GapAwareTrackingToken.newInstance(10, Collections.singleton(9L)));
+        assertEquals(10, replayToken.position());
+    }
 }


### PR DESCRIPTION
Hi,

I have written following construct a few times now:
```
     if (token instanceof GlobalSequenceTrackingToken) {
          return ((GlobalSequenceTrackingToken) token).getGlobalIndex();  
    } else if (token instanceof GapAwareTrackingToken) { 
          return ((GapAwareTrackingToken) token).getIndex();  
    } else { 
          return -1L; 
    }
```

We use this index for monitoring purposes to see where our trackingEventProcessors are and for debugging and general troubleshooting.

While writing this it felt like this should actually be a feature of the TrackingToken interface because it represents a position.
It might be useful for other people as well.

However, I did not find a meaningful implementation for the `MergedTrackingToken` which uses the default implementation of `-1L`.

Regards,

Tom