### PR TITLE
Parallelize TrackingEventProcessor shutdown

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -184,6 +184,7 @@ public class EventProcessingModule
 
     @Override
     public void shutdown() {
+        eventProcessors.forEach((name, component) -> component.get().initiateShutdown());
         eventProcessors.forEach((name, component) -> component.get().shutDown());
     }
     //</editor-fold>

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
@@ -65,5 +65,7 @@ public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMe
      * method will block until the shutdown is complete. Can be a no-op for event processors that don't support
      * asynchronous shutdown.
      */
-    default void initiateShutdown() {}
+    default void initiateShutdown() {
+        // Default is synchronous shutdown.
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
@@ -56,7 +56,14 @@ public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMe
     void start();
 
     /**
-     * Stop processing events.
+     * Stops processing events. Blocks until the shutdown is complete.
      */
     void shutDown();
+
+    /**
+     * Begins shutting down. Does not block until shutdown is complete. Calling {@link #shutDown()} after this
+     * method will block until the shutdown is complete. Can be a no-op for event processors that don't support
+     * asynchronous shutdown.
+     */
+    default void initiateShutdown() {}
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -586,12 +586,13 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
     }
 
     /**
-     * Shut down the processor.
+     * Shuts down the processor. Blocks until shutdown is complete.
      */
     @Override
     public void shutDown() {
-        if (state.getAndSet(State.SHUT_DOWN).isRunning()) {
-            logger.info("Shutdown state set for Processor '{}'. Awaiting termination...", getName());
+        initiateShutdown();
+        if (activeProcessorThreads() > 0) {
+            logger.info("Processor '{}' awaiting termination...", getName());
             try {
                 while (activeProcessorThreads() > 0) {
                     Thread.sleep(1);
@@ -600,6 +601,17 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
                 logger.info("Thread was interrupted while waiting for TrackingProcessor '{}' shutdown.", getName());
                 Thread.currentThread().interrupt();
             }
+        }
+    }
+
+    /**
+     * Begins shutting down. Does not block until shutdown is complete. Calling {@link #shutDown()} after this
+     * method will block until the shutdown is complete.
+     */
+    @Override
+    public void initiateShutdown() {
+        if (state.getAndSet(State.SHUT_DOWN).isRunning()) {
+            logger.info("Shutdown state set for Processor '{}'.", getName());
         }
     }
 


### PR DESCRIPTION
My application shutdown time is dominated by the sequential shutdown of all the `TrackingEventProcessor`s, each of which sleeps for a brief period. Shut them down in parallel instead.