### PR TITLE
Allow checked exceptions from CallbackBehavior

### DIFF
--- a/test/src/main/java/org/axonframework/test/utils/CallbackBehavior.java
+++ b/test/src/main/java/org/axonframework/test/utils/CallbackBehavior.java
@@ -37,5 +37,5 @@ public interface CallbackBehavior {
      *
      * @throws Exception If the onFailure method of the callback must be invoked
      */
-    Object handle(Object commandPayload, MetaData commandMetaData);
+    Object handle(Object commandPayload, MetaData commandMetaData) throws Exception;
 }


### PR DESCRIPTION
Its Javadoc says callbacks can throw checked exceptions, but the method
declaration doesn't allow them.