### PR TITLE
Fix SequenceEventStorageEngine.readSnapshot

### DIFF
--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -212,6 +212,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
@@ -94,8 +94,11 @@ public class SequenceEventStorageEngine implements EventStorageEngine {
 
     @Override
     public Optional<DomainEventMessage<?>> readSnapshot(String aggregateIdentifier) {
-        return Optional.ofNullable(activeStorage.readSnapshot(aggregateIdentifier).orElseGet(
-                () -> historicStorage.readSnapshot(aggregateIdentifier).orElse(null)));
+        Optional<DomainEventMessage<?>> result = activeStorage.readSnapshot(aggregateIdentifier);
+        if (result.isPresent()) {
+            return result;
+        }
+        return historicStorage.readSnapshot(aggregateIdentifier);
     }
 
     @Override


### PR DESCRIPTION
fix SequenceEventStorageEngine.readSnapshot: `historicStorage` was never called