### PR TITLE
Allow TrackingEventProcessor start to be deferred

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -161,7 +161,7 @@ public class EventProcessingModule
 
     @Override
     public void start() {
-        eventProcessors.forEach((name, component) -> component.get().start());
+        eventProcessors.forEach((name, component) -> component.get().startAutomatically());
     }
 
     @Override

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -143,6 +143,33 @@ public class DefaultConfigurerTest {
     }
 
     @Test
+    public void defaultConfigurationWithTrackingProcessorAutoStartDisabled() throws Exception {
+        Configurer configurer = DefaultConfigurer.defaultConfiguration();
+        String processorName = "myProcessor";
+        configurer.eventProcessing()
+                  .registerTrackingEventProcessor(processorName,
+                                                  Configuration::eventStore,
+                                                  c -> TrackingEventProcessorConfiguration.forParallelProcessing(2)
+                                                          .andAutoStart(false))
+                  .byDefaultAssignTo(processorName)
+                  .registerDefaultSequencingPolicy(c -> new FullConcurrencyPolicy())
+                  .registerEventHandler(c -> (EventMessageHandler) event -> null);
+        Configuration config = configurer
+                .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                .start();
+        try {
+            TrackingEventProcessor processor = config.eventProcessingConfiguration()
+                                                     .eventProcessor(processorName, TrackingEventProcessor.class)
+                                                     .orElseThrow(RuntimeException::new);
+            assertFalse(processor.isRunning());
+            processor.start();
+            assertTrue(processor.isRunning());
+        } finally {
+            config.shutdown();
+        }
+    }
+
+    @Test
     public void defaultConfigurationWithUpcaster() {
         AtomicInteger counter = new AtomicInteger();
         Configuration config = DefaultConfigurer.defaultConfiguration().configureEmbeddedEventStore(

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
@@ -62,6 +62,14 @@ public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMe
     void shutDown();
 
     /**
+     * Starts processing events if this processor is configured to start automatically. Automatic startup can be
+     * disabled for some event processor types.
+     */
+    default void startAutomatically() {
+        start();
+    }
+
+    /**
      * Initiates a shutdown, providing a {@link CompletableFuture} that completes when the shutdown process is
      * finished.
      *

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -79,6 +79,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
     private final TransactionManager transactionManager;
     private final int batchSize;
     private final int segmentsSize;
+    private final boolean autoStart;
 
     private final ThreadFactory threadFactory;
     private final AtomicReference<State> state = new AtomicReference<>(State.NOT_STARTED);
@@ -125,6 +126,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
         this.eventAvailabilityTimeout = config.getEventAvailabilityTimeout();
         this.storeTokenBeforeProcessing = builder.storeTokenBeforeProcessing;
         this.batchSize = config.getBatchSize();
+        this.autoStart = config.isAutoStart();
 
         this.messageSource = builder.messageSource;
         this.tokenStore = builder.tokenStore;
@@ -177,6 +179,18 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
         State previousState = state.getAndSet(State.STARTED);
         if (!previousState.isRunning()) {
             startSegmentWorkers();
+        }
+    }
+
+    /**
+     * Start this processor if it is configured for automatic startup.
+     *
+     * @see #start()
+     */
+    @Override
+    public void startAutomatically() {
+        if (autoStart) {
+            start();
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
@@ -48,6 +48,7 @@ public class TrackingEventProcessorConfiguration {
     private Function<String, ThreadFactory> threadFactory;
     private long tokenClaimInterval;
     private int eventAvailabilityTimeout = 1000;
+    private boolean autoStart;
 
     /**
      * Initialize a configuration with single threaded processing.
@@ -76,6 +77,7 @@ public class TrackingEventProcessorConfiguration {
         this.maxThreadCount = numberOfSegments;
         this.threadFactory = pn -> new AxonThreadFactory("EventProcessor[" + pn + "]");
         this.tokenClaimInterval = DEFAULT_TOKEN_CLAIM_INTERVAL;
+        this.autoStart = true;
     }
 
     /**
@@ -163,6 +165,20 @@ public class TrackingEventProcessorConfiguration {
     }
 
     /**
+     * Sets whether or not to automatically start the processor when event processing is initialized. If false, the
+     * application must explicitly start the processor. This can be useful if the application needs to perform its
+     * own initialization before it begins processing new events.
+     *
+     * @param autoStart {@code true} to automatically start the processor (the default), {@code false} if the
+     *                  application will start the processor itself.
+     * @return {@code this} for method chaining
+     */
+    public TrackingEventProcessorConfiguration andAutoStart(boolean autoStart) {
+        this.autoStart = autoStart;
+        return this;
+    }
+
+    /**
      * @return the maximum number of events to process in a single batch.
      */
     public int getBatchSize() {
@@ -217,5 +233,12 @@ public class TrackingEventProcessorConfiguration {
      */
     public long getTokenClaimInterval() {
         return tokenClaimInterval;
+    }
+
+    /**
+     * @return {@code} true if the processor should be started automatically by the framework.
+     */
+    public boolean isAutoStart() {
+        return autoStart;
     }
 }


### PR DESCRIPTION
This may not fit with the improvements that are being discussed for startup and graceful shutdown, but may be worthwhile as a stopgap until those improvements are ready. It's what I'm using locally to prevent `TrackingEventProcessor` from polling the event store and calling event handlers before my application is fully initialized.