### PR TITLE
Add a polling time to the EventBuffer

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
@@ -32,38 +32,51 @@ import org.mockito.stubbing.*;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Test class to verify the implementation of the {@link EventBuffer} class.
+ *
+ * @author Marc Gathier
+ * @author Steven van Beelen
+ */
 public class EventBufferTest {
+
     private EventUpcaster stubUpcaster;
+    private XStreamSerializer serializer;
+
     private EventBuffer testSubject;
 
-    private XStreamSerializer serializer;
     private org.axonframework.serialization.SerializedObject<byte[]> serializedObject;
 
     @Before
     public void setUp() {
         stubUpcaster = mock(EventUpcaster.class);
-        when(stubUpcaster.upcast(any())).thenAnswer((Answer<Stream<IntermediateEventRepresentation>>) invocationOnMock -> (Stream<IntermediateEventRepresentation>) invocationOnMock.getArguments()[0]);
-        serializer = XStreamSerializer.builder().build();
+        //noinspection unchecked
+        when(stubUpcaster.upcast(any()))
+                .thenAnswer((Answer<Stream<IntermediateEventRepresentation>>) invocationOnMock ->
+                        (Stream<IntermediateEventRepresentation>) invocationOnMock.getArguments()[0]
+                );
 
+        serializer = XStreamSerializer.defaultSerializer();
         serializedObject = serializer.serialize("some object", byte[].class);
+
+        testSubject = new EventBuffer(stubUpcaster, serializer);
     }
 
     @Test
     public void testDataUpcastAndDeserialized() throws InterruptedException {
-        testSubject = new EventBuffer(stubUpcaster, serializer);
-
         assertFalse(testSubject.hasNextAvailable());
         testSubject.push(createEventData(1L));
         assertTrue(testSubject.hasNextAvailable());
 
-        TrackedEventMessage<?> peeked = testSubject.peek().orElseThrow(() -> new AssertionError("Expected value to be available"));
+        TrackedEventMessage<?> peeked =
+                testSubject.peek().orElseThrow(() -> new AssertionError("Expected value to be available"));
         assertEquals(new GlobalSequenceTrackingToken(1L), peeked.trackingToken());
         assertTrue(peeked instanceof DomainEventMessage<?>);
 
@@ -73,13 +86,13 @@ public class EventBufferTest {
         assertFalse(testSubject.hasNextAvailable());
         assertFalse(testSubject.hasNextAvailable(10, TimeUnit.MILLISECONDS));
 
+        //noinspection unchecked
         verify(stubUpcaster).upcast(isA(Stream.class));
     }
 
     @Test
     public void testConsumptionIsRecorded() {
-        stubUpcaster = stream -> stream.filter(i -> false);
-        testSubject = new EventBuffer(stubUpcaster, serializer);
+        testSubject = new EventBuffer(stream -> stream.filter(i -> false), serializer);
 
         testSubject.push(createEventData(1));
         testSubject.push(createEventData(2));
@@ -92,20 +105,49 @@ public class EventBufferTest {
         assertEquals(3, consumed.get());
     }
 
-    private EventWithToken createEventData(long sequence) {
-        return EventWithToken.newBuilder()
-                             .setToken(sequence)
-                             .setEvent(Event.newBuilder()
-                                            .setPayload(SerializedObject.newBuilder()
-                                                                        .setData(ByteString.copyFrom(serializedObject.getData()))
-                                                                        .setType(serializedObject.getType().getName()))
-                                            .setMessageIdentifier(UUID.randomUUID().toString())
-                                            .setAggregateType("Test")
-                                            .setAggregateSequenceNumber(sequence)
-                                            .setTimestamp(System.currentTimeMillis())
-                                            .setAggregateIdentifier("1235"))
-                             .build();
+    @Test(timeout = 2000)
+    public void testNextAvailableDoesNotBlockIndefinitelyIfTheStreamIsClosedExceptionally()
+            throws InterruptedException {
+        RuntimeException expected = new RuntimeException("Some Exception");
+        AtomicReference<Exception> result = new AtomicReference<>();
+
+        // Create and start "nextAvailable" thread
+        Thread pollingThread = new Thread(() -> {
+            try {
+                testSubject.nextAvailable();
+            } catch (Exception e) {
+                result.set(e);
+            }
+        });
+        pollingThread.start();
+        // Sleep to give "pollingThread" time to enter event polling operation
+        Thread.sleep(50);
+        // Fail the EventBuffer, which should close the stream
+        testSubject.fail(expected);
+        // Wait for the pollingThread to be resolved due to the thrown RuntimeException
+        pollingThread.join();
+
+        assertEquals(expected, result.get());
     }
 
+    private EventWithToken createEventData(long sequence) {
+        SerializedObject payload = SerializedObject.newBuilder()
+                                                   .setData(ByteString.copyFrom(serializedObject.getData()))
+                                                   .setType(serializedObject.getType().getName())
+                                                   .build();
 
+        Event event = Event.newBuilder()
+                           .setPayload(payload)
+                           .setMessageIdentifier(UUID.randomUUID().toString())
+                           .setAggregateType("Test")
+                           .setAggregateSequenceNumber(sequence)
+                           .setTimestamp(System.currentTimeMillis())
+                           .setAggregateIdentifier("1235")
+                           .build();
+
+        return EventWithToken.newBuilder()
+                             .setToken(sequence)
+                             .setEvent(event)
+                             .build();
+    }
 }


### PR DESCRIPTION
This PR adds a polling time to the `EventBuffer`, used during the `EventBuffer#hasNextAvailable(int, TimeUnit)` method to ensure nobody accidentally performs said call that'll block for the given duration. 
This would indefinite blocking would occur if the timeout is long **and** the `EventBuffer#fail(RuntimeException)` is issued (typically because the connection to Axon Server is broken). 
The `EventBuffer#nextAvailable()` operation for example calls `EventBuffer#hasNextAvailable(int, TimeUnit)` with `Integer.MAX_VALUE`, thus potentially blocking  they entire `EventBuffer` in case of a failure. 

Specifically, the `EventBuffer` now has a `pollingTimeMillis` field, defaulted to 500ms, which will be used to periodically block the polling operation, which will make the buffer re-enter the verification if it has failed.
This PR additionally has a couple of minor indentation adjustments and JavaDoc.

This fix followed from issue #1227, but does no count as a full resolution of the problem.