### PR TITLE
Fix time window in SlidingTimeWindowReservoir

### DIFF
--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/reservoir/SlidingTimeWindowReservoir.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/reservoir/SlidingTimeWindowReservoir.java
@@ -60,7 +60,7 @@ public class SlidingTimeWindowReservoir {
         this.clock = clock;
         this.measurements = new ConcurrentSkipListMap<>();
         this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
-        this.lastTick = new AtomicLong(clock.wallTime() * COLLISION_BUFFER);
+        this.lastTick = new AtomicLong(clock.monotonicTime() * COLLISION_BUFFER);
         this.count = new AtomicLong();
     }
 
@@ -89,7 +89,7 @@ public class SlidingTimeWindowReservoir {
     private long getTick() {
         for (; ; ) {
             final long oldTick = lastTick.get();
-            final long tick = clock.wallTime() * COLLISION_BUFFER;
+            final long tick = clock.monotonicTime() * COLLISION_BUFFER;
             // ensure the tick is strictly incrementing even if there are duplicate ticks
             final long newTick = tick - oldTick > 0 ? tick : oldTick + 1;
             if (lastTick.compareAndSet(oldTick, newTick)) {

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/reservoir/SlidingTimeWindowReservoirTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/reservoir/SlidingTimeWindowReservoirTest.java
@@ -34,7 +34,7 @@ public class SlidingTimeWindowReservoirTest {
 
     @Test
     public void storesMeasurementsWithDuplicateTicks() {
-        when(clock.wallTime()).thenReturn(20L);
+        when(clock.monotonicTime()).thenReturn(20L);
 
         reservoir.update(1L);
         reservoir.update(2L);
@@ -44,19 +44,19 @@ public class SlidingTimeWindowReservoirTest {
 
     @Test
     public void boundsMeasurementsToATimeWindow() {
-        when(clock.wallTime()).thenReturn(0L);
+        when(clock.monotonicTime()).thenReturn(0L);
         reservoir.update(1L);
 
-        when(clock.wallTime()).thenReturn(5L);
+        when(clock.monotonicTime()).thenReturn(5L);
         reservoir.update(2L);
 
-        when(clock.wallTime()).thenReturn(10L);
+        when(clock.monotonicTime()).thenReturn(10L);
         reservoir.update(3L);
 
-        when(clock.wallTime()).thenReturn(15L);
+        when(clock.monotonicTime()).thenReturn(15L);
         reservoir.update(4L);
 
-        when(clock.wallTime()).thenReturn(20L);
+        when(clock.monotonicTime()).thenReturn(20L);
         reservoir.update(5L);
 
         assertEquals(Arrays.asList(4L, 5L), reservoir.getMeasurements());


### PR DESCRIPTION
The time window given to the constructor of SlidingTimeWindowReservoir is converted to nanoseconds. However, the keys used in the field measurements are in milliseconds. This results in incorrect behavior when invoking the trim method. Less measurements are removed than required.