### PR TITLE
Profile configuration to disable-axon-server

### DIFF
--- a/spring-boot-autoconfigure/src/main/resources/application-disable-axon-server.properties
+++ b/spring-boot-autoconfigure/src/main/resources/application-disable-axon-server.properties
@@ -1,0 +1,1 @@
+spring.autoconfigure.exclude=org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration


### PR DESCRIPTION
This should be enough to fulfill #1247 

By running the app with `-Dspring.profiles.active=disable-axon-server`(or using ENV, ...)

The application properties will be loaded and thus the autoconfiguration of axon server connector will be excluded from the context.

This allows to switch between axon-Server (prod) and local eventStore (test, dev) by adding a profile and do not require excluding the dependency from the starter. 

