### PR TITLE
Introduction of DisallowReplay annotation

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation marking a Handler (or class) as being capable of handling replays, or not, depending on the value
+ * passed.
+ * <p>
+ * When placed on the type (class) level, the setting applies to all handlers that don't explicitly override it
+ * on the method level.
+ * <p>
+ * Marking methods as not allowing replay will not change the routing of a message (i.e. will not invoke another
+ * handler method). Messages that would otherwise be handled by such handler are simply ignored.
+ *
+ * @author Allard Buijze
+ * @since 3.2
+ */
+@Documented
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AllowReplay {
+
+    /**
+     * Whether to allow replays on this handler, or not. Defaults to {@code true}
+     *
+     * @return Whether to allow replays on this handler, or not
+     */
+    boolean value() default true;
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ import java.lang.annotation.Target;
  * <p>
  * Marking methods as not allowing replay will not change the routing of a message (i.e. will not invoke another
  * handler method). Messages that would otherwise be handled by such handler are simply ignored.
+ *
+ * @author Tom Briers
+ * @since 4.2
  */
 @Documented
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.METHOD})

--- a/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation marking a Handler (or class) as being not be able to handle replays
+ * Annotation marking a Handler (or class) as not being able to handle replays
  * <p>
  * When placed on the type (class) level, the setting applies to all handlers that don't explicitly override it
  * on the method level.

--- a/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DisallowReplay.java
@@ -16,30 +16,24 @@
 
 package org.axonframework.eventhandling;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Annotation marking a Handler (or class) as being capable of handling replays, or not, depending on the value
- * passed.
+ * Annotation marking a Handler (or class) as being not be able to handle replays
  * <p>
  * When placed on the type (class) level, the setting applies to all handlers that don't explicitly override it
  * on the method level.
  * <p>
  * Marking methods as not allowing replay will not change the routing of a message (i.e. will not invoke another
  * handler method). Messages that would otherwise be handled by such handler are simply ignored.
- *
- * @author Allard Buijze
- * @since 3.2
  */
 @Documented
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AllowReplay {
-
-    /**
-     * Whether to allow replays on this handler, or not. Defaults to {@code true}
-     *
-     * @return Whether to allow replays on this handler, or not
-     */
-    boolean value() default true;
+@AllowReplay(false)
+public @interface DisallowReplay {
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.replay;
+
+import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackingToken;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ReplayAwareMessageHandlerWrapperTest {
+
+    private SomeHandler handler;
+    private AnnotationEventHandlerAdapter testSubject;
+    private ReplayToken replayToken;
+    private GlobalSequenceTrackingToken regularToken;
+
+    @Before
+    public void setUp() {
+        handler = new SomeHandler();
+        testSubject = new AnnotationEventHandlerAdapter(handler);
+        regularToken = new GlobalSequenceTrackingToken(1L);
+        replayToken = new ReplayToken(regularToken);
+    }
+
+    @Test
+    public void testInvokeWithReplayTokens() throws Exception {
+        GenericTrackedEventMessage<Object> stringEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage("1"));
+        GenericTrackedEventMessage<Object> longEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage(1L));
+        assertTrue(testSubject.canHandle(stringEvent));
+        assertTrue(testSubject.canHandle(longEvent));
+        testSubject.handle(stringEvent);
+        testSubject.handle(longEvent);
+
+        assertTrue(handler.receivedLongs.isEmpty());
+        assertFalse(handler.receivedStrings.isEmpty());
+    }
+
+    @AllowReplay(false)
+    private static class SomeHandler {
+
+        private List<String> receivedStrings = new ArrayList<>();
+        private List<Long> receivedLongs = new ArrayList<>();
+
+        @AllowReplay
+        @EventHandler
+        public void handle(String event, TrackingToken token) {
+            assertFalse(token instanceof ReplayToken);
+            receivedStrings.add(event);
+        }
+
+        @EventHandler()
+        public void handle(Long event, TrackingToken token) {
+            assertFalse(token instanceof ReplayToken);
+            receivedLongs.add(event);
+        }
+    }
+
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -16,8 +16,13 @@
 
 package org.axonframework.eventhandling.replay;
 
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.AllowReplay;
+import org.axonframework.eventhandling.AnnotationEventHandlerAdapter;
+import org.axonframework.eventhandling.DisallowReplay;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.ReplayToken;
 import org.axonframework.eventhandling.TrackingToken;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +34,7 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class ReplayAwareMessageHandlerWrapperTest {
+public class ReplayAwareMessageHandlerWrapperWithDisallowReplayTest {
 
     private SomeHandler handler;
     private AnnotationEventHandlerAdapter testSubject;
@@ -57,7 +62,7 @@ public class ReplayAwareMessageHandlerWrapperTest {
         assertFalse(handler.receivedStrings.isEmpty());
     }
 
-    @AllowReplay(false)
+    @DisallowReplay
     private static class SomeHandler {
 
         private List<String> receivedStrings = new ArrayList<>();

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test in order to verify that the {@link DisallowReplay} class has the expected behaviour.
+ * Test in order to verify that the {@link DisallowReplay} annotation has the expected behaviour.
  */
 public class ReplayAwareMessageHandlerWrapperWithDisallowReplayTest {
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -39,14 +39,12 @@ public class ReplayAwareMessageHandlerWrapperWithDisallowReplayTest {
     private SomeHandler handler;
     private AnnotationEventHandlerAdapter testSubject;
     private ReplayToken replayToken;
-    private GlobalSequenceTrackingToken regularToken;
 
     @Before
     public void setUp() {
         handler = new SomeHandler();
         testSubject = new AnnotationEventHandlerAdapter(handler);
-        regularToken = new GlobalSequenceTrackingToken(1L);
-        replayToken = new ReplayToken(regularToken);
+        replayToken = new ReplayToken(new GlobalSequenceTrackingToken(1L));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -34,6 +34,9 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Test in order to verify that the {@link DisallowReplay} class has the expected behaviour.
+ */
 public class ReplayAwareMessageHandlerWrapperWithDisallowReplayTest {
 
     private SomeHandler handler;

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hi, 

As I understand the logic for the AllowReplay annotation, it is as follows:

- No annotation: replay is allowed
- Annotation without boolean: replay is allowed
- Annotation with boolean: boolean value is use to decide the replay

Given this logic, the only time we seem to add the AllowReplay annotation is to not allow a replay.  To make this more explicit I thougt it would be usefull to have the 'inverted' annotation: "DisallowReplay".

Regards,

Tom.