### PR TITLE
[#1279] JdbcAutoConfiguration depends on JPA persistence API

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -1,21 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,17 +20,15 @@ import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jdbc.UnitOfWorkAwareConnectionProviderWrapper;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
-import org.axonframework.modelling.saga.repository.SagaStore;
-import org.axonframework.modelling.saga.repository.jdbc.GenericSagaSqlSchema;
-import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
-import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
+import org.axonframework.modelling.saga.repository.SagaStore;
+import org.axonframework.modelling.saga.repository.jdbc.GenericSagaSqlSchema;
+import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.spring.jdbc.SpringDataSourceConnectionProvider;
@@ -57,16 +39,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.sql.SQLException;
 import javax.sql.DataSource;
 
-@ConditionalOnBean(DataSource.class)
+/**
+ * Auto configuration class for Axon's JDBC specific infrastructure components.
+ *
+ * @author Allard Buijze
+ * @since 3.1
+ */
 @Configuration
+@ConditionalOnBean(DataSource.class)
 @AutoConfigureAfter(value = {JpaAutoConfiguration.class, JpaEventStoreAutoConfiguration.class})
 public class JdbcAutoConfiguration {
 
-    @ConditionalOnMissingBean({EventStorageEngine.class, EventStore.class})
     @Bean
+    @ConditionalOnMissingBean({EventStorageEngine.class, EventStore.class})
     public EventStorageEngine eventStorageEngine(Serializer defaultSerializer,
                                                  PersistenceExceptionResolver persistenceExceptionResolver,
                                                  @Qualifier("eventSerializer") Serializer eventSerializer,
@@ -83,28 +70,20 @@ public class JdbcAutoConfiguration {
                                      .build();
     }
 
-    @ConditionalOnMissingBean
-    @ConditionalOnBean(DataSource.class)
     @Bean
-    public PersistenceExceptionResolver dataSourcePersistenceExceptionResolver(DataSource dataSource)
-            throws SQLException {
-        return new SQLErrorCodesResolver(dataSource);
-    }
-
-    @ConditionalOnMissingBean({DataSource.class, PersistenceExceptionResolver.class, EventStore.class})
-    @Bean
+    @ConditionalOnMissingBean({PersistenceExceptionResolver.class, EventStore.class})
     public PersistenceExceptionResolver jdbcSQLErrorCodesResolver() {
         return new JdbcSQLErrorCodesResolver();
     }
 
-    @ConditionalOnMissingBean
     @Bean
+    @ConditionalOnMissingBean
     public ConnectionProvider connectionProvider(DataSource dataSource) {
         return new UnitOfWorkAwareConnectionProviderWrapper(new SpringDataSourceConnectionProvider(dataSource));
     }
 
-    @ConditionalOnMissingBean
     @Bean
+    @ConditionalOnMissingBean
     public TokenStore tokenStore(ConnectionProvider connectionProvider, Serializer serializer) {
         return JdbcTokenStore.builder()
                              .connectionProvider(connectionProvider)
@@ -112,8 +91,8 @@ public class JdbcAutoConfiguration {
                              .build();
     }
 
-    @ConditionalOnMissingBean(SagaStore.class)
     @Bean
+    @ConditionalOnMissingBean(SagaStore.class)
     public JdbcSagaStore sagaStore(ConnectionProvider connectionProvider, Serializer serializer) {
         return JdbcSagaStore.builder()
                             .connectionProvider(connectionProvider)

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
@@ -1,21 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +16,11 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore;
+import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
 import org.axonframework.serialization.Serializer;
@@ -45,24 +31,32 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.sql.SQLException;
 import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
 
+/**
+ * Auto configuration class for Axon's JPA specific infrastructure components.
+ *
+ * @author Allard Buijze
+ * @since 3.0.3
+ */
+@Configuration
 @ConditionalOnBean(EntityManagerFactory.class)
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventhandling.tokenstore",
         "org.axonframework.modelling.saga.repository.jpa"
 })
-@Configuration
 public class JpaAutoConfiguration {
 
-    @ConditionalOnMissingBean
     @Bean
+    @ConditionalOnMissingBean
     public EntityManagerProvider entityManagerProvider() {
         return new ContainerManagedEntityManagerProvider();
     }
 
-    @ConditionalOnMissingBean
     @Bean
+    @ConditionalOnMissingBean
     public TokenStore tokenStore(Serializer serializer, EntityManagerProvider entityManagerProvider) {
         return JpaTokenStore.builder()
                             .entityManagerProvider(entityManagerProvider)
@@ -70,12 +64,20 @@ public class JpaAutoConfiguration {
                             .build();
     }
 
-    @ConditionalOnMissingBean(SagaStore.class)
     @Bean
+    @ConditionalOnMissingBean(SagaStore.class)
     public JpaSagaStore sagaStore(Serializer serializer, EntityManagerProvider entityManagerProvider) {
         return JpaSagaStore.builder()
                            .entityManagerProvider(entityManagerProvider)
                            .serializer(serializer)
                            .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(DataSource.class)
+    public PersistenceExceptionResolver persistenceExceptionResolver(DataSource dataSource)
+            throws SQLException {
+        return new SQLErrorCodesResolver(dataSource);
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,20 @@
 
 package org.axonframework.springboot;
 
+import org.axonframework.common.jdbc.ConnectionProvider;
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.axonframework.common.jdbc.UnitOfWorkAwareConnectionProviderWrapper;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.*;
+import org.junit.runner.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
@@ -38,27 +42,27 @@ import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import javax.sql.DataSource;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests JDBC auto-configuration.
  *
  * @author Milan Savic
  */
+@RunWith(SpringRunner.class)
+@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @ContextConfiguration(classes = JdbcAutoConfigurationTest.Context.class)
 @EnableAutoConfiguration(exclude = {
         JpaRepositoriesAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class,
-        AxonServerAutoConfiguration.class})
-@RunWith(SpringRunner.class)
-@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+        AxonServerAutoConfiguration.class
+})
 public class JdbcAutoConfigurationTest {
 
     @Autowired
@@ -69,10 +73,17 @@ public class JdbcAutoConfigurationTest {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.getBean(EventStorageEngine.class) instanceof JdbcEventStorageEngine);
+        assertTrue(applicationContext.getBean(PersistenceExceptionResolver.class) instanceof JdbcSQLErrorCodesResolver);
+        assertTrue(
+                applicationContext.getBean(ConnectionProvider.class) instanceof UnitOfWorkAwareConnectionProviderWrapper
+        );
         assertTrue(applicationContext.getBean(TokenStore.class) instanceof JdbcTokenStore);
         assertTrue(applicationContext.getBean(SagaStore.class) instanceof JdbcSagaStore);
-        assertEquals(applicationContext.getBean(TokenStore.class),
-                     applicationContext.getBean(EventProcessingConfiguration.class).tokenStore("test"));
+
+        assertEquals(
+                applicationContext.getBean(TokenStore.class),
+                applicationContext.getBean(EventProcessingConfiguration.class).tokenStore("test")
+        );
     }
 
     @Configuration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
@@ -1,9 +1,29 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.springboot;
 
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore;
+import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
+import org.axonframework.springboot.util.jpa.ContainerManagedEntityManagerProvider;
 import org.junit.*;
 import org.junit.runner.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +33,7 @@ import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests JPA auto-configuration
@@ -27,14 +47,19 @@ import static org.junit.Assert.assertTrue;
 public class JpaAutoConfigurationTest {
 
     @Autowired
-    private TokenStore tokenStore;
-
+    private EntityManagerProvider entityManagerProvider;
     @Autowired
-    private SagaStore sagaStore;
+    private TokenStore tokenStore;
+    @Autowired
+    private SagaStore<?> sagaStore;
+    @Autowired
+    private PersistenceExceptionResolver persistenceExceptionResolver;
 
     @Test
     public void testContextInitialization() {
+        assertTrue(entityManagerProvider instanceof ContainerManagedEntityManagerProvider);
         assertTrue(tokenStore instanceof JpaTokenStore);
         assertTrue(sagaStore instanceof JpaSagaStore);
+        assertTrue(persistenceExceptionResolver instanceof SQLErrorCodesResolver);
     }
 }


### PR DESCRIPTION
The `SQLErrorCodesResolver` bean creation method wrongfully resides in the `JdbcAutoConfiguration`, whilst it's a JPA specific implementation. 
This PR moves that method should towards the `JpaAutoConfiguration`. 
Additionally, the tests are updated accordingly, as well as some Javadoc and copyright notice updates

This PR resolves bug #1279