### PR TITLE
[#874] Use DisruptorCommandBus as Local Segment to create Repositories

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -49,6 +49,7 @@ import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.Registration;
+import org.axonframework.messaging.Distributed;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
@@ -81,7 +82,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerCommandBus implements CommandBus {
+public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus> {
 
     private static final Logger logger = LoggerFactory.getLogger(AxonServerCommandBus.class);
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -69,7 +69,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static org.axonframework.axonserver.connector.ErrorCode.UNSUPPORTED_INSTRUCTION;
 import static org.axonframework.axonserver.connector.util.ProcessingInstructionHelper.priority;
 import static org.axonframework.commandhandling.GenericCommandResultMessage.asCommandResultMessage;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -343,6 +342,11 @@ public class AxonServerCommandBus implements CommandBus {
                 registration,
                 () -> commandProcessor.unsubscribe(commandName)
         );
+    }
+
+    @Override
+    public CommandBus localSegment() {
+        return localSegment;
     }
 
     @Override

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.config;
 
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.distributed.DistributedCommandBus;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.eventsourcing.GenericAggregateFactory;
 import org.axonframework.eventsourcing.NoSnapshotTriggerDefinition;
@@ -64,6 +66,30 @@ public class AggregateConfigurerTest {
         when(disruptorCommandBus.createRepository(any(), any(), any(), any(), any(), any()))
                 .thenReturn(expectedRepository);
         when(mockConfiguration.commandBus()).thenReturn(disruptorCommandBus);
+
+        testSubject.initialize(mockConfiguration);
+
+        Repository<TestAggregate> resultRepository = testSubject.repository();
+
+        assertEquals(expectedRepository, resultRepository);
+        //noinspection unchecked
+        verify(disruptorCommandBus).createRepository(
+                eq(testEventStore), isA(GenericAggregateFactory.class), eq(NoSnapshotTriggerDefinition.INSTANCE),
+                eq(testParameterResolverFactory), any(), any()
+        );
+    }
+
+    @Test
+    public void testConfiguredDisruptorCommandBusAsLocalSegmentCreatesTheRepository() {
+        //noinspection unchecked
+        Repository<Object> expectedRepository = mock(Repository.class);
+
+        DisruptorCommandBus disruptorCommandBus = mock(DisruptorCommandBus.class);
+        when(disruptorCommandBus.createRepository(any(), any(), any(), any(), any(), any()))
+                .thenReturn(expectedRepository);
+        CommandBus distributedCommandBusImplementation = mock(CommandBus.class);
+        when(distributedCommandBusImplementation.localSegment()).thenReturn(disruptorCommandBus);
+        when(mockConfiguration.commandBus()).thenReturn(distributedCommandBusImplementation);
 
         testSubject.initialize(mockConfiguration);
 

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.config;
+
+import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
+import org.axonframework.eventsourcing.GenericAggregateFactory;
+import org.axonframework.eventsourcing.NoSnapshotTriggerDefinition;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.modelling.command.Repository;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class to validate the {@link AggregateConfigurer}'s inner workings.
+ *
+ * @author Steven van Beelen
+ */
+public class AggregateConfigurerTest {
+
+    private Configuration mockConfiguration;
+
+    private EventStore testEventStore;
+    private ParameterResolverFactory testParameterResolverFactory;
+
+    private AggregateConfigurer<TestAggregate> testSubject;
+
+    @Before
+    public void setUp() {
+        mockConfiguration = mock(Configuration.class);
+
+        testEventStore = mock(EventStore.class);
+        when(mockConfiguration.eventBus()).thenReturn(testEventStore);
+        when(mockConfiguration.eventStore()).thenReturn(testEventStore);
+
+        testParameterResolverFactory = mock(ParameterResolverFactory.class);
+        when(mockConfiguration.parameterResolverFactory()).thenReturn(testParameterResolverFactory);
+
+        testSubject = new AggregateConfigurer<>(TestAggregate.class);
+    }
+
+    @Test
+    public void testConfiguredDisruptorCommandBusCreatesTheRepository() {
+        //noinspection unchecked
+        Repository<Object> expectedRepository = mock(Repository.class);
+
+        DisruptorCommandBus disruptorCommandBus = mock(DisruptorCommandBus.class);
+        when(disruptorCommandBus.createRepository(any(), any(), any(), any(), any(), any()))
+                .thenReturn(expectedRepository);
+        when(mockConfiguration.commandBus()).thenReturn(disruptorCommandBus);
+
+        testSubject.initialize(mockConfiguration);
+
+        Repository<TestAggregate> resultRepository = testSubject.repository();
+
+        assertEquals(expectedRepository, resultRepository);
+        //noinspection unchecked
+        verify(disruptorCommandBus).createRepository(
+                eq(testEventStore), isA(GenericAggregateFactory.class), eq(NoSnapshotTriggerDefinition.INSTANCE),
+                eq(testParameterResolverFactory), any(), any()
+        );
+    }
+
+    private static class TestAggregate {
+
+        TestAggregate() {
+            // No-op constructor
+        }
+    }
+}

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.config;
 
-import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.distributed.DistributedCommandBus;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.eventsourcing.GenericAggregateFactory;
@@ -87,7 +86,7 @@ public class AggregateConfigurerTest {
         DisruptorCommandBus disruptorCommandBus = mock(DisruptorCommandBus.class);
         when(disruptorCommandBus.createRepository(any(), any(), any(), any(), any(), any()))
                 .thenReturn(expectedRepository);
-        CommandBus distributedCommandBusImplementation = mock(CommandBus.class);
+        DistributedCommandBus distributedCommandBusImplementation = mock(DistributedCommandBus.class);
         when(distributedCommandBusImplementation.localSegment()).thenReturn(disruptorCommandBus);
         when(mockConfiguration.commandBus()).thenReturn(distributedCommandBusImplementation);
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -76,15 +76,4 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      * @return a handle to unsubscribe the {@code handler}. When unsubscribed it will no longer receive commands.
      */
     Registration subscribe(String commandName, MessageHandler<? super CommandMessage<?>> handler);
-
-    /**
-     * Return the {@link CommandBus} which is regarded as the local segment for this implementation. Would return the
-     * CommandBus used to dispatch and handle command in a local environment to bridge the gap in a distributed set up.
-     * Might return {@code this} if no distributed CommandBus is used.
-     *
-     * @return the {@link CommandBus} which is the local segment for this implementation
-     */
-    default CommandBus localSegment() {
-        return this;
-    }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,11 +30,11 @@ import org.axonframework.messaging.MessageHandlerInterceptorSupport;
  * @since 0.5
  */
 public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMessage<?>>,
-                                    MessageDispatchInterceptorSupport<CommandMessage<?>> {
+        MessageDispatchInterceptorSupport<CommandMessage<?>> {
 
     /**
-     * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name.
-     * No feedback is given about the status of the dispatching process. Implementations may return immediately after
+     * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name. No
+     * feedback is given about the status of the dispatching process. Implementations may return immediately after
      * asserting a valid handler is registered for the given command.
      *
      * @param <C>     The payload type of the command to dispatch
@@ -45,8 +45,8 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
     <C> void dispatch(CommandMessage<C> command);
 
     /**
-     * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name.
-     * When the command is processed, one of the callback's methods is called, depending on the result of the processing.
+     * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name. When the
+     * command is processed, one of the callback's methods is called, depending on the result of the processing.
      * <p/>
      * When the method returns, the only guarantee provided by the CommandBus implementation is that the command has
      * been successfully received. Implementations are highly recommended to perform basic validation of the command
@@ -68,8 +68,8 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      * Subscribe the given {@code handler} to commands with the given {@code commandName}.
      * <p/>
      * If a subscription already exists for the given name, the behavior is undefined. Implementations may throw an
-     * Exception to refuse duplicate subscription or alternatively decide whether the existing or new
-     * {@code handler} gets the subscription.
+     * Exception to refuse duplicate subscription or alternatively decide whether the existing or new {@code handler}
+     * gets the subscription.
      *
      * @param commandName The name of the command to subscribe the handler to
      * @param handler     The handler instance that handles the given type of command
@@ -77,4 +77,14 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      */
     Registration subscribe(String commandName, MessageHandler<? super CommandMessage<?>> handler);
 
+    /**
+     * Return the {@link CommandBus} which is regarded as the local segment for this implementation. Would return the
+     * CommandBus used to dispatch and handle command in a local environment to bridge the gap in a distributed set up.
+     * Might return {@code this} if no distributed CommandBus is used.
+     *
+     * @return the {@link CommandBus} which is the local segment for this implementation
+     */
+    default CommandBus localSegment() {
+        return this;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -27,6 +27,7 @@ import org.axonframework.commandhandling.distributed.commandfilter.DenyAll;
 import org.axonframework.commandhandling.distributed.commandfilter.DenyCommandNameFilter;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
+import org.axonframework.messaging.Distributed;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
@@ -52,7 +53,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Allard Buijze
  * @since 2.0
  */
-public class DistributedCommandBus implements CommandBus {
+public class DistributedCommandBus implements CommandBus, Distributed<CommandBus> {
 
     /**
      * The initial load factor of this node when it is registered with the {@link CommandRouter}.

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,11 @@
 
 package org.axonframework.commandhandling.distributed;
 
-import org.axonframework.commandhandling.*;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.MonitorAwareCallback;
+import org.axonframework.commandhandling.NoHandlerForCommandException;
 import org.axonframework.commandhandling.callbacks.LoggingCallback;
 import org.axonframework.commandhandling.distributed.commandfilter.CommandNameFilter;
 import org.axonframework.commandhandling.distributed.commandfilter.DenyAll;
@@ -39,8 +43,8 @@ import static org.axonframework.commandhandling.GenericCommandResultMessage.asCo
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Implementation of a {@link CommandBus} that is aware of multiple instances of a CommandBus working together to
- * spread load. Each "physical" CommandBus instance is considered a "segment" of a conceptual distributed CommandBus.
+ * Implementation of a {@link CommandBus} that is aware of multiple instances of a CommandBus working together to spread
+ * load. Each "physical" CommandBus instance is considered a "segment" of a conceptual distributed CommandBus.
  * <p/>
  * The DistributedCommandBus relies on a {@link CommandBusConnector} to dispatch commands and replies to different
  * segments of the CommandBus. Depending on the implementation used, each segment may run in a different JVM.
@@ -71,9 +75,8 @@ public class DistributedCommandBus implements CommandBus {
     /**
      * Instantiate a Builder to be able to create a {@link DistributedCommandBus}.
      * <p>
-     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.
-     * The {@link CommandRouter} and {@link CommandBusConnector} are <b>hard requirements</b> and as such should be
-     * provided.
+     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}. The {@link CommandRouter} and {@link
+     * CommandBusConnector} are <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link DistributedCommandBus}
      */
@@ -84,8 +87,8 @@ public class DistributedCommandBus implements CommandBus {
     /**
      * Instantiate a {@link DistributedCommandBus} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link CommandRouter}, {@link CommandBusConnector} and {@link MessageMonitor} are not
-     * {@code null}, and will throw an {@link AxonConfigurationException} if any of them is {@code null}.
+     * Will assert that the {@link CommandRouter}, {@link CommandBusConnector} and {@link MessageMonitor} are not {@code
+     * null}, and will throw an {@link AxonConfigurationException} if any of them is {@code null}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link DistributedCommandBus} instance
      */
@@ -192,6 +195,17 @@ public class DistributedCommandBus implements CommandBus {
     }
 
     /**
+     * {@inheritDoc}
+     * <p>
+     * Will call {@link CommandBusConnector#localSegment()}. If this returns an {@link Optional#empty()}, this method
+     * defaults to returning {@code this} as last resort.
+     */
+    @Override
+    public CommandBus localSegment() {
+        return connector.localSegment().orElse(this);
+    }
+
+    /**
      * Returns the current load factor of this node.
      *
      * @return the current load factor
@@ -211,8 +225,8 @@ public class DistributedCommandBus implements CommandBus {
     }
 
     /**
-     * Registers the given list of dispatch interceptors to the command bus. All incoming commands will pass through
-     * the interceptors at the given order before the command is dispatched toward the command handler.
+     * Registers the given list of dispatch interceptors to the command bus. All incoming commands will pass through the
+     * interceptors at the given order before the command is dispatched toward the command handler.
      *
      * @param dispatchInterceptor The interceptors to invoke when commands are dispatched
      * @return handle to unregister the interceptor
@@ -232,9 +246,8 @@ public class DistributedCommandBus implements CommandBus {
     /**
      * Builder class to instantiate a {@link DistributedCommandBus}.
      * <p>
-     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.
-     * The {@link CommandRouter} and {@link CommandBusConnector} are <b>hard requirements</b> and as such should be
-     * provided.
+     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}. The {@link CommandRouter} and {@link
+     * CommandBusConnector} are <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
@@ -283,8 +296,8 @@ public class DistributedCommandBus implements CommandBus {
         }
 
         /**
-         * Sets the callback to use when commands are dispatched in a "fire and forget" method, such as
-         * {@link #dispatch(CommandMessage)}. Defaults to using no callback, which requests the connectors to use a
+         * Sets the callback to use when commands are dispatched in a "fire and forget" method, such as {@link
+         * #dispatch(CommandMessage)}. Defaults to using no callback, which requests the connectors to use a
          * fire-and-forget strategy for dispatching event.
          *
          * @param defaultCommandCallback the callback to invoke when no explicit callback is provided for a command

--- a/messaging/src/main/java/org/axonframework/messaging/Distributed.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Distributed.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+/**
+ * A contract towards being a distributed message bus implementation. The generic {@code T} defines the type of message
+ * bus which is distributed.
+ *
+ * @param <MessageBus> the message bus which is distributed
+ * @author Steven van Beelen
+ * @since 4.2.2
+ */
+public interface Distributed<MessageBus> {
+
+    /**
+     * Return the message bus of type {@code MessageBus} which is regarded as the local segment for this implementation.
+     * Would return the message bus used to dispatch and handle messages in a local environment to bridge the gap in a
+     * distributed set up.
+     *
+     * @return a {@code MessageBus} which is the local segment for this distributed message bus implementation
+     */
+    MessageBus localSegment();
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,21 @@
 
 package org.axonframework.commandhandling.distributed;
 
-import org.axonframework.commandhandling.*;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandCallback;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.commandhandling.GenericCommandResultMessage;
+import org.axonframework.commandhandling.NoHandlerForCommandException;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.monitoring.MessageMonitor;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.junit.*;
 
 import java.util.Optional;
 
@@ -123,7 +126,7 @@ public class DistributedCommandBusTest {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("unknown");
         when(mockCommandRouter.findDestination(testCommandMessage)).thenReturn(Optional.empty());
 
-        CommandCallback callback = mock(CommandCallback.class);
+        CommandCallback<Object, Object> callback = mock(CommandCallback.class);
         testSubject.dispatch(testCommandMessage, callback);
 
         verify(mockCommandRouter).findDestination(testCommandMessage);
@@ -132,7 +135,7 @@ public class DistributedCommandBusTest {
         verify(mockMessageMonitor, never()).onMessageIngested(any());
         verify(mockMonitorCallback, never()).reportSuccess();
 
-        ArgumentCaptor<CommandResultMessage> commandResultMessageCaptor =
+        ArgumentCaptor<CommandResultMessage<Object>> commandResultMessageCaptor =
                 ArgumentCaptor.forClass(CommandResultMessage.class);
         verify(callback).onResult(any(), commandResultMessageCaptor.capture());
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
@@ -144,14 +147,14 @@ public class DistributedCommandBusTest {
     public void testDispatchWithCallbackAndMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
 
-        CommandCallback mockCallback = mock(CommandCallback.class);
+        CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         testSubject.dispatch(testCommandMessage, mockCallback);
 
         verify(mockCommandRouter).findDestination(testCommandMessage);
         verify(mockConnector).send(eq(mockMember), eq(testCommandMessage), any(CommandCallback.class));
         verify(mockMessageMonitor).onMessageIngested(any());
         verify(mockMonitorCallback).reportSuccess();
-        ArgumentCaptor<CommandResultMessage> commandResultMessageCaptor =
+        ArgumentCaptor<CommandResultMessage<Object>> commandResultMessageCaptor =
                 ArgumentCaptor.forClass(CommandResultMessage.class);
         verify(mockCallback).onResult(eq(testCommandMessage), commandResultMessageCaptor.capture());
         assertFalse(commandResultMessageCaptor.getValue().isExceptional());
@@ -163,7 +166,7 @@ public class DistributedCommandBusTest {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
         when(mockCommandRouter.findDestination(testCommandMessage)).thenReturn(Optional.empty());
 
-        CommandCallback mockCallback = mock(CommandCallback.class);
+        CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         testSubject.dispatch(testCommandMessage, mockCallback);
 
         verify(mockCommandRouter).findDestination(testCommandMessage);
@@ -171,7 +174,7 @@ public class DistributedCommandBusTest {
         verify(mockConnector, never()).send(eq(mockMember), eq(testCommandMessage));
         verify(mockMessageMonitor).onMessageIngested(any());
         verify(mockMonitorCallback).reportFailure(any());
-        ArgumentCaptor<CommandResultMessage> commandResultMessageCaptor =
+        ArgumentCaptor<CommandResultMessage<Object>> commandResultMessageCaptor =
                 ArgumentCaptor.forClass(CommandResultMessage.class);
         verify(mockCallback).onResult(eq(testCommandMessage), commandResultMessageCaptor.capture());
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
@@ -183,17 +186,27 @@ public class DistributedCommandBusTest {
     public void testDispatchFailingCommandWithCallbackAndMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("fail");
 
-        CommandCallback mockCallback = mock(CommandCallback.class);
+        CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         testSubject.dispatch(testCommandMessage, mockCallback);
 
         verify(mockCommandRouter).findDestination(testCommandMessage);
         verify(mockConnector).send(eq(mockMember), eq(testCommandMessage), any(CommandCallback.class));
         verify(mockMessageMonitor).onMessageIngested(any());
         verify(mockMonitorCallback).reportFailure(isA(Exception.class));
-        ArgumentCaptor<CommandResultMessage> commandResultMessageCaptor =
+        ArgumentCaptor<CommandResultMessage<Object>> commandResultMessageCaptor =
                 ArgumentCaptor.forClass(CommandResultMessage.class);
         verify(mockCallback).onResult(eq(testCommandMessage), commandResultMessageCaptor.capture());
         assertEquals(Exception.class, commandResultMessageCaptor.getValue().exceptionResult().getClass());
+    }
+
+    @Test
+    public void testLocalSegmentReturnsTheCommandBusConnectorsLocalSegmentResult() {
+        CommandBus expectedLocalSegment = mock(CommandBus.class);
+        when(mockConnector.localSegment()).thenReturn(Optional.of(expectedLocalSegment));
+
+        CommandBus resultLocalSegment = testSubject.localSegment();
+
+        assertEquals(expectedLocalSegment, resultLocalSegment);
     }
 
     private static class StubCommandBusConnector implements CommandBusConnector {


### PR DESCRIPTION
The `AggregateConfigurer` only checked whether the `Configuration#commandBus` instance was of type `DisruptorCommandBus`. In that case, the `DisruptorCommandBus` would be used to create the Aggregate's `Repository`. 

However, if the `DisruptorCommandBus` is the local segment when an `AxonServerCommandBus` or  `DistributedCommandBus` is used, then it would not be used by the `AggregateConfigurer` is it didn't check the local segment's instance type.

This is resolved in this PR, by adding a `CommandBus#localSegment` method which is called in the `AggregateConfigurer`.

This PR resolve bug #874 