### PR TITLE
Fix Javadoc typos

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -40,7 +40,7 @@ public class AxonServerConfiguration {
     private static final String DEFAULT_CONTEXT = "default";
 
     /**
-     * Comma separated list of AxonDB servers. Each element is hostname or hostname:grpcPort. When no grpcPort is
+     * Comma separated list of AxonServer servers. Each element is hostname or hostname:grpcPort. When no grpcPort is
      * specified, default port 8123 is used.
      */
     private String servers = DEFAULT_SERVERS;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
@@ -25,7 +25,7 @@ import org.axonframework.serialization.Serializer;
 import java.util.Map;
 
 /**
- * Wrapper around standard Axon Framework serializer that can deserialize Metadata from AxonDB events.
+ * Wrapper around standard Axon Framework serializer that can deserialize Metadata from AxonServer events.
  */
 class GrpcMetaDataAwareSerializer implements Serializer {
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/QueryResult.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/QueryResult.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Single result row from a Query to the AxonDB.
+ * Single result row from a Query to the AxonServer.
  *
  * When applying aggregation functions in the query (min/max/groupby/count/avg) you will get values for the identifier.
  * Same identifier may occur more than once as the results get updated.


### PR DESCRIPTION
This PR fixes AxonDB / AxonServer related typos in Javadoc.

A couple of places had AxonDB instead of AxonServer in the Javadoc, this change will update it to AxonServer. 