### PR TITLE
overload end method to allow ending of Saga in reactive context

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaLifecycle.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaLifecycle.java
@@ -88,6 +88,13 @@ public abstract class SagaLifecycle extends Scope {
     }
 
     /**
+     * Marks the saga as ended. Ended saga's may be cleaned up by the repository when they are committed.
+     *
+     * @return the {@link SagaLifecycle} which needs to be ended
+     */
+    public static void end(SagaLifecycle sagaScope) { sagaScope.doEnd(); }
+
+    /**
      * {@link SagaLifecycle} instance method to mark the current saga as ended.
      */
     protected abstract void doEnd();


### PR DESCRIPTION
Currently, calling SagaLifeCycle.end() from another thread will fail because the Scope is not available anymore. This happens in callbacks, for instance when using a Reactive context. 
This overloaded method allows to pass in a SagaLifeCycle so it becomes possible to programmatically end a Saga from a callback.