### PR TITLE
Fix peek-then-consume in MultiStreamableMessageSource

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/MultiStreamableMessageSource.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/MultiStreamableMessageSource.java
@@ -454,6 +454,7 @@ public class MultiStreamableMessageSource implements StreamableMessageSource<Tra
             if (peekedMessage != null) {
                 TrackedEventMessage next = peekedMessage;
                 peekedMessage = null;
+                trackingToken = (MultiSourceTrackingToken) next.trackingToken();
                 return next;
             }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
@@ -159,6 +159,7 @@ public class MultiStreamableMessageSourceTest {
 
         assertTrue(singleEventStream.peek().isPresent());
         TrackedEventMessage peekedMessageA = singleEventStream.peek().get();
+        MultiSourceTrackingToken tokenA = (MultiSourceTrackingToken) peekedMessageA.trackingToken();
         assertEquals(pubToStreamA.getPayload(), peekedMessageA.getPayload());
 
         //message is still consumable and consumed message equal to peeked
@@ -167,9 +168,13 @@ public class MultiStreamableMessageSourceTest {
         //peek and consume another
         assertTrue(singleEventStream.peek().isPresent());
         TrackedEventMessage peekedMessageB = singleEventStream.peek().get();
+        MultiSourceTrackingToken tokenB = (MultiSourceTrackingToken) peekedMessageB.trackingToken();
         assertEquals(pubToStreamB.getPayload(), peekedMessageB.getPayload());
 
         assertEquals(peekedMessageB.getPayload(), singleEventStream.nextAvailable().getPayload());
+
+        //consuming from second stream doesn't alter token from first stream
+        assertEquals(tokenA.getTokenForStream("eventStoreA"), tokenB.getTokenForStream("eventStoreA"));
 
         singleEventStream.close();
     }


### PR DESCRIPTION
If you called `peek()` on a `MultiStreamableMessageSource`, then called `nextAvailable()` twice, the first `nextAvailable()` would give you the peeked event, and the second call would give you the next available event. But if the two events were from different underlying message sources, the tracking token update from the first event would be discarded. If you then released the segment and let another node claim it, the other node would have no way of knowing that the peeked event had already been consumed, and would deliver it again.