### PR TITLE
Fix NPE in MultiSourceTrackingToken.covers()

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
@@ -131,8 +131,13 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
 
         //as soon as one delegated token doesn't cover return false
         for (Map.Entry<String, TrackingToken> trackingTokenEntry : trackingTokens.entrySet()) {
-            if (!trackingTokenEntry.getValue().covers(otherMultiToken.trackingTokens
-                                                              .get(trackingTokenEntry.getKey()))) {
+            TrackingToken constituent = trackingTokenEntry.getValue();
+            TrackingToken otherConstituent = otherMultiToken.trackingTokens.get(trackingTokenEntry.getKey());
+            if (constituent == null) {
+                if (otherConstituent != null) {
+                    return false;
+                }
+            } else if (otherConstituent != null && !constituent.covers(otherConstituent)) {
                 return false;
             }
         }

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
@@ -136,6 +136,12 @@ public class MultiSourceTrackingTokenTest {
         newTokens.put("token2", new GlobalSequenceTrackingToken(0));
 
         assertTrue(testSubject.covers(new MultiSourceTrackingToken(newTokens)));
+
+        newTokens.put("token2", null);
+        MultiSourceTrackingToken tokenWithNullConstituent = new MultiSourceTrackingToken(newTokens);
+        assertTrue(testSubject.covers(tokenWithNullConstituent));
+
+        assertTrue(tokenWithNullConstituent.covers(tokenWithNullConstituent));
     }
 
     @Test
@@ -145,6 +151,10 @@ public class MultiSourceTrackingTokenTest {
         newTokens.put("token2", new GlobalSequenceTrackingToken(0));
 
         assertFalse(testSubject.covers(new MultiSourceTrackingToken(newTokens)));
+
+        newTokens.put("token2", null);
+        MultiSourceTrackingToken tokenWithNullConstituent = new MultiSourceTrackingToken(newTokens);
+        assertFalse(tokenWithNullConstituent.covers(testSubject));
     }
 
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
@@ -136,12 +136,6 @@ public class MultiSourceTrackingTokenTest {
         newTokens.put("token2", new GlobalSequenceTrackingToken(0));
 
         assertTrue(testSubject.covers(new MultiSourceTrackingToken(newTokens)));
-
-        newTokens.put("token2", null);
-        MultiSourceTrackingToken tokenWithNullConstituent = new MultiSourceTrackingToken(newTokens);
-        assertTrue(testSubject.covers(tokenWithNullConstituent));
-
-        assertTrue(tokenWithNullConstituent.covers(tokenWithNullConstituent));
     }
 
     @Test
@@ -151,9 +145,17 @@ public class MultiSourceTrackingTokenTest {
         newTokens.put("token2", new GlobalSequenceTrackingToken(0));
 
         assertFalse(testSubject.covers(new MultiSourceTrackingToken(newTokens)));
+    }
 
+    @Test
+    public void coversNullConstituents() {
+        Map<String, TrackingToken> newTokens = new HashMap<>();
+        newTokens.put("token1", new GlobalSequenceTrackingToken(0));
         newTokens.put("token2", null);
         MultiSourceTrackingToken tokenWithNullConstituent = new MultiSourceTrackingToken(newTokens);
+
+        assertTrue(tokenWithNullConstituent.covers(tokenWithNullConstituent));
+        assertTrue(testSubject.covers(tokenWithNullConstituent));
         assertFalse(tokenWithNullConstituent.covers(testSubject));
     }
 


### PR DESCRIPTION
On an empty event store, a constituent in `MultiSourceTrackingToken`
can be null. This causes NPE to be thrown if the `covers()` method is
called. Resetting the tokens on a tracking event processor can trigger
the exception.