### PR TITLE
Code changes to reflect the new message names in the AxonServer gRPC API

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,9 @@
 
 package org.axonframework.axonserver.connector.processor;
 
-import io.axoniq.axonserver.grpc.control.MergeEventProcessorSegment;
-import io.axoniq.axonserver.grpc.control.PauseEventProcessor;
+import io.axoniq.axonserver.grpc.control.EventProcessorReference;
+import io.axoniq.axonserver.grpc.control.EventProcessorSegmentReference;
 import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
-import io.axoniq.axonserver.grpc.control.ReleaseEventProcessorSegment;
-import io.axoniq.axonserver.grpc.control.RequestEventProcessorInfo;
-import io.axoniq.axonserver.grpc.control.SplitEventProcessorSegment;
-import io.axoniq.axonserver.grpc.control.StartEventProcessor;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.processor.grpc.GrpcEventProcessorMapping;
 import org.axonframework.axonserver.connector.processor.grpc.PlatformInboundMessage;
@@ -85,26 +81,26 @@ public class EventProcessorControlService {
     }
 
     private void pauseProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
-        PauseEventProcessor pauseEventProcessor = platformOutboundInstruction.getPauseEventProcessor();
+        EventProcessorReference pauseEventProcessor = platformOutboundInstruction.getPauseEventProcessor();
         String processorName = pauseEventProcessor.getProcessorName();
         eventProcessorController.pauseProcessor(processorName);
     }
 
     private void startProcessor(PlatformOutboundInstruction platformOutboundInstruction) {
-        StartEventProcessor startEventProcessor = platformOutboundInstruction.getStartEventProcessor();
+        EventProcessorReference startEventProcessor = platformOutboundInstruction.getStartEventProcessor();
         String processorName = startEventProcessor.getProcessorName();
         eventProcessorController.startProcessor(processorName);
     }
 
     private void releaseSegment(PlatformOutboundInstruction platformOutboundInstruction) {
-        ReleaseEventProcessorSegment releaseSegment = platformOutboundInstruction.getReleaseSegment();
+        EventProcessorSegmentReference releaseSegment = platformOutboundInstruction.getReleaseSegment();
         String processorName = releaseSegment.getProcessorName();
         int segmentIdentifier = releaseSegment.getSegmentIdentifier();
         eventProcessorController.releaseSegment(processorName, segmentIdentifier);
     }
 
     private void getEventProcessorInfo(PlatformOutboundInstruction platformOutboundInstruction) {
-        RequestEventProcessorInfo requestInfo = platformOutboundInstruction.getRequestEventProcessorInfo();
+        EventProcessorReference requestInfo = platformOutboundInstruction.getRequestEventProcessorInfo();
         String processorName = requestInfo.getProcessorName();
         try {
             EventProcessor processor = eventProcessorController.getEventProcessor(processorName);
@@ -115,7 +111,7 @@ public class EventProcessorControlService {
     }
 
     private void splitSegment(PlatformOutboundInstruction platformOutboundInstruction) {
-        SplitEventProcessorSegment splitSegment = platformOutboundInstruction.getSplitEventProcessorSegment();
+        EventProcessorSegmentReference splitSegment = platformOutboundInstruction.getSplitEventProcessorSegment();
         int segmentId = splitSegment.getSegmentIdentifier();
         String processorName = splitSegment.getProcessorName();
         try {
@@ -126,7 +122,7 @@ public class EventProcessorControlService {
     }
 
     private void mergeSegment(PlatformOutboundInstruction platformOutboundInstruction) {
-        MergeEventProcessorSegment mergeSegment = platformOutboundInstruction.getMergeEventProcessorSegment();
+        EventProcessorSegmentReference mergeSegment = platformOutboundInstruction.getMergeEventProcessorSegment();
         String processorName = mergeSegment.getProcessorName();
         int segmentId = mergeSegment.getSegmentIdentifier();
         try {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessage.java
@@ -17,14 +17,13 @@
 package org.axonframework.axonserver.connector.processor.grpc;
 
 import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
-import io.axoniq.axonserver.grpc.control.EventProcessorInfo.EventTrackerInfo;
+import io.axoniq.axonserver.grpc.control.EventProcessorInfo.SegmentStatus;
 import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
 import org.axonframework.eventhandling.EventTrackerStatus;
 import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingToken;
 
 import java.util.List;
-import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 
@@ -53,11 +52,11 @@ public class TrackingEventProcessorInfoMessage implements PlatformInboundMessage
 
     @Override
     public PlatformInboundInstruction instruction() {
-        List<EventTrackerInfo> trackerInfo = eventProcessor.processingStatus()
-                                                           .entrySet()
-                                                           .stream()
-                                                           .map(this::buildTrackerInfo)
-                                                           .collect(toList());
+        List<SegmentStatus> trackerInfo = eventProcessor.processingStatus()
+                                                        .values()
+                                                        .stream()
+                                                        .map(this::buildTrackerInfo)
+                                                        .collect(toList());
 
         EventProcessorInfo eventProcessorInfo =
                 EventProcessorInfo.newBuilder()
@@ -67,7 +66,7 @@ public class TrackingEventProcessorInfoMessage implements PlatformInboundMessage
                                   .setAvailableThreads(eventProcessor.availableProcessorThreads())
                                   .setRunning(eventProcessor.isRunning())
                                   .setError(eventProcessor.isError())
-                                  .addAllEventTrackersInfo(trackerInfo)
+                                  .addAllSegmentStatus(trackerInfo)
                                   .build();
 
         return PlatformInboundInstruction.newBuilder()
@@ -75,15 +74,15 @@ public class TrackingEventProcessorInfoMessage implements PlatformInboundMessage
                                          .build();
     }
 
-    private EventTrackerInfo buildTrackerInfo(Map.Entry<Integer, EventTrackerStatus> e) {
-        return EventTrackerInfo.newBuilder()
-                               .setSegmentId(e.getKey())
-                               .setCaughtUp(e.getValue().isCaughtUp())
-                               .setReplaying(e.getValue().isReplaying())
-                               .setOnePartOf(e.getValue().getSegment().getMask() + 1)
-                               .setTokenPosition(getPosition(e.getValue().getTrackingToken()))
-                               .setErrorState(e.getValue().isErrorState() ? buildErrorMessage(e.getValue().getError()) : "")
-                               .build();
+    private SegmentStatus buildTrackerInfo(EventTrackerStatus status) {
+        return SegmentStatus.newBuilder()
+                            .setSegmentId(status.getSegment().getSegmentId())
+                            .setCaughtUp(status.isCaughtUp())
+                            .setReplaying(status.isReplaying())
+                            .setOnePartOf(status.getSegment().getMask() + 1)
+                            .setTokenPosition(getPosition(status.getTrackingToken()))
+                            .setErrorState(status.isErrorState() ? buildErrorMessage(status.getError()) : "")
+                            .build();
     }
 
     private long getPosition(TrackingToken trackingToken) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessageTest.java
@@ -60,11 +60,11 @@ public class TrackingEventProcessorInfoMessageTest {
         EventProcessorInfo eventProcessorInfo = testSubject.instruction().getEventProcessorInfo();
         assertEquals("ProcessorName", eventProcessorInfo.getProcessorName());
         assertEquals(3, eventProcessorInfo.getActiveThreads());
-        assertEquals(2, eventProcessorInfo.getEventTrackersInfoCount());
+        assertEquals(2, eventProcessorInfo.getSegmentStatusCount());
         assertFalse(eventProcessorInfo.getRunning());
         assertTrue(eventProcessorInfo.getError());
         assertTrue(eventProcessorInfo.getAvailableThreads()>0);
-        EventProcessorInfo.EventTrackerInfo eventTrackersInfo1 = eventProcessorInfo.getEventTrackersInfo(0);
+        EventProcessorInfo.SegmentStatus eventTrackersInfo1 = eventProcessorInfo.getSegmentStatus(0);
         assertEquals(0,eventTrackersInfo1.getSegmentId());
         assertEquals(2, eventTrackersInfo1.getOnePartOf());
         assertTrue(eventTrackersInfo1.getCaughtUp());
@@ -72,7 +72,7 @@ public class TrackingEventProcessorInfoMessageTest {
         assertEquals(100, eventTrackersInfo1.getTokenPosition());
         assertEquals("", eventTrackersInfo1.getErrorState());
 
-        EventProcessorInfo.EventTrackerInfo eventTrackersInfo2 = eventProcessorInfo.getEventTrackersInfo(1);
+        EventProcessorInfo.SegmentStatus eventTrackersInfo2 = eventProcessorInfo.getSegmentStatus(1);
         assertEquals(1,eventTrackersInfo2.getSegmentId());
         assertEquals(2, eventTrackersInfo2.getOnePartOf());
         assertTrue(eventTrackersInfo2.getCaughtUp());

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,14 +16,11 @@
 
 package org.axonframework.axonserver.connector.query.subscription;
 
-import io.axoniq.axonserver.grpc.query.QueryResponse;
-import io.axoniq.axonserver.grpc.query.QueryUpdate;
-import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
-import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
-import io.axoniq.axonserver.grpc.query.SubscriptionQueryResponse;
+import io.axoniq.axonserver.grpc.query.*;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.queryhandling.SubscriptionQueryBackpressure;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 import reactor.core.publisher.FluxSink;
 
 import java.util.ArrayList;


### PR DESCRIPTION
EventTrackerInfo has been renamed to SegmentStatus

Renamed to EventProcessorReference:
 - PauseEventProcessor
 - RequestEventProcessorInfo
 - StartEventProcessor

Renamed to EventProcessorSegmentReference:
 - MergeEventProcessorSegment
 - ReleaseEventProcessorSegment
 - SplitEventProcessorSegment