### PR TITLE
Drafted out changes to call all event handlers

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -76,12 +76,14 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
 
     @Override
     public Object handle(EventMessage<?> event) throws Exception {
+        Object firstResult = null;
         for (MessageHandlingMember<? super Object> handler : inspector.getHandlers()) {
             if (handler.canHandle(event)) {
-                return handler.handle(event, annotatedEventListener);
+                final Object intermediate = handler.handle(event, annotatedEventListener);
+                firstResult = firstResult == null ? intermediate : firstResult;
             }
         }
-        return null;
+        return firstResult;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
@@ -1,0 +1,46 @@
+package org.axonframework.eventhandling;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnnotationEventHandlerAdapterTest {
+
+    private AnnotationEventHandlerAdapter testSubject;
+    private StubEventhandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new StubEventhandler();
+        testSubject = new AnnotationEventHandlerAdapter(handler);
+    }
+
+    @Test
+    public void invokeAllHandlers() throws Exception {
+        testSubject.handle(GenericEventMessage.asEventMessage(new StubEvent()));
+
+        assertEquals(2, handler.invocationCount);
+    }
+
+    class StubEventhandler {
+        private int invocationCount;
+
+        @EventHandler
+        public void on(StubConcept event) {
+            invocationCount++;
+        }
+
+        @EventHandler
+        public void on(StubEvent event) {
+            invocationCount++;
+        }
+    }
+
+    interface StubConcept {
+    }
+
+    private class StubEvent implements StubConcept {
+    }
+
+}

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -31,6 +31,7 @@ import org.axonframework.messaging.annotation.*;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
@@ -244,7 +245,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
         }
 
         private void doPublish(EventMessage<?> message, T target) {
-            getHandler(message).ifPresent(h -> {
+            getHandler(message).forEach(h -> {
                 try {
                     h.handle(message, target);
                 } catch (Exception e) {
@@ -281,8 +282,8 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
          * @return the handler of the message if present on the model
          */
         @SuppressWarnings("unchecked")
-        protected Optional<MessageHandlingMember<? super T>> getHandler(Message<?> message) {
-            return eventHandlers.stream().filter(handler -> handler.canHandle(message)).findAny();
+        protected Stream<MessageHandlingMember<? super T>> getHandler(Message<?> message) {
+            return eventHandlers.stream().filter(handler -> handler.canHandle(message));
         }
 
         @Override

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -92,7 +92,7 @@ public class AnnotatedSagaTest {
         s.handle(new GenericEventMessage<>(new RegularEvent("id")));
         s.handle(new GenericEventMessage<>(new Object()));
         s.handle(new GenericEventMessage<>(new SagaEndEvent("id")));
-        assertEquals(2, testSubject.invocationCount);
+        assertEquals(3, testSubject.invocationCount);
         assertFalse(s.isActive());
     }
 
@@ -118,7 +118,7 @@ public class AnnotatedSagaTest {
         s.handle(new GenericEventMessage<>(new UniformAccessEvent("id")));
         s.handle(new GenericEventMessage<>(new Object()));
         s.handle(new GenericEventMessage<>(new SagaEndEvent("id")));
-        assertEquals(2, testSubject.invocationCount);
+        assertEquals(3, testSubject.invocationCount);
         assertFalse(s.isActive());
     }
 


### PR DESCRIPTION
All Event Handlers are called now, however the contract is intact, i.e. the result of the first handler is returned.