### PR TITLE
[#1097] Problem with ScopeDescriptor after migration from axon 3.4 to 4.1

### DIFF
--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-modelling</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.3</version>
@@ -49,6 +55,19 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/legacy/src/main/java/org/axonframework/commandhandling/model/AggregateScopeDescriptor.java
+++ b/legacy/src/main/java/org/axonframework/commandhandling/model/AggregateScopeDescriptor.java
@@ -1,0 +1,46 @@
+package org.axonframework.commandhandling.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+/**
+ * Implementation of the {@link org.axonframework.modelling.command.AggregateScopeDescriptor} used to bridge serialized
+ * versions of this descriptor when migrating from Axon 3.x to Axon 4.x.
+ *
+ * @author Steven van Beelen
+ * @since 4.2
+ * @deprecated in favor of the {@link org.axonframework.modelling.command.AggregateScopeDescriptor}
+ */
+@Deprecated
+public class AggregateScopeDescriptor extends org.axonframework.modelling.command.AggregateScopeDescriptor {
+
+    // Fields {@code type} and {@code identifier} are used during Java and XStream de-/serialization through methods
+    // {@link #readObject(ObjectInputStream)} and {@link #readResolve()}.
+    @SuppressWarnings("unused")
+    private String type;
+    @SuppressWarnings("unused")
+    private Object identifier;
+
+    /**
+     * Instantiate a AggregateScopeDescriptor with the provided {@code type} and {@code identifier}.
+     *
+     * @param type       A {@link String} describing the type of the Saga
+     * @param identifier An {@link Object} denoting the identifier of the Saga
+     */
+
+    @JsonCreator
+    public AggregateScopeDescriptor(@JsonProperty("type") String type, @JsonProperty("identifier") Object identifier) {
+        super(type, identifier);
+    }
+
+    private void readObject(ObjectInputStream objectInputStream) throws IOException, ClassNotFoundException {
+        objectInputStream.defaultReadObject();
+    }
+
+    private Object readResolve() {
+        return new org.axonframework.modelling.command.AggregateScopeDescriptor(type, identifier);
+    }
+}

--- a/legacy/src/main/java/org/axonframework/eventhandling/saga/SagaScopeDescriptor.java
+++ b/legacy/src/main/java/org/axonframework/eventhandling/saga/SagaScopeDescriptor.java
@@ -1,0 +1,27 @@
+package org.axonframework.eventhandling.saga;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Implementation of the {@link org.axonframework.modelling.saga.SagaScopeDescriptor} used to bridge serialized versions
+ * of this descriptor when migrating from Axon 3.x to Axon 4.x.
+ *
+ * @author Steven van Beelen
+ * @since 4.2
+ * @deprecated in favor of the {@link org.axonframework.modelling.saga.SagaScopeDescriptor}
+ */
+@Deprecated
+public class SagaScopeDescriptor extends org.axonframework.modelling.saga.SagaScopeDescriptor {
+
+    /**
+     * Instantiate a SagaScopeDescriptor with the provided {@code type} and {@code identifier}.
+     *
+     * @param type       A {@link String} describing the type of the Saga
+     * @param identifier An {@link Object} denoting the identifier of the Saga
+     */
+    @JsonCreator
+    public SagaScopeDescriptor(@JsonProperty("type") String type, @JsonProperty("identifier") Object identifier) {
+        super(type, identifier);
+    }
+}

--- a/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
@@ -1,0 +1,63 @@
+package org.axonframework.commandhandling.model;
+
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test whether the serialized form of the {@link org.axonframework.commandhandling.model.AggregateScopeDescriptor} can
+ * be deserialized into the {@link AggregateScopeDescriptor}, using the {@link XStreamSerializer} and
+ * {@link JacksonSerializer}.
+ *
+ * @author Steven van Beelen
+ */
+public class AggregateScopeDescriptorTest {
+
+    private static final String LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME =
+            "org.axonframework.commandhandling.model.AggregateScopeDescriptor";
+    private static final String AGGREGATE_TYPE = "aggregate-type";
+    private static final String AGGREGATE_ID = "aggregate-id";
+
+    @Test
+    public void testXStreamSerializationOfOldAggregateScopeDescriptor() {
+        XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
+
+        String xmlSerializedScopeDescriptor =
+                "<org.axonframework.commandhandling.model.AggregateScopeDescriptor serialization=\"custom\">"
+                        + "<org.axonframework.commandhandling.model.AggregateScopeDescriptor>"
+                        + "<default>"
+                        + "<identifier class=\"string\">" + AGGREGATE_ID + "</identifier>"
+                        + "<type>" + AGGREGATE_TYPE + "</type>"
+                        + "</default>"
+                        + "</org.axonframework.commandhandling.model.AggregateScopeDescriptor>"
+                        + "</org.axonframework.commandhandling.model.AggregateScopeDescriptor>";
+        SerializedObject<String> serializedScopeDescriptor = new SimpleSerializedObject<>(
+                xmlSerializedScopeDescriptor, String.class, LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME, null
+        );
+
+        org.axonframework.modelling.command.AggregateScopeDescriptor result =
+                serializer.deserialize(serializedScopeDescriptor);
+        assertEquals(AGGREGATE_TYPE, result.getType());
+        assertEquals(AGGREGATE_ID, result.getIdentifier());
+    }
+
+    @Test
+    public void testJacksonSerializationOfOldAggregateScopeDescriptor() {
+        JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
+
+        String jacksonSerializedScopeDescriptor =
+                "{\"type\":\"" + AGGREGATE_TYPE + "\",\"identifier\":\"" + AGGREGATE_ID + "\"}";
+        SerializedObject<String> serializedScopeDescriptor = new SimpleSerializedObject<>(
+                jacksonSerializedScopeDescriptor, String.class, LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME, null
+        );
+
+        org.axonframework.modelling.command.AggregateScopeDescriptor result =
+                serializer.deserialize(serializedScopeDescriptor);
+        assertEquals(AGGREGATE_TYPE, result.getType());
+        assertEquals(AGGREGATE_ID, result.getIdentifier());
+    }
+}

--- a/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
@@ -1,0 +1,57 @@
+package org.axonframework.eventhandling.saga;
+
+import org.axonframework.modelling.saga.SagaScopeDescriptor;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test whether the serialized form of the {@link org.axonframework.eventhandling.saga.SagaScopeDescriptor} can be
+ * deserialized into the {@link SagaScopeDescriptor}, using the {@link XStreamSerializer} and {@link JacksonSerializer}.
+ *
+ * @author Steven van Beelen
+ */
+public class SagaScopeDescriptorTest {
+
+    private static final String LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME =
+            "org.axonframework.eventhandling.saga.SagaScopeDescriptor";
+    private static final String SAGA_TYPE = "saga-type";
+    private static final String SAGA_ID = "saga-id";
+
+    @Test
+    public void testXStreamSerializationOfOldSagaScopeDescriptor() {
+        XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
+
+        String xmlSerializedScopeDescriptor =
+                "<org.axonframework.eventhandling.saga.SagaScopeDescriptor>"
+                        + "<type>" + SAGA_TYPE + "</type>"
+                        + "<identifier class=\"string\">" + SAGA_ID + "</identifier>"
+                        + "</org.axonframework.eventhandling.saga.SagaScopeDescriptor>";
+        SerializedObject<String> serializedScopeDescriptor = new SimpleSerializedObject<>(
+                xmlSerializedScopeDescriptor, String.class, LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME, null
+        );
+
+        SagaScopeDescriptor result = serializer.deserialize(serializedScopeDescriptor);
+        assertEquals(SAGA_TYPE, result.getType());
+        assertEquals(SAGA_ID, result.getIdentifier());
+    }
+
+    @Test
+    public void testJacksonSerializationOfOldSagaScopeDescriptor() {
+        JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
+
+        String jacksonSerializedScopeDescriptor =
+                "{\"type\":\"" + SAGA_TYPE + "\",\"identifier\":\"" + SAGA_ID + "\"}";
+        SerializedObject<String> serializedScopeDescriptor = new SimpleSerializedObject<>(
+                jacksonSerializedScopeDescriptor, String.class, LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME, null
+        );
+
+        SagaScopeDescriptor result = serializer.deserialize(serializedScopeDescriptor);
+        assertEquals(SAGA_TYPE, result.getType());
+        assertEquals(SAGA_ID, result.getIdentifier());
+    }
+}


### PR DESCRIPTION
This PR introduces legacy versions of the `AggregateScopeDescriptor` and `SagaScopeDescriptor` in the `axon-legacy` package. This will for example ensure that people migrating from Axon 3.x to 4.2 will be able to reuse their scheduled messages.