### PR TITLE
PessimisticLockFactory log fix

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -219,7 +219,7 @@ public class PessimisticLockFactory implements LockFactory {
         /**
          * Builds the PessimisticLockFactory instance using the properties defined in this builder
          *
-         * @return a fully configured PessimisticLockfactory instance
+         * @return a fully configured PessimisticLockFactory instance
          */
         public PessimisticLockFactory build() {
             return new PessimisticLockFactory(this);
@@ -263,7 +263,7 @@ public class PessimisticLockFactory implements LockFactory {
                         checkForDeadlock();
                         if (attempts < 1) {
                             throw new LockAcquisitionFailedException(
-                                    "Failed to acquire lock for aggregate identifier(" + identifier + "), maximum attempts exceeded (" + maximumQueued + ")"
+                                    "Failed to acquire lock for aggregate identifier(" + identifier + "), maximum attempts exceeded (" + acquireAttempts + ")"
                             );
                         }
                     } while (!lock.tryLock(lockAttemptTimeout, TimeUnit.MILLISECONDS));

--- a/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
@@ -146,7 +146,7 @@ public class PessimisticLockFactoryTest {
     }
 
     @Test(timeout = 5000, expected = LockAcquisitionFailedException.class)
-    public void testAquireBackoff() {
+    public void testAcquireBackoff() {
         final PessimisticLockFactory lockFactory = PessimisticLockFactory.builder()
                                                                          .acquireAttempts(10)
                                                                          .queueLengthThreshold(Integer.MAX_VALUE)


### PR DESCRIPTION
Fixed the variable in the log - we want to log acquireAttempts instead of maximum queued threads.