### PR TITLE
Fix [#1174] - Event Gateway not exposed in 4.1.2

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -47,6 +47,8 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventhandling.async.SequencingPolicy;
 import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
+import org.axonframework.eventhandling.gateway.DefaultEventGateway;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
@@ -211,6 +213,12 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
     @Bean
     public QueryGateway queryGateway(QueryBus queryBus) {
         return DefaultQueryGateway.builder().queryBus(queryBus).build();
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public EventGateway eventGateway(EventBus eventBus) {
+        return DefaultEventGateway.builder().eventBus(eventBus).build();
     }
 
     @Bean


### PR DESCRIPTION
Adds the Event Gateway as a bean as it is on master branch
This PR resolve #1174.