### PR TITLE
Added logic to force a disconnection to AxonServer

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -303,11 +303,21 @@ public class AxonServerConnectionManager {
         inputStream.onNext(instruction);
     }
 
+    /**
+     * Stops the Connection Manager, closing any active connections and preventing new connections from being created.
+     */
     public void shutdown() {
+        shutdown = true;
+        disconnect();
+        scheduler.shutdown();
+    }
+
+    /**
+     * Disconnects any active connection, forcing a new connection to be established when one is requested.
+     */
+    public void disconnect() {
         if (channel != null) {
             shutdown(channel);
         }
-        shutdown = true;
-        scheduler.shutdown();
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,7 @@
 
 package org.axonframework.axonserver.connector.event;
 
-import io.axoniq.axonserver.grpc.event.Confirmation;
-import io.axoniq.axonserver.grpc.event.Event;
-import io.axoniq.axonserver.grpc.event.EventStoreGrpc;
-import io.axoniq.axonserver.grpc.event.EventWithToken;
-import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetAggregateSnapshotsRequest;
-import io.axoniq.axonserver.grpc.event.GetEventsRequest;
-import io.axoniq.axonserver.grpc.event.GetFirstTokenRequest;
-import io.axoniq.axonserver.grpc.event.GetLastTokenRequest;
-import io.axoniq.axonserver.grpc.event.GetTokenAtRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsRequest;
-import io.axoniq.axonserver.grpc.event.QueryEventsResponse;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrRequest;
-import io.axoniq.axonserver.grpc.event.ReadHighestSequenceNrResponse;
-import io.axoniq.axonserver.grpc.event.TrackingToken;
+import io.axoniq.axonserver.grpc.event.*;
 import io.grpc.Channel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -239,7 +225,7 @@ public class AxonServerEventStoreClient {
     }
 
     private void stopChannelToEventStore() {
-
+        axonServerConnectionManager.disconnect();
     }
 
     public CompletableFuture<ReadHighestSequenceNrResponse> lastSequenceNumberFor(String aggregateIdentifier) {


### PR DESCRIPTION
This is triggered when the AxonServerEventStoreClient receives an error
indicating that the connected node is not the leader, or is otherwise
unable to respond to the request.

Resolves #1029