### PR TITLE
Processing of scope messages via Event Processors.

### DIFF
--- a/config/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
+++ b/config/src/main/java/org/axonframework/config/ConfigurationScopeAwareProvider.java
@@ -16,9 +16,9 @@
 
 package org.axonframework.config;
 
+import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.common.Assert;
-import org.axonframework.modelling.saga.AbstractSagaManager;
 import org.axonframework.messaging.ScopeAware;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
@@ -66,7 +66,7 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
     private List<ScopeAware> retrieveScopeAwareComponents() {
         List<ScopeAware> components = new ArrayList<>();
         components.addAll(retrieveAggregateRepositories());
-        components.addAll(retrieveSagaManagers());
+        components.addAll(retrieveEventProcessors());
         return components;
     }
 
@@ -76,11 +76,9 @@ public class ConfigurationScopeAwareProvider implements ScopeAwareProvider {
                             .collect(toList());
     }
 
-    private List<AbstractSagaManager> retrieveSagaManagers() {
-        return configuration.eventProcessingConfiguration()
-                            .sagaConfigurations()
-                            .stream()
-                            .map(SagaConfiguration::manager)
-                            .collect(toList());
+    private List<EventProcessor> retrieveEventProcessors() {
+        return new ArrayList<>(configuration.eventProcessingConfiguration()
+                                            .eventProcessors()
+                                            .values());
     }
 }

--- a/config/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationScopeAwareProviderTest.java
@@ -16,19 +16,19 @@
 
 package org.axonframework.config;
 
-import org.axonframework.modelling.command.Repository;
-import org.axonframework.modelling.saga.AbstractSagaManager;
+import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.messaging.ScopeAware;
 import org.axonframework.messaging.ScopeDescriptor;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.axonframework.modelling.command.Repository;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.junit.*;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,10 +52,7 @@ public class ConfigurationScopeAwareProviderTest {
     private Repository aggregateRepository;
 
     @Mock
-    private SagaConfiguration sagaConfiguration;
-
-    @Mock
-    private AbstractSagaManager sagaManager;
+    private EventProcessor eventProcessor;
 
     @Mock
     private EventProcessingModule eventProcessingConfiguration;
@@ -82,15 +79,14 @@ public class ConfigurationScopeAwareProviderTest {
     }
 
     @Test
-    public void providesScopeAwareSagasFromModuleConfiguration() {
-        when(eventProcessingConfiguration.sagaConfigurations())
-                .thenReturn(singletonList(sagaConfiguration));
-        when(sagaConfiguration.manager()).thenReturn(sagaManager);
+    public void providesScopeAwareEventProcessorsFromModuleConfiguration() {
+        when(eventProcessingConfiguration.eventProcessors())
+                .thenReturn(singletonMap("myProcessor", eventProcessor));
 
         List<ScopeAware> components = scopeAwareProvider.provideScopeAwareStream(anyScopeDescriptor())
                                                         .collect(toList());
 
-        assertThat(components, equalTo(singletonList(sagaManager)));
+        assertThat(components, equalTo(singletonList(eventProcessor)));
     }
 
     @Test

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventHandlerInvoker.java
@@ -16,12 +16,16 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.ScopeAware;
+import org.axonframework.messaging.ScopeDescriptor;
+
 /**
  * Interface for an event message handler that defers handling to one or more other handlers.
  *
  * @author Rene de Waele
  */
-public interface EventHandlerInvoker {
+public interface EventHandlerInvoker extends ScopeAware {
 
     /**
      * Check whether or not this invoker has handlers that can handle the given {@code eventMessage} for a given
@@ -70,5 +74,15 @@ public interface EventHandlerInvoker {
      * Performs any activities that are required to reset the state managed by handlers assigned to this invoker.
      */
     default void performReset() {
+    }
+
+    @Override
+    default void send(Message<?> message, ScopeDescriptor scopeDescription) throws Exception {
+        // noop
+    }
+
+    @Override
+    default boolean canResolve(ScopeDescriptor scopeDescription) {
+        return false;
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessor.java
@@ -16,8 +16,11 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptorSupport;
+import org.axonframework.messaging.ScopeAware;
+import org.axonframework.messaging.ScopeDescriptor;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Allard Buijze
  * @since 1.2
  */
-public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMessage<?>> {
+public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMessage<?>>, ScopeAware {
 
     /**
      * Returns the name of this event processor. This name is used to detect distributed instances of the
@@ -69,5 +72,15 @@ public interface EventProcessor extends MessageHandlerInterceptorSupport<EventMe
      */
     default CompletableFuture<Void> shutdownAsync() {
         return CompletableFuture.runAsync(this::shutDown);
+    }
+
+    @Override
+    default void send(Message<?> message, ScopeDescriptor scopeDescription) throws Exception {
+        // noop
+    }
+
+    @Override
+    default boolean canResolve(ScopeDescriptor scopeDescription) {
+        return false;
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.ScopeDescriptor;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -102,5 +105,20 @@ public class MultiEventHandlerInvoker implements EventHandlerInvoker {
         delegates.stream()
                  .filter(EventHandlerInvoker::supportsReset)
                  .forEach(EventHandlerInvoker::performReset);
+    }
+
+    @Override
+    public void send(Message<?> message, ScopeDescriptor scopeDescription) throws Exception {
+        for (EventHandlerInvoker invoker : delegates) {
+            if (invoker.canResolve(scopeDescription)) {
+                invoker.send(message, scopeDescription);
+            }
+        }
+    }
+
+    @Override
+    public boolean canResolve(ScopeDescriptor scopeDescription) {
+        return delegates.stream()
+                        .anyMatch(ehi -> ehi.canResolve(scopeDescription));
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
@@ -46,7 +46,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Allard Buijze
  * @since 0.7
  */
-public abstract class AbstractSagaManager<T> implements EventHandlerInvoker, ScopeAware {
+public abstract class AbstractSagaManager<T> implements EventHandlerInvoker {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractSagaManager.class);
 


### PR DESCRIPTION
Provides a single point of message distribution to event handlers (via Event Processors). Especially useful in cases when we want to coordinate event and deadline processing by sagas. Have in mind that concurrent access to a saga is already prevented by `SagaRepository`. 

The issue that arises with this implementation is postponing deadline execution in Tracking Event Processors. In time-critical applications, this might cause serious issues. This implementation assumes that deadlines (scope messages) are of greater importance than other events, thus addressing this issue. However, postponing is not avoided.

I'm creating this draft PR in order to start a discussion on the usefulness of this change.

Relates to #1236 