### PR TITLE
Adds the ability to validate the isDeleted state of an Aggregate in the TestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -265,6 +265,20 @@ public class Reporter {
         throw new AxonAssertionError(sb.toString());
     }
 
+    /**
+     * Report an error due to a difference in the expected state of the `isDeleted` marker on the Aggregate.
+     *
+     * @param expectedDeletedState <code>true</code> if the Aggregate should have been marked as deleted, but was not.
+     *                             <code>false</code> if the Aggregate should not have been marked as deleted, but was.
+     */
+    public void reportIncorrectDeletedState(boolean expectedDeletedState) {
+        if (expectedDeletedState) {
+            throw new AxonAssertionError("Aggregate should have been marked for deletion, but this did not happen");
+        } else {
+            throw new AxonAssertionError("Aggregate has been marked for deletion, but this was not expected");
+        }
+    }
+
     private void appendProbableCause(Throwable probableCause, StringBuilder sb) {
         if (probableCause != null) {
             sb.append(NEWLINE);

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -273,4 +273,18 @@ public interface ResultValidator<T> {
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectDeadlinesMet(Object... expected);
+
+    /**
+     * Asserts that the Aggregate has been marked for deletion.
+     *
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectMarkedDeleted();
+
+    /**
+     * Asserts that the Aggregate has NOT been marked for deletion.
+     *
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectNotMarkedDeleted();
 }

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -20,18 +20,14 @@ import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.deadline.DeadlineMessage;
-import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.deadline.DeadlineManagerValidator;
 import org.axonframework.test.deadline.StubDeadlineManager;
-import org.axonframework.test.matchers.EqualFieldsMatcher;
-import org.axonframework.test.matchers.FieldFilter;
-import org.axonframework.test.matchers.Matchers;
-import org.axonframework.test.matchers.MapEntryMatcher;
-import org.axonframework.test.matchers.PayloadMatcher;
+import org.axonframework.test.matchers.*;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
@@ -297,6 +293,24 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
         if (!matcher.matches(actualException)) {
             reporter.reportWrongException(actualException, description);
         }
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectMarkedDeleted() {
+        if (!state.get().isDeleted()) {
+            reporter.reportIncorrectDeletedState(true);
+        }
+
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectNotMarkedDeleted() {
+        if (state.get().isDeleted()) {
+            reporter.reportIncorrectDeletedState(false);
+        }
+
         return this;
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
@@ -53,17 +53,13 @@ public class FixtureTest_MarkDeleted {
                .expectNotMarkedDeleted();
     }
 
-    @Test
+    @Test(expected = AxonAssertionError.class)
     public void testCreateAggregateYieldsLiveAggregateInverted() {
-        try {
-            fixture.registerInjectableResource(new HardToCreateResource());
-            fixture.givenNoPriorActivity()
-                    .when(new CreateAggregateCommand("id"))
-                    .expectEvents(new MyEvent("id", 0))
-                    .expectMarkedDeleted();
-        } catch (Throwable t) {
-            assertEquals(AxonAssertionError.class, t.getClass());
-        }
+        fixture.registerInjectableResource(new HardToCreateResource());
+        fixture.givenNoPriorActivity()
+                .when(new CreateAggregateCommand("id"))
+                .expectEvents(new MyEvent("id", 0))
+                .expectMarkedDeleted();
     }
 
     @Test
@@ -74,16 +70,12 @@ public class FixtureTest_MarkDeleted {
                .expectMarkedDeleted();
     }
 
-    @Test
+    @Test(expected = AxonAssertionError.class)
     public void testDeletedAggregateYieldsAggregateMarkedDeletedInverted() {
-        try {
-            fixture.given(new MyEvent("id", 0))
-                    .when(new DeleteCommand("id", false))
-                    .expectEvents(new MyAggregateDeletedEvent(false))
-                    .expectNotMarkedDeleted();
-        } catch (Throwable t) {
-            assertEquals(AxonAssertionError.class, t.getClass());
-        }
+        fixture.given(new MyEvent("id", 0))
+                .when(new DeleteCommand("id", false))
+                .expectEvents(new MyAggregateDeletedEvent(false))
+                .expectNotMarkedDeleted();
     }
 
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
@@ -22,7 +22,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -45,6 +44,7 @@ public class FixtureTest_MarkDeleted {
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
     public void testCreateAggregateYieldsLiveAggregate() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenNoPriorActivity()
@@ -63,6 +63,7 @@ public class FixtureTest_MarkDeleted {
     }
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
     public void testDeletedAggregateYieldsAggregateMarkedDeleted() {
         fixture.given(new MyEvent("id", 0))
                .when(new DeleteCommand("id", false))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.test.AxonAssertionError;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Jan-Hendrik Kuperus
+ */
+public class FixtureTest_MarkDeleted {
+
+    private FixtureConfiguration<AnnotatedAggregate> fixture;
+
+    @Before
+    public void setUp() {
+        fixture = new AggregateTestFixture<>(AnnotatedAggregate.class);
+    }
+
+    @After
+    public void tearDown() {
+        if (CurrentUnitOfWork.isStarted()) {
+            fail("A unit of work is still running");
+        }
+    }
+
+    @Test
+    public void testCreateAggregateYieldsLiveAggregate() {
+        fixture.registerInjectableResource(new HardToCreateResource());
+        fixture.givenNoPriorActivity()
+               .when(new CreateAggregateCommand("id"))
+               .expectEvents(new MyEvent("id", 0))
+               .expectNotMarkedDeleted();
+    }
+
+    @Test
+    public void testCreateAggregateYieldsLiveAggregateInverted() {
+        try {
+            fixture.registerInjectableResource(new HardToCreateResource());
+            fixture.givenNoPriorActivity()
+                    .when(new CreateAggregateCommand("id"))
+                    .expectEvents(new MyEvent("id", 0))
+                    .expectMarkedDeleted();
+        } catch (Throwable t) {
+            assertEquals(AxonAssertionError.class, t.getClass());
+        }
+    }
+
+    @Test
+    public void testDeletedAggregateYieldsAggregateMarkedDeleted() {
+        fixture.given(new MyEvent("id", 0))
+               .when(new DeleteCommand("id", false))
+               .expectEvents(new MyAggregateDeletedEvent(false))
+               .expectMarkedDeleted();
+    }
+
+    @Test
+    public void testDeletedAggregateYieldsAggregateMarkedDeletedInverted() {
+        try {
+            fixture.given(new MyEvent("id", 0))
+                    .when(new DeleteCommand("id", false))
+                    .expectEvents(new MyAggregateDeletedEvent(false))
+                    .expectNotMarkedDeleted();
+        } catch (Throwable t) {
+            assertEquals(AxonAssertionError.class, t.getClass());
+        }
+    }
+
+}


### PR DESCRIPTION
The ResultValidator is extended to support two methods which express an expectation of
whether the Aggregate should have been marked as deleted or not. The test-suite for
TestFixture has been extended to cover these situations using the AnnotatedAggregate.