### PR TITLE
[#907] Allow customizing the ScheduledExecutorService for AxonServerConnectionManager

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -68,7 +68,9 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
 
     private AxonServerConnectionManager buildAxonServerConnectionManager(Configuration c) {
         AxonServerConnectionManager axonServerConnectionManager =
-                new AxonServerConnectionManager(c.getComponent(AxonServerConfiguration.class));
+                AxonServerConnectionManager.builder()
+                                           .axonServerConfiguration(c.getComponent(AxonServerConfiguration.class))
+                                           .build();
         c.onShutdown(axonServerConnectionManager::shutdown);
         return axonServerConnectionManager;
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -56,7 +56,11 @@ public class AxonServerConnectionManagerTest {
     public void checkWhetherConnectionPreferenceIsSent() {
         TagsConfiguration tags = new TagsConfiguration(Collections.singletonMap("key", "value"));
         AxonServerConfiguration configuration = AxonServerConfiguration.builder().build();
-        AxonServerConnectionManager axonServerConnectionManager = new AxonServerConnectionManager(configuration, tags);
+        AxonServerConnectionManager axonServerConnectionManager =
+                AxonServerConnectionManager.builder()
+                                           .axonServerConfiguration(configuration)
+                                           .tagsConfiguration(tags)
+                                           .build();
 
         assertNotNull(axonServerConnectionManager.getChannel());
 
@@ -68,9 +72,9 @@ public class AxonServerConnectionManagerTest {
         assertEquals(1, expectedTags.size());
         assertEquals("value", expectedTags.get("key"));
 
-        assertWithin(1, TimeUnit.SECONDS, () -> {
-            assertEquals(1, secondNode.getPlatformService().getClientIdentificationRequests().size());
-        });
+        assertWithin(1,
+                     TimeUnit.SECONDS,
+                     () -> assertEquals(1, secondNode.getPlatformService().getClientIdentificationRequests().size()));
 
         List<ClientIdentification> clients = secondNode.getPlatformService().getClientIdentificationRequests();
         Map<String, String> connectionExpectedTags = clients.get(0).getTagsMap();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -25,8 +25,8 @@ import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ErrorCode;
-import org.axonframework.axonserver.connector.TestStreamObserver;
 import org.axonframework.axonserver.connector.TargetContextResolver;
+import org.axonframework.axonserver.connector.TestStreamObserver;
 import org.axonframework.axonserver.connector.TestTargetContextResolver;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandExecutionException;
@@ -84,7 +84,9 @@ public class AxonServerCommandBusTest {
         configuration.setNewPermitsThreshold(10);
         configuration.setNrOfNewPermits(1000);
         configuration.setContext(BOUNDED_CONTEXT);
-        axonServerConnectionManager = spy(new AxonServerConnectionManager(configuration));
+        axonServerConnectionManager = spy(AxonServerConnectionManager.builder()
+                                                                     .axonServerConfiguration(configuration)
+                                                                     .build());
         testSubject = new AxonServerCommandBus(
                 axonServerConnectionManager, configuration, localSegment, serializer, command -> "RoutingKey",
                 CommandPriorityCalculator.defaultCommandPriorityCalculator(), targetContextResolver

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClientTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClientTest.java
@@ -45,7 +45,9 @@ public class AxonServerEventStoreClientTest {
         configuration.setNewPermitsThreshold(10);
         configuration.setNrOfNewPermits(1000);
         configuration.setContext(BOUNDED_CONTEXT);
-        axonServerConnectionManager = spy(new AxonServerConnectionManager(configuration));
+        axonServerConnectionManager = spy(AxonServerConnectionManager.builder()
+                                                                     .axonServerConfiguration(configuration)
+                                                                     .build());
 
         testSubject = new AxonServerEventStoreClient(configuration, axonServerConnectionManager);
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -48,10 +48,13 @@ public class AxonServerEventStoreTest {
                                                                 .componentName("JUNIT")
                                                                 .flowControl(2, 1, 1)
                                                                 .build();
+        AxonServerConnectionManager axonServerConnectionManager =
+                AxonServerConnectionManager.builder()
+                                           .axonServerConfiguration(config)
+                                           .build();
         testSubject = AxonServerEventStore.builder()
                                           .configuration(config)
-                                          .platformConnectionManager(new AxonServerConnectionManager(config))
-
+                                          .platformConnectionManager(axonServerConnectionManager)
                                           .build();
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -25,8 +25,8 @@ import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ErrorCode;
-import org.axonframework.axonserver.connector.TestStreamObserver;
 import org.axonframework.axonserver.connector.TargetContextResolver;
+import org.axonframework.axonserver.connector.TestStreamObserver;
 import org.axonframework.axonserver.connector.TestTargetContextResolver;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MetaData;
@@ -91,7 +91,9 @@ public class AxonServerQueryBusTest {
         configuration.setNewPermitsThreshold(10);
         configuration.setNrOfNewPermits(1000);
         configuration.setContext(BOUNDED_CONTEXT);
-        axonServerConnectionManager = spy(new AxonServerConnectionManager(configuration));
+        axonServerConnectionManager = spy(AxonServerConnectionManager.builder()
+                                                                     .axonServerConfiguration(configuration)
+                                                                     .build());
 
         testSubject = new AxonServerQueryBus(
                 axonServerConnectionManager, configuration, localSegment.queryUpdateEmitter(), localSegment, serializer,
@@ -139,8 +141,12 @@ public class AxonServerQueryBusTest {
 
     @Test
     public void queryWhenQueryServiceStubFails() {
+        AxonServerConnectionManager axonServerConnectionManager =
+                AxonServerConnectionManager.builder()
+                                           .axonServerConfiguration(configuration)
+                                           .build();
         AxonServerQueryBus testSubject = spy(new AxonServerQueryBus(
-                new AxonServerConnectionManager(configuration), configuration, localSegment.queryUpdateEmitter(),
+                axonServerConnectionManager, configuration, localSegment.queryUpdateEmitter(),
                 localSegment, serializer, serializer, QueryPriorityCalculator.defaultQueryPriorityCalculator(),
                 targetContextResolver
         ));

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -102,9 +102,12 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
     }
 
     @Bean(destroyMethod = "shutdown")
-    public AxonServerConnectionManager platformConnectionManager(AxonServerConfiguration routingConfiguration,
+    public AxonServerConnectionManager platformConnectionManager(AxonServerConfiguration axonServerConfiguration,
                                                                  TagsConfigurationProperties tagsConfigurationProperties) {
-        return new AxonServerConnectionManager(routingConfiguration, tagsConfigurationProperties.toTagsConfiguration());
+        return AxonServerConnectionManager.builder()
+                                          .axonServerConfiguration(axonServerConfiguration)
+                                          .tagsConfiguration(tagsConfigurationProperties.toTagsConfiguration())
+                                          .build();
     }
 
     @Bean(destroyMethod = "disconnect")


### PR DESCRIPTION
This pull request makes it possible to configure the `ScheduledExecutorService` used to schedule the reconnect tasks in the `AxonServerConnectionManager` to your hearts content. Currently, this is hard coded for you, whilst (as explained in #907) there are scenarios where it is beneficial if this could be adjusted or the control pulled in to the users own hands.

Making this configurable has been done by setting up the Builder pattern in the `AxonServerConnectionManager` in a similar fashion as the other framework components. Due to this, the constructors have been deprecated and all usages replaced with this Builder.