### PR TITLE
Lazy initialization of Serializers to prevent erroneous warning messages

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -130,8 +131,8 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private AxonServerConfiguration configuration;
         private AxonServerConnectionManager axonServerConnectionManager;
-        private Serializer snapshotSerializer = XStreamSerializer.builder().build();
-        private Serializer eventSerializer = XStreamSerializer.builder().build();
+        private Supplier<Serializer> snapshotSerializer = XStreamSerializer::defaultSerializer;
+        private Supplier<Serializer> eventSerializer = XStreamSerializer::defaultSerializer;
         private EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
         private Predicate<? super DomainEventData<?>> snapshotFilter;
 
@@ -195,7 +196,7 @@ public class AxonServerEventStore extends AbstractEventStore {
          */
         public Builder snapshotSerializer(Serializer snapshotSerializer) {
             assertNonNull(snapshotSerializer, "The Snapshot Serializer may not be null");
-            this.snapshotSerializer = snapshotSerializer;
+            this.snapshotSerializer = () -> snapshotSerializer;
             return this;
         }
 
@@ -212,7 +213,7 @@ public class AxonServerEventStore extends AbstractEventStore {
          */
         public Builder eventSerializer(Serializer eventSerializer) {
             assertNonNull(eventSerializer, "The Event Serializer may not be null");
-            this.eventSerializer = eventSerializer;
+            this.eventSerializer = () -> eventSerializer;
             return this;
         }
 
@@ -268,13 +269,13 @@ public class AxonServerEventStore extends AbstractEventStore {
             AxonServerEventStoreClient eventStoreClient = new AxonServerEventStoreClient(configuration,
                                                                                          axonServerConnectionManager);
             super.storageEngine(AxonIQEventStorageEngine.builder()
-                                                        .snapshotSerializer(snapshotSerializer)
+                                                        .snapshotSerializer(snapshotSerializer.get())
                                                         .upcasterChain(upcasterChain)
                                                         .snapshotFilter(snapshotFilter)
-                                                        .eventSerializer(eventSerializer)
+                                                        .eventSerializer(eventSerializer.get())
                                                         .configuration(configuration)
                                                         .eventStoreClient(eventStoreClient)
-                                                        .converter(new GrpcMetaDataConverter(eventSerializer))
+                                                        .converter(new GrpcMetaDataConverter(eventSerializer.get()))
                                                         .build());
         }
 

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,6 +37,7 @@ import java.sql.Date;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ExceptionUtils.findException;
@@ -91,7 +92,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager {
         this.scheduler = builder.scheduler;
         this.scopeAwareProvider = builder.scopeAwareProvider;
         this.transactionManager = builder.transactionManager;
-        this.serializer = builder.serializer;
+        this.serializer = builder.serializer.get();
         this.refireImmediatelyPolicy = builder.refireImmediatelyPolicy;
 
         try {
@@ -195,7 +196,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager {
         private Scheduler scheduler;
         private ScopeAwareProvider scopeAwareProvider;
         private TransactionManager transactionManager = NoTransactionManager.INSTANCE;
-        private Serializer serializer = XStreamSerializer.builder().build();
+        private Supplier<Serializer> serializer = XStreamSerializer::defaultSerializer;
         private Predicate<Throwable> refireImmediatelyPolicy =
                 throwable -> !findException(throwable, t -> t instanceof AxonNonTransientException).isPresent();
 
@@ -249,7 +250,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager {
          */
         public Builder serializer(Serializer serializer) {
             assertNonNull(serializer, "Serializer may not be null");
-            this.serializer = serializer;
+            this.serializer = () -> serializer;
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,14 +30,7 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.quartz.JobBuilder;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -227,7 +220,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
          * de-/serializing event messages.
          */
         public DirectEventJobDataBinder() {
-            this(XStreamSerializer.builder().build());
+            this(XStreamSerializer.defaultSerializer());
         }
 
         /**

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,6 +39,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
@@ -71,7 +72,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
         builder.validate();
         this.connectionProvider = builder.connectionProvider;
         this.sqlSchema = builder.sqlSchema;
-        this.serializer = builder.serializer;
+        this.serializer = builder.serializer.get();
     }
 
     /**
@@ -307,7 +308,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
 
         private ConnectionProvider connectionProvider;
         private SagaSqlSchema sqlSchema = new GenericSagaSqlSchema();
-        private Serializer serializer = XStreamSerializer.builder().build();
+        private Supplier<Serializer> serializer = XStreamSerializer::defaultSerializer;
 
         /**
          * Sets the {@link ConnectionProvider} which provides access to a JDBC connection.
@@ -361,7 +362,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
          */
         public Builder serializer(Serializer serializer) {
             assertNonNull(serializer, "Serializer may not be null");
-            this.serializer = serializer;
+            this.serializer = () -> serializer;
             return this;
         }
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,15 +27,16 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityNotFoundException;
 import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityNotFoundException;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -108,7 +109,7 @@ public class JpaSagaStore implements SagaStore<Object> {
     protected JpaSagaStore(Builder builder) {
         builder.validate();
         this.entityManagerProvider = builder.entityManagerProvider;
-        this.serializer = builder.serializer;
+        this.serializer = builder.serializer.get();
         addNamedQueriesTo(this.entityManagerProvider.getEntityManager());
     }
 
@@ -357,7 +358,7 @@ public class JpaSagaStore implements SagaStore<Object> {
     public static class Builder {
 
         private EntityManagerProvider entityManagerProvider;
-        private Serializer serializer = XStreamSerializer.builder().build();
+        private Supplier<Serializer> serializer = XStreamSerializer::defaultSerializer;
 
         /**
          * Sets the {@link EntityManagerProvider} which provides the {@link EntityManager} used to access the
@@ -381,7 +382,7 @@ public class JpaSagaStore implements SagaStore<Object> {
          */
         public Builder serializer(Serializer serializer) {
             assertNonNull(serializer, "Serializer may not be null");
-            this.serializer = serializer;
+            this.serializer = () -> serializer;
             return this;
         }
 


### PR DESCRIPTION
The default XStream based serializer is only initialized when no explicit
serializers have been configured. This ensures that the warning message
about XStream's security subsystem not being initialized isn't logged
unless an unsafe instance is really used.
Furthermore, this allows XStream to be excluded from the dependencies
when it isn't used at runtime.

Resolves #1054