### PR TITLE
Make Commit Timeout configurable

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -152,7 +152,7 @@ public class AxonServerConfiguration {
     /**
      * Timeout (in milliseconds) to wait for response on commit
      */
-    private int commitTimeout = 30000;
+    private int commitTimeout = 10000;
 
     /**
      * Instantiate a default {@link AxonServerConfiguration}.

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -149,6 +149,10 @@ public class AxonServerConfiguration {
      * GRPC max inbound message size, 0 keeps default value
      */
     private int maxMessageSize = 0;
+    /**
+     * Timeout (in milliseconds) to wait for response on commit
+     */
+    private int commitTimeout = 30000;
 
     /**
      * Instantiate a default {@link AxonServerConfiguration}.
@@ -354,6 +358,14 @@ public class AxonServerConfiguration {
 
     public void setSnapshotPrefetch(int snapshotPrefetch) {
         this.snapshotPrefetch = snapshotPrefetch;
+    }
+
+    public int getCommitTimeout() {
+        return commitTimeout;
+    }
+
+    public void setCommitTimeout(int commitTimeout) {
+        this.commitTimeout = commitTimeout;
     }
 
     @SuppressWarnings("unused")

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -300,7 +300,9 @@ public class AxonServerConnectionManager {
     }
 
     public void send(PlatformInboundInstruction instruction){
-        inputStream.onNext(instruction);
+        if (getChannel() != null) {
+            inputStream.onNext(instruction);
+        }
     }
 
     public void shutdown() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AppendEventTransaction.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AppendEventTransaction.java
@@ -29,11 +29,14 @@ import java.util.concurrent.TimeoutException;
  * Sends one or more events to AxonServer in a single transaction.
  */
 public class AppendEventTransaction {
+
+    private final int timeout;
     private final StreamObserver<Event> eventStreamObserver;
     private final CompletableFuture<Confirmation> observer;
     private final EventCipher eventCipher;
 
-    public AppendEventTransaction(StreamObserver<Event> eventStreamObserver, CompletableFuture<Confirmation> observer, EventCipher eventCipher) {
+    public AppendEventTransaction(int timeout, StreamObserver<Event> eventStreamObserver, CompletableFuture<Confirmation> observer, EventCipher eventCipher) {
+        this.timeout = timeout;
         this.eventStreamObserver = eventStreamObserver;
         this.observer = observer;
         this.eventCipher = eventCipher;
@@ -45,7 +48,7 @@ public class AppendEventTransaction {
 
     public void commit() throws InterruptedException, ExecutionException, TimeoutException {
         eventStreamObserver.onCompleted();
-        observer.get(10, TimeUnit.SECONDS);
+        observer.get(timeout, TimeUnit.MILLISECONDS);
     }
 
     public void rollback(Throwable reason) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClient.java
@@ -60,6 +60,7 @@ public class AxonServerEventStoreClient {
     private final ContextAddingInterceptor contextAddingInterceptor;
     private final EventCipher eventCipher;
     private final AxonServerConnectionManager axonServerConnectionManager;
+    private final int timeout;
 
     private boolean shutdown;
 
@@ -73,6 +74,7 @@ public class AxonServerEventStoreClient {
         this.tokenAddingInterceptor = new TokenAddingInterceptor(eventStoreConfiguration.getToken());
         this.eventCipher = eventStoreConfiguration.getEventCipher();
         this.axonServerConnectionManager = axonServerConnectionManager;
+        this.timeout = eventStoreConfiguration.getCommitTimeout();
         contextAddingInterceptor = new ContextAddingInterceptor(eventStoreConfiguration.getContext());
     }
 
@@ -191,7 +193,7 @@ public class AxonServerEventStoreClient {
 
     public AppendEventTransaction createAppendEventConnection() {
         CompletableFuture<Confirmation> futureConfirmation = new CompletableFuture<>();
-        return new AppendEventTransaction(eventStoreStub().appendEvent(new StreamObserver<Confirmation>() {
+        return new AppendEventTransaction(timeout, eventStoreStub().appendEvent(new StreamObserver<Confirmation>() {
             @Override
             public void onNext(Confirmation confirmation) {
                 futureConfirmation.complete(confirmation);


### PR DESCRIPTION
This PR makes it possible to configure the `commitTimeout` when events should be appended to the Event Store present in Axon Server from an Axon Server Client instance.