### PR TITLE
Configurable event filtering for EventSourcingRepository

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -20,6 +20,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
+import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcingRepository;
 import org.axonframework.eventsourcing.GenericAggregateFactory;
@@ -38,6 +39,7 @@ import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaMode
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.lang.String.format;
 import static org.axonframework.common.Assert.state;
@@ -58,6 +60,8 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     private final Component<SnapshotTriggerDefinition> snapshotTriggerDefinition;
     private final Component<CommandTargetResolver> commandTargetResolver;
     private final Component<AggregateModel<A>> metaModel;
+    private final Component<Predicate<? super DomainEventMessage<?>>> filter;
+    private final Component<Boolean> filterByAggregateType;
     private final List<Registration> registrations = new ArrayList<>();
     private Configuration parent;
 
@@ -84,6 +88,9 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                                                     c -> NoSnapshotTriggerDefinition.INSTANCE);
         aggregateFactory =
                 new Component<>(() -> parent, name("aggregateFactory"), c -> new GenericAggregateFactory<>(aggregate));
+        filter = new Component<>(() -> parent, "filter<" + aggregate.getSimpleName() + ">", c -> null);
+        filterByAggregateType =
+                new Component<>(() -> parent, "filterByAggregateType<" + aggregate.getSimpleName() + ">", c -> false);
         repository = new Component<>(
                 () -> parent,
                 "Repository<" + aggregate.getSimpleName() + ">",
@@ -101,13 +108,19 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                                                                                        c.handlerDefinition(aggregate),
                                                                                        c::repository);
                     }
-                    return EventSourcingRepository.builder(aggregate)
+
+                    EventSourcingRepository.Builder<A> builder = EventSourcingRepository.builder(aggregate)
                             .aggregateModel(metaModel.get())
                             .aggregateFactory(aggregateFactory.get())
                             .eventStore(c.eventStore())
                             .snapshotTriggerDefinition(snapshotTriggerDefinition.get())
-                            .repositoryProvider(c::repository)
-                            .build();
+                            .repositoryProvider(c::repository);
+                    if (filter.get() != null) {
+                        builder = builder.filter(filter.get());
+                    } else if (filterByAggregateType.get()) {
+                        builder = builder.filterByAggregateType();
+                    }
+                    return builder.build();
                 });
         commandHandler = new Component<>(() -> parent, "aggregateCommandHandler<" + aggregate.getSimpleName() + ">",
                                          c -> AggregateAnnotationCommandHandler.<A>builder()
@@ -254,6 +267,40 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     public AggregateConfigurer<A> configureSnapshotTrigger(
             Function<Configuration, SnapshotTriggerDefinition> snapshotTriggerDefinition) {
         this.snapshotTriggerDefinition.update(snapshotTriggerDefinition);
+        return this;
+    }
+
+    /**
+     * Configures an event filter for the EventSourcingRepository for the Aggregate type under configuration.
+     * By default, no filter is applied to the event stream.
+     * <p>
+     * Note that this configuration is ignored if a custom repository instance is configured.
+     *
+     * @see EventSourcingRepository.Builder#filter(Predicate)
+     * @param filterBuilder The function creating the filter.
+     * @return this configurer instance for chaining
+     */
+    public AggregateConfigurer<A> configureEventFilter(
+            Function<Configuration, Predicate<? super DomainEventMessage<?>>> filterBuilder) {
+        this.filter.update(filterBuilder);
+        return this;
+    }
+
+    /**
+     * Configures a function that determines whether or not the EventSourcingRepository for the Aggregate type
+     * under configuration should filter out events with non-matching types. This may be used to support installations
+     * where multiple Aggregate types share overlapping Aggregate IDs.
+     * <p>
+     * Note that this configuration is ignored if a custom repository instance is configured, and that
+     * {@link #configureEventFilter(Function)} overrides this.
+     *
+     * @see EventSourcingRepository.Builder#filterByAggregateType()
+     * @param filterConfigurationPredicate The function determining whether or not to filter events by Aggregate type.
+     * @return this configurer instance for chaining
+     */
+    public AggregateConfigurer<A> configureFilterEventsByAggregateType(
+            Function<Configuration, Boolean> filterConfigurationPredicate) {
+        this.filterByAggregateType.update(filterConfigurationPredicate);
         return this;
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -18,6 +18,7 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.common.caching.Cache;
 import org.axonframework.common.lock.LockFactory;
+import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventsourcing.conflictresolution.ConflictResolution;
 import org.axonframework.eventsourcing.conflictresolution.DefaultConflictResolver;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
@@ -34,6 +35,7 @@ import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.modelling.command.inspection.AggregateModel;
 
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -53,6 +55,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
     private final SnapshotTriggerDefinition snapshotTriggerDefinition;
     private final AggregateFactory<T> aggregateFactory;
     private final RepositoryProvider repositoryProvider;
+    private final Predicate<? super DomainEventMessage<?>> filter;
 
     /**
      * Instantiate a {@link EventSourcingRepository} based on the fields contained in the {@link Builder}.
@@ -78,6 +81,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         this.aggregateFactory = builder.buildAggregateFactory();
         this.snapshotTriggerDefinition = builder.snapshotTriggerDefinition;
         this.repositoryProvider = builder.repositoryProvider;
+        this.filter = builder.filter;
     }
 
     /**
@@ -136,12 +140,15 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
      * add pre or postprocessing to the loading of an event stream
      *
      * @param aggregateIdentifier the identifier of the aggregate to load
-     * @return the domain event stream for the given aggregateIdentifier and this repository's aggregate type
+     * @return the domain event stream for the given aggregateIdentifier, with filter applied if one was configured
      */
     protected DomainEventStream readEvents(String aggregateIdentifier) {
-        return eventStore
-                .readEvents(aggregateIdentifier)
-                .filter(message -> aggregateModel().type().equals(message.getType()));
+        DomainEventStream fullStream = eventStore.readEvents(aggregateIdentifier);
+        if (filter != null) {
+            return fullStream.filter(filter);
+        } else {
+            return fullStream;
+        }
     }
 
     @Override
@@ -213,6 +220,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         private AggregateFactory<T> aggregateFactory;
         protected RepositoryProvider repositoryProvider;
         protected Cache cache;
+        protected Predicate<? super DomainEventMessage<?>> filter;
 
         /**
          * Creates a builder for a Repository for given {@code aggregateType}.
@@ -314,6 +322,31 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
             return this;
         }
 
+        /**
+         * Sets the {@link Predicate} used to filter events when reading from the EventStore. By default, all
+         * events with the Aggregate identifier passed to {@link EventSourcingRepository#readEvents(String)} are
+         * returned. Calls to {@link #filterByAggregateType()} will overwrite this configuration and vice versa.
+         *
+         * @param filter a {@link Predicate} that may return false to discard events.
+         */
+        public Builder<T> filter(Predicate<? super DomainEventMessage<?>> filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Configures a filter that rejects events with a different Aggregate type than the one specified by this
+         * Repository's {@link AggregateModel}. This may be used to enable multiple Aggregate types to share
+         * overlapping Aggregate identifiers. Calls to {@link #filter(Predicate)} will overwrite this configuration
+         * and vice versa.
+         *
+         * <p>If the caller supplies an explicit {@link AggregateModel} to this Builder, that must be done before
+         * calling this method.
+         */
+        public Builder<T> filterByAggregateType() {
+            final String aggregateType = buildAggregateModel().type();
+            return filter(event -> aggregateType.equals(event.getType()));
+        }
 
         /**
          * Initializes a {@link EventSourcingRepository} or {@link CachingEventSourcingRepository} as specified through

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -136,10 +136,12 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
      * add pre or postprocessing to the loading of an event stream
      *
      * @param aggregateIdentifier the identifier of the aggregate to load
-     * @return the domain event stream for the given aggregateIdentifier
+     * @return the domain event stream for the given aggregateIdentifier and this repository's aggregate type
      */
     protected DomainEventStream readEvents(String aggregateIdentifier) {
-        return eventStore.readEvents(aggregateIdentifier);
+        return eventStore
+                .readEvents(aggregateIdentifier)
+                .filter(message -> aggregateModel().type().equals(message.getType()));
     }
 
     @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -85,9 +85,7 @@ public class EventSourcingRepositoryTest {
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance());
         DomainEventMessage event2 =
                 new GenericDomainEventMessage<>("type", identifier, (long) 2, "Mock contents", emptyInstance());
-        DomainEventMessage event3 =
-                new GenericDomainEventMessage<>("otherType", identifier, (long) 1, "Other contents", emptyInstance());
-        when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(event1, event2, event3));
+        when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(event1, event2));
 
         Aggregate<TestAggregate> aggregate = testSubject.load(identifier, null);
 
@@ -98,15 +96,32 @@ public class EventSourcingRepositoryTest {
         assertEquals(0, aggregate.invoke(TestAggregate::getLiveEvents).size());
 
         // now the aggregate is loaded (and hopefully correctly locked)
-        StubDomainEvent event4 = new StubDomainEvent();
+        StubDomainEvent event3 = new StubDomainEvent();
 
-        aggregate.execute(r -> r.apply(event4));
+        aggregate.execute(r -> r.apply(event3));
 
         CurrentUnitOfWork.commit();
 
         verify(mockEventStore, times(1)).publish((EventMessage) anyVararg());
         assertEquals(1, aggregate.invoke(TestAggregate::getLiveEvents).size());
-        assertSame(event4, aggregate.invoke(TestAggregate::getLiveEvents).get(0).getPayload());
+        assertSame(event3, aggregate.invoke(TestAggregate::getLiveEvents).get(0).getPayload());
+    }
+
+    @Test
+    public void testFilterEventsByType() {
+        String identifier = UUID.randomUUID().toString();
+        DomainEventMessage event1 =
+                new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance());
+        DomainEventMessage event2 =
+                new GenericDomainEventMessage<>("otherType", identifier, (long) 1, "Other contents", emptyInstance());
+        when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(event1, event2));
+
+        Aggregate<TestAggregate> aggregate = testSubject.load(identifier, null);
+
+        assertEquals(1, aggregate.invoke(TestAggregate::getHandledEvents).size());
+        assertSame(event1, aggregate.invoke(TestAggregate::getHandledEvents).get(0));
+
+        assertEquals(0, aggregate.invoke(TestAggregate::getLiveEvents).size());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -65,6 +65,7 @@ public class EventSourcingRepositoryTest {
                                              .aggregateFactory(stubAggregateFactory)
                                              .eventStore(mockEventStore)
                                              .snapshotTriggerDefinition(triggerDefinition)
+                                             .filterByAggregateType()
                                              .build();
         unitOfWork = DefaultUnitOfWork.startAndGet(new GenericMessage<>("test"));
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/StubAggregate.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/StubAggregate.java
@@ -18,12 +18,14 @@ package org.axonframework.integrationtests.commandhandling;
 
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateRoot;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 /**
  * @author Allard Buijze
  */
+@AggregateRoot(type = "test")
 public class StubAggregate {
 
     private int changeCounter;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/StubAggregate.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/StubAggregate.java
@@ -16,16 +16,14 @@
 
 package org.axonframework.integrationtests.commandhandling;
 
-import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.eventsourcing.EventSourcingHandler;
-import org.axonframework.modelling.command.AggregateRoot;
+import org.axonframework.modelling.command.AggregateIdentifier;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 /**
  * @author Allard Buijze
  */
-@AggregateRoot(type = "test")
 public class StubAggregate {
 
     private int changeCounter;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
@@ -28,6 +28,7 @@ import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateRoot;
 import org.axonframework.modelling.command.Repository;
 import org.junit.Before;
 import org.junit.Test;
@@ -232,6 +233,7 @@ public class SynchronousLoopbackTest {
         }
     }
 
+    @AggregateRoot(type = "test")
     private static class CountingAggregate {
 
         private static final long serialVersionUID = -2927751585905120260L;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
@@ -28,7 +28,6 @@ import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.modelling.command.AggregateIdentifier;
-import org.axonframework.modelling.command.AggregateRoot;
 import org.axonframework.modelling.command.Repository;
 import org.junit.Before;
 import org.junit.Test;
@@ -233,7 +232,6 @@ public class SynchronousLoopbackTest {
         }
     }
 
-    @AggregateRoot(type = "test")
     private static class CountingAggregate {
 
         private static final long serialVersionUID = -2927751585905120260L;

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -371,7 +371,7 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                         c -> beanFactory.getBean(aggregateAnnotation.repository(), Repository.class));
             }
 
-            aggregateConf.configureFilterEventsByAggregateType(c -> aggregateAnnotation.filterByAggregateType());
+            aggregateConf.configureFilterEventsByType(c -> aggregateAnnotation.filterEventsByType());
 
             if (!"".equals(aggregateAnnotation.commandTargetResolver())) {
                 aggregateConf.configureCommandTargetResolver(c -> getBean(aggregateAnnotation.commandTargetResolver(),

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -371,6 +371,8 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                         c -> beanFactory.getBean(aggregateAnnotation.repository(), Repository.class));
             }
 
+            aggregateConf.configureFilterEventsByAggregateType(c -> aggregateAnnotation.filterByAggregateType());
+
             if (!"".equals(aggregateAnnotation.commandTargetResolver())) {
                 aggregateConf.configureCommandTargetResolver(c -> getBean(aggregateAnnotation.commandTargetResolver(),
                                                                           c));

--- a/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
+++ b/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
@@ -71,4 +71,10 @@ public @interface Aggregate {
      * will be used.
      */
     String commandTargetResolver() default "";
+
+    /**
+     * Sets whether or not to filter events by Aggregate type. This is used to support installations where multiple
+     * Aggregate types can have overlapping Aggregate identifiers.
+     */
+    boolean filterByAggregateType() default false;
 }

--- a/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
+++ b/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
@@ -74,7 +74,8 @@ public @interface Aggregate {
 
     /**
      * Sets whether or not to filter events by Aggregate type. This is used to support installations where multiple
-     * Aggregate types can have overlapping Aggregate identifiers.
+     * Aggregate types can have overlapping Aggregate identifiers. This is only meaningful for event-sourced
+     * Aggregates.
      */
-    boolean filterByAggregateType() default false;
+    boolean filterEventsByType() default false;
 }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -373,7 +373,7 @@ public class SpringAxonAutoConfigurerTest {
             return mock(CommandTargetResolver.class);
         }
 
-        @Aggregate
+        @Aggregate(type = "MyCustomAggregateType", filterByAggregateType = true)
         public static class MyAggregate {
 
             @AggregateIdentifier

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -373,7 +373,7 @@ public class SpringAxonAutoConfigurerTest {
             return mock(CommandTargetResolver.class);
         }
 
-        @Aggregate(type = "MyCustomAggregateType", filterByAggregateType = true)
+        @Aggregate(type = "MyCustomAggregateType", filterEventsByType = true)
         public static class MyAggregate {
 
             @AggregateIdentifier


### PR DESCRIPTION
This acts as a sanity check and also eases migration from Axon 2, per discussion in https://groups.google.com/forum/#!msg/axonframework/fVKTSZrfYqY/n2IFnXzmCgAJ