### PR TITLE
[#1230] Make Legacy TrackingTokens deserializable by Jackson

### DIFF
--- a/legacy/src/main/java/org/axonframework/commandhandling/model/AggregateScopeDescriptor.java
+++ b/legacy/src/main/java/org/axonframework/commandhandling/model/AggregateScopeDescriptor.java
@@ -30,7 +30,6 @@ public class AggregateScopeDescriptor extends org.axonframework.modelling.comman
      * @param type       A {@link String} describing the type of the Saga
      * @param identifier An {@link Object} denoting the identifier of the Saga
      */
-
     @JsonCreator
     public AggregateScopeDescriptor(@JsonProperty("type") String type, @JsonProperty("identifier") Object identifier) {
         super(type, identifier);

--- a/legacy/src/main/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingToken.java
+++ b/legacy/src/main/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingToken.java
@@ -16,39 +16,39 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.beans.ConstructorProperties;
 import java.io.Serializable;
 import java.util.Collection;
 
 /**
- * Class copied from Axon 3 to be able to restore Axon 3 Tokens from Axon 4 applications.
+ * Implementation of the {@link org.axonframework.eventhandling.GapAwareTrackingToken} used to bridge serialized
+ * versions of this descriptor when migrating from Axon 3.x to Axon 4.x.
  *
- * @deprecated this class is available for backward compatibility with instances that were serialized with Axon 3. Use
- * {@link org.axonframework.eventhandling.GapAwareTrackingToken} instead.
+ * @author Steven van Beelen
+ * @since 4.0.1
+ * @deprecated in favor of the {@link org.axonframework.eventhandling.GapAwareTrackingToken}
  */
 @Deprecated
-public class GapAwareTrackingToken implements Serializable {
+public class GapAwareTrackingToken
+        extends org.axonframework.eventhandling.GapAwareTrackingToken
+        implements Serializable {
 
     private static final long serialVersionUID = -4691964346972539244L;
 
-    private int index;
+    // Fields {@code index} and {@code gaps} are used during Java and XStream de-/serialization through method
+    // {@link #readResolve()}
+    @SuppressWarnings("unused")
+    private long index;
+    @SuppressWarnings("unused")
     private Collection<Long> gaps;
 
-    /**
-     * Get the highest global sequence of events seen up until the point of this tracking token.
-     *
-     * @return the highest global event sequence number seen so far
-     */
-    public long getIndex() {
-        return index;
-    }
-
-    /**
-     * Get a {@link Collection} of this token's gaps.
-     *
-     * @return the gaps of this token
-     */
-    public Collection<Long> getGaps() {
-        return gaps;
+    @JsonCreator
+    @ConstructorProperties({"index", "gaps"})
+    public GapAwareTrackingToken(@JsonProperty("index") long index, @JsonProperty("gaps") Collection<Long> gaps) {
+        super(index, createSortedSetOf(gaps, index));
     }
 
     private Object readResolve() {

--- a/legacy/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingToken.java
+++ b/legacy/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingToken.java
@@ -16,29 +16,41 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.beans.ConstructorProperties;
 import java.io.Serializable;
 
 
 /**
- * Class copied from Axon 3 to be able to restore Axon 3 Tokens from Axon 4 applications.
+ * Implementation of the {@link org.axonframework.eventhandling.GlobalSequenceTrackingToken} used to bridge serialized
+ * versions of this descriptor when migrating from Axon 3.x to Axon 4.x.
  *
- * @deprecated this class is available for backward compatibility with instances that were serialized with Axon 3. Use
- * {@link org.axonframework.eventhandling.GlobalSequenceTrackingToken} instead.
+ * @author Steven van Beelen
+ * @since 4.0.1
+ * @deprecated in favor of the {@link org.axonframework.eventhandling.GlobalSequenceTrackingToken}
  */
 @Deprecated
-public class GlobalSequenceTrackingToken implements Serializable {
+public class GlobalSequenceTrackingToken
+        extends org.axonframework.eventhandling.GlobalSequenceTrackingToken
+        implements Serializable {
 
     private static final long serialVersionUID = 6161638247685258537L;
 
+    // Field {@code globalIndex} is used during Java and XStream de-/serialization through method {@link #readResolve()}
+    @SuppressWarnings("unused")
     private long globalIndex;
 
     /**
-     * Get the global sequence number of the event
+     * Initializes a {@link GlobalSequenceTrackingToken} from the given {@code globalIndex} of the event.
      *
-     * @return the global sequence number of the event
+     * @param globalIndex the global sequence number of the event
      */
-    public long getGlobalIndex() {
-        return globalIndex;
+    @JsonCreator
+    @ConstructorProperties({"globalIndex"})
+    public GlobalSequenceTrackingToken(@JsonProperty("globalIndex") long globalIndex) {
+        super(globalIndex);
     }
 
     private Object readResolve() {

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
@@ -1,0 +1,83 @@
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import java.util.List;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test whether the serialized form of the {@link org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken} can
+ * be deserialized into the {@link GapAwareTrackingToken}, using the {@link XStreamSerializer} and
+ * {@link JacksonSerializer}.
+ *
+ * @author Steven van Beelen
+ */
+public class GapAwareTrackingTokenTest {
+
+    private static final String LEGACY_GAP_AWARE_TRACKING_TOKEN_CLASS_NAME =
+            "org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken";
+    private static final int TOKEN_INDEX = 75;
+    private static final List<Long> TOKEN_GAPS = Stream.of(0L, 25L, 58L).collect(Collectors.toList());
+
+    @Test
+    public void testXStreamSerializationOfOldGapAwareTrackingToken() {
+        XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
+
+        String xmlSerializedGapAwareTrackingToken =
+                "<org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken>"
+                        + "<index>" + TOKEN_INDEX + "</index>"
+                        + "<gaps class=\"java.util.concurrent.ConcurrentSkipListSet\">"
+                        + "<m class=\"java.util.concurrent.ConcurrentSkipListMap\" serialization=\"custom\">"
+                        + "<unserializable-parents/>"
+                        + "<java.util.concurrent.ConcurrentSkipListMap>"
+                        + "<default/>"
+                        + "<long>" + TOKEN_GAPS.get(0) + "</long><boolean>true</boolean>"
+                        + "<long>" + TOKEN_GAPS.get(1) + "</long><boolean>true</boolean>"
+                        + "<long>" + TOKEN_GAPS.get(2) + "</long><boolean>true</boolean>"
+                        + "<null/>"
+                        + "</java.util.concurrent.ConcurrentSkipListMap>"
+                        + "</m><"
+                        + "/gaps>"
+                        + "</org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken>";
+        SerializedObject<String> serializedGapAwareTrackingToken = new SimpleSerializedObject<>(
+                xmlSerializedGapAwareTrackingToken, String.class, LEGACY_GAP_AWARE_TRACKING_TOKEN_CLASS_NAME, null
+        );
+
+        GapAwareTrackingToken result = serializer.deserialize(serializedGapAwareTrackingToken);
+        assertEquals(TOKEN_INDEX, result.getIndex());
+        SortedSet<Long> resultGaps = result.getGaps();
+        assertFalse(resultGaps.isEmpty());
+        for (Long tokenGap : TOKEN_GAPS) {
+            assertTrue(resultGaps.contains(tokenGap));
+        }
+    }
+
+    @Test
+    public void testJacksonSerializationOfOldGapAwareTrackingToken() {
+        JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
+
+        String jacksonSerializedGapAwareTrackingToken =
+                "{\"index\": " + TOKEN_INDEX + ", \"gaps\": "
+                        + "[" + TOKEN_GAPS.get(0) + ", " + TOKEN_GAPS.get(1) + ", " + TOKEN_GAPS.get(2) + "]}";
+        SerializedObject<String> serializedGapAwareTrackingToken = new SimpleSerializedObject<>(
+                jacksonSerializedGapAwareTrackingToken, String.class, LEGACY_GAP_AWARE_TRACKING_TOKEN_CLASS_NAME, null
+        );
+
+        GapAwareTrackingToken result = serializer.deserialize(serializedGapAwareTrackingToken);
+        assertEquals(TOKEN_INDEX, result.getIndex());
+        SortedSet<Long> resultGaps = result.getGaps();
+        assertFalse(resultGaps.isEmpty());
+        for (Long tokenGap : TOKEN_GAPS) {
+            assertTrue(resultGaps.contains(tokenGap));
+        }
+    }
+}

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
@@ -1,0 +1,56 @@
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test whether the serialized form of the
+ * {@link org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken} can be deserialized into the
+ * {@link GlobalSequenceTrackingToken}, using the {@link XStreamSerializer} and {@link JacksonSerializer}.
+ *
+ * @author Steven van Beelen
+ */
+public class GlobalSequenceTrackingTokenTest {
+
+    private static final String LEGACY_GLOBAL_SEQUENCE_TRACKING_TOKEN_CLASS_NAME =
+            "org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken";
+    private static final int GLOBAL_INDEX = 10;
+
+    @Test
+    public void testXStreamSerializationOfOldGlobalSequenceTrackingToken() {
+        XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
+
+        String xmlSerializedGlobalSequenceTrackingToken =
+                "<org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken>"
+                        + "<globalIndex>" + GLOBAL_INDEX + "</globalIndex>"
+                        + "</org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken>";
+        SerializedObject<String> serializedGlobalSequenceTrackingToken = new SimpleSerializedObject<>(
+                xmlSerializedGlobalSequenceTrackingToken, String.class,
+                LEGACY_GLOBAL_SEQUENCE_TRACKING_TOKEN_CLASS_NAME, null
+        );
+
+        GlobalSequenceTrackingToken result = serializer.deserialize(serializedGlobalSequenceTrackingToken);
+        assertEquals(GLOBAL_INDEX, result.getGlobalIndex());
+    }
+
+    @Test
+    public void testJacksonSerializationOfOldGlobalSequenceTrackingToken() {
+        JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
+
+        String jacksonSerializedGlobalSequenceTrackingToken =
+                "{\"globalIndex\": " + GLOBAL_INDEX + "}";
+        SerializedObject<String> serializedGlobalSequenceTrackingToken = new SimpleSerializedObject<>(
+                jacksonSerializedGlobalSequenceTrackingToken, String.class,
+                LEGACY_GLOBAL_SEQUENCE_TRACKING_TOKEN_CLASS_NAME, null
+        );
+
+        GlobalSequenceTrackingToken result = serializer.deserialize(serializedGlobalSequenceTrackingToken);
+        assertEquals(GLOBAL_INDEX, result.getGlobalIndex());
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
@@ -68,14 +68,14 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
     /**
      * This constructor is mean't to be used for deserialization. <br>
      * Please use {@link #newInstance(long, Collection)} to create new instances.
-     * 
+     *
      * @param index the highest global sequence number of events up until (and including) this tracking token
      * @param gaps  global sequence numbers of events that have not been seen yet even though these sequence numbers are
      *              smaller than the current index. These missing sequence numbers may be filled in later when those
      *              events get committed to the store or may never be filled in if those events never get committed.
      */
     @JsonCreator
-    @ConstructorProperties({ "index", "gaps" })
+    @ConstructorProperties({"index", "gaps"})
     public GapAwareTrackingToken(@JsonProperty("index") long index, @JsonProperty("gaps") Collection<Long> gaps) {
         this(index, createSortedSetOf(gaps, index), 0);
     }
@@ -86,6 +86,15 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
         this.gapTruncationIndex = gapTruncationIndex;
     }
 
+    /**
+     * Construct a {@link SortedSet} of the given {@code gaps} to be set in this Tracking Token. The given {@code index}
+     * will be consolidated to ensure the last gap in the set is smaller. If this is not the case, an
+     * {@link IllegalArgumentException} is thrown
+     *
+     * @param gaps  the {@link Collection} of gaps to created a {@link SortedSet} out of
+     * @param index a {@code long} which is required to be bigger than the last known gap in the set
+     * @return a {@link SortedSet} constructed out of the given {@code gaps}
+     */
     protected static SortedSet<Long> createSortedSetOf(Collection<Long> gaps, long index) {
         if (gaps.isEmpty()) {
             return Collections.emptySortedSet();
@@ -184,7 +193,8 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
         GapAwareTrackingToken other = (GapAwareTrackingToken) otherToken;
         SortedSet<Long> newGaps = CollectionUtils.intersect(this.gaps, other.gaps, ConcurrentSkipListSet::new);
         long min = Math.min(this.index, other.index) + 1;
-        SortedSet<Long> mergedGaps = CollectionUtils.merge(this.gaps.tailSet(min), other.gaps.tailSet(min), ConcurrentSkipListSet::new);
+        SortedSet<Long> mergedGaps =
+                CollectionUtils.merge(this.gaps.tailSet(min), other.gaps.tailSet(min), ConcurrentSkipListSet::new);
         newGaps.addAll(mergedGaps);
 
         return new GapAwareTrackingToken(Math.max(this.index, other.index), newGaps,

--- a/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
@@ -73,7 +73,6 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
      * @param gaps  global sequence numbers of events that have not been seen yet even though these sequence numbers are
      *              smaller than the current index. These missing sequence numbers may be filled in later when those
      *              events get committed to the store or may never be filled in if those events never get committed.
-     * @param gaps
      */
     @JsonCreator
     @ConstructorProperties({ "index", "gaps" })
@@ -87,7 +86,7 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
         this.gapTruncationIndex = gapTruncationIndex;
     }
 
-    private static SortedSet<Long> createSortedSetOf(Collection<Long> gaps, long index) {
+    protected static SortedSet<Long> createSortedSetOf(Collection<Long> gaps, long index) {
         if (gaps.isEmpty()) {
             return Collections.emptySortedSet();
         }


### PR DESCRIPTION
The legacy tracking tokens provided in the `axon-legacy` module provide the means to deserialize Axon 3.x tokens into Axon 4.x tokens. However, the current implementation only works for Java and XStream serialized tokens and not for Jackson variants.
This PR adjusts the legacy tokens such that the `JacksonSerializer` can also deserialize old version towards the new implementation.

More specifically, this PR provides adjustments for the legacy `GapAwareTrackingToken` and the `GlobalSequenceTrackingToken`.

This PR resolves #1230.