### PR TITLE
Handler Comparator Hierarchy Fix

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,6 @@ package org.axonframework.messaging.annotation;
 
 import java.lang.reflect.Executable;
 import java.util.Comparator;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
@@ -49,11 +48,9 @@ public final class HandlerComparator {
     }
 
     private static int compareHierarchy(Class<?> o1, Class<?> o2) {
-        if (Objects.equals(o1, o2)) {
-            return 0;
-        } else if (o1.isAssignableFrom(o2)) {
+        if (o1.isInterface() && !o2.isInterface()){
             return 1;
-        } else if (o2.isAssignableFrom(o1)) {
+        } else if (!o1.isInterface() && o2.isInterface()) {
             return -1;
         }
         return Integer.compare(depthOf(o2), depthOf(o1));
@@ -62,9 +59,16 @@ public final class HandlerComparator {
     private static int depthOf(Class<?> o1) {
         int depth = 0;
         Class<?> type = o1;
-        while (type != null && !Object.class.equals(type)) {
-            depth++;
-            type = type.getSuperclass();
+        if (o1.isInterface()) {
+            while (type.getInterfaces().length > 0) {
+                depth++;
+                type = type.getInterfaces()[0];
+            }
+        } else {
+            while (type != null) {
+                depth++;
+                type = type.getSuperclass();
+            }
         }
         if (o1.isAnnotation()) {
             depth += 1000;

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerHierarchyTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerHierarchyTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.junit.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests sorting of handlers using {@link HandlerComparator}. Event types have complex hierarchical inheritance.
+ *
+ * @author Milan Savic
+ */
+public class HandlerHierarchyTest {
+
+    private interface C {}
+    private interface D extends C {}
+    private interface H extends D {}
+    private interface E extends D {}
+    private static abstract class F implements D {}
+    private static class I implements H {}
+    private static abstract class G implements E {}
+    private static class A {}
+    private static class B {}
+
+    private static class MyEventHandler {
+
+        @EventHandler public void handle(E event) {}
+        @EventHandler public void handle(G event) {}
+        @EventHandler public void handle(A event) {}
+        @EventHandler public void handle(B event) {}
+        @EventHandler public void handle(I event) {}
+        @EventHandler public void handle(F event) {}
+    }
+
+    @Test
+    public void testHierarchySort() throws NoSuchMethodException {
+        MultiParameterResolverFactory multiParameterResolverFactory = MultiParameterResolverFactory.ordered(new DefaultParameterResolverFactory());
+
+        MessageHandlingMember<?> bHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", B.class),
+                                                                                 EventMessage.class,
+                                                                                 B.class,
+                                                                                 multiParameterResolverFactory);
+        MessageHandlingMember<?> iHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", I.class),
+                                                                                 EventMessage.class,
+                                                                                 I.class,
+                                                                                 multiParameterResolverFactory);
+        MessageHandlingMember<?> fHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", F.class),
+                                                                                 EventMessage.class,
+                                                                                 F.class,
+                                                                                 multiParameterResolverFactory);
+        MessageHandlingMember<?> aHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", A.class),
+                                                                                 EventMessage.class,
+                                                                                 A.class,
+                                                                                 multiParameterResolverFactory);
+        MessageHandlingMember<?> gHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", G.class),
+                                                                                 EventMessage.class,
+                                                                                 G.class,
+                                                                                 multiParameterResolverFactory);
+        MessageHandlingMember<?> eHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", E.class),
+                                                                                 EventMessage.class,
+                                                                                 E.class,
+                                                                                 multiParameterResolverFactory);
+
+        List<MessageHandlingMember<?>> handlers = Arrays.asList(bHandler,
+                                                                iHandler,
+                                                                fHandler,
+                                                                aHandler,
+                                                                gHandler,
+                                                                eHandler);
+
+        handlers.sort(HandlerComparator.instance());
+        assertTrue(handlers.indexOf(gHandler) < handlers.indexOf(eHandler));
+    }
+}


### PR DESCRIPTION
Changed the way we compare handlers - classes take precedence over interfaces. Depth of interface hierarchy is calculated based on interface inheritance level.

Co-Authored Sara Pellegrini