### PR TITLE
Migrate modules configuration, disruptor, legacy, spring, spring-boot-autoconfigure to JUnit5

### DIFF
--- a/config/src/test/java/org/axonframework/config/ConfigAssertions.java
+++ b/config/src/test/java/org/axonframework/config/ConfigAssertions.java
@@ -19,7 +19,7 @@ package org.axonframework.config;
 import java.util.List;
 
 import static java.util.Arrays.stream;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Assertion utils for axon {@link Configuration}.

--- a/config/src/test/java/org/axonframework/config/ConfigurationParameterResolverFactoryTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationParameterResolverFactoryTest.java
@@ -20,15 +20,15 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.annotation.ParameterResolver;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class ConfigurationParameterResolverFactoryTest {
+class ConfigurationParameterResolverFactoryTest {
 
     private Configuration configuration;
     private ConfigurationParameterResolverFactory testSubject;
@@ -36,8 +36,8 @@ public class ConfigurationParameterResolverFactoryTest {
     private Method method;
     private CommandBus commandBus;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         configuration = mock(Configuration.class);
         commandBus = SimpleCommandBus.builder().build();
         when(configuration.getComponent(CommandBus.class)).thenReturn(commandBus);
@@ -48,14 +48,14 @@ public class ConfigurationParameterResolverFactoryTest {
     }
 
     @Test
-    public void testReturnsNullOnUnavailableParameter() {
+    void testReturnsNullOnUnavailableParameter() {
         assertNull(testSubject.createInstance(method, parameters, 0));
 
         verify(configuration).getComponent(String.class);
     }
 
     @Test
-    public void testConfigurationContainsRequestedParameter() {
+    void testConfigurationContainsRequestedParameter() {
         ParameterResolver<?> actual = testSubject.createInstance(method, parameters, 1);
         assertNotNull(actual);
         assertSame(commandBus, actual.resolveParameterValue(new GenericMessage<>("test")));
@@ -63,7 +63,7 @@ public class ConfigurationParameterResolverFactoryTest {
         verify(configuration).getComponent(CommandBus.class);
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public void donorMethod(String type, CommandBus commandBus) {
 
     }

--- a/config/src/test/java/org/axonframework/config/ConfigurationResourceInjectorTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationResourceInjectorTest.java
@@ -20,21 +20,21 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.inject.Inject;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ConfigurationResourceInjectorTest {
 
     private Configuration configuration;
     private ConfigurationResourceInjector testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         configuration = DefaultConfigurer.defaultConfiguration()
                 .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
                 .buildConfiguration();
@@ -42,7 +42,7 @@ public class ConfigurationResourceInjectorTest {
     }
 
     @Test
-    public void testInjectorHasResource() {
+    void testInjectorHasResource() {
         Saga saga = new Saga();
         testSubject.injectResources(saga);
 

--- a/config/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -20,18 +20,19 @@ import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.saga.AbstractSagaManager;
 import org.axonframework.messaging.ScopeAware;
 import org.axonframework.messaging.ScopeDescriptor;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
@@ -39,8 +40,8 @@ import static org.mockito.Mockito.*;
  *
  * @author Rob van der Linden Vooren
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ConfigurationScopeAwareProviderTest {
+@ExtendWith(MockitoExtension.class)
+class ConfigurationScopeAwareProviderTest {
 
     @Mock
     private Configuration configuration;
@@ -62,14 +63,14 @@ public class ConfigurationScopeAwareProviderTest {
 
     private ConfigurationScopeAwareProvider scopeAwareProvider;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(configuration.eventProcessingConfiguration()).thenReturn(eventProcessingConfiguration);
         scopeAwareProvider = new ConfigurationScopeAwareProvider(configuration);
     }
 
     @Test
-    public void providesScopeAwareAggregatesFromModuleConfiguration() {
+    void providesScopeAwareAggregatesFromModuleConfiguration() {
         when(configuration.findModules(AggregateConfiguration.class)).thenCallRealMethod();
         when(configuration.getModules())
                 .thenReturn(singletonList(new WrappingModuleConfiguration(aggregateConfiguration)));
@@ -78,11 +79,11 @@ public class ConfigurationScopeAwareProviderTest {
         List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
                                                         .collect(toList());
 
-        assertThat(components, equalTo(singletonList(aggregateRepository)));
+        assertEquals(singletonList(aggregateRepository), components);
     }
 
     @Test
-    public void providesScopeAwareSagasFromModuleConfiguration() {
+    void providesScopeAwareSagasFromModuleConfiguration() {
         when(eventProcessingConfiguration.sagaConfigurations())
                 .thenReturn(singletonList(sagaConfiguration));
         when(sagaConfiguration.manager()).thenReturn(sagaManager);
@@ -90,18 +91,19 @@ public class ConfigurationScopeAwareProviderTest {
         List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
                                                         .collect(toList());
 
-        assertThat(components, equalTo(singletonList(sagaManager)));
+        assertEquals(singletonList(sagaManager), components);
     }
 
+    @MockitoSettings(strictness = Strictness.LENIENT)
     @Test
-    public void lazilyInitializes() {
+    void lazilyInitializes() {
         new ConfigurationScopeAwareProvider(configuration);
 
         verifyZeroInteractions(configuration);
     }
 
     @Test
-    public void cachesScopeAwareComponentsOnceProvisioned() {
+    void cachesScopeAwareComponentsOnceProvisioned() {
         when(configuration.findModules(AggregateConfiguration.class)).thenCallRealMethod();
         when(configuration.getModules())
                 .thenReturn(singletonList(new WrappingModuleConfiguration(aggregateConfiguration)));
@@ -116,7 +118,7 @@ public class ConfigurationScopeAwareProviderTest {
         List<ScopeAware> second = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor()).collect(toList());
         verifyZeroInteractions(configuration);
         verifyZeroInteractions(aggregateConfiguration);
-        assertThat(second, equalTo(first));
+        assertEquals(first, second);
     }
 
     private static ScopeDescriptor anyScopeDescriptor() {

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -29,8 +29,11 @@ import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,21 +43,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.axonframework.common.ReflectionUtils.getFieldValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class EventProcessingModuleTest {
+@ExtendWith(MockitoExtension.class)
+class EventProcessingModuleTest {
 
     private Configurer configurer;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         configurer = DefaultConfigurer.defaultConfiguration();
     }
 
     @Test
-    public void testAssignmentRules() {
+    void testAssignmentRules() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
         AnnotatedBean annotatedBean = new AnnotatedBean();
@@ -85,7 +89,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testProcessorsDefaultToSubscribingWhenUsingSimpleEventBus() {
+    void testProcessorsDefaultToSubscribingWhenUsingSimpleEventBus() {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .configureEventBus(c -> SimpleEventBus.builder().build())
                                                        .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
@@ -98,18 +102,19 @@ public class EventProcessingModuleTest {
         assertTrue(configuration.eventProcessingConfiguration().eventProcessor("tracking").map(p -> p instanceof SubscribingEventProcessor).orElse(false));
     }
 
-    @Test(expected = AxonConfigurationException.class)
-    public void testAssigningATrackingProcessorFailsWhenUsingSimpleEventBus() {
-        DefaultConfigurer.defaultConfiguration()
-                         .configureEventBus(c -> SimpleEventBus.builder().build())
-                         .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
-                                                  .registerEventHandler(c -> new TrackingEventHandler())
-                                                  .registerTrackingEventProcessor("tracking"))
-                         .start();
+    @Test
+    void testAssigningATrackingProcessorFailsWhenUsingSimpleEventBus() {
+        Configurer configurer = DefaultConfigurer.defaultConfiguration()
+                .configureEventBus(c -> SimpleEventBus.builder().build())
+                .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
+                        .registerEventHandler(c -> new TrackingEventHandler())
+                        .registerTrackingEventProcessor("tracking"));
+
+        assertThrows(AxonConfigurationException.class, configurer::start);
     }
 
     @Test
-    public void testAssignmentRulesOverrideThoseWithLowerPriority() {
+    void testAssignmentRulesOverrideThoseWithLowerPriority() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
         configurer.eventProcessing()
@@ -141,7 +146,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testDefaultAssignToKeepsAnnotationScanning() {
+    void testDefaultAssignToKeepsAnnotationScanning() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         AnnotatedBean annotatedBean = new AnnotatedBean();
         Object object = new Object();
@@ -165,7 +170,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testTypeAssignment() {
+    void testTypeAssignment() {
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("myGroup", c -> "java.lang".equals(c.getPackage().getName()))
                   .registerSaga(Object.class)
@@ -182,7 +187,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testAssignSequencingPolicy() throws NoSuchFieldException {
+    void testAssignSequencingPolicy() throws NoSuchFieldException {
         Object mockHandler = new Object();
         Object specialHandler = new Object();
         SequentialPolicy sequentialPolicy = new SequentialPolicy();
@@ -213,7 +218,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testAssignInterceptors() {
+    void testAssignInterceptors() {
         StubInterceptor interceptor1 = new StubInterceptor();
         StubInterceptor interceptor2 = new StubInterceptor();
         configurer.eventProcessing()
@@ -233,7 +238,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testConfigureMonitor() throws Exception {
+    void testConfigureMonitor() throws Exception {
         MessageCollectingMonitor subscribingMonitor = new MessageCollectingMonitor();
         MessageCollectingMonitor trackingMonitor = new MessageCollectingMonitor(1);
         CountDownLatch tokenStoreInvocation = new CountDownLatch(1);
@@ -256,7 +261,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testConfigureDefaultListenerInvocationErrorHandler() throws Exception {
+    void testConfigureDefaultListenerInvocationErrorHandler() throws Exception {
         GenericEventMessage<Boolean> errorThrowingEventMessage = new GenericEventMessage<>(true);
 
         int expectedListenerInvocationErrorHandlerCalls = 2;
@@ -282,7 +287,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testConfigureListenerInvocationErrorHandlerPerEventProcessor() throws Exception {
+    void testConfigureListenerInvocationErrorHandlerPerEventProcessor() throws Exception {
         GenericEventMessage<Boolean> errorThrowingEventMessage = new GenericEventMessage<>(true);
 
         int expectedErrorHandlerCalls = 1;
@@ -312,7 +317,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testConfigureDefaultErrorHandler() throws Exception {
+    void testConfigureDefaultErrorHandler() throws Exception {
         GenericEventMessage<Integer> failingEventMessage = new GenericEventMessage<>(1000);
 
         int expectedErrorHandlerCalls = 2;
@@ -339,8 +344,8 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testTrackingProcessorsUsesConfiguredDefaultStreamableMessageSource() {
-        StreamableMessageSource<TrackedEventMessage<?>> mock = mock(StreamableMessageSource.class);
+    void testTrackingProcessorsUsesConfiguredDefaultStreamableMessageSource(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mock) {
         configurer.eventProcessing().configureDefaultStreamableMessageSource(c -> mock);
         configurer.eventProcessing().usingTrackingEventProcessors();
         configurer.registerEventHandler(c -> new TrackingEventHandler());
@@ -352,9 +357,9 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testTrackingProcessorsUsesSpecificSource() {
-        StreamableMessageSource<TrackedEventMessage<?>> mock = mock(StreamableMessageSource.class);
-        StreamableMessageSource<TrackedEventMessage<?>> mock2 = mock(StreamableMessageSource.class);
+    void testTrackingProcessorsUsesSpecificSource(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mock,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mock2) {
         configurer.eventProcessing()
                   .configureDefaultStreamableMessageSource(c -> mock)
                   .registerTrackingEventProcessor("tracking", c -> mock2)
@@ -367,8 +372,8 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testSubscribingProcessorsUsesConfiguredDefaultSubscribableMessageSource() {
-        SubscribableMessageSource<EventMessage<?>> mock = mock(SubscribableMessageSource.class);
+    void testSubscribingProcessorsUsesConfiguredDefaultSubscribableMessageSource(
+            @Mock SubscribableMessageSource<EventMessage<?>> mock) {
         configurer.eventProcessing().configureDefaultSubscribableMessageSource(c -> mock);
         configurer.eventProcessing().usingSubscribingEventProcessors();
         configurer.registerEventHandler(c -> new SubscribingEventHandler());
@@ -380,9 +385,9 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testSubscribingProcessorsUsesSpecificSource() {
-        SubscribableMessageSource<EventMessage<?>> mock = mock(SubscribableMessageSource.class);
-        SubscribableMessageSource<EventMessage<?>> mock2 = mock(SubscribableMessageSource.class);
+    void testSubscribingProcessorsUsesSpecificSource(
+            @Mock SubscribableMessageSource<EventMessage<?>> mock,
+            @Mock SubscribableMessageSource<EventMessage<?>> mock2) {
         configurer.eventProcessing()
                   .configureDefaultSubscribableMessageSource(c -> mock)
                   .registerSubscribingEventProcessor("subscribing", c -> mock2)
@@ -396,7 +401,7 @@ public class EventProcessingModuleTest {
 
 
     @Test
-    public void testConfigureErrorHandlerPerEventProcessor() throws Exception {
+    void testConfigureErrorHandlerPerEventProcessor() throws Exception {
         GenericEventMessage<Integer> failingEventMessage = new GenericEventMessage<>(1000);
 
         int expectedErrorHandlerCalls = 1;
@@ -427,7 +432,7 @@ public class EventProcessingModuleTest {
     }
 
     @Test
-    public void testPackageOfObject() {
+    void testPackageOfObject() {
         String expectedPackageName = EventProcessingModule.class.getPackage().getName();
         assertEquals(expectedPackageName, EventProcessingModule.packageOfObject(this));
     }

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -105,10 +105,10 @@ class EventProcessingModuleTest {
     @Test
     void testAssigningATrackingProcessorFailsWhenUsingSimpleEventBus() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration()
-                .configureEventBus(c -> SimpleEventBus.builder().build())
-                .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
-                        .registerEventHandler(c -> new TrackingEventHandler())
-                        .registerTrackingEventProcessor("tracking"));
+                                                 .configureEventBus(c -> SimpleEventBus.builder().build())
+                                                 .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
+                                                                          .registerEventHandler(c -> new TrackingEventHandler())
+                                                                          .registerTrackingEventProcessor("tracking"));
 
         assertThrows(AxonConfigurationException.class, configurer::start);
     }

--- a/config/src/test/java/org/axonframework/config/MessageMonitorFactoryBuilderTest.java
+++ b/config/src/test/java/org/axonframework/config/MessageMonitorFactoryBuilderTest.java
@@ -18,13 +18,13 @@ package org.axonframework.config;
 
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.function.BiFunction;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MessageMonitorFactoryBuilderTest {
+class MessageMonitorFactoryBuilderTest {
 
     private MessageMonitor<Message<?>> defaultMonitor = (message) -> null;
 
@@ -34,7 +34,7 @@ public class MessageMonitorFactoryBuilderTest {
     private static class D {}
 
     @Test
-    public void validateRulesWithoutTypeHierarchy() {
+    void validateRulesWithoutTypeHierarchy() {
         MessageMonitor<Message<?>> aMonitor = (message) -> null;
         MessageMonitor<Message<?>> bMonitor = (message) -> null;
         MessageMonitor<Message<?>> cMonitor = (message) -> null;
@@ -67,12 +67,12 @@ public class MessageMonitorFactoryBuilderTest {
     private static class M extends L {}
     private static class N extends M implements I {}
 
-    MessageMonitor<Message<?>> kMonitor = (message) -> null;
-    MessageMonitor<Message<?>> mMonitor = (message) -> null;
-    MessageMonitor<Message<?>> iMonitor = (message) -> null;
+    private MessageMonitor<Message<?>> kMonitor = (message) -> null;
+    private MessageMonitor<Message<?>> mMonitor = (message) -> null;
+    private MessageMonitor<Message<?>> iMonitor = (message) -> null;
 
     @Test
-    public void validateTypeHierarchy() {
+    void validateTypeHierarchy() {
         BiFunction<Class<?>, String, MessageMonitor<Message<?>>> factory = new MessageMonitorFactoryBuilder()
                 .add((conf, type, name) -> defaultMonitor)
                 .add(K.class, (conf, type, name) -> kMonitor)
@@ -109,7 +109,7 @@ public class MessageMonitorFactoryBuilderTest {
     }
 
     @Test
-    public void validateMultipleClassesForSameName() {
+    void validateMultipleClassesForSameName() {
         BiFunction<Class<?>, String, MessageMonitor<Message<?>>> factory = new MessageMonitorFactoryBuilder()
                 .add((conf, type, name) -> defaultMonitor)
                 .add(K.class, "name", (conf, type, name) -> kMonitor)

--- a/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
@@ -22,16 +22,19 @@ import org.axonframework.modelling.saga.AnnotatedSagaManager;
 import org.axonframework.modelling.saga.SagaRepository;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class SagaConfigurerTest {
+@ExtendWith(MockitoExtension.class)
+class SagaConfigurerTest {
 
     @Test
-    public void testNullChecksOnSagaConfigurer() {
+    void testNullChecksOnSagaConfigurer() {
         SagaConfigurer<Object> configurer = SagaConfigurer.forType(Object.class);
         assertConfigurerNullCheck(() -> SagaConfigurer.forType(null), "Saga type should be checked for null");
         assertConfigurerNullCheck(() -> configurer.configureSagaStore(null), "Saga store builder should be checked for null");
@@ -41,9 +44,9 @@ public class SagaConfigurerTest {
     }
 
     @Test
-    public void testDefaultConfiguration() {
-        ListenerInvocationErrorHandler listenerInvocationErrorHandler = mock(ListenerInvocationErrorHandler.class);
-        SagaStore store = mock(SagaStore.class);
+    void testDefaultConfiguration(
+            @Mock ListenerInvocationErrorHandler listenerInvocationErrorHandler,
+            @Mock SagaStore store) {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .eventProcessing(ep -> ep.registerSaga(Object.class))
                                                        .registerComponent(ListenerInvocationErrorHandler.class,
@@ -60,10 +63,10 @@ public class SagaConfigurerTest {
     }
 
     @Test
-    public void testCustomConfiguration() {
+    void testCustomConfiguration(
+            @Mock SagaRepository<Object> repository,
+            @Mock AnnotatedSagaManager<Object> manager) {
         SagaStore<Object> sagaStore = new InMemorySagaStore();
-        SagaRepository<Object> repository = mock(SagaRepository.class);
-        AnnotatedSagaManager<Object> manager = mock(AnnotatedSagaManager.class);
         String processingGroup = "myProcessingGroup";
 
         EventProcessingModule eventProcessingModule = new EventProcessingModule();

--- a/config/src/test/java/org/axonframework/config/SingleEventProcessorAssigningToMultipleInvokersTest.java
+++ b/config/src/test/java/org/axonframework/config/SingleEventProcessorAssigningToMultipleInvokersTest.java
@@ -19,19 +19,19 @@ package org.axonframework.config;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Testing functionality of assigning different invokers (saga or event handlers) to the same event processor.
  *
  * @author Milan Savic
  */
-public class SingleEventProcessorAssigningToMultipleInvokersTest {
+class SingleEventProcessorAssigningToMultipleInvokersTest {
 
     @Test
-    public void testMultipleAssignmentsToTrackingProcessor() {
+    void testMultipleAssignmentsToTrackingProcessor() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .registerEventHandler(config -> new EventHandler1())
@@ -57,7 +57,7 @@ public class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    public void testMultipleAssignmentsToSubscribingProcessor() {
+    void testMultipleAssignmentsToSubscribingProcessor() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .usingSubscribingEventProcessors()
@@ -85,7 +85,7 @@ public class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    public void testMultipleAssignmentsWithProvidedProcessorName() {
+    void testMultipleAssignmentsWithProvidedProcessorName() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("processor1", clazz -> clazz.equals(Saga3.class))
@@ -120,7 +120,7 @@ public class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    public void testProcessorGroupAssignment() {
+    void testProcessorGroupAssignment() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .registerEventProcessor("myProcessor", (name, conf, eventHandlerInvoker) ->
@@ -145,7 +145,7 @@ public class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    public void testProcessorGroupAssignmentByRule() {
+    void testProcessorGroupAssignmentByRule() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("myProcessor", clazz -> clazz.equals(Saga3.class))

--- a/config/src/test/java/org/axonframework/config/utils/AssertUtils.java
+++ b/config/src/test/java/org/axonframework/config/utils/AssertUtils.java
@@ -30,7 +30,7 @@ public abstract class AssertUtils {
     }
 
     /**
-     * Assert that the given {@code assertion} succeeds with the given {@code time} and {@code unit}.
+     * Assert that the given {@code assertion} succeeds with the given {@code duration}.
      *
      * @param duration  specifies the time in which the assertion must
      *                  pass

--- a/config/src/test/java/org/axonframework/config/utils/AssertUtils.java
+++ b/config/src/test/java/org/axonframework/config/utils/AssertUtils.java
@@ -16,7 +16,9 @@
 
 package org.axonframework.config.utils;
 
-import java.util.concurrent.TimeUnit;
+import org.opentest4j.AssertionFailedError;
+
+import java.time.Duration;
 
 /**
  * Utility class for special assertions
@@ -30,20 +32,19 @@ public abstract class AssertUtils {
     /**
      * Assert that the given {@code assertion} succeeds with the given {@code time} and {@code unit}.
      *
-     * @param time      an {@code int} which paired with the {@code unit} specifies the time in which the assertion must
+     * @param duration  specifies the time in which the assertion must
      *                  pass
-     * @param unit      a {@link TimeUnit} in which {@code time} is expressed
      * @param assertion a {@link Runnable} containing the assertion to succeed within the deadline
      */
     @SuppressWarnings("Duplicates")
-    public static void assertWithin(int time, TimeUnit unit, Runnable assertion) {
+    public static void assertRetryingWithin(Duration duration, Runnable assertion) {
         long now = System.currentTimeMillis();
-        long deadline = now + unit.toMillis(time);
+        long deadline = now + duration.toMillis();
         do {
             try {
                 assertion.run();
                 break;
-            } catch (AssertionError e) {
+            } catch (AssertionFailedError e) {
                 if (now >= deadline) {
                     throw e;
                 }

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvokerTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvokerTest.java
@@ -35,8 +35,8 @@ import org.axonframework.modelling.command.AggregateScopeDescriptor;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.axonframework.modelling.saga.SagaScopeDescriptor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatchers;
 
 import java.io.ByteArrayOutputStream;
@@ -48,10 +48,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class CommandHandlerInvokerTest {
+class CommandHandlerInvokerTest {
 
     private CommandHandlerInvoker testSubject;
     private EventStore mockEventStore;
@@ -66,8 +66,8 @@ public class CommandHandlerInvokerTest {
     private static AtomicInteger messageHandlingCounter;
 
     @SuppressWarnings("unchecked")
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockEventStore = mock(EventStore.class);
         mockCache = mock(Cache.class);
         doAnswer(invocation -> {
@@ -94,7 +94,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void usesProvidedParameterResolverFactoryToResolveParameters() {
+    void usesProvidedParameterResolverFactoryToResolveParameters() {
         ParameterResolverFactory parameterResolverFactory =
                 spy(ClasspathParameterResolverFactory.forClass(StubAggregate.class));
         testSubject.createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
@@ -108,8 +108,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testLoadFromRepositoryStoresLoadedAggregateInCache() throws Exception {
+    void testLoadFromRepositoryStoresLoadedAggregateInCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -128,8 +127,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testLoadFromRepositoryLoadsFromCache() throws Exception {
+    void testLoadFromRepositoryLoadsFromCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -148,8 +146,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testAddToRepositoryAddsInCache() throws Exception {
+    void testAddToRepositoryAddsInCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -168,7 +165,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testCacheEntryInvalidatedOnRecoveryEntry() {
+    void testCacheEntryInvalidatedOnRecoveryEntry() {
         commandHandlingEntry.resetAsRecoverEntry(aggregateIdentifier);
         testSubject.onEvent(commandHandlingEntry, 0, true);
 
@@ -177,7 +174,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testCreateRepositoryReturnsSameInstanceOnSecondInvocation() {
+    void testCreateRepositoryReturnsSameInstanceOnSecondInvocation() {
         final Repository<StubAggregate> repository1 = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -191,7 +188,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
+    void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -204,7 +201,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
+    void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -215,7 +212,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testCanResolveReturnsFalseForNonMatchingAggregateType() {
+    void testCanResolveReturnsFalseForNonMatchingAggregateType() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -228,7 +225,7 @@ public class CommandHandlerInvokerTest {
     }
 
     @Test
-    public void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
+    void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
         String testAggregateId = "some-identifier";
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload());

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBenchmark.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBenchmark.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
@@ -72,8 +72,8 @@ public class DisruptorCommandBusBenchmark {
         eventStore.countDownLatch.await(5, TimeUnit.SECONDS);
         long end = System.currentTimeMillis();
         try {
-            assertEquals("Seems that some events are not stored", COMMAND_COUNT,
-                         eventStore.readEvents(aggregateIdentifier).asStream().count());
+            assertEquals(COMMAND_COUNT,
+                         eventStore.readEvents(aggregateIdentifier).asStream().count(), "Seems that some events are not stored");
             System.out.println("Did " + ((COMMAND_COUNT * 1000L) / (end - start)) + " commands per second");
         } finally {
             commandBus.stop();

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBuilderTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBuilderTest.java
@@ -17,17 +17,19 @@
 package org.axonframework.disruptor.commandhandling;
 
 import org.axonframework.common.AxonConfigurationException;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class DisruptorCommandBusBuilderTest {
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    @Test(expected = AxonConfigurationException.class)
-    public void testSetIllegalPublisherThreadCount() {
-        DisruptorCommandBus.builder().publisherThreadCount(0).build();
+class DisruptorCommandBusBuilderTest {
+
+    @Test
+    void testSetIllegalPublisherThreadCount() {
+        assertThrows(AxonConfigurationException.class, () -> DisruptorCommandBus.builder().publisherThreadCount(0));
     }
 
-    @Test(expected = AxonConfigurationException.class)
-    public void testSetIllegalInvokerThreadCount() {
-        DisruptorCommandBus.builder().invokerThreadCount(0).build();
+    @Test
+    void testSetIllegalInvokerThreadCount() {
+        assertThrows(AxonConfigurationException.class, () -> DisruptorCommandBus.builder().invokerThreadCount(0));
     }
 }

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
@@ -44,15 +44,17 @@ import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.command.*;
 import org.axonframework.modelling.saga.SagaScopeDescriptor;
 import org.axonframework.monitoring.MessageMonitor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.lang.reflect.Executable;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -64,13 +66,13 @@ import java.util.function.Consumer;
 import static java.util.Collections.singletonList;
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class DisruptorCommandBusTest {
+class DisruptorCommandBusTest {
 
     private static final int COMMAND_COUNT = 100 * 1000;
     private static final String COMMAND_RETURN_VALUE = "dummyVal";
@@ -82,8 +84,8 @@ public class DisruptorCommandBusTest {
     private TransactionManager mockTransactionManager;
     private ParameterResolverFactory parameterResolverFactory;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         aggregateIdentifier = UUID.randomUUID().toString();
         stubHandler = new StubHandler();
         eventStore = new InMemoryEventStore();
@@ -93,14 +95,14 @@ public class DisruptorCommandBusTest {
         messageHandlingCounter = new AtomicInteger(0);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         testSubject.stop();
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testCallbackInvokedBeforeUnitOfWorkCleanup() throws Exception {
+    void testCallbackInvokedBeforeUnitOfWorkCleanup() throws Exception {
         MessageHandlerInterceptor mockHandlerInterceptor = mock(MessageHandlerInterceptor.class);
         MessageDispatchInterceptor mockDispatchInterceptor = mock(MessageDispatchInterceptor.class);
         when(mockDispatchInterceptor.handle(isA(CommandMessage.class))).thenAnswer(new Parameter(0));
@@ -152,7 +154,7 @@ public class DisruptorCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testPublishUnsupportedCommand() {
+    void testPublishUnsupportedCommand() {
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         CommandCallback callback = mock(CommandCallback.class);
         testSubject = DisruptorCommandBus.builder()
@@ -176,7 +178,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testEventStreamsDecoratedOnReadAndWrite() throws InterruptedException {
+    void testEventStreamsDecoratedOnReadAndWrite() throws InterruptedException {
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -214,7 +216,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void usesProvidedParameterResolverFactoryToResolveParameters() {
+    void usesProvidedParameterResolverFactoryToResolveParameters() {
         testSubject = DisruptorCommandBus.builder().build();
         testSubject.createRepository(eventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                      parameterResolverFactory);
@@ -226,7 +228,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testEventPublicationExecutedWithinTransaction() throws Exception {
+    void testEventPublicationExecutedWithinTransaction() throws Exception {
         MessageHandlerInterceptor mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         Transaction mockTransaction = mock(Transaction.class);
@@ -246,8 +248,9 @@ public class DisruptorCommandBusTest {
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
-    @Test(timeout = 10000)
-    public void testAggregatesBlacklistedAndRecoveredOnError_WithAutoReschedule() throws Exception {
+    @Test
+    @Timeout(value = 10)
+    void testAggregatesBlacklistedAndRecoveredOnError_WithAutoReschedule() throws Exception {
         MessageHandlerInterceptor mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         CommandCallback mockCallback = dispatchCommands(mockInterceptor, customExecutor, asCommandMessage(
@@ -265,8 +268,9 @@ public class DisruptorCommandBusTest {
     }
 
     @SuppressWarnings({"unchecked", "Duplicates"})
-    @Test(timeout = 10000)
-    public void testAggregatesBlacklistedAndRecoveredOnError_WithoutReschedule() throws Exception {
+    @Test
+    @Timeout(value = 10)
+    void testAggregatesBlacklistedAndRecoveredOnError_WithoutReschedule() throws Exception {
         MessageHandlerInterceptor mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
 
@@ -325,7 +329,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testCreateAggregate() {
+    void testCreateAggregate() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -353,7 +357,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testCommandReturnsAValue() {
+    void testCommandReturnsAValue() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -378,7 +382,7 @@ public class DisruptorCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testMessageMonitoring() {
+    void testMessageMonitoring() {
         eventStore.storedEvents.clear();
         final AtomicLong successCounter = new AtomicLong();
         final AtomicLong failureCounter = new AtomicLong();
@@ -438,19 +442,20 @@ public class DisruptorCommandBusTest {
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCommandRejectedAfterShutdown() {
+    @Test
+    void testCommandRejectedAfterShutdown() {
         testSubject = DisruptorCommandBus.builder().build();
         testSubject.subscribe(StubCommand.class.getName(), stubHandler);
         stubHandler.setRepository(testSubject.createRepository(eventStore,
                                                                new GenericAggregateFactory<>(StubAggregate.class)));
 
         testSubject.stop();
-        testSubject.dispatch(asCommandMessage(new Object()));
+        assertThrows(IllegalStateException.class, () -> testSubject.dispatch(asCommandMessage(new Object())));
     }
 
-    @Test(timeout = 10000)
-    public void testCommandProcessedAndEventsStored() throws InterruptedException {
+    @Test
+    @Timeout(value = 10)
+    void testCommandProcessedAndEventsStored() throws InterruptedException {
         testSubject = DisruptorCommandBus.builder().build();
         testSubject.subscribe(StubCommand.class.getName(), stubHandler);
         stubHandler.setRepository(testSubject.createRepository(eventStore,
@@ -462,11 +467,12 @@ public class DisruptorCommandBusTest {
         }
 
         eventStore.countDownLatch.await(5, TimeUnit.SECONDS);
-        assertEquals("Seems that some events are not stored", 0, eventStore.countDownLatch.getCount());
+
+        assertEquals(0, eventStore.countDownLatch.getCount(), "Seems that some events are not stored");
     }
 
     @Test
-    public void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
+    void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -478,7 +484,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
+    void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -488,7 +494,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testCanResolveReturnsFalseForNonMatchingAggregateType() {
+    void testCanResolveReturnsFalseForNonMatchingAggregateType() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -500,7 +506,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
+    void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload());
         AggregateScopeDescriptor testDescriptor =
@@ -516,8 +522,8 @@ public class DisruptorCommandBusTest {
         assertEquals(1, messageHandlingCounter.get());
     }
 
-    @Test(expected = MessageHandlerInvocationException.class)
-    public void testSendThrowsMessageHandlerInvocationExceptionIfHandleFails() throws Exception {
+    @Test
+    void testSendThrowsMessageHandlerInvocationExceptionIfHandleFails() throws Exception {
         DeadlineMessage<FailingEvent> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new FailingEvent());
         AggregateScopeDescriptor testDescriptor =
@@ -528,11 +534,11 @@ public class DisruptorCommandBusTest {
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
         );
 
-        testRepository.send(testMsg, testDescriptor);
+        assertThrows(MessageHandlerInvocationException.class, () -> testRepository.send(testMsg, testDescriptor));
     }
 
     @Test
-    public void testSendFailsSilentlyOnAggregateNotFoundException() throws Exception {
+    void testSendFailsSilentlyOnAggregateNotFoundException() throws Exception {
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload());
         AggregateScopeDescriptor testDescriptor =
@@ -549,7 +555,7 @@ public class DisruptorCommandBusTest {
     }
 
     @Test
-    public void testDuplicateCommandHandlerResolverSetsTheExpectedHandler() throws Exception {
+    void testDuplicateCommandHandlerResolverSetsTheExpectedHandler() throws Exception {
         DuplicateCommandHandlerResolver testDuplicateCommandHandlerResolver = DuplicateCommandHandlerResolution.silentOverride();
 
         testSubject = DisruptorCommandBus.builder()
@@ -569,7 +575,7 @@ public class DisruptorCommandBusTest {
         FutureCallback<Object, Object> callback = new FutureCallback<>();
         testSubject.dispatch(testMessage, callback);
 
-        assertTrue("Expected command to complete", callback.awaitCompletion(2, TimeUnit.SECONDS));
+        assertTrue(callback.awaitCompletion(2, TimeUnit.SECONDS), "Expected command to complete");
         verify(initialHandler, never()).handle(testMessage);
         verify(duplicateHandler).handle(testMessage);
     }
@@ -755,7 +761,7 @@ public class DisruptorCommandBusTest {
 
     }
 
-    static class FailingEvent {
+    private static class FailingEvent {
 
     }
 

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest_MultiThreaded.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest_MultiThreaded.java
@@ -42,7 +42,7 @@ import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.mockito.*;
 import org.mockito.stubbing.*;
 
@@ -55,13 +55,13 @@ import java.util.stream.Stream;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class DisruptorCommandBusTest_MultiThreaded {
+class DisruptorCommandBusTest_MultiThreaded {
 
     private static final int COMMAND_COUNT = 100;
     private static final int AGGREGATE_COUNT = 10;
@@ -69,8 +69,8 @@ public class DisruptorCommandBusTest_MultiThreaded {
     private DisruptorCommandBus testSubject;
     private Repository<StubAggregate> spiedRepository;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         StubHandler stubHandler = new StubHandler();
         inMemoryEventStore = InMemoryEventStore.builder().build();
         testSubject = DisruptorCommandBus.builder()
@@ -89,14 +89,14 @@ public class DisruptorCommandBusTest_MultiThreaded {
         stubHandler.setRepository(spiedRepository);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         testSubject.stop();
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testDispatchLargeNumberCommandForDifferentAggregates() throws Exception {
+    void testDispatchLargeNumberCommandForDifferentAggregates() throws Exception {
         final Map<Object, Object> garbageCollectionPrevention = new ConcurrentHashMap<>();
         doAnswer(trackCreateAndLoad(garbageCollectionPrevention)).when(spiedRepository).newInstance(any());
         doAnswer(trackCreateAndLoad(garbageCollectionPrevention)).when(spiedRepository).load(isA(String.class));

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorRepositoryTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorRepositoryTest.java
@@ -28,18 +28,18 @@ import org.axonframework.eventsourcing.GenericAggregateFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class DisruptorRepositoryTest {
+class DisruptorRepositoryTest {
 
     private final EventStore eventStore = mock(EventStore.class);
 
     @Test
-    public void testDisruptorCommandBusRepositoryNotAvailableOutsideOfInvokerThread() {
+    void testDisruptorCommandBusRepositoryNotAvailableOutsideOfInvokerThread() {
         DisruptorCommandBus commandBus = DisruptorCommandBus.builder().build();
         Repository<TestAggregate> repository = commandBus
                 .createRepository(eventStore, new GenericAggregateFactory<>(TestAggregate.class));

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/FirstLevelCacheTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/FirstLevelCacheTest.java
@@ -1,36 +1,36 @@
 package org.axonframework.disruptor.commandhandling;
 
 import org.axonframework.eventsourcing.EventSourcedAggregate;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.stream.IntStream;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
-public class FirstLevelCacheTest {
+class FirstLevelCacheTest {
 
     private EventSourcedAggregate<MyAggregate> cacheable;
     private FirstLevelCache<MyAggregate> cache;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         cacheable = mock(EventSourcedAggregate.class);
         cache = new FirstLevelCache<>();
     }
 
     @Test
-    public void shouldPut() {
+    void shouldPut() {
         cache.put("key", cacheable);
 
-        assertEquals(cache.size(), 1);
+        assertEquals(1, cache.size());
     }
 
     @Test
-    public void shouldGet() {
+    void shouldGet() {
         cache.put("key", cacheable);
         EventSourcedAggregate<MyAggregate> cached = cache.get("key");
 
@@ -38,7 +38,7 @@ public class FirstLevelCacheTest {
     }
 
     @Test
-    public void shouldRemove() {
+    void shouldRemove() {
         cache.put("key", cacheable);
         EventSourcedAggregate<MyAggregate> cached = cache.remove("key");
 
@@ -48,7 +48,7 @@ public class FirstLevelCacheTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void shouldClearWeakValues() throws Exception {
+    void shouldClearWeakValues() throws Exception {
 
         FirstLevelCache<FirstLevelCacheTest.MyAggregate> myCache = new FirstLevelCache<>();
 

--- a/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
@@ -4,9 +4,9 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test whether the serialized form of the {@link org.axonframework.commandhandling.model.AggregateScopeDescriptor} can
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class AggregateScopeDescriptorTest {
+class AggregateScopeDescriptorTest {
 
     private static final String LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME =
             "org.axonframework.commandhandling.model.AggregateScopeDescriptor";
@@ -23,7 +23,7 @@ public class AggregateScopeDescriptorTest {
     private static final String AGGREGATE_ID = "aggregate-id";
 
     @Test
-    public void testXStreamSerializationOfOldAggregateScopeDescriptor() {
+    void testXStreamSerializationOfOldAggregateScopeDescriptor() {
         XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
 
         String xmlSerializedScopeDescriptor =
@@ -46,7 +46,7 @@ public class AggregateScopeDescriptorTest {
     }
 
     @Test
-    public void testJacksonSerializationOfOldAggregateScopeDescriptor() {
+    void testJacksonSerializationOfOldAggregateScopeDescriptor() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedScopeDescriptor =

--- a/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
@@ -5,9 +5,9 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test whether the serialized form of the {@link org.axonframework.eventhandling.saga.SagaScopeDescriptor} can be
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class SagaScopeDescriptorTest {
+class SagaScopeDescriptorTest {
 
     private static final String LEGACY_SCOPE_DESCRIPTOR_CLASS_NAME =
             "org.axonframework.eventhandling.saga.SagaScopeDescriptor";
@@ -23,7 +23,7 @@ public class SagaScopeDescriptorTest {
     private static final String SAGA_ID = "saga-id";
 
     @Test
-    public void testXStreamSerializationOfOldSagaScopeDescriptor() {
+    void testXStreamSerializationOfOldSagaScopeDescriptor() {
         XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
 
         String xmlSerializedScopeDescriptor =
@@ -41,7 +41,7 @@ public class SagaScopeDescriptorTest {
     }
 
     @Test
-    public void testJacksonSerializationOfOldSagaScopeDescriptor() {
+    void testJacksonSerializationOfOldSagaScopeDescriptor() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedScopeDescriptor =

--- a/legacy/src/test/java/org/axonframework/eventhandling/scheduling/quartz/LegacyAwareJobDataBinderTest.java
+++ b/legacy/src/test/java/org/axonframework/eventhandling/scheduling/quartz/LegacyAwareJobDataBinderTest.java
@@ -17,27 +17,27 @@ package org.axonframework.eventhandling.scheduling.quartz;
 
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.quartz.JobDataMap;
 
 import java.io.ObjectInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-public class LegacyAwareJobDataBinderTest {
+class LegacyAwareJobDataBinderTest {
 
     private LegacyAwareJobDataBinder testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new LegacyAwareJobDataBinder();
     }
 
     @Test
-    public void testReadLegacyInstance() {
+    void testReadLegacyInstance() {
         JobDataMap legacyJobDataMap = mock(JobDataMap.class);
         when(legacyJobDataMap.get("org.axonframework.domain.EventMessage")).thenAnswer(
                 i -> {
@@ -57,7 +57,7 @@ public class LegacyAwareJobDataBinderTest {
     }
 
     @Test
-    public void testReadRecentInstance() {
+    void testReadRecentInstance() {
         JobDataMap legacyJobDataMap = mock(JobDataMap.class);
         when(legacyJobDataMap.get(EventMessage.class.getName())).thenReturn(new GenericEventMessage<>("new"));
 

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
@@ -5,14 +5,14 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test whether the serialized form of the {@link org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken} can
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GapAwareTrackingTokenTest {
+class GapAwareTrackingTokenTest {
 
     private static final String LEGACY_GAP_AWARE_TRACKING_TOKEN_CLASS_NAME =
             "org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken";
@@ -29,7 +29,7 @@ public class GapAwareTrackingTokenTest {
     private static final List<Long> TOKEN_GAPS = Stream.of(0L, 25L, 58L).collect(Collectors.toList());
 
     @Test
-    public void testXStreamSerializationOfOldGapAwareTrackingToken() {
+    void testXStreamSerializationOfOldGapAwareTrackingToken() {
         XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
 
         String xmlSerializedGapAwareTrackingToken =
@@ -62,7 +62,7 @@ public class GapAwareTrackingTokenTest {
     }
 
     @Test
-    public void testJacksonSerializationOfOldGapAwareTrackingToken() {
+    void testJacksonSerializationOfOldGapAwareTrackingToken() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedGapAwareTrackingToken =

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
@@ -5,9 +5,9 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test whether the serialized form of the
@@ -16,14 +16,14 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GlobalSequenceTrackingTokenTest {
+class GlobalSequenceTrackingTokenTest {
 
     private static final String LEGACY_GLOBAL_SEQUENCE_TRACKING_TOKEN_CLASS_NAME =
             "org.axonframework.eventsourcing.eventstore.GlobalSequenceTrackingToken";
     private static final int GLOBAL_INDEX = 10;
 
     @Test
-    public void testXStreamSerializationOfOldGlobalSequenceTrackingToken() {
+    void testXStreamSerializationOfOldGlobalSequenceTrackingToken() {
         XStreamSerializer serializer = XStreamSerializer.defaultSerializer();
 
         String xmlSerializedGlobalSequenceTrackingToken =
@@ -40,7 +40,7 @@ public class GlobalSequenceTrackingTokenTest {
     }
 
     @Test
-    public void testJacksonSerializationOfOldGlobalSequenceTrackingToken() {
+    void testJacksonSerializationOfOldGlobalSequenceTrackingToken() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedGlobalSequenceTrackingToken =

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -43,8 +43,8 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -58,7 +58,7 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
@@ -67,12 +67,12 @@ import java.util.List;
 
 import static java.util.Collections.singleton;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AxonAutoConfigurationTest.Context.class)
 @EnableAutoConfiguration(exclude = {JmxAutoConfiguration.class, WebClientAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class, DataSourceAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationTest {
 
@@ -92,7 +92,7 @@ public class AxonAutoConfigurationTest {
     private Snapshotter snapshotter;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
         assertNotNull(configurer);
         assertNotNull(snapshotter);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
@@ -50,8 +50,8 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -65,14 +65,14 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AxonAutoConfigurationWithDisruptorTest.Context.class)
 @EnableAutoConfiguration(exclude = {JmxAutoConfiguration.class, WebClientAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class, DataSourceAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationWithDisruptorTest {
 
@@ -86,7 +86,7 @@ public class AxonAutoConfigurationWithDisruptorTest {
     private AxonConfiguration configuration;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
         assertNotNull(configurer);
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
@@ -48,8 +48,8 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -61,20 +61,20 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AxonAutoConfigurationWithEventSerializerPropertiesTest.TestContext.class)
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         AxonServerAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")
 public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
@@ -86,7 +86,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     private EntityManager entityManager;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(CommandBus.class));
@@ -111,7 +111,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     }
 
     @Test
-    public void testEventStorageEngineUsesSerializerBean() {
+    void testEventStorageEngineUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final Serializer messageSerializer = applicationContext.getBean("messageSerializer", Serializer.class);
@@ -123,7 +123,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     }
 
     @Test
-    public void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefinedObjectMapperBean() {
+    void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefinedObjectMapperBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final ObjectMapper objectMapper = applicationContext.getBean("testObjectMapper", ObjectMapper.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
@@ -47,8 +47,8 @@ import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -60,19 +60,19 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationWithEventSerializerTest {
 
@@ -83,7 +83,7 @@ public class AxonAutoConfigurationWithEventSerializerTest {
     private EntityManager entityManager;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(CommandBus.class));
@@ -104,7 +104,7 @@ public class AxonAutoConfigurationWithEventSerializerTest {
     }
 
     @Test
-    public void testEventStorageEngineUsesSerializerBean() {
+    void testEventStorageEngineUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("myEventSerializer", Serializer.class);
         final JpaEventStorageEngine engine = applicationContext.getBean(JpaEventStorageEngine.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
@@ -32,8 +32,8 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.Upcaster;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -53,17 +53,17 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationWithHibernateTest {
 
@@ -80,7 +80,7 @@ public class AxonAutoConfigurationWithHibernateTest {
     private Snapshotter snapshotter;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
         assertNotNull(snapshotter);
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsTest.java
@@ -36,8 +36,8 @@ import com.codahale.metrics.MetricRegistry;
 import org.axonframework.metrics.GlobalMetricRegistry;
 import org.axonframework.metrics.MetricsConfigurerModule;
 import org.axonframework.springboot.autoconfig.MicrometerMetricsAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -48,18 +48,18 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class, WebClientAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
         DataSourceAutoConfiguration.class, MicrometerMetricsAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class AxonAutoConfigurationWithMetricsTest {
+class AxonAutoConfigurationWithMetricsTest {
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -74,7 +74,7 @@ public class AxonAutoConfigurationWithMetricsTest {
     private MetricsConfigurerModule metricsConfigurerModule;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.containsBean("metricRegistry"));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
@@ -24,8 +24,8 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.metrics.GlobalMetricRegistry;
 import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.springboot.autoconfig.MicrometerMetricsAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -39,19 +39,19 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class, WebClientAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
         DataSourceAutoConfiguration.class, MicrometerMetricsAutoConfiguration.class
 })
 @TestPropertySource("classpath:test.metrics.application.properties")
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
 
@@ -65,7 +65,7 @@ public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
     private GlobalMetricRegistry globalMetricRegistry;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.containsBean("metricRegistry"));
@@ -80,7 +80,7 @@ public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
     }
 
     @Test
-    public void testAxonServerEventStoreRequestedMonitor() {
+    void testAxonServerEventStoreRequestedMonitor() {
         assertNotNull(applicationContext.getBean(AxonServerEventStore.class));
 
         MessageMonitorFactory monitor = applicationContext.getBean("mockMessageMonitorFactory", MessageMonitorFactory.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsTest.java
@@ -20,8 +20,8 @@ import com.codahale.metrics.MetricRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.axonframework.micrometer.GlobalMetricRegistry;
 import org.axonframework.micrometer.MetricsConfigurerModule;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -30,17 +30,17 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class, WebClientAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
         DataSourceAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
-public class AxonAutoConfigurationWithMicrometerMetricsTest {
+class AxonAutoConfigurationWithMicrometerMetricsTest {
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -64,7 +64,7 @@ public class AxonAutoConfigurationWithMicrometerMetricsTest {
     private org.axonframework.metrics.MetricsConfigurerModule metricsModuleMetricsConfigurerModule;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(MeterRegistry.class));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest.java
@@ -19,8 +19,8 @@ package org.axonframework.springboot;
 import com.codahale.metrics.MetricRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.axonframework.micrometer.GlobalMetricRegistry;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -30,9 +30,9 @@ import org.springframework.boot.autoconfigure.web.reactive.function.client.WebCl
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
@@ -40,8 +40,8 @@ import static org.junit.Assert.*;
         DataSourceAutoConfiguration.class
 })
 @TestPropertySource("classpath:test.metrics.application.properties")
-@RunWith(SpringRunner.class)
-public class AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest {
+@ExtendWith(SpringExtension.class)
+class AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest {
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -62,7 +62,7 @@ public class AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest {
     private org.axonframework.metrics.MetricsConfigurerModule metricsModuleMetricsConfigurerModule;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(meterRegistry);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOnlyEventSerializerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOnlyEventSerializerTest.java
@@ -35,8 +35,8 @@ package org.axonframework.springboot;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -48,14 +48,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {JmxAutoConfiguration.class, WebClientAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class, DataSourceAutoConfiguration.class})
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonAutoConfigurationWithOnlyEventSerializerTest {
 
@@ -71,7 +71,7 @@ public class AxonAutoConfigurationWithOnlyEventSerializerTest {
     private Serializer messageSerializer;
 
     @Test
-    public void testRevertsToDefaultSerializer() {
+    void testRevertsToDefaultSerializer() {
         assertNotNull(serializer);
         assertNotNull(eventSerializer);
         assertNotNull(messageSerializer);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTagsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTagsTest.java
@@ -18,8 +18,8 @@ package org.axonframework.springboot;
 
 import org.axonframework.config.TagsConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -28,32 +28,32 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests whether gathering of Axon tags is properly configured.
  *
  * @author Milan Savic
  */
+@ExtendWith(SpringExtension.class)
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         AxonServerAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:test.tags.application.properties")
-public class AxonAutoConfigurationWithTagsTest {
+class AxonAutoConfigurationWithTagsTest {
 
     @Autowired
     private ApplicationContext applicationContext;
 
     @Test
-    public void testConfig() {
+    void testConfig() {
         TagsConfiguration tagsConfiguration = applicationContext.getBean(TagsConfiguration.class);
         assertNotNull(tagsConfiguration);
         Map<String, String> tags = tagsConfiguration.getTags();

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithoutObjectMapperTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithoutObjectMapperTest.java
@@ -33,8 +33,8 @@
 package org.axonframework.springboot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -47,8 +47,11 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
@@ -56,16 +59,16 @@ import org.springframework.test.context.junit4.SpringRunner;
         DataSourceAutoConfiguration.class,
         JacksonAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializer-without-jackson.test.properties")
-public class AxonAutoConfigurationWithoutObjectMapperTest {
+class AxonAutoConfigurationWithoutObjectMapperTest {
 
     @Autowired
     private ApplicationContext applicationContext;
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void testNoObjectMapperBeanIsCreatedIfNoJacksonSerializerIsSpecified() {
-        applicationContext.getBean(ObjectMapper.class);
+    @Test
+    void testNoObjectMapperBeanIsCreatedIfNoJacksonSerializerIsSpecified() {
+        assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean(ObjectMapper.class));
+
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonHandlerConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonHandlerConfigurationTest.java
@@ -37,8 +37,8 @@ import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.queryhandling.QueryHandler;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -50,10 +50,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AxonHandlerConfigurationTest.Context.class)
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
@@ -61,7 +62,6 @@ import static org.junit.Assert.*;
         HibernateJpaAutoConfiguration.class,
         DataSourceAutoConfiguration.class,
         AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class AxonHandlerConfigurationTest {
 
@@ -72,7 +72,7 @@ public class AxonHandlerConfigurationTest {
     private CommandGateway commandGateway;
 
     @Test
-    public void testMessageRoutedToCorrectMethod() throws Exception {
+    void testMessageRoutedToCorrectMethod() throws Exception {
         assertEquals("Command: info", commandGateway.send("info").get());
         assertEquals("Query: info", queryGateway.query("info", String.class).get());
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
@@ -27,8 +27,7 @@ import org.axonframework.eventhandling.SimpleEventHandlerInvoker;
 import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.async.FullConcurrencyPolicy;
 import org.axonframework.eventhandling.async.SequencingPolicy;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -41,14 +40,12 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.common.ReflectionUtils.ensureAccessible;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestPropertySource("classpath:test-processors.application.properties")
@@ -57,7 +54,6 @@ import static org.junit.Assert.*;
         WebClientAutoConfiguration.class,
         DataSourceAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class EventProcessorConfigurationTest {
 
@@ -68,14 +64,14 @@ public class EventProcessorConfigurationTest {
     private SequencingPolicy expectedPolicy;
 
     @Test
-    public void testPublishSomeEvents() throws Exception {
+    void testPublishSomeEvents() throws Exception {
         Map<String, EventProcessor> processors = eventProcessingConfiguration.eventProcessors();
         assertEquals(3, processors.size());
         EventProcessor eventProcessor = processors.get("first");
         assertNotNull(eventProcessor);
         assertEquals(TrackingEventProcessor.class, eventProcessor.getClass());
         long tokenClaimInterval = ReflectionUtils.getFieldValue(TrackingEventProcessor.class.getDeclaredField("tokenClaimInterval"), eventProcessor);
-        assertEquals("Must be 5000 ms by default", tokenClaimInterval, 5000L);
+        assertEquals(5000L, tokenClaimInterval, "Must be 5000 ms by default");
         MultiEventHandlerInvoker invoker = (MultiEventHandlerInvoker) ensureAccessible(
                 AbstractEventProcessor.class.getDeclaredMethod("eventHandlerInvoker")
         ).invoke(eventProcessor);
@@ -88,15 +84,14 @@ public class EventProcessorConfigurationTest {
     }
 
     @Test
-    public void verifyTokenClaimIntervalCanBeSetViaSpringConfiguration() throws Exception {
+    void verifyTokenClaimIntervalCanBeSetViaSpringConfiguration() throws Exception {
         Map<String, EventProcessor> processors = eventProcessingConfiguration.eventProcessors();
         assertEquals(3, processors.size());
         EventProcessor eventProcessor = processors.get("non_default_token_claim_interval");
         assertNotNull(eventProcessor);
         assertEquals(TrackingEventProcessor.class, eventProcessor.getClass());
         long tokenClaimInterval = ReflectionUtils.getFieldValue(TrackingEventProcessor.class.getDeclaredField("tokenClaimInterval"), eventProcessor);
-        assertEquals("It must be possible to override token claim interval via Spring Configuration",
-                tokenClaimInterval, 60000000L);
+        assertEquals(60000000L, tokenClaimInterval, "It must be possible to override token claim interval via Spring Configuration");
     }
 
     @Configuration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
@@ -24,8 +24,8 @@ import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
@@ -36,14 +36,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,12 +52,12 @@ import static org.mockito.Mockito.when;
  *
  * @author Milan Savic
  */
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = JdbcAutoConfigurationTest.Context.class)
 @EnableAutoConfiguration(exclude = {
         JpaRepositoriesAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class,
         AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class JdbcAutoConfigurationTest {
 
@@ -65,7 +65,7 @@ public class JdbcAutoConfigurationTest {
     private ApplicationContext applicationContext;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.getBean(EventStorageEngine.class) instanceof JdbcEventStorageEngine);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
@@ -4,27 +4,27 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests JPA auto-configuration
  *
  * @author Sara Pellegrini
  */
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class JpaAutoConfigurationTest {
+class JpaAutoConfigurationTest {
 
     @Autowired
     private TokenStore tokenStore;
@@ -33,7 +33,7 @@ public class JpaAutoConfigurationTest {
     private SagaStore sagaStore;
 
     @Test
-    public void testContextInitialization() {
+    void testContextInitialization() {
         assertTrue(tokenStore instanceof JpaTokenStore);
         assertTrue(sagaStore instanceof JpaSagaStore);
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
@@ -2,16 +2,16 @@ package org.axonframework.springboot;
 
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStore;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests JPA EventStore auto-configuration
@@ -19,17 +19,17 @@ import static org.junit.Assert.*;
  * @author Sara Pellegrini
  */
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class JpaEventStoreAutoConfigurationWithAxonServerTest {
+class JpaEventStoreAutoConfigurationWithAxonServerTest {
 
     @Autowired
     private EventStore eventStore;
 
     @Test
-    public void testEventStore() {
+    void testEventStore() {
         assertTrue(eventStore instanceof AxonServerEventStore);
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
@@ -5,16 +5,16 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests JPA EventStore auto-configuration
@@ -22,11 +22,11 @@ import static org.junit.Assert.*;
  * @author Sara Pellegrini
  */
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
+class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
 
     @Autowired
     private EventStorageEngine eventStorageEngine;
@@ -35,7 +35,7 @@ public class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
     private EventStore eventStore;
 
     @Test
-    public void testEventStore() {
+    void testEventStore() {
         assertTrue(eventStorageEngine instanceof JpaEventStorageEngine);
         assertTrue(eventStore instanceof EmbeddedEventStore);
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
@@ -28,8 +28,8 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -51,16 +51,16 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
+@ExtendWith(SpringExtension.class)
 @SpringBootConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class TrackingEventProcessorIntegrationTest {
 
@@ -99,16 +99,15 @@ public class TrackingEventProcessorIntegrationTest {
         assertFalse(countDownLatch1.await(1, TimeUnit.SECONDS));
         publishEvent("test3");
         publishEvent("test4");
-        assertTrue("Expected all 4 events to have been delivered", countDownLatch1.await(2, TimeUnit.SECONDS));
-        assertTrue("Expected all 4 events to have been delivered", countDownLatch2.await(2, TimeUnit.SECONDS));
+        assertTrue(countDownLatch1.await(2, TimeUnit.SECONDS), "Expected all 4 events to have been delivered");
+        assertTrue(countDownLatch2.await(2, TimeUnit.SECONDS), "Expected all 4 events to have been delivered");
 
-        eventProcessingModule.eventProcessors().forEach((name, ep) -> assertFalse(((TrackingEventProcessor) ep)
-                                                                                          .isError()));
+        eventProcessingModule.eventProcessors()
+                .forEach((name, ep) -> assertFalse(((TrackingEventProcessor) ep).isError()));
 
         eventProcessingModule.shutdown();
-        eventProcessingModule.eventProcessors().forEach((name, ep) -> assertFalse("Processor ended with error",
-                                                                                  ((TrackingEventProcessor) ep)
-                                                                                          .isError()));
+        eventProcessingModule.eventProcessors()
+                .forEach((name, ep) -> assertFalse(((TrackingEventProcessor) ep).isError(), "Processor ended with error"));
     }
 
     private void publishEvent(String... events) {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -25,8 +25,8 @@ import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -36,16 +36,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class AxonServerAutoConfigurationTest {
+class AxonServerAutoConfigurationTest {
 
     private static final TargetContextResolver<Message<?>> CUSTOM_TARGET_CONTEXT_RESOLVER =
             m -> "some-custom-context-resolution";
@@ -76,19 +76,19 @@ public class AxonServerAutoConfigurationTest {
     private QueryUpdateEmitter updateEmitter;
 
     @Test
-    public void testAxonServerQueryBusConfiguration() {
+    void testAxonServerQueryBusConfiguration() {
         assertTrue(queryBus instanceof AxonServerQueryBus);
         assertSame(updateEmitter, queryBus.queryUpdateEmitter());
     }
 
     @Test
-    public void testAxonServerCommandBusBeanTypesConfiguration() {
+    void testAxonServerCommandBusBeanTypesConfiguration() {
         assertTrue(commandBus instanceof AxonServerCommandBus);
         assertTrue(localSegment instanceof SimpleCommandBus);
     }
 
     @Test
-    public void testAxonServerDefaultCommandBusConfiguration() {
+    void testAxonServerDefaultCommandBusConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .run(context -> {
                               assertThat(context).getBeanNames(CommandBus.class)
@@ -101,7 +101,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testAxonServerUserDefinedCommandBusConfiguration() {
+    void testAxonServerUserDefinedCommandBusConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ExplicitUserCommandBusConfiguration.class)
                           .run(context -> {
@@ -113,7 +113,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testAxonServerUserDefinedLocalSegmentConfiguration() {
+    void testAxonServerUserDefinedLocalSegmentConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ExplicitUserLocalSegmentConfiguration.class)
                           .run(context -> {
@@ -127,7 +127,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testAxonServerWrongUserDefinedLocalSegmentConfiguration() {
+    void testAxonServerWrongUserDefinedLocalSegmentConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ExplicitWrongUserLocalSegmentConfiguration.class)
                           .run(context -> {
@@ -139,7 +139,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testNonAxonServerCommandBusConfiguration() {
+    void testNonAxonServerCommandBusConfiguration() {
         this.contextRunner.run(context -> {
             assertThat(context).getBeanNames(CommandBus.class)
                                .hasSize(1);
@@ -149,7 +149,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testDefaultTargetContextResolverIsNoOp() {
+    void testDefaultTargetContextResolverIsNoOp() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .run(context -> {
                               assertThat(context).getBeanNames(TargetContextResolver.class)
@@ -160,7 +160,7 @@ public class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    public void testCustomTargetContextResolverIsConfigured() {
+    void testCustomTargetContextResolverIsConfigured() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(TargetContextResolverConfiguration.class)
                           .run(context -> {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
@@ -35,8 +35,8 @@ package org.axonframework.springboot.autoconfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
@@ -48,10 +48,11 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
@@ -59,16 +60,15 @@ import static org.junit.Assert.*;
         DataSourceAutoConfiguration.class,
         JacksonAutoConfiguration.class
 })
-@RunWith(SpringRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")
-public class ObjectMapperAutoConfigurationTest {
+class ObjectMapperAutoConfigurationTest {
 
     @Autowired
     private ApplicationContext applicationContext;
 
     @Test
-    public void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefaultAxonObjectMapperBean() {
+    void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefaultAxonObjectMapperBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final ObjectMapper objectMapper = applicationContext.getBean("defaultAxonObjectMapper", ObjectMapper.class);

--- a/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_CustomValues.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_CustomValues.java
@@ -19,8 +19,8 @@ package org.axonframework.spring.config;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.spring.config.annotation.AnnotationCommandHandlerBeanPostProcessor;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -30,14 +30,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration(classes = AnnotationDrivenConfigurationTest_CustomValues.Context.class)
 public class AnnotationDrivenConfigurationTest_CustomValues {
@@ -49,7 +49,7 @@ public class AnnotationDrivenConfigurationTest_CustomValues {
     private DefaultListableBeanFactory beanFactory;
 
     @Test
-    public void testCommandHandlerPostProcessorBeanDefinitionContainCustomValues() {
+    void testCommandHandlerPostProcessorBeanDefinitionContainCustomValues() {
         BeanDefinition beanDefinition =  beanFactory.getBeanDefinition(
                 "__axon-annotation-command-handler-bean-post-processor");
         assertEquals(AnnotationCommandHandlerBeanPostProcessor.class.getName(), beanDefinition.getBeanClassName());

--- a/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_DefaultValues.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_DefaultValues.java
@@ -22,8 +22,8 @@ import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.SimpleEventBus;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,14 +31,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration(classes = AnnotationDrivenConfigurationTest_DefaultValues.Context.class)
 public class AnnotationDrivenConfigurationTest_DefaultValues {
@@ -47,7 +47,7 @@ public class AnnotationDrivenConfigurationTest_DefaultValues {
     private ApplicationContext applicationContext;
 
     @Test
-    public void testAnnotationConfigurationAnnotationWrapsBeans() {
+    void testAnnotationConfigurationAnnotationWrapsBeans() {
         Object eventHandler = applicationContext.getBean("eventHandler");
         Object commandHandler = applicationContext.getBean("commandHandler");
 

--- a/spring/src/test/java/org/axonframework/spring/config/AutoWiredEventSourcedAggregateTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AutoWiredEventSourcedAggregateTest.java
@@ -25,8 +25,8 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.spring.stereotype.Aggregate;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,15 +35,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.persistence.Id;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration
 public class AutoWiredEventSourcedAggregateTest {
@@ -52,7 +52,7 @@ public class AutoWiredEventSourcedAggregateTest {
     private Repository<Context.MyAggregate> myAggregateRepository;
 
     @Test
-    public void testAggregateIsWiredUsingStateStorage() {
+    void testAggregateIsWiredUsingStateStorage() {
         assertEquals(EventSourcingRepository.class, myAggregateRepository.getClass());
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/AutoWiredStateStoredAggregateTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AutoWiredStateStoredAggregateTest.java
@@ -25,8 +25,8 @@ import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageE
 import org.axonframework.modelling.command.GenericJpaRepository;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.spring.stereotype.Aggregate;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,16 +35,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Scope;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration
 public class AutoWiredStateStoredAggregateTest {
@@ -53,7 +53,7 @@ public class AutoWiredStateStoredAggregateTest {
     private Repository<Context.MyAggregate> myAggregateRepository;
 
     @Test
-    public void testAggregateIsWiredUsingStateStorage() {
+    void testAggregateIsWiredUsingStateStorage() {
         assertEquals(GenericJpaRepository.class, myAggregateRepository.getClass());
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/EventHandlerRegistrarTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventHandlerRegistrarTest.java
@@ -19,8 +19,8 @@ package org.axonframework.spring.config;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.config.ModuleConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.springframework.core.annotation.Order;
@@ -31,15 +31,15 @@ import java.util.function.Function;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 
-public class EventHandlerRegistrarTest {
+class EventHandlerRegistrarTest {
 
     private AxonConfiguration axonConfig;
     private ModuleConfiguration eventConfiguration;
     private EventProcessingConfigurer eventConfigurer;
     private EventHandlerRegistrar testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         axonConfig = mock(AxonConfiguration.class);
         eventConfiguration = mock(ModuleConfiguration.class);
         eventConfigurer = mock(EventProcessingConfigurer.class);
@@ -47,7 +47,7 @@ public class EventHandlerRegistrarTest {
     }
 
     @Test
-    public void testBeansRegisteredInOrder() {
+    void testBeansRegisteredInOrder() {
         testSubject.setEventHandlers(Arrays.asList(new OrderedBean(), new LateOrderedBean(), new UnorderedBean()));
 
         InOrder inOrder = Mockito.inOrder(eventConfigurer);

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleConfigTest.java
@@ -25,8 +25,8 @@ import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.interceptors.LoggingInterceptor;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,18 +34,18 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.annotation.Import;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests configuration of {@link EventProcessingModule}.
  *
  * @author Milan Savic
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class EventProcessingModuleConfigTest {
 
@@ -53,7 +53,7 @@ public class EventProcessingModuleConfigTest {
     private EventProcessingModule eventProcessingConfiguration;
 
     @Test
-    public void testEventProcessingConfiguration() {
+    void testEventProcessingConfiguration() {
         assertEquals(3, eventProcessingConfiguration.eventProcessors().size());
         assertTrue(eventProcessingConfiguration.eventProcessor("processor2").isPresent());
         assertTrue(eventProcessingConfiguration.eventProcessor("subscribingProcessor").isPresent());

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleWithInterceptorsTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleWithInterceptorsTest.java
@@ -25,8 +25,8 @@ import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.annotation.MetaDataValue;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,18 +34,18 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.annotation.Import;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test ensures that any handler interceptor registered via {@link EventProcessingModule} is triggered.
  *
  * @author Milan Savic
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class EventProcessingModuleWithInterceptorsTest {
 
@@ -55,7 +55,7 @@ public class EventProcessingModuleWithInterceptorsTest {
     private Context.MyEventHandler myEventHandler;
 
     @Test
-    public void testInterceptorRegistration() {
+    void testInterceptorRegistration() {
         eventBus.publish(GenericEventMessage.asEventMessage("myEvent"));
         assertEquals("myMetaDataValue", myEventHandler.getMetaDataValue());
     }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration.java
@@ -35,8 +35,8 @@ import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,16 +47,16 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.singletonMap;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration
 public class SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration {
@@ -71,10 +71,10 @@ public class SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration {
     private Context.MyOtherEventHandler myOtherEventHandler;
 
     @Test
-    public void testEventHandlerIsRegisteredWithCustomProcessor() {
+    void testEventHandlerIsRegisteredWithCustomProcessor() {
         eventBus.publish(asEventMessage("Testing 123"));
 
-        assertNotNull("Expected EventBus to be wired", myEventHandler.eventBus);
+        assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");
         assertTrue(myEventHandler.received.contains("value"));
         assertTrue(myOtherEventHandler.received.contains("Testing 123"));
     }

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessorTest.java
@@ -20,8 +20,8 @@ import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.MessageHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 
 import java.lang.annotation.ElementType;
@@ -29,25 +29,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Allard Buijze
  */
-public class AnnotationCommandHandlerBeanPostProcessorTest {
+class AnnotationCommandHandlerBeanPostProcessorTest {
 
     private AnnotationCommandHandlerBeanPostProcessor testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new AnnotationCommandHandlerBeanPostProcessor();
     }
 
     @SuppressWarnings({"unchecked"})
     @Test
-    public void testCommandHandlerCallsRedirectToAdapter() throws Exception {
+    void testCommandHandlerCallsRedirectToAdapter() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new AnnotatedCommandHandler(), "beanName");
@@ -65,7 +65,7 @@ public class AnnotationCommandHandlerBeanPostProcessorTest {
     }
 
     @Test
-    public void testCommandHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
+    void testCommandHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new CustomAnnotatedCommandHandler(), "beanName");

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
@@ -21,8 +21,8 @@ import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.QueryHandler;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 
 import java.lang.annotation.ElementType;
@@ -30,22 +30,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class AnnotationQueryHandlerBeanPostProcessorTest {
+class AnnotationQueryHandlerBeanPostProcessorTest {
 
     private AnnotationQueryHandlerBeanPostProcessor testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new AnnotationQueryHandlerBeanPostProcessor();
     }
 
     @SuppressWarnings({"unchecked"})
     @Test
-    public void testQueryHandlerCallsRedirectToAdapter() throws Exception {
+    void testQueryHandlerCallsRedirectToAdapter() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new AnnotatedQueryHandler(), "beanName");
@@ -64,7 +64,7 @@ public class AnnotationQueryHandlerBeanPostProcessorTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    public void testQueryHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
+    void testQueryHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new CustomAnnotatedQueryHandler(), "beanName");

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBeanTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBeanTest.java
@@ -26,7 +26,7 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.spring.config.annotation.StubAggregate;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.*;
  * @author Allard Buijze
  * @author Nakul Mishra
  */
-public class SpringAggregateSnapshotterFactoryBeanTest {
+class SpringAggregateSnapshotterFactoryBeanTest {
 
     private SpringAggregateSnapshotterFactoryBean testSubject;
     private PlatformTransactionManager mockTransactionManager;
@@ -52,8 +52,8 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     private ApplicationContext mockApplicationContext;
     private Executor executor;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockApplicationContext = mock(ApplicationContext.class);
         mockEventStore = mock(EventStore.class);
         mockRepositoryProvider = mock(RepositoryProvider.class);
@@ -85,7 +85,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testSnapshotCreatedNoTransaction() {
+    void testSnapshotCreatedNoTransaction() {
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         snapshotter.scheduleSnapshot(StubAggregate.class, aggregateIdentifier);
 
@@ -94,7 +94,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testRetrieveAggregateFactoryFromRepositoryIfNotExplicitlyAvailable() {
+    void testRetrieveAggregateFactoryFromRepositoryIfNotExplicitlyAvailable() {
         testSubject.setEventStore(null);
         reset(mockApplicationContext);
         when(mockApplicationContext.getBean(EventStore.class)).thenReturn(mockEventStore);
@@ -110,7 +110,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testSnapshotCreatedNewlyCreatedTransactionCommitted() {
+    void testSnapshotCreatedNewlyCreatedTransactionCommitted() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus newlyCreatedTransaction = new SimpleTransactionStatus(true);
@@ -124,7 +124,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testSnapshotCreatedExistingTransactionNotCommitted() {
+    void testSnapshotCreatedExistingTransactionNotCommitted() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(false);
@@ -137,7 +137,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testSnapshotCreatedExistingTransactionNotRolledBack() {
+    void testSnapshotCreatedExistingTransactionNotRolledBack() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(false);
@@ -152,7 +152,7 @@ public class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    public void testSnapshotCreatedNewTransactionRolledBack() {
+    void testSnapshotCreatedNewTransactionRolledBack() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(true);

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactoryTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactoryTest.java
@@ -18,48 +18,48 @@ package org.axonframework.spring.eventsourcing;
 
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.spring.domain.SpringWiredAggregate;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"/META-INF/spring/spring-prototype-aggregate-factory.xml"})
-@RunWith(SpringJUnit4ClassRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class SpringPrototypeAggregateFactoryTest {
+class SpringPrototypeAggregateFactoryTest {
 
     @Autowired
     private SpringPrototypeAggregateFactory<SpringWiredAggregate> testSubject;
 
     @Test
-    public void testContextStarts() {
+    void testContextStarts() {
         assertNotNull(testSubject);
     }
 
     @Test
-    public void testCreateNewAggregateInstance() {
+    void testCreateNewAggregateInstance() {
         SpringWiredAggregate aggregate = testSubject.createAggregateRoot("id2", new GenericDomainEventMessage<>("type", "id2", 0,
                                                                                                                 "FirstEvent"));
-        assertTrue("Aggregate's init method not invoked", aggregate.isInitialized());
-        assertNotNull("ContextAware method not invoked", aggregate.getContext());
-        Assert.assertEquals("it's here", aggregate.getSpringConfiguredName());
+        assertTrue(aggregate.isInitialized(), "Aggregate's init method not invoked");
+        assertNotNull(aggregate.getContext(), "ContextAware method not invoked");
+        assertEquals("it's here", aggregate.getSpringConfiguredName());
     }
 
     @Test
-    public void testProcessSnapshotAggregateInstance() {
+    void testProcessSnapshotAggregateInstance() {
         SpringWiredAggregate aggregate = testSubject.createAggregateRoot("id2",
                                                                      new GenericDomainEventMessage<>("type", "id2", 5,
                                                                                                      new SpringWiredAggregate()));
-        assertTrue("Aggregate's init method not invoked", aggregate.isInitialized());
-        assertNotNull("ContextAware method not invoked", aggregate.getContext());
-        Assert.assertEquals("it's here", aggregate.getSpringConfiguredName());
+        assertTrue(aggregate.isInitialized(), "Aggregate's init method not invoked");
+        assertNotNull(aggregate.getContext(), "ContextAware method not invoked");
+        assertEquals("it's here", aggregate.getSpringConfiguredName());
     }
 }

--- a/spring/src/test/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProviderTest.java
+++ b/spring/src/test/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProviderTest.java
@@ -22,8 +22,8 @@ import org.axonframework.common.transaction.Transaction;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,18 +32,18 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Connection;
 import javax.sql.DataSource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SpringDataSourceConnectionProviderTest.Context.class)
-@RunWith(SpringJUnit4ClassRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class SpringDataSourceConnectionProviderTest {
 
@@ -58,8 +58,8 @@ public class SpringDataSourceConnectionProviderTest {
     private ConnectionProvider connectionProvider;
     private SpringTransactionManager springTransactionManager;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         springTransactionManager  = new SpringTransactionManager(transactionManager);
     }
 
@@ -81,7 +81,7 @@ public class SpringDataSourceConnectionProviderTest {
     }
 
     @Test
-    public void testConnectionCommittedWhenTransactionScopeInsideUnitOfWork() throws Exception {
+    void testConnectionCommittedWhenTransactionScopeInsideUnitOfWork() throws Exception {
         doAnswer(invocation -> {
             final Object spy = spy(invocation.callRealMethod());
             mockConnection = (Connection) spy;

--- a/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
@@ -2,8 +2,8 @@ package org.axonframework.spring.messaging;
 
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.SimpleEventBus;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.PayloadApplicationEvent;
 import org.springframework.context.annotation.Bean;
@@ -12,16 +12,16 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.event.EventListener;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class ApplicationContextEventPublisherTest {
 
@@ -32,7 +32,7 @@ public class ApplicationContextEventPublisherTest {
     private EventBus eventBus;
 
     @Test
-    public void testEventsForwardedToListenerBean() {
+    void testEventsForwardedToListenerBean() {
         eventBus.publish(asEventMessage("test"));
 
         assertEquals("test", listenerBean.getEvents().get(0));

--- a/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
@@ -21,26 +21,26 @@ import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created on 04/02/17.
  *
  * @author Reda.Housni-Alaoui
  */
-public class DefaultEventMessageConverterTest {
+class DefaultEventMessageConverterTest {
 
 	private EventMessageConverter eventMessageConverter = new DefaultEventMessageConverter();
 
 	@Test
-	public void given_generic_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
+	void given_generic_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
 		Instant instant = Instant.EPOCH;
 		String id = UUID.randomUUID().toString();
 
@@ -62,7 +62,7 @@ public class DefaultEventMessageConverterTest {
 	}
 
 	@Test
-	public void given_domain_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
+	void given_domain_event_message_when_converting_twice_then_resulting_event_should_be_the_same(){
 		Instant instant = Instant.EPOCH;
 		String id = UUID.randomUUID().toString();
 		String aggId = UUID.randomUUID().toString();

--- a/spring/src/test/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapterTest.java
@@ -19,8 +19,8 @@ package org.axonframework.spring.messaging;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.spring.utils.StubDomainEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -29,19 +29,19 @@ import static org.mockito.Mockito.*;
 /**
  * @author Allard Buijze
  */
-public class InboundEventMessageChannelAdapterTest {
+class InboundEventMessageChannelAdapterTest {
 
     private EventBus mockEventBus;
     private InboundEventMessageChannelAdapter testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockEventBus = mock(EventBus.class);
         testSubject = new InboundEventMessageChannelAdapter(mockEventBus);
     }
 
     @Test
-    public void testMessagePayloadIsPublished() {
+    void testMessagePayloadIsPublished() {
         testSubject = new InboundEventMessageChannelAdapter();
         StubDomainEvent event = new StubDomainEvent();
         testSubject.handleMessage(new GenericMessage<Object>(event));

--- a/spring/src/test/java/org/axonframework/spring/messaging/OutboundEventMessageChannelAdapterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/OutboundEventMessageChannelAdapterTest.java
@@ -20,8 +20,8 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.spring.utils.StubDomainEvent;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 
@@ -32,21 +32,21 @@ import static org.mockito.Mockito.*;
  * @author Allard Buijze
  * @author Nakul Mishra
  */
-public class OutboundEventMessageChannelAdapterTest {
+class OutboundEventMessageChannelAdapterTest {
 
     private OutboundEventMessageChannelAdapter testSubject;
     private EventBus mockEventBus;
     private MessageChannel mockChannel;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockEventBus = mock(EventBus.class);
         mockChannel = mock(MessageChannel.class);
         testSubject = new OutboundEventMessageChannelAdapter(mockEventBus, mockChannel);
     }
 
     @Test
-    public void testMessageForwardedToChannel() {
+    void testMessageForwardedToChannel() {
         StubDomainEvent event = new StubDomainEvent();
         testSubject.handle(singletonList(new GenericEventMessage<>(event)));
 
@@ -54,7 +54,7 @@ public class OutboundEventMessageChannelAdapterTest {
     }
 
     @Test
-    public void testEventListenerRegisteredOnInit() {
+    void testEventListenerRegisteredOnInit() {
         verify(mockEventBus, never()).subscribe(any());
         testSubject.afterPropertiesSet();
         verify(mockEventBus).subscribe(any());
@@ -62,7 +62,7 @@ public class OutboundEventMessageChannelAdapterTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    public void testFilterBlocksEvents() {
+    void testFilterBlocksEvents() {
         testSubject = new OutboundEventMessageChannelAdapter(mockEventBus, mockChannel, m -> !m.getPayloadType().isAssignableFrom(Class.class));
         testSubject.handle(singletonList(newDomainEvent()));
         verify(mockEventBus, never()).publish(isA(EventMessage.class));

--- a/spring/src/test/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManagerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManagerTest.java
@@ -14,8 +14,8 @@
 package org.axonframework.spring.messaging.unitofwork;
 
 import org.axonframework.common.transaction.Transaction;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -26,14 +26,14 @@ import static org.mockito.Mockito.*;
 /**
  * @author Allard Buijze
  */
-public class SpringTransactionManagerTest {
+class SpringTransactionManagerTest {
 
     private SpringTransactionManager testSubject;
     private PlatformTransactionManager transactionManager;
     private TransactionStatus underlyingTransactionStatus;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         underlyingTransactionStatus = mock(TransactionStatus.class);
         transactionManager = mock(PlatformTransactionManager.class);
         testSubject = new SpringTransactionManager(transactionManager);
@@ -43,7 +43,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testManageTransaction_CustomTransactionStatus() {
+    void testManageTransaction_CustomTransactionStatus() {
         testSubject = new SpringTransactionManager(transactionManager, mock(TransactionDefinition.class));
         testSubject.startTransaction().commit();
 
@@ -52,7 +52,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testManageTransaction_DefaultTransactionStatus() {
+    void testManageTransaction_DefaultTransactionStatus() {
         testSubject.startTransaction().commit();
 
         verify(transactionManager).getTransaction(isA(DefaultTransactionDefinition.class));
@@ -60,7 +60,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testCommitTransaction_NoCommitOnInactiveTransaction() {
+    void testCommitTransaction_NoCommitOnInactiveTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isCompleted()).thenReturn(true);
         transaction.commit();
@@ -69,7 +69,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testCommitTransaction_NoRollbackOnInactiveTransaction() {
+    void testCommitTransaction_NoRollbackOnInactiveTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isCompleted()).thenReturn(true);
         transaction.rollback();
@@ -78,7 +78,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testCommitTransaction_NoCommitOnNestedTransaction() {
+    void testCommitTransaction_NoCommitOnNestedTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isNewTransaction()).thenReturn(false);
         transaction.commit();
@@ -87,7 +87,7 @@ public class SpringTransactionManagerTest {
     }
 
     @Test
-    public void testCommitTransaction_NoRollbackOnNestedTransaction() {
+    void testCommitTransaction_NoRollbackOnNestedTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isNewTransaction()).thenReturn(false);
         transaction.rollback();

--- a/spring/src/test/java/org/axonframework/spring/saga/SpringResourceInjectorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/saga/SpringResourceInjectorTest.java
@@ -20,7 +20,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.modelling.saga.ResourceInjector;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
@@ -37,14 +37,14 @@ public class SpringResourceInjectorTest {
 
     private static ResourceInjector testSubject;
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    static void beforeClass() {
         ApplicationContext appCtx = new AnnotationConfigApplicationContext(Context.class);
         testSubject = appCtx.getBean(ResourceInjector.class);
     }
 
     @Test
-    public void testInjectSaga() {
+    void testInjectSaga() {
         InjectableSaga injectableSaga = new InjectableSaga();
         testSubject.injectResources(injectableSaga);
         assertNotNull(injectableSaga.getCommandBus());
@@ -52,10 +52,10 @@ public class SpringResourceInjectorTest {
         assertNull(injectableSaga.getEventBus());
     }
 
-    @Test(expected = BeanCreationException.class)
-    public void testResourcesNotAvailable() {
+    @Test
+    void testResourcesNotAvailable() {
         ProblematicInjectableSaga injectableSaga = new ProblematicInjectableSaga();
-        testSubject.injectResources(injectableSaga);
+        assertThrows(BeanCreationException.class, () -> testSubject.injectResources(injectableSaga));
     }
 
     public static class InjectableSaga {


### PR DESCRIPTION
Migrate modules configuration, disruptor, legacy, spring, spring-boot-autoconfigure to JUnit5.

Rename `AssertUtils.assertWithin` to `assertRetryingWithin` to clarify that the assertion can be retried.