### PR TITLE
[#1035] Utilize TransactionManager on append events operation

### DIFF
--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -198,7 +198,8 @@ public class DefaultConfigurerTest {
         assertEquals(1, config.getModules().size());
         assertExpectedModules(config,
                               AggregateConfiguration.class);
-        verify(transactionManager).startTransaction();
+
+        verify(transactionManager, times(2)).startTransaction();
     }
 
     @Test
@@ -222,7 +223,8 @@ public class DefaultConfigurerTest {
         assertTrue(config.getModules()
                          .stream()
                          .anyMatch(m -> m instanceof AggregateConfiguration));
-        verify(transactionManager).startTransaction();
+
+        verify(transactionManager, times(2)).startTransaction();
     }
 
     @Test
@@ -274,7 +276,8 @@ public class DefaultConfigurerTest {
         assertEquals(1, config.getModules().size());
         assertExpectedModules(config,
                               AggregateConfiguration.class);
-        verify(transactionManager).startTransaction();
+
+        verify(transactionManager, times(2)).startTransaction();
     }
 
     @Test


### PR DESCRIPTION
This pull request ensure that the `JpaEventStorageEngine` uses the `TransactionManager` to perform the `appendEvents(List<EventMessage>, Serializer)` call in a Transaction, always.

Typically, this transaction is started by the `CommandGateway` is that's the starting point of entering an Aggregate/External Command Handler, and applying events as a result of that.
However, if somebody would want to publish events directly when utilizing the `JpaEventStorageEngine`, then that would form an issue from a Transaction perspective.

This pull request resolve #1035