### PR TITLE
Keep UnitOfWork root exception when rollback failed

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
+++ b/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.common.jdbc;
 
+import org.axonframework.messaging.ExecutionException;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 
@@ -87,9 +88,10 @@ public class UnitOfWorkAwareConnectionProviderWrapper implements ConnectionProvi
                     }
                 } catch (SQLException ex) {
                     if (u.getExecutionResult().isExceptionResult()) {
-                        Throwable executeException = u.getExecutionResult().getExceptionResult();
+                        ExecutionException executeException =
+                            new ExecutionException("Unable to rollback transaction", u.getExecutionResult().getExceptionResult());
                         executeException.addSuppressed(ex);
-                        throw new JdbcException("Unable to rollback transaction", executeException);
+                        throw executeException;
                     }
                     throw new JdbcException("Unable to rollback transaction", ex);
                 }

--- a/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
+++ b/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
@@ -86,6 +86,9 @@ public class UnitOfWorkAwareConnectionProviderWrapper implements ConnectionProvi
                         cx.rollback();
                     }
                 } catch (SQLException ex) {
+                    if(u.root().getExecutionResult().isExceptionResult()){
+                        ex.addSuppressed(u.root().getExecutionResult().getExceptionResult());
+                    }
                     throw new JdbcException("Unable to rollback transaction", ex);
                 }
             });

--- a/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
+++ b/messaging/src/main/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapper.java
@@ -86,8 +86,10 @@ public class UnitOfWorkAwareConnectionProviderWrapper implements ConnectionProvi
                         cx.rollback();
                     }
                 } catch (SQLException ex) {
-                    if(u.root().getExecutionResult().isExceptionResult()){
-                        ex.addSuppressed(u.root().getExecutionResult().getExceptionResult());
+                    if (u.getExecutionResult().isExceptionResult()) {
+                        Throwable executeException = u.getExecutionResult().getExceptionResult();
+                        executeException.addSuppressed(ex);
+                        throw new JdbcException("Unable to rollback transaction", executeException);
                     }
                     throw new JdbcException("Unable to rollback transaction", ex);
                 }

--- a/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
+++ b/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.common.jdbc;
 
+import org.axonframework.messaging.ExecutionException;
 import org.axonframework.messaging.GenericResultMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
@@ -132,8 +133,9 @@ public class UnitOfWorkAwareConnectionProviderWrapperTest {
         testSubject.getConnection();
         try {
             uow.rollback();
-        } catch (JdbcException e) {
+        } catch (ExecutionException e) {
             assertEquals(NullPointerException.class, e.getCause().getClass());
+            assertEquals(SQLException.class, e.getSuppressed()[0].getClass());
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
+++ b/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
@@ -123,7 +123,7 @@ public class UnitOfWorkAwareConnectionProviderWrapperTest {
             @Override
             public ExecutionResult getExecutionResult() {
                 return new ExecutionResult(
-                    GenericResultMessage.asResultMessage(new NullPointerException()));
+                    GenericResultMessage.asResultMessage(new IllegalArgumentException()));
             }
         };
         doThrow(SQLException.class).when(mockConnection)
@@ -134,7 +134,7 @@ public class UnitOfWorkAwareConnectionProviderWrapperTest {
         try {
             uow.rollback();
         } catch (ExecutionException e) {
-            assertEquals(NullPointerException.class, e.getCause().getClass());
+            assertEquals(IllegalArgumentException.class, e.getCause().getClass());
             assertEquals(SQLException.class, e.getSuppressed()[0].getClass());
         }
     }


### PR DESCRIPTION
Currently, when connection rollback failed, the original exception is lost.
This makes it harder to investigate the problem why the `UnitOfWork` was rolled-back.