### PR TITLE
Add EventGateway to configuration

### DIFF
--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -18,6 +18,7 @@ package org.axonframework.config;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.deadline.DeadlineManager;
@@ -165,6 +166,15 @@ public interface Configuration {
      */
     default QueryGateway queryGateway() {
         return getComponent(QueryGateway.class);
+    }
+
+    /**
+     * Returns the Event Gateway defined in this Configuration.
+     *
+     * @return the EventGateway defined in this configuration
+     */
+    default EventGateway eventGateway() {
+        return getComponent(EventGateway.class);
     }
 
     /**

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -21,6 +21,8 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.eventhandling.gateway.DefaultEventGateway;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
@@ -227,6 +229,7 @@ public class DefaultConfigurer implements Configurer {
                        new Component<>(config, "resourceInjector", this::defaultResourceInjector));
         components.put(DeadlineManager.class, new Component<>(config, "deadlineManager", this::defaultDeadlineManager));
         components.put(EventUpcaster.class, upcasterChain);
+        components.put(EventGateway.class, new Component<>(config, "eventGateway", this::defaultEventGateway));
     }
 
     /**
@@ -354,6 +357,17 @@ public class DefaultConfigurer implements Configurer {
         return SimpleEventBus.builder()
                              .messageMonitor(config.messageMonitor(EventBus.class, "eventBus"))
                              .build();
+    }
+
+    /**
+     * Returns a {@link DefaultEventGateway} that will use the configuration's {@link EventBus} to publish
+     * events.
+     *
+     * @param config The configuration that supplies the event bus.
+     * @return The default event gateway.
+     */
+    protected EventGateway defaultEventGateway(Configuration config) {
+        return DefaultEventGateway.builder().eventBus(config.eventBus()).build();
     }
 
     /**

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -47,6 +47,8 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventhandling.async.SequencingPolicy;
 import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
+import org.axonframework.eventhandling.gateway.DefaultEventGateway;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
@@ -219,6 +221,12 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
         return SimpleEventBus.builder()
                              .messageMonitor(configuration.messageMonitor(EventStore.class, "eventStore"))
                              .build();
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public EventGateway eventGateway(EventBus eventBus) {
+        return DefaultEventGateway.builder().eventBus(eventBus).build();
     }
 
     @SuppressWarnings("unchecked")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -40,6 +40,7 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.EventCountSnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.SnapshotTriggerDefinition;
@@ -118,6 +119,7 @@ public class AxonAutoConfigurationTest {
         assertNotNull(applicationContext.getBean(QueryBus.class));
         assertNotNull(applicationContext.getBean(EventStore.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
+        assertNotNull(applicationContext.getBean(EventGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
         assertEquals(MultiParameterResolverFactory.class,
                      applicationContext.getBean(ParameterResolverFactory.class).getClass());

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
@@ -39,6 +39,7 @@ import org.axonframework.config.Configurer;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
@@ -93,6 +94,7 @@ public class AxonAutoConfigurationWithDisruptorTest {
         assertEquals(DisruptorCommandBus.class, applicationContext.getBean(CommandBus.class).getClass());
         assertNotNull(applicationContext.getBean(EventBus.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
+        assertNotNull(applicationContext.getBean(EventGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
         assertEquals(1, applicationContext.getBeansOfType(EventStorageEngine.class).size());
         assertEquals(0, applicationContext.getBeansOfType(TokenStore.class).size());

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
@@ -39,6 +39,7 @@ import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
@@ -91,6 +92,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
         assertNotNull(applicationContext.getBean(CommandBus.class));
         assertNotNull(applicationContext.getBean(EventBus.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
+        assertNotNull(applicationContext.getBean(EventGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
         assertNotNull(applicationContext.getBean("messageSerializer", Serializer.class));
         assertNotNull(applicationContext.getBean("eventSerializer", Serializer.class));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
@@ -38,6 +38,7 @@ import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
@@ -88,6 +89,7 @@ public class AxonAutoConfigurationWithEventSerializerTest {
         assertNotNull(applicationContext.getBean(CommandBus.class));
         assertNotNull(applicationContext.getBean(EventBus.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
+        assertNotNull(applicationContext.getBean(EventGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
         AxonConfiguration axonConfiguration = applicationContext.getBean(AxonConfiguration.class);
         assertNotSame(axonConfiguration.serializer(), axonConfiguration.eventSerializer());

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
@@ -39,6 +39,7 @@ import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
@@ -96,6 +97,7 @@ public class AxonAutoConfigurationWithHibernateTest {
         assertNotNull(applicationContext.getBean(CommandBus.class));
         assertNotNull(applicationContext.getBean(EventBus.class));
         assertNotNull(applicationContext.getBean(CommandGateway.class));
+        assertNotNull(applicationContext.getBean(EventGateway.class));
         assertNotNull(applicationContext.getBean(Serializer.class));
         assertNotNull(applicationContext.getBean(TokenStore.class));
         assertNotNull(applicationContext.getBean(JpaEventStorageEngine.class));

--- a/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
@@ -19,8 +19,6 @@ package org.axonframework.spring.config;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
-import org.axonframework.eventhandling.gateway.DefaultEventGateway;
-import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
@@ -138,18 +136,6 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Bean
     public QueryGateway queryGateway(QueryBus queryBus) {
         return DefaultQueryGateway.builder().queryBus(queryBus).build();
-    }
-
-    /**
-     * Returns the EventGateway used to publish events
-     *
-     * @param eventBus the event bus to be used by the gateway
-     * @return the EventGateway used to publish events
-     */
-    @NoBeanOfType(EventGateway.class)
-    @Bean
-    public EventGateway eventGateway(EventBus eventBus) {
-        return DefaultEventGateway.builder().eventBus(eventBus).build();
     }
 
     @Override

--- a/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AxonConfiguration.java
@@ -19,6 +19,8 @@ package org.axonframework.spring.config;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.eventhandling.gateway.DefaultEventGateway;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
@@ -136,6 +138,18 @@ public class AxonConfiguration implements Configuration, InitializingBean, Appli
     @Bean
     public QueryGateway queryGateway(QueryBus queryBus) {
         return DefaultQueryGateway.builder().queryBus(queryBus).build();
+    }
+
+    /**
+     * Returns the EventGateway used to publish events
+     *
+     * @param eventBus the event bus to be used by the gateway
+     * @return the EventGateway used to publish events
+     */
+    @NoBeanOfType(EventGateway.class)
+    @Bean
+    public EventGateway eventGateway(EventBus eventBus) {
+        return DefaultEventGateway.builder().eventBus(eventBus).build();
     }
 
     @Override


### PR DESCRIPTION
The PR resolves [#1047](https://github.com/AxonFramework/AxonFramework/issues/1047)

Streamline EventGateway with CommandGateway/QueryGateway:

Adding it to spring boot autoconfiguration as well as to axon configuration and configurer,
exactly like in case of CommandGateway/QueryGateway.