### PR TITLE
[#698] Make LoggingInterceptor implement Message Dispatch Interceptor

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2016. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,24 +18,30 @@ package org.axonframework.messaging.interceptors;
 
 import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.function.BiFunction;
+
 import static java.lang.String.format;
 
 /**
- * Message Handler Interceptor that logs incoming messages and their result to a SLF4J logger. Allow configuration of
- * the name under which the logger should log the statements.
+ * {@link MessageDispatchInterceptor} and {@link MessageHandlerInterceptor} implementation that logs dispatched and
+ * incoming messages, and their result, to a SLF4J logger. Allows configuration of the name under which the logger
+ * should log the statements.
  * <p/>
- * Incoming messages and successful executions are logged at the {@code INFO} level. Processing errors are logged
- * using the {@code WARN} level.
+ * Dispatched, incoming messages and successful executions are logged at the {@code INFO} level. Processing errors are
+ * logged using the {@code WARN} level.
  *
  * @author Allard Buijze
  * @since 0.6
  */
-public class LoggingInterceptor<T extends Message<?>> implements MessageHandlerInterceptor<T> {
+public class LoggingInterceptor<T extends Message<?>>
+        implements MessageDispatchInterceptor<T>, MessageHandlerInterceptor<T> {
 
     private final Logger logger;
 
@@ -61,6 +67,14 @@ public class LoggingInterceptor<T extends Message<?>> implements MessageHandlerI
     }
 
     @Override
+    public BiFunction<Integer, T, T> handle(List<? extends T> messages) {
+        return (i, message) -> {
+            logger.info("Dispatched messages: [{}]", message.getPayloadType().getSimpleName());
+            return message;
+        };
+    }
+
+    @Override
     public Object handle(UnitOfWork<? extends T> unitOfWork, InterceptorChain interceptorChain)
             throws Exception {
         T message = unitOfWork.getMessage();
@@ -68,8 +82,8 @@ public class LoggingInterceptor<T extends Message<?>> implements MessageHandlerI
         try {
             Object returnValue = interceptorChain.proceed();
             logger.info("[{}] executed successfully with a [{}] return value",
-                    message.getPayloadType().getSimpleName(),
-                    returnValue == null ? "null" : returnValue.getClass().getSimpleName());
+                        message.getPayloadType().getSimpleName(),
+                        returnValue == null ? "null" : returnValue.getClass().getSimpleName());
             return returnValue;
         } catch (Exception t) {
             logger.warn(format("[%s] execution failed:", message.getPayloadType().getSimpleName()), t);


### PR DESCRIPTION
Let the `LoggingInterceptor` implement both the `MessageHandlerInterceptor` and the `MessageDispatchInterceptor`. Doing so will allow a `LoggingInterceptor` to be used to log on dispatching a message and upon handling an incoming message.

This PR resolves #698