### PR TITLE
Updates version of XStream (fixes CVE-2013-7285 vulnerability)

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.10</version>
+            <version>1.4.11.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>xpp3</groupId>


### PR DESCRIPTION
Our OWASP-tooling identified XStream 1.4.10 to have a vulnerability. Version 1.4.11.1 fixes this vulnerability.