### PR TITLE
Deal with null MetaData values in the GrpcMetaDataConverter

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
@@ -20,6 +20,7 @@ import com.google.protobuf.ByteString;
 import io.axoniq.axonserver.grpc.MetaDataValue;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
 
 import java.util.HashMap;
@@ -77,15 +78,30 @@ public class GrpcMetaDataConverter {
             builder.setBooleanValue((Boolean) value);
         } else {
             SerializedObject<byte[]> serializedObject = serializer.serialize(value, byte[].class);
-            builder.setBytesValue(io.axoniq.axonserver.grpc.SerializedObject
-                                          .newBuilder()
-                                          .setType(serializedObject.getType().getName())
-                                          .setData(ByteString.copyFrom(serializedObject.getData()))
-                                          .setRevision(getOrDefault(serializedObject.getType().getRevision(), ""))
-                                          .build());
+            SerializedType serializedType = serializedObject.getType();
+
+            if (isNonEmptyType(serializedType)) {
+                builder.setBytesValue(io.axoniq.axonserver.grpc.SerializedObject
+                                              .newBuilder()
+                                              .setType(serializedType.getName())
+                                              .setData(ByteString.copyFrom(serializedObject.getData()))
+                                              .setRevision(getOrDefault(serializedType.getRevision(), ""))
+                                              .build());
+            }
         }
 
         return builder.build();
+    }
+
+    /**
+     * Check whether the {@code serializedType} equals {@link SerializedType#emptyType()}.
+     *
+     * @param serializedType the type to check whether it equals {@link SerializedType#emptyType()}
+     * @return {@code true} if the {@code serializedType} does not equal the {@link SerializedType#emptyType()} and
+     * {@code false} if it does
+     */
+    private boolean isNonEmptyType(SerializedType serializedType) {
+        return !serializedType.getName().equals(SerializedType.emptyType().getName());
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
@@ -80,7 +80,7 @@ public class GrpcMetaDataConverter {
             SerializedObject<byte[]> serializedObject = serializer.serialize(value, byte[].class);
             SerializedType serializedType = serializedObject.getType();
 
-            if (isNonEmptyType(serializedType)) {
+            if (!SerializedType.isEmptyType(serializedType)) {
                 builder.setBytesValue(io.axoniq.axonserver.grpc.SerializedObject
                                               .newBuilder()
                                               .setType(serializedType.getName())
@@ -91,17 +91,6 @@ public class GrpcMetaDataConverter {
         }
 
         return builder.build();
-    }
-
-    /**
-     * Check whether the {@code serializedType} equals {@link SerializedType#emptyType()}.
-     *
-     * @param serializedType the type to check whether it equals {@link SerializedType#emptyType()}
-     * @return {@code true} if the {@code serializedType} does not equal the {@link SerializedType#emptyType()} and
-     * {@code false} if it does
-     */
-    private boolean isNonEmptyType(SerializedType serializedType) {
-        return !serializedType.getName().equals(SerializedType.emptyType().getName());
     }
 
     /**

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
@@ -1,0 +1,244 @@
+package org.axonframework.axonserver.connector.util;
+
+import io.axoniq.axonserver.grpc.MetaDataValue;
+import io.axoniq.axonserver.grpc.SerializedObject;
+import org.axonframework.serialization.Revision;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test whether the {@link GrpcMetaDataConverter} can cope with several forms of the {@link MetaDataValue}. Born out of
+ * the scenario that gRPC is of pulling a serialized object of type {@code empty} over the wire, which any used
+ * {@link Serializer} would be incapable of handling correctly.
+ *
+ * @author Steven van Beelen
+ */
+public class GrpcMetaDataConverterTest {
+
+    private final Serializer serializer = spy(XStreamSerializer.defaultSerializer());
+    private final GrpcMetaDataConverter testSubject = new GrpcMetaDataConverter(serializer);
+
+    @Test
+    public void testConvertStringToMetaDataValue() {
+        String testValue = "some-text";
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
+
+        assertEquals(testValue, result.getTextValue());
+    }
+
+    @Test
+    public void testConvertDoubleToMetaDataValue() {
+        double testValue = 10d;
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
+
+        assertEquals(testValue, result.getDoubleValue(), 0);
+    }
+
+    @Test
+    public void testConvertFloatToMetaDataValue() {
+        float testValue = 10f;
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
+
+        assertEquals(testValue, result.getDoubleValue(), 0);
+    }
+
+    @Test
+    public void testConvertIntegerToMetaDataValue() {
+        int testValue = 10;
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
+
+        assertEquals(testValue, result.getNumberValue());
+    }
+
+    @Test
+    public void testConvertLongToMetaDataValue() {
+        long testValue = 10L;
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
+
+        assertEquals(testValue, result.getNumberValue());
+    }
+
+    @Test
+    public void testConvertBooleanToMetaDataValue() {
+        MetaDataValue result = testSubject.convertToMetaDataValue(true);
+
+        assertTrue(result.getBooleanValue());
+    }
+
+    @Test
+    public void testConvertObjectToMetaDataValueUsesSerializer() {
+        TestObject testObject = new TestObject("some-text");
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
+
+        verify(serializer).serialize(testObject, byte[].class);
+
+        SerializedObject resultBytes = result.getBytesValue();
+        assertEquals(TestObject.class.getName(), resultBytes.getType());
+        assertNotNull(resultBytes.getData());
+        assertEquals("", resultBytes.getRevision());
+    }
+
+    @Test
+    public void testConvertObjectWithRevisionToMetaDataValue() {
+        RevisionTestObject testObject = new RevisionTestObject("some-text");
+
+        MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
+
+        verify(serializer).serialize(testObject, byte[].class);
+
+        SerializedObject resultBytes = result.getBytesValue();
+        assertEquals(RevisionTestObject.class.getName(), resultBytes.getType());
+        assertNotNull(resultBytes.getData());
+        assertEquals("some-revision", resultBytes.getRevision());
+    }
+
+    @Test
+    public void testConvertNullToMetaDataValue() {
+        MetaDataValue result = testSubject.convertToMetaDataValue(null);
+
+        verify(serializer).serialize(null, byte[].class);
+
+        assertEquals(MetaDataValue.DataCase.DATA_NOT_SET, result.getDataCase());
+    }
+
+    @Test
+    public void testConvertFromTextMetaDataValue() {
+        String expected = "some-text";
+        MetaDataValue testMetaData = MetaDataValue.newBuilder()
+                                                  .setTextValue(expected)
+                                                  .build();
+
+        Object resultObject = testSubject.convertFromMetaDataValue(testMetaData);
+
+        assertTrue(resultObject instanceof String);
+        String result = (String) resultObject;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testConvertFromBytesMetaDataValue() {
+        TestObject testObject = new TestObject("some-text");
+        MetaDataValue testMetaData = testSubject.convertToMetaDataValue(testObject);
+
+        Object resultObject = testSubject.convertFromMetaDataValue(testMetaData);
+
+        verify(serializer).deserialize(isA(GrpcSerializedObject.class));
+        assertTrue(resultObject instanceof TestObject);
+        assertEquals(testObject, resultObject);
+    }
+
+    @Test
+    public void testConvertFromBytesMetaDataValueOfTypeEmptyReturnsNull() {
+        MetaDataValue testMetaData = testSubject.convertToMetaDataValue(null);
+
+        assertNull(testSubject.convertFromMetaDataValue(testMetaData));
+    }
+
+    @Test
+    public void testConvertFromDoubleMetaDataValue() {
+        @SuppressWarnings("WrapperTypeMayBePrimitive")
+        Double expected = 10d;
+        MetaDataValue testMetaData = MetaDataValue.newBuilder()
+                                                  .setDoubleValue(expected)
+                                                  .build();
+
+        Object resultObject = testSubject.convertFromMetaDataValue(testMetaData);
+
+        assertTrue(resultObject instanceof Double);
+        Double result = (Double) resultObject;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testConvertFromNumberMetaDataValue() {
+        @SuppressWarnings("WrapperTypeMayBePrimitive")
+        Long expected = 10L;
+        MetaDataValue testMetaData = MetaDataValue.newBuilder()
+                                                  .setNumberValue(expected)
+                                                  .build();
+
+        Object resultObject = testSubject.convertFromMetaDataValue(testMetaData);
+
+        assertTrue(resultObject instanceof Long);
+        Long result = (Long) resultObject;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testConvertFromBooleanMetaDataValue() {
+        MetaDataValue testMetaData = MetaDataValue.newBuilder()
+                                                  .setBooleanValue(true)
+                                                  .build();
+
+        Object resultObject = testSubject.convertFromMetaDataValue(testMetaData);
+
+        assertTrue(resultObject instanceof Boolean);
+        Boolean result = (Boolean) resultObject;
+        assertTrue(result);
+    }
+
+    @Test
+    public void testConvertFromDataNotSetMetaDataValue() {
+        MetaDataValue testMetaData = MetaDataValue.getDefaultInstance();
+
+        assertNull(testSubject.convertFromMetaDataValue(testMetaData));
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestObject {
+
+        private final String testField;
+
+        private TestObject(String testField) {
+            this.testField = testField;
+        }
+
+        public String getTestField() {
+            return testField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestObject that = (TestObject) o;
+            return Objects.equals(testField, that.testField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(testField);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Revision("some-revision")
+    private static class RevisionTestObject {
+
+        private final String testField;
+
+        private RevisionTestObject(String testField) {
+            this.testField = testField;
+        }
+
+        public String getTestField() {
+            return testField;
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
@@ -45,7 +45,7 @@ public interface SerializedType {
      *
      * @throws NullPointerException if the given {@link SerializedType} is {@code null}
      */
-    static boolean isEmptyType(SerializedType serializedType) throws NullPointerException {
+    static boolean isEmptyType(SerializedType serializedType) {
         return emptyType().getName().equals(serializedType.getName());
     }
 

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
@@ -35,6 +35,21 @@ public interface SerializedType {
     }
 
     /**
+     * Check whether the {@code serializedType} equals {@link SerializedType#emptyType#getName()} and returns a
+     * corresponding {@code true} or {@code false} whether this is the case or not. The given {@code serializedType}
+     * should not be {@code null} as otherwise a {@link NullPointerException} will be thrown.
+     *
+     * @param serializedType the type to check whether it equals {@link SerializedType#emptyType()}
+     * @return {@code true} if the {@code serializedType} does equals the {@link SerializedType#emptyType()#getName()}
+     * and {@code false} if it does
+     *
+     * @throws NullPointerException if the given {@link SerializedType} is {@code null}
+     */
+    static boolean isEmptyType(SerializedType serializedType) throws NullPointerException {
+        return emptyType().getName().equals(serializedType.getName());
+    }
+
+    /**
      * Returns the name of the serialized type. This may be the class name of the serialized object, or an alias for
      * that name.
      *


### PR DESCRIPTION
The `GrpcMetaDataConverter` currently we create a `MetaDataValue` containing the type `empty` if the `GrpcMetaDataConverter#convertToMetaDataValue(Object)` method receives a `null`.
This occurs because the `Serializer` will change the type to 'empty' as a fallback. 

However, when such a `MetaDataValue` is pulled through the `GrpcMetaDataConverter#convertFromMetaDataValue(MetaDataValue)`, the used `Serializer` will fail, stating it does not know the serialized type `empty` (and rightfully so).

Thus, it would be beneficial if the 'convertTo' method does not set a `null` serialized object, but instead returns an empty `MetaDataValue` instance.

This is exactly what this PR does, including several test cases to verify the validity of the `convertToMetaDataValue` and `convertFromMetaDataValue` methods.