### PR TITLE
Shutdown Event Processors in order

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -184,7 +184,12 @@ public class EventProcessingModule
 
     @Override
     public void shutdown() {
-        eventProcessors.forEach((name, component) -> component.get().shutDown());
+        eventProcessors
+                .values()
+                .stream()
+                .map(Component::get)
+                .sorted(comparing(EventProcessor::shutDownPriority).reversed())
+                .forEach(EventProcessor::shutDown);
     }
     //</editor-fold>
 

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -22,7 +22,6 @@ import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.async.FullConcurrencyPolicy;
 import org.axonframework.eventhandling.async.SequentialPolicy;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
-import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.MessageHandlerInterceptor;
@@ -375,10 +374,7 @@ public class EventProcessingModuleTest {
     @Test
     public void testShutdown() throws NoSuchFieldException {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
-                .configureEventBus(c -> EmbeddedEventStore
-                        .builder()
-                        .storageEngine(new InMemoryEventStorageEngine())
-                        .build())
+                .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
                 .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
                         .registerEventHandler(c -> new TrackingEventHandler())
                         .registerTrackingEventProcessor("tracking")

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -17,7 +17,6 @@
 package org.axonframework.config;
 
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.async.FullConcurrencyPolicy;
@@ -388,8 +387,7 @@ public class EventProcessingModuleTest {
 
         configuration.shutdown();
 
-        assertNull(ReflectionUtils
-                .getFieldValue(SubscribingEventProcessor.class.getDeclaredField("eventBusRegistration"),
+        assertNull(getFieldValue(SubscribingEventProcessor.class.getDeclaredField("eventBusRegistration"),
                         configuration.eventProcessingConfiguration().eventProcessor("subscribing", SubscribingEventProcessor.class).get()));
         assertFalse(configuration.eventProcessingConfiguration().eventProcessor("tracking", TrackingEventProcessor.class).get().isRunning());
     }

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -373,7 +373,7 @@ public class EventProcessingModuleTest {
 
     @Test
     public void testShutdown() throws NoSuchFieldException {
-        Configuration configuration = DefaultConfigurer.defaultConfiguration()
+        Configuration configuration = configurer
                 .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
                 .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
                         .registerEventHandler(c -> new TrackingEventHandler())

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
@@ -59,4 +59,14 @@ public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMe
      * Stop processing events.
      */
     void shutDown();
+
+    /**
+     * Returns the priority in the shutdown cycle of this processor
+     * A higher value means it is shutdown earlier
+     *
+     * @return the shutdownPriority of this event processor
+     */
+    default int shutDownPriority() {
+        return 0;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -612,6 +612,11 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
         }
     }
 
+    @Override
+    public int shutDownPriority() {
+        return Integer.MAX_VALUE;
+    }
+
     /**
      * Returns the number of threads this processor has available to assign segments. These threads may or may not
      * already be active.


### PR DESCRIPTION
Hi,

We noticed that the eventProcessors are shutdown in a random order.
TrackingEventProcessors wait until they are finished with their work but SubscribingEventProcessors are just unregistered.

It feels more safe to us to shutdown the TrackingEventProcessors first because they might need a SubscribingEventProcessor to successfully finish their work.

This pull request is a possible implementation for this.  (It should be 'future-proof')

I am not 100% happy with the unit test because I cannot check the actual order and I have to use reflection.  (I did not want to add a possible unnecessary getter)  Nevertheless it checks if a shutdown has been called.

Tom.