### PR TITLE
Fix issue where not all upcast results were taken into account

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,30 +19,44 @@ package org.axonframework.axonserver.connector.event.axon;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.event.StubServer;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
+import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.junit.*;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 public class AxonServerEventStoreTest {
 
     private StubServer server;
     private AxonServerEventStore testSubject;
+    private EventUpcaster upcasterChain;
 
     @Before
     public void setUp() throws Exception {
         server = new StubServer(6123);
         server.start();
+        upcasterChain = mock(EventUpcaster.class);
+        when(upcasterChain.upcast(any())).thenAnswer(i -> i.getArgument(0));
         AxonServerConfiguration config = AxonServerConfiguration.builder()
                                                                 .servers("localhost:6123")
                                                                 .componentName("JUNIT")
@@ -55,6 +69,9 @@ public class AxonServerEventStoreTest {
         testSubject = AxonServerEventStore.builder()
                                           .configuration(config)
                                           .platformConnectionManager(axonServerConnectionManager)
+                                          .upcasterChain(upcasterChain)
+                                          .eventSerializer(JacksonSerializer.defaultSerializer())
+                                          .snapshotSerializer(XStreamSerializer.defaultSerializer())
                                           .build();
     }
 
@@ -80,6 +97,49 @@ public class AxonServerEventStoreTest {
         stream.close();
 
         assertEquals(Arrays.asList("Test1", "Test2", "Test3"), received);
+    }
+
+    @Test
+    public void testLoadEventsWithMultiUpcaster() {
+        reset(upcasterChain);
+        when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
+            Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
+            return si.flatMap(i -> Stream.of(i, i));
+        });
+        testSubject.publish(new GenericDomainEventMessage<>("aggregateType", "aggregateId", 0, "Test1"),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 1, "Test2"),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 2, "Test3"));
+
+        DomainEventStream actual = testSubject.readEvents("aggregateId");
+        assertTrue(actual.hasNext());
+        assertEquals("Test1", actual.next().getPayload());
+        assertEquals("Test1", actual.next().getPayload());
+        assertEquals("Test2", actual.next().getPayload());
+        assertEquals("Test2", actual.next().getPayload());
+        assertEquals("Test3", actual.next().getPayload());
+        assertEquals("Test3", actual.next().getPayload());
+        assertFalse(actual.hasNext());
+    }
+
+    @Test
+    public void testLoadSnapshotAndEventsWithMultiUpcaster() {
+        reset(upcasterChain);
+        when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
+            Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
+            return si.flatMap(i -> Stream.of(i, i));
+        });
+        testSubject.publish(new GenericDomainEventMessage<>("aggregateType", "aggregateId", 0, "Test1"),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 1, "Test2"),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 2, "Test3"));
+        testSubject.storeSnapshot(new GenericDomainEventMessage<>("aggregateType", "aggregateId", 1, "Snapshot1"));
+
+        DomainEventStream actual = testSubject.readEvents("aggregateId");
+        assertTrue(actual.hasNext());
+        assertEquals("Snapshot1", actual.next().getPayload());
+        assertEquals("Snapshot1", actual.next().getPayload());
+        assertEquals("Test3", actual.next().getPayload());
+        assertEquals("Test3", actual.next().getPayload());
+        assertFalse(actual.hasNext());
     }
 
     @Test(expected = EventStoreException.class)

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
@@ -19,8 +19,7 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.messaging.MetaData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -117,12 +116,7 @@ public class ConcatenatingDomainEventStreamTest {
         assertSame(event1.getPayload(), concat.next().getPayload());
         assertSame(event1.getPayload(), concat.next().getPayload());
         assertSame(event2.getPayload(), concat.next().getPayload());
-
-        assertSame(event3.getPayload(), concat.peek().getPayload());
-
         assertSame(event3.getPayload(), concat.next().getPayload());
-
-        assertSame(event4.getPayload(), concat.peek().getPayload());
         assertSame(event4.getPayload(), concat.next().getPayload());
         assertFalse(concat.hasNext());
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,8 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.messaging.MetaData;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,15 +39,15 @@ public class ConcatenatingDomainEventStreamTest {
 
     @Before
     public void setUp() {
-        event1 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
+        event1 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), 0,
                                                  "Mock contents 1", MetaData.emptyInstance());
-        event2 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 1,
+        event2 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), 1,
                                                  "Mock contents 2", MetaData.emptyInstance());
-        event3 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 2,
+        event3 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), 2,
                                                  "Mock contents 3", MetaData.emptyInstance());
-        event4 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 3,
+        event4 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), 3,
                                                  "Mock contents 4", MetaData.emptyInstance());
-        event5 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 4,
+        event5 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), 4,
                                                  "Mock contents 5", MetaData.emptyInstance());
     }
 
@@ -94,6 +95,26 @@ public class ConcatenatingDomainEventStreamTest {
                                                                       DomainEventStream.of(event3, event4));
 
         assertTrue(concat.hasNext());
+        assertSame(event1.getPayload(), concat.next().getPayload());
+        assertSame(event2.getPayload(), concat.next().getPayload());
+
+        assertSame(event3.getPayload(), concat.peek().getPayload());
+
+        assertSame(event3.getPayload(), concat.next().getPayload());
+
+        assertSame(event4.getPayload(), concat.peek().getPayload());
+        assertSame(event4.getPayload(), concat.next().getPayload());
+        assertFalse(concat.hasNext());
+    }
+
+    @Test
+    public void testConcatDoesNotSkipDuplicateSequencesInSameStream() {
+        DomainEventStream concat = new ConcatenatingDomainEventStream(DomainEventStream.of(event1, event1, event2),
+                                                                      DomainEventStream.of(event2, event2, event3),
+                                                                      DomainEventStream.of(event3, event4));
+
+        assertTrue(concat.hasNext());
+        assertSame(event1.getPayload(), concat.next().getPayload());
         assertSame(event1.getPayload(), concat.next().getPayload());
         assertSame(event2.getPayload(), concat.next().getPayload());
 


### PR DESCRIPTION
When using the AxonServer Connector, and upcasting a single entry into
multiple entries, only the first of these entries was taken into account. This PR fixes that.

Resolves #1263