### PR TITLE
[#1157] Don't double-record published events if SagaTestFixture is invoked twice

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -42,6 +42,7 @@ public class EventValidator implements EventMessageHandler {
     private final List<EventMessage> publishedEvents = new ArrayList<>();
     private final EventBus eventBus;
     private final FieldFilter fieldFilter;
+    private boolean recording = false;
 
     /**
      * Initializes the event validator to monitor the given {@code eventBus}.
@@ -96,7 +97,10 @@ public class EventValidator implements EventMessageHandler {
      * Starts recording event published by the event bus.
      */
     public void startRecording() {
-        eventBus.subscribe(eventMessages -> eventMessages.forEach(this::handle));
+        if (!recording) {
+            eventBus.subscribe(eventMessages -> eventMessages.forEach(this::handle));
+            recording = true;
+        }
     }
 
     @SuppressWarnings({"unchecked"})

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -385,4 +385,22 @@ public class AnnotatedSagaTest {
                .expectDispatchedCommands("Say hi!");
         verify(mock).send(anyString());
     }
+
+    @Test
+    public void testPublishEventFromSecondFixtureCall() {
+        String identifier = UUID.randomUUID().toString();
+        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
+        fixture.whenAggregate(identifier).publishes(new TriggerSagaStartEvent(identifier))
+                .expectActiveSagas(1)
+                .expectAssociationWith("identifier", identifier)
+                .expectPublishedEvents();
+        fixture.whenAggregate(identifier).publishes(new TriggerExistingSagaEvent(identifier))
+                .expectActiveSagas(1)
+                .expectAssociationWith("identifier", identifier)
+                .expectPublishedEventsMatching(
+                        Matchers.payloadsMatching(
+                                Matchers.exactSequenceOf(
+                                        CoreMatchers.isA(SagaWasTriggeredEvent.class),
+                                        Matchers.andNoMore())));
+    }
 }

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -398,9 +398,6 @@ public class AnnotatedSagaTest {
                 .expectActiveSagas(1)
                 .expectAssociationWith("identifier", identifier)
                 .expectPublishedEventsMatching(
-                        Matchers.payloadsMatching(
-                                Matchers.exactSequenceOf(
-                                        CoreMatchers.isA(SagaWasTriggeredEvent.class),
-                                        Matchers.andNoMore())));
+                        payloadsMatching(exactSequenceOf(any(SagaWasTriggeredEvent.class), andNoMore())));
     }
 }


### PR DESCRIPTION
This pull request resolves #1157