### PR TITLE
Improved exception handling in (non-AxonServer) distributed scenarios

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
@@ -30,7 +30,6 @@ import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandResultMessage;
 import org.axonframework.common.AxonException;
 import org.axonframework.messaging.GenericMessage;
-import org.axonframework.messaging.HandlerExecutionException;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.LazyDeserializingObject;
@@ -123,7 +122,7 @@ public class CommandSerializer {
             Throwable throwable = commandResultMessage.exceptionResult();
             responseBuilder.setErrorCode(ErrorCode.COMMAND_EXECUTION_ERROR.errorCode());
             responseBuilder.setErrorMessage(ExceptionSerializer.serialize(configuration.getClientId(), throwable));
-            HandlerExecutionException.resolveDetails(throwable).ifPresent(details -> {
+            commandResultMessage.exceptionDetails().ifPresent(details -> {
                 responseBuilder.setPayload(objectSerializer.apply(details));
             });
         } else if (commandResultMessage.getPayload() != null) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QuerySerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QuerySerializer.java
@@ -24,7 +24,6 @@ import io.axoniq.axonserver.grpc.query.QueryResponse;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.util.*;
-import org.axonframework.messaging.HandlerExecutionException;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.serialization.Serializer;
@@ -134,9 +133,8 @@ public class QuerySerializer {
             responseBuilder.setErrorMessage(
                     ExceptionSerializer.serialize(configuration.getClientId(), exceptionResult)
             );
-            HandlerExecutionException.resolveDetails(exceptionResult).ifPresent(details -> {
-                responseBuilder.setPayload(exceptionDetailsSerializer.apply(details));
-            });
+            queryResponse.exceptionDetails()
+                         .ifPresent(details -> responseBuilder.setPayload(exceptionDetailsSerializer.apply(details)));
         } else {
             responseBuilder.setPayload(payloadSerializer.apply(queryResponse));
         }

--- a/messaging/src/main/java/org/axonframework/commandhandling/callbacks/FutureCallback.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/callbacks/FutureCallback.java
@@ -16,11 +16,7 @@
 
 package org.axonframework.commandhandling.callbacks;
 
-import org.axonframework.commandhandling.CommandCallback;
-import org.axonframework.commandhandling.CommandExecutionException;
-import org.axonframework.commandhandling.CommandMessage;
-import org.axonframework.commandhandling.CommandResultMessage;
-import org.axonframework.commandhandling.GenericCommandResultMessage;
+import org.axonframework.commandhandling.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -44,11 +40,7 @@ public class FutureCallback<C, R> extends CompletableFuture<CommandResultMessage
     @Override
     public void onResult(CommandMessage<? extends C> commandMessage,
                          CommandResultMessage<? extends R> commandResultMessage) {
-        if (!commandResultMessage.isExceptional()) {
-            super.complete(commandResultMessage);
-        } else {
-            super.completeExceptionally(commandResultMessage.exceptionResult());
-        }
+        super.complete(commandResultMessage);
     }
 
     /**
@@ -62,7 +54,6 @@ public class FutureCallback<C, R> extends CompletableFuture<CommandResultMessage
      * method.
      *
      * @return the result of the command handler execution.
-     *
      * @see #get()
      */
     public CommandResultMessage<? extends R> getResult() {
@@ -72,6 +63,8 @@ public class FutureCallback<C, R> extends CompletableFuture<CommandResultMessage
             Thread.currentThread().interrupt();
             return new GenericCommandResultMessage<>((R) null);
         } catch (ExecutionException e) {
+            return asCommandResultMessage(e.getCause());
+        } catch (Exception e) {
             return asCommandResultMessage(e);
         }
     }
@@ -80,12 +73,12 @@ public class FutureCallback<C, R> extends CompletableFuture<CommandResultMessage
      * Waits if necessary for at most the given time for the command handling to complete, and then retrieves its
      * result, if available.
      * <p/>
-     * Unlike {@link #get(long, java.util.concurrent.TimeUnit)}, this method will throw the original exception. Only
-     * checked exceptions are wrapped in a {@link CommandExecutionException}.
+     * Unlike {@link #get(long, java.util.concurrent.TimeUnit)}, this method will report the original exception from
+     * within a CommandResultMessage, rather than throwing an {@link ExecutionException}.
      * <p/>
-     * If the timeout expired or the thread is interrupted before completion, {@code null} is returned. In case of
-     * an interrupt, the interrupt flag will have been set back on the thread. To distinguish between an interrupt and
-     * a {@code null} result, use the {@link #isDone()}
+     * If the timeout expired or the thread is interrupted before completion, the returned {@link CommandResultMessage}
+     * will contain an {@link InterruptedException} or {@link TimeoutException}. In case of
+     * an interrupt, the interrupt flag will have been set back on the thread.
      *
      * @param timeout the maximum time to wait
      * @param unit    the time unit of the timeout argument
@@ -96,10 +89,10 @@ public class FutureCallback<C, R> extends CompletableFuture<CommandResultMessage
             return get(timeout, unit);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return new GenericCommandResultMessage<>((R) null);
-        } catch (TimeoutException e) {
-            return new GenericCommandResultMessage<>((R) null);
+            return new GenericCommandResultMessage<>(e);
         } catch (ExecutionException e) {
+            return asCommandResultMessage(e.getCause());
+        } catch (Exception e) {
             return asCommandResultMessage(e);
         }
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/ReplyMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/ReplyMessage.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.commandhandling.distributed;
 
+import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandResultMessage;
 import org.axonframework.messaging.MetaData;
@@ -90,7 +91,10 @@ public abstract class ReplyMessage implements Serializable {
         MetaData metaData = serializer.deserialize(serializedMetaData);
 
         if (exceptionDescription != null) {
-            return new GenericCommandResultMessage<>(new RemoteHandlingException(exceptionDescription), metaData);
+            return new GenericCommandResultMessage<>(new CommandExecutionException("The remote handler threw an exception",
+                                                                                   new RemoteHandlingException(exceptionDescription),
+                                                                                   payload),
+                                                     metaData);
         }
         return new GenericCommandResultMessage<>(payload, metaData);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -148,13 +148,12 @@ public class DefaultCommandGateway extends AbstractCommandGateway implements Com
     }
 
     private RuntimeException asRuntime(Throwable e) {
-        Throwable failure = e.getCause();
-        if (failure instanceof Error) {
-            throw (Error) failure;
-        } else if (failure instanceof RuntimeException) {
-            return (RuntimeException) failure;
+        if (e instanceof Error) {
+            throw (Error) e;
+        } else if (e instanceof RuntimeException) {
+            return (RuntimeException) e;
         } else {
-            return new CommandExecutionException("An exception occurred while executing a command", failure);
+            return new CommandExecutionException("An exception occurred while executing a command", e);
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
@@ -34,22 +34,6 @@ public abstract class HandlerExecutionException extends AxonException {
     private final Object details;
 
     /**
-     * Resolve details from the given {@code throwable}, taking into account that the details may be available in any
-     * of the {@code HandlerExecutionException}s is the "cause" chain.
-     *
-     * @param throwable The exception to resolve the details from
-     * @return an Optional containing details, if present in the given {@code throwable}
-     */
-    public static Optional<Object> resolveDetails(Throwable throwable) {
-        if (throwable instanceof HandlerExecutionException) {
-            return ((HandlerExecutionException) throwable).getDetails();
-        } else if (throwable != null && throwable.getCause() != null) {
-            return resolveDetails(throwable.getCause());
-        }
-        return Optional.empty();
-    }
-
-    /**
      * Initializes an execution exception with given {@code message}. The cause and application-specific details are
      * set to {@code null}.
      *
@@ -81,6 +65,23 @@ public abstract class HandlerExecutionException extends AxonException {
     public HandlerExecutionException(String message, Throwable cause, Object details) {
         super(message, cause);
         this.details = details;
+    }
+
+    /**
+     * Resolve details from the given {@code throwable}, taking into account that the details may be available in any
+     * of the {@code HandlerExecutionException}s is the "cause" chain.
+     *
+     * @param throwable The exception to resolve the details from
+     * @param <R>       The type of details expected
+     * @return an Optional containing details, if present in the given {@code throwable}
+     */
+    public static <R> Optional<R> resolveDetails(Throwable throwable) {
+        if (throwable instanceof HandlerExecutionException) {
+            return ((HandlerExecutionException) throwable).getDetails();
+        } else if (throwable != null && throwable.getCause() != null) {
+            return resolveDetails(throwable.getCause());
+        }
+        return Optional.empty();
     }
 
     /**


### PR DESCRIPTION
Exceptions are reported as part of the ReplyMessage. This Message now
exposes ExceptionDetails explicitly.
FutureCallback now just completes successfully with a message, even if
that message contains an exception result.
Gateways now throw exceptions related to timeout and interrupts instead
of returning null.