### PR TITLE
Added ability to configure default command callback

### DIFF
--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
@@ -62,11 +62,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -156,6 +154,7 @@ public class DisruptorCommandBusTest {
     @Test
     public void testPublishUnsupportedCommand() {
         ExecutorService customExecutor = Executors.newCachedThreadPool();
+        CommandCallback callback = mock(CommandCallback.class);
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
                                          .producerType(ProducerType.SINGLE)
@@ -163,9 +162,9 @@ public class DisruptorCommandBusTest {
                                          .executor(customExecutor)
                                          .invokerThreadCount(2)
                                          .publisherThreadCount(3)
+                                         .defaultCommandCallback(callback)
                                          .build();
-        CommandCallback callback = mock(CommandCallback.class);
-        testSubject.dispatch(asCommandMessage("Test"), callback);
+        testSubject.dispatch(asCommandMessage("Test"));
         customExecutor.shutdownNow();
         ArgumentCaptor<CommandResultMessage<?>> commandResultMessageCaptor =
                 ArgumentCaptor.forClass(CommandResultMessage.class);

--- a/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,7 +71,7 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
      * The {@link TransactionManager} is defaulted to a {@link NoTransactionManager}, the {@link MessageMonitor} is
      * defaulted to a {@link NoOpMessageMonitor}, {@link RollbackConfiguration} defaults to a
      * {@link RollbackConfigurationType#UNCHECKED_EXCEPTIONS}, the {@link DuplicateCommandHandlerResolver} defaults to
-     * {@link DuplicateCommandHandlerResolution#LOG_AND_RETURN_DUPLICATE} and the {@link Executor} defaults to a
+     * {@link DuplicateCommandHandlerResolution#logAndOverride()} and the {@link Executor} defaults to a
      * {@link Executors#newCachedThreadPool}. The default{@code executor} uses an {@link AxonThreadFactory} to create
      * threads with a sensible naming scheme. The TransactionManager, MessageMonitor, RollbackConfiguration and Executor
      * are <b>hard requirements</b>. Thus setting them to {@code null} will result in an
@@ -113,7 +113,7 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
      * {@link DuplicateCommandHandlerResolver} and {@link Executor} are respectively defaulted to a
      * {@link NoTransactionManager}, a {@link NoOpMessageMonitor}, a
      * {@link RollbackConfigurationType#UNCHECKED_EXCEPTIONS}, a
-     * {@link DuplicateCommandHandlerResolution#LOG_AND_RETURN_DUPLICATE}and a {@link Executors#newCachedThreadPool}.
+     * {@link DuplicateCommandHandlerResolution#logAndOverride()}and a {@link Executors#newCachedThreadPool}.
      * The default {@code executor} uses an {@link AxonThreadFactory} to create threads with a sensible naming scheme.
      * The TransactionManager, MessageMonitor, RollbackConfiguration and Executor are <b>hard requirements</b>. Thus
      * setting them to {@code null} will result in an {@link AxonConfigurationException}.
@@ -139,6 +139,12 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
         @Override
         public Builder rollbackConfiguration(RollbackConfiguration rollbackConfiguration) {
             super.rollbackConfiguration(rollbackConfiguration);
+            return this;
+        }
+
+        @Override
+        public Builder defaultCommandCallback(CommandCallback<Object, Object> defaultCommandCallback) {
+            super.defaultCommandCallback(defaultCommandCallback);
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@
 
 package org.axonframework.commandhandling;
 
-import org.axonframework.commandhandling.callbacks.LoggingCallback;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageDispatchInterceptorSupport;
 import org.axonframework.messaging.MessageHandler;
@@ -43,9 +42,9 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      * @throws NoHandlerForCommandException when no command handler is registered for the given {@code command}'s name.
      * @see GenericCommandMessage#asCommandMessage(Object)
      */
-    default <C> void dispatch(CommandMessage<C> command) {
-        dispatch(command, LoggingCallback.INSTANCE);
-    }
+    /*default*/ <C> void dispatch(CommandMessage<C> command);// {
+    //dispatch(command, LoggingCallback.INSTANCE);
+    //}
 
     /**
      * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name.

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -42,9 +42,7 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      * @throws NoHandlerForCommandException when no command handler is registered for the given {@code command}'s name.
      * @see GenericCommandMessage#asCommandMessage(Object)
      */
-    /*default*/ <C> void dispatch(CommandMessage<C> command);// {
-    //dispatch(command, LoggingCallback.INSTANCE);
-    //}
+    <C> void dispatch(CommandMessage<C> command);
 
     /**
      * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name.

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.commandhandling;
 
+import org.axonframework.commandhandling.callbacks.NoOpCallback;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.MessageHandler;
@@ -95,6 +96,20 @@ public class SimpleCommandBusTest {
         assertFalse(CurrentUnitOfWork.isStarted());
         assertFalse(unitOfWork.get().isRolledBack());
         assertFalse(unitOfWork.get().isActive());
+    }
+
+    @Test
+    public void testFireAndForgetUsesDefaultCallback() {
+        CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
+        testSubject = SimpleCommandBus.builder()
+                                      .defaultCommandCallback(mockCallback).build();
+
+        CommandMessage<Object> command = asCommandMessage("test");
+        testSubject.dispatch(command, NoOpCallback.INSTANCE);
+        verify(mockCallback, never()).onResult(any(), any());
+
+        testSubject.dispatch(command);
+        verify(mockCallback).onResult(eq(command), any());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,17 @@
 
 package org.axonframework.commandhandling.distributed;
 
-import org.axonframework.commandhandling.CommandCallback;
-import org.axonframework.commandhandling.CommandMessage;
-import org.axonframework.commandhandling.CommandResultMessage;
-import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.commandhandling.GenericCommandResultMessage;
-import org.axonframework.commandhandling.NoHandlerForCommandException;
+import org.axonframework.commandhandling.*;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.monitoring.MessageMonitor;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Optional;
@@ -75,6 +73,22 @@ public class DistributedCommandBusTest {
         verify(mockConnector).send(eq(mockMember), eq(testCommandMessage), any(CommandCallback.class));
         verify(mockMessageMonitor).onMessageIngested(any());
         verify(mockMonitorCallback).reportSuccess();
+    }
+
+    @Test
+    public void testDefaultCallbackIsUsedWhenFireAndForget() {
+        CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
+        testSubject = DistributedCommandBus.builder()
+                                           .commandRouter(mockCommandRouter)
+                                           .connector(mockConnector)
+                                           .messageMonitor(mockMessageMonitor)
+                                           .defaultCommandCallback(mockCallback)
+                                           .build();
+
+        CommandMessage<Object> message = GenericCommandMessage.asCommandMessage("test");
+        testSubject.dispatch(message);
+
+        verify(mockCallback).onResult(eq(message), any());
     }
 
     @Test


### PR DESCRIPTION
The default command callback is used when a fire-and-forget dispatch
method is used.