### PR TITLE
Migrate module test to JUnit5

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
             <optional>true</optional>
         </dependency>
 

--- a/test/src/test/java/org/axonframework/test/aggregate/AggregateDeadlineSchedulingTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/AggregateDeadlineSchedulingTest.java
@@ -23,40 +23,40 @@ import org.axonframework.deadline.annotation.DeadlineHandler;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
-public class AggregateDeadlineSchedulingTest {
+class AggregateDeadlineSchedulingTest {
 
     private static final int TRIGGER_DURATION_MINUTES = 10;
 
     private AggregateTestFixture<MyAggregate> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(MyAggregate.class);
     }
 
     @Test
-    public void testDeadlineScheduling() {
+    void testDeadlineScheduling() {
         fixture.givenNoPriorActivity()
                .when(new CreateMyAggregateCommand("id"))
                .expectScheduledDeadline(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), "deadlineDetails");
     }
 
     @Test
-    public void testDeadlineSchedulingTypeMatching() {
+    void testDeadlineSchedulingTypeMatching() {
         fixture.givenNoPriorActivity()
                .when(new CreateMyAggregateCommand("id"))
                .expectScheduledDeadlineOfType(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), String.class);
     }
 
     @Test
-    public void testDeadlineMet() {
+    void testDeadlineMet() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(new CreateMyAggregateCommand("id"))
                .whenThenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -64,7 +64,7 @@ public class AggregateDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineWhichCancelsSchedule() {
+    void testDeadlineWhichCancelsSchedule() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(new CreateMyAggregateCommand("id"))
                .when(new ResetTriggerCommand("id"))
@@ -72,7 +72,7 @@ public class AggregateDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineWhichCancelsAll() {
+    void testDeadlineWhichCancelsAll() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(new CreateMyAggregateCommand("id"))
                .when(new ResetAllTriggerCommand("id"))
@@ -80,7 +80,7 @@ public class AggregateDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineDispatcherInterceptor() {
+    void testDeadlineDispatcherInterceptor() {
         fixture.registerDeadlineDispatchInterceptor(
                 messages -> (i, m) -> GenericDeadlineMessage
                         .asDeadlineMessage(m.getDeadlineName(), "fakeDeadlineDetails", m.getTimestamp()))
@@ -91,7 +91,7 @@ public class AggregateDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineHandlerInterceptor() {
+    void testDeadlineHandlerInterceptor() {
         fixture.registerDeadlineHandlerInterceptor((uow, chain) -> {
                     uow.transformMessage(deadlineMessage -> GenericDeadlineMessage
                             .asDeadlineMessage(deadlineMessage.getDeadlineName(), "fakeDeadlineDetails", deadlineMessage.getTimestamp()));

--- a/test/src/test/java/org/axonframework/test/aggregate/AnnotatedAggregate.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/AnnotatedAggregate.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
@@ -49,8 +49,8 @@ class AnnotatedAggregate implements AnnotatedAggregateInterface {
 
     @CommandHandler
     public AnnotatedAggregate(CreateAggregateCommand command, EventBus eventBus, HardToCreateResource resource) {
-        assertNotNull("resource should not be null", resource);
-        assertNotNull("Expected EventBus to be injected as resource", eventBus);
+        assertNotNull(resource, "resource should not be null");
+        assertNotNull(eventBus, "Expected EventBus to be injected as resource");
         apply(new MyEvent(command.getAggregateIdentifier() == null ?
                                   UUID.randomUUID() : command.getAggregateIdentifier(), 0));
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
@@ -28,53 +28,52 @@ import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.FixtureExecutionException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class FixtureTest_Annotated {
+class FixtureTest_Annotated {
 
     private FixtureConfiguration<AnnotatedAggregate> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(AnnotatedAggregate.class);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         if (CurrentUnitOfWork.isStarted()) {
             fail("A unit of work is still running");
         }
     }
 
     @Test
-    public void testNullIdentifierIsRejected() {
-        try {
-            fixture.given(new MyEvent(null, 0))
-                   .when(new TestCommand("test"))
-                   .expectEvents(new MyEvent("test", 1))
-                   .expectSuccessfulHandlerExecution();
-            fail("Expected test fixture to report failure");
-        } catch (AxonAssertionError error) {
-            assertTrue("Expected test to fail with IncompatibleAggregateException", error.getMessage().contains("IncompatibleAggregateException"));
-        }
+    void testNullIdentifierIsRejected() {
+        AxonAssertionError error = assertThrows(AxonAssertionError.class, () ->
+                fixture.given(new MyEvent(null, 0))
+                       .when(new TestCommand("test"))
+                       .expectEvents(new MyEvent("test", 1))
+                       .expectSuccessfulHandlerExecution()
+        );
+
+        assertTrue(error.getMessage().contains("IncompatibleAggregateException"), "Expected test to fail with IncompatibleAggregateException");
     }
 
     @Test
-    public void testEventsCarryCorrectTimestamp() {
+    void testEventsCarryCorrectTimestamp() {
         fixture.givenCurrentTime(Instant.EPOCH)
                .andGiven(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .andGivenCommands(new TestCommand("AggregateId"))
@@ -99,7 +98,7 @@ public class FixtureTest_Annotated {
     }
 
     @Test
-    public void testClockStandsStillDuringExecution() {
+    void testClockStandsStillDuringExecution() {
         fixture.given(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .when(new TestCommand("AggregateId"));
 
@@ -111,7 +110,7 @@ public class FixtureTest_Annotated {
     }
 
     @Test
-    public void testAggregateCommandHandlersOverwrittenByCustomHandlers() {
+    void testAggregateCommandHandlersOverwrittenByCustomHandlers() {
         final AtomicBoolean invoked = new AtomicBoolean(false);
         fixture.registerCommandHandler(CreateAggregateCommand.class, commandMessage -> {
             invoked.set(true);
@@ -119,28 +118,28 @@ public class FixtureTest_Annotated {
         });
 
         fixture.given().when(new CreateAggregateCommand()).expectEvents();
-        assertTrue("", invoked.get());
+        assertTrue(invoked.get(), "");
     }
 
     @Test
-    public void testAggregateIdentifier_ServerGeneratedIdentifier() {
+    void testAggregateIdentifier_ServerGeneratedIdentifier() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.given()
                .when(new CreateAggregateCommand());
     }
 
-    @Test(expected = FixtureExecutionException.class)
-    public void testUnavailableResourcesCausesFailure() {
-        fixture.given()
-               .when(new CreateAggregateCommand());
+    @Test
+    void testUnavailableResourcesCausesFailure() {
+        TestExecutor<AnnotatedAggregate> given = fixture.given();
+        assertThrows(FixtureExecutionException.class, () -> given.when(new CreateAggregateCommand()));
     }
 
     @Test
-    public void testAggregateIdentifier_IdentifierAutomaticallyDeducted() {
+    void testAggregateIdentifier_IdentifierAutomaticallyDeducted() {
         fixture.given(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .when(new TestCommand("AggregateId"))
                .expectEvents(new MyEvent("AggregateId", 3))
-               .expectState(Assert::assertNotNull);
+               .expectState(Assertions::assertNotNull);
 
         DomainEventStream events = fixture.getEventStore().readEvents("AggregateId");
         for (int t = 0; t < 3; t++) {
@@ -151,13 +150,13 @@ public class FixtureTest_Annotated {
         }
     }
 
-    @Test(expected = FixtureExecutionException.class)
-    public void testFixtureGivenCommands_ResourcesNotAvailable() {
-        fixture.givenCommands(new CreateAggregateCommand("aggregateId"));
+    @Test
+    void testFixtureGivenCommands_ResourcesNotAvailable() {
+        assertThrows(FixtureExecutionException.class, () -> fixture.givenCommands(new CreateAggregateCommand("aggregateId")));
     }
 
     @Test
-    public void testFixtureGivenCommands_ResourcesAvailable() {
+    void testFixtureGivenCommands_ResourcesAvailable() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenCommands(new CreateAggregateCommand("aggregateId"),
                               new TestCommand("aggregateId"),
@@ -168,7 +167,7 @@ public class FixtureTest_Annotated {
     }
 
     @Test
-    public void testAggregateIdentifier_CustomTargetResolver() {
+    void testAggregateIdentifier_CustomTargetResolver() {
         CommandTargetResolver mockCommandTargetResolver = mock(CommandTargetResolver.class);
         when(mockCommandTargetResolver.resolveTarget(any())).thenReturn(new VersionedAggregateIdentifier("aggregateId", 0L));
 
@@ -181,50 +180,53 @@ public class FixtureTest_Annotated {
         verify(mockCommandTargetResolver).resolveTarget(any());
     }
 
-    @Test(expected = FixtureExecutionException.class)
-    public void testAggregate_InjectCustomResourceAfterCreatingAnnotatedHandler() {
+    @Test
+    void testAggregate_InjectCustomResourceAfterCreatingAnnotatedHandler() {
         // a 'when' will cause command handlers to be registered.
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.given()
                .when(new CreateAggregateCommand("AggregateId"));
-        fixture.registerInjectableResource("I am injectable");
-    }
 
-    @Test(expected = EventStoreException.class)
-    public void testFixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
-        fixture.getEventStore().publish(
-                new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()),
-                new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()));
-    }
-
-    @Test(expected = EventStoreException.class)
-    public void testFixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
-        String identifier = UUID.randomUUID().toString();
-        fixture.getEventStore().publish(
-                new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
-                new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()));
+        assertThrows(FixtureExecutionException.class, () -> fixture.registerInjectableResource("I am injectable"));
     }
 
     @Test
-    public void testFixture_AggregateDeleted() {
+    void testFixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
+        assertThrows(EventStoreException.class, () ->
+                fixture.getEventStore().publish(
+                        new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()),
+                        new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()))
+        );
+    }
+
+    @Test
+    void testFixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
+        String identifier = UUID.randomUUID().toString();
+        assertThrows(EventStoreException.class, () ->
+                fixture.getEventStore().publish(
+                        new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
+                        new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()))
+        );
+    }
+
+    @Test
+    void testFixture_AggregateDeleted() {
         fixture.given(new MyEvent("aggregateId", 5))
                .when(new DeleteCommand("aggregateId", false))
                .expectEvents(new MyAggregateDeletedEvent(false));
     }
 
     @Test
-    public void testFixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
+    void testFixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
         TestExecutor exec = fixture.given(new MyEvent("aggregateId", 5));
-        try {
-            exec.when(new DeleteCommand("aggregateId", true));
-            fail("Fixture should have failed");
-        } catch (AssertionError error) {
-            assertTrue("Wrong message: " + error.getMessage(), error.getMessage().contains("considered deleted"));
-        }
+        AssertionError error = assertThrows(AssertionError.class,
+                () -> exec.when(new DeleteCommand("aggregateId", true))
+        );
+        assertTrue(error.getMessage().contains("considered deleted"), "Wrong message: " + error.getMessage());
     }
 
     @Test
-    public void testAndGiven() {
+    void testAndGiven() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenCommands(new CreateAggregateCommand("aggregateId"))
                .andGiven(new MyEvent("aggregateId", 1))
@@ -233,7 +235,7 @@ public class FixtureTest_Annotated {
     }
 
     @Test
-    public void testAndGivenCommands() {
+    void testAndGivenCommands() {
         fixture.given(new MyEvent("aggregateId", 1))
                .andGivenCommands(new TestCommand("aggregateId"))
                .when(new TestCommand("aggregateId"))
@@ -241,7 +243,7 @@ public class FixtureTest_Annotated {
     }
 
     @Test
-    public void testMultipleAndGivenCommands() {
+    void testMultipleAndGivenCommands() {
         fixture.given(new MyEvent("aggregateId", 1))
                .andGivenCommands(new TestCommand("aggregateId"))
                .andGivenCommands(new TestCommand("aggregateId"))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -25,13 +25,13 @@ import org.axonframework.messaging.*;
 import org.axonframework.messaging.correlation.SimpleCorrelationDataProvider;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.command.AggregateIdentifier;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,13 +41,13 @@ import java.util.function.BiFunction;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.axonframework.test.aggregate.FixtureTest_CommandInterceptors.InterceptorAggregate.AGGREGATE_IDENTIFIER;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class FixtureTest_CommandInterceptors {
+@ExtendWith(MockitoExtension.class)
+class FixtureTest_CommandInterceptors {
 
     private static final String DISPATCH_META_DATA_KEY = "dispatchKey";
     private static final String DISPATCH_META_DATA_VALUE = "dispatchValue";
@@ -63,13 +63,13 @@ public class FixtureTest_CommandInterceptors {
     @Mock
     private MessageHandlerInterceptor<CommandMessage<?>> mockCommandHandlerInterceptor;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(InterceptorAggregate.class);
     }
 
     @Test
-    public void testRegisteredCommandDispatchInterceptorsAreInvoked() {
+    void testRegisteredCommandDispatchInterceptorsAreInvoked() {
         when(firstMockCommandDispatchInterceptor.handle(any(CommandMessage.class)))
                 .thenAnswer(it -> it.getArguments()[0]);
         fixture.registerCommandDispatchInterceptor(firstMockCommandDispatchInterceptor);
@@ -95,7 +95,7 @@ public class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    public void testRegisteredCommandDispatchInterceptorIsInvokedAndAltersAppliedEvent() {
+    void testRegisteredCommandDispatchInterceptorIsInvokedAndAltersAppliedEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
@@ -111,7 +111,7 @@ public class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    public void testRegisteredCommandDispatchInterceptorIsInvokedForFixtureMethodsGivenCommands() {
+    void testRegisteredCommandDispatchInterceptorIsInvokedForFixtureMethodsGivenCommands() {
         fixture.registerCommandDispatchInterceptor(new TestCommandDispatchInterceptor());
 
         MetaData expectedValues =
@@ -124,7 +124,7 @@ public class FixtureTest_CommandInterceptors {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testRegisteredCommandHandlerInterceptorsAreInvoked() throws Exception {
+    void testRegisteredCommandHandlerInterceptorsAreInvoked() throws Exception {
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
         when(mockCommandHandlerInterceptor.handle(any(UnitOfWork.class), any(InterceptorChain.class)))
                 .thenAnswer(InvocationOnMock::getArguments);
@@ -147,7 +147,7 @@ public class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    public void testRegisteredCommandHandlerInterceptorIsInvokedAndAltersEvent() {
+    void testRegisteredCommandHandlerInterceptorIsInvokedAndAltersEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
@@ -163,7 +163,7 @@ public class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    public void testRegisteredCommandHandlerInterceptorIsInvokedForFixtureMethodsGivenCommands() {
+    void testRegisteredCommandHandlerInterceptorIsInvokedForFixtureMethodsGivenCommands() {
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
 
         Map<String, Object> expectedMetaDataMap = new HashMap<>();
@@ -175,7 +175,7 @@ public class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    public void testRegisteredCommandDispatchAndHandlerInterceptorAreBothInvokedAndAlterEvent() {
+    void testRegisteredCommandDispatchAndHandlerInterceptorAreBothInvokedAndAlterEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
@@ -18,24 +18,24 @@ package org.axonframework.test.aggregate;
 
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.NoHandlerForCommandException;
-import org.axonframework.modelling.command.TargetAggregateIdentifier;
-import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import org.axonframework.test.FixtureExecutionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FixtureTest_ExceptionHandling {
+class FixtureTest_ExceptionHandling {
 
     private final FixtureConfiguration<MyAggregate> fixture = new AggregateTestFixture<>(MyAggregate.class);
 
     @Test
-    public void testCreateAggregate() {
+    void testCreateAggregate() {
         fixture.givenCommands().when(
                 new CreateMyAggregateCommand("14")
         ).expectEvents(
@@ -44,35 +44,33 @@ public class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    public void givenUnknownCommand() {
-        try {
-            fixture.givenCommands(
-                    new CreateMyAggregateCommand("14"),
-                    new UnknownCommand("14")
-            );
-            fail("Expected FixtureExecutionException");
-        } catch (FixtureExecutionException fee) {
-            assertEquals(NoHandlerForCommandException.class, fee.getCause().getClass());
-        }
+    void givenUnknownCommand() {
+        FixtureExecutionException fee = assertThrows(FixtureExecutionException.class, () -> fixture.givenCommands(
+                new CreateMyAggregateCommand("14"),
+                new UnknownCommand("14")
+        ));
+        assertEquals(NoHandlerForCommandException.class, fee.getCause().getClass());
     }
 
     @Test
-    public void testWhenExceptionTriggeringCommand() {
+    void testWhenExceptionTriggeringCommand() {
         fixture.givenCommands(new CreateMyAggregateCommand("14")).when(
                 new ExceptionTriggeringCommand("14")
         ).expectException(RuntimeException.class);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testGivenExceptionTriggeringCommand() {
-        fixture.givenCommands(
-                new CreateMyAggregateCommand("14"),
-                new ExceptionTriggeringCommand("14")
-        );
+    @Test
+    void testGivenExceptionTriggeringCommand() {
+        assertThrows(RuntimeException.class, () ->
+                        fixture.givenCommands(
+                                new CreateMyAggregateCommand("14"),
+                                new ExceptionTriggeringCommand("14")
+                        )
+                );
     }
 
     @Test
-    public void testGivenCommandWithInvalidIdentifier() {
+    void testGivenCommandWithInvalidIdentifier() {
         fixture.givenCommands(
                 new CreateMyAggregateCommand("1")
         ).when(
@@ -81,7 +79,7 @@ public class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    public void testExceptionMessageCheck() {
+    void testExceptionMessageCheck() {
         fixture.givenCommands(
                 new CreateMyAggregateCommand("1")
         ).when(
@@ -91,7 +89,7 @@ public class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    public void testExceptionMessageCheckWithMatcher() {
+    void testExceptionMessageCheckWithMatcher() {
         fixture.givenCommands(
                 new CreateMyAggregateCommand("1")
         ).when(
@@ -100,11 +98,13 @@ public class FixtureTest_ExceptionHandling {
                 .expectExceptionMessage(containsString("You"));
     }
 
-    @Test(expected = FixtureExecutionException.class)
-    public void testWhenCommandWithInvalidIdentifier() {
-        fixture.givenCommands(
-                new CreateMyAggregateCommand("1"),
-                new ValidMyAggregateCommand("2")
+    @Test
+    void testWhenCommandWithInvalidIdentifier() {
+        assertThrows(FixtureExecutionException.class, () ->
+                fixture.givenCommands(
+                        new CreateMyAggregateCommand("1"),
+                        new ValidMyAggregateCommand("2")
+                )
         );
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
@@ -21,17 +21,17 @@ import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcingHandler;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 /**
  * @author Allard Buijze
  */
-public class FixtureTest_Hierarchy {
+class FixtureTest_Hierarchy {
 
     @Test
-    public void testFixtureSetupWithAggregateHierarchy() {
+    void testFixtureSetupWithAggregateHierarchy() {
         new AggregateTestFixture<>(AbstractAggregate.class)
                 .registerAggregateFactory(new AggregateFactory<AbstractAggregate>() {
                     @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
@@ -18,26 +18,27 @@ package org.axonframework.test.aggregate;
 
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.test.AxonAssertionError;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Jan-Hendrik Kuperus
  */
-public class FixtureTest_MarkDeleted {
+class FixtureTest_MarkDeleted {
 
     private FixtureConfiguration<AnnotatedAggregate> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(AnnotatedAggregate.class);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         if (CurrentUnitOfWork.isStarted()) {
             fail("A unit of work is still running");
         }
@@ -45,7 +46,7 @@ public class FixtureTest_MarkDeleted {
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
-    public void testCreateAggregateYieldsLiveAggregate() {
+    void testCreateAggregateYieldsLiveAggregate() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenNoPriorActivity()
                .when(new CreateAggregateCommand("id"))
@@ -53,30 +54,34 @@ public class FixtureTest_MarkDeleted {
                .expectNotMarkedDeleted();
     }
 
-    @Test(expected = AxonAssertionError.class)
-    public void testCreateAggregateYieldsLiveAggregateInverted() {
+    @Test
+    void testCreateAggregateYieldsLiveAggregateInverted() {
         fixture.registerInjectableResource(new HardToCreateResource());
-        fixture.givenNoPriorActivity()
-                .when(new CreateAggregateCommand("id"))
-                .expectEvents(new MyEvent("id", 0))
-                .expectMarkedDeleted();
+
+        assertThrows(AxonAssertionError.class, () ->
+                fixture.givenNoPriorActivity()
+                        .when(new CreateAggregateCommand("id"))
+                        .expectEvents(new MyEvent("id", 0))
+                        .expectMarkedDeleted());
     }
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
-    public void testDeletedAggregateYieldsAggregateMarkedDeleted() {
+    void testDeletedAggregateYieldsAggregateMarkedDeleted() {
         fixture.given(new MyEvent("id", 0))
                .when(new DeleteCommand("id", false))
                .expectEvents(new MyAggregateDeletedEvent(false))
                .expectMarkedDeleted();
     }
 
-    @Test(expected = AxonAssertionError.class)
-    public void testDeletedAggregateYieldsAggregateMarkedDeletedInverted() {
-        fixture.given(new MyEvent("id", 0))
-                .when(new DeleteCommand("id", false))
-                .expectEvents(new MyAggregateDeletedEvent(false))
-                .expectNotMarkedDeleted();
+    @Test
+    void testDeletedAggregateYieldsAggregateMarkedDeletedInverted() {
+        assertThrows(AxonAssertionError.class, () ->
+                fixture.given(new MyEvent("id", 0))
+                        .when(new DeleteCommand("id", false))
+                        .expectEvents(new MyAggregateDeletedEvent(false))
+                        .expectNotMarkedDeleted());
+
     }
 
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
@@ -22,8 +22,8 @@ import org.axonframework.messaging.MessageHandler;
 import org.axonframework.test.AxonAssertionError;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.axonframework.test.matchers.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -39,18 +39,18 @@ import static org.mockito.Mockito.verify;
  * @author Allard Buijze
  * @since 0.7
  */
-public class FixtureTest_MatcherParams {
+class FixtureTest_MatcherParams {
 
     private FixtureConfiguration<StandardAggregate> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(StandardAggregate.class);
         fixture.registerAggregateFactory(new StandardAggregate.Factory());
     }
 
     @Test
-    public void testFirstFixture() {
+    void testFirstFixture() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -59,7 +59,7 @@ public class FixtureTest_MatcherParams {
     }
 
     @Test
-    public void testPayloadsMatch() {
+    void testPayloadsMatch() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -68,7 +68,7 @@ public class FixtureTest_MatcherParams {
     }
 
     @Test
-    public void testPayloadsMatchExact() {
+    void testPayloadsMatchExact() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -77,7 +77,7 @@ public class FixtureTest_MatcherParams {
     }
 
     @Test
-    public void testPayloadsMatchPredicate() {
+    void testPayloadsMatchPredicate() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -86,105 +86,97 @@ public class FixtureTest_MatcherParams {
     }
 
     @Test
-    public void testFixture_UnexpectedException() {
+    void testFixture_UnexpectedException() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture
-                    .registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new StrangeCommand("aggregateId"))
-                    .expectResultMessageMatching(new DoesMatch<>());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue(e.getMessage().contains("but got <exception of type [StrangeCommandReceivedException]>"));
-        }
+
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture
+                        .registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new StrangeCommand("aggregateId"))
+                        .expectResultMessageMatching(new DoesMatch<>())
+        );
+        assertTrue(e.getMessage().contains("but got <exception of type [StrangeCommandReceivedException]>"));
     }
 
     @Test
-    public void testFixture_UnexpectedReturnValue() {
+    void testFixture_UnexpectedReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture.registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new TestCommand("aggregateId"))
-                    .expectException(new DoesMatch());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue(e.getMessage().contains("The command handler returned normally, but an exception was expected"));
-            assertTrue(e.getMessage().contains(
-                    "<anything> but returned with <null>"));
-        }
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture.registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new TestCommand("aggregateId"))
+                        .expectException(new DoesMatch<>())
+        );
+        assertTrue(e.getMessage().contains("The command handler returned normally, but an exception was expected"));
+        assertTrue(e.getMessage().contains(
+                "<anything> but returned with <null>"));
     }
 
     @Test
-    public void testFixture_WrongReturnValue() {
+    void testFixture_WrongReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture.registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new TestCommand("aggregateId"))
-                    .expectResultMessageMatching(new DoesNotMatch<>());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue(e.getMessage().contains("<something you can never give me> but got <GenericCommandResultMessage{payload={null}"));
-        }
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture.registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new TestCommand("aggregateId"))
+                        .expectResultMessageMatching(new DoesNotMatch<>())
+        );
+        assertTrue(e.getMessage().contains("<something you can never give me> but got <GenericCommandResultMessage{payload={null}"));
     }
 
     @Test
-    public void testFixture_WrongExceptionType() {
+    void testFixture_WrongExceptionType() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture.registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new StrangeCommand("aggregateId"))
-                    .expectException(new DoesNotMatch());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue(e.getMessage().contains(
-                    "<something you can never give me> but got <exception of type [StrangeCommandReceivedException]>"));
-        }
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture.registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new StrangeCommand("aggregateId"))
+                        .expectException(new DoesNotMatch<>())
+        );
+        assertTrue(e.getMessage().contains(
+                "<something you can never give me> but got <exception of type [StrangeCommandReceivedException]>"));
     }
 
     @Test
-    public void testFixture_ExpectedPublishedSameAsStored() {
+    void testFixture_ExpectedPublishedSameAsStored() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture
-                    .registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new StrangeCommand("aggregateId"))
-                    .expectEvents(new DoesMatch<List<? extends EventMessage>>());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue(e.getMessage().contains("The published events do not match the expected events"));
-            assertTrue(e.getMessage().contains("FixtureTest_MatcherParams$DoesMatch <|> "));
-            assertTrue(e.getMessage().contains("probable cause"));
-        }
+
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture
+                        .registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new StrangeCommand("aggregateId"))
+                        .expectEvents(new DoesMatch<List<? extends EventMessage>>())
+        );
+        assertTrue(e.getMessage().contains("The published events do not match the expected events"));
+        assertTrue(e.getMessage().contains("FixtureTest_MatcherParams$DoesMatch <|> "));
+        assertTrue(e.getMessage().contains("probable cause"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testFixture_DispatchMetaDataInCommand() throws Exception {
+    void testFixture_DispatchMetaDataInCommand() throws Exception {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -203,22 +195,21 @@ public class FixtureTest_MatcherParams {
     }
 
     @Test
-    public void testFixture_EventDoesNotMatch() {
+    void testFixture_EventDoesNotMatch() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
         MyCommandHandler commandHandler = new MyCommandHandler(fixture.getRepository(),
                                                                fixture.getEventBus());
-        try {
-            fixture
-                    .registerAnnotatedCommandHandler(commandHandler)
-                    .given(givenEvents)
-                    .when(new TestCommand("aggregateId"))
-                    .expectEventsMatching(new DoesNotMatch<>());
-            fail("Expected an AxonAssertionError");
-        } catch (AxonAssertionError e) {
-            assertTrue("Wrong message: " + e.getMessage(), e.getMessage().contains("something you can never give me"));
-        }
+
+        AxonAssertionError e = assertThrows(AxonAssertionError.class, () ->
+                fixture
+                        .registerAnnotatedCommandHandler(commandHandler)
+                        .given(givenEvents)
+                        .when(new TestCommand("aggregateId"))
+                        .expectEventsMatching(new DoesNotMatch<>())
+        );
+        assertTrue(e.getMessage().contains("something you can never give me"), "Wrong message: " + e.getMessage());
     }
 
     private static class DoesMatch<T> extends BaseMatcher<T> {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Resources.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Resources.java
@@ -20,30 +20,30 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.eventsourcing.EventSourcingHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executor;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class FixtureTest_Resources {
+class FixtureTest_Resources {
 
     private FixtureConfiguration<AggregateWithResources> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(AggregateWithResources.class);
     }
 
     @Test
-    public void testResourcesAreScopedToSingleTest_ConstructorPartOne() {
+    void testResourcesAreScopedToSingleTest_ConstructorPartOne() {
         // executing the same test should pass, as resources are scoped to a single test only
         final Executor resource = mock(Executor.class);
         fixture.registerInjectableResource(resource)
@@ -55,12 +55,12 @@ public class FixtureTest_Resources {
     }
 
     @Test
-    public void testResourcesAreScopedToSingleTest_ConstructorPartTwo() {
+    void testResourcesAreScopedToSingleTest_ConstructorPartTwo() {
         testResourcesAreScopedToSingleTest_ConstructorPartOne();
     }
 
     @Test
-    public void testResourcesAreScopedToSingleTest_MethodPartOne() {
+    void testResourcesAreScopedToSingleTest_MethodPartOne() {
         // executing the same test should pass, as resources are scoped to a single test only
         final Executor resource = mock(Executor.class);
         fixture.registerInjectableResource(resource)
@@ -73,7 +73,7 @@ public class FixtureTest_Resources {
     }
 
     @Test
-    public void testResourcesAreScopedToSingleTest_MethodPartTwo() {
+    void testResourcesAreScopedToSingleTest_MethodPartTwo() {
         testResourcesAreScopedToSingleTest_MethodPartOne();
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_SpawningNewAggregate.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_SpawningNewAggregate.java
@@ -24,9 +24,9 @@ import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.axonframework.eventsourcing.EventSourcedAggregate;
 import org.axonframework.eventsourcing.EventSourcingHandler;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.junit.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -41,18 +41,18 @@ import static org.mockito.Mockito.*;
  *
  * @author Milan Savic
  */
-@RunWith(MockitoJUnitRunner.class)
-public class FixtureTest_SpawningNewAggregate {
+@ExtendWith(MockitoExtension.class)
+class FixtureTest_SpawningNewAggregate {
 
     private FixtureConfiguration<Aggregate1> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(Aggregate1.class);
     }
 
     @Test
-    public void testFixtureWithoutRepositoryProviderInjected() {
+    void testFixtureWithoutRepositoryProviderInjected() {
         fixture.givenNoPriorActivity()
                .when(new CreateAggregate1Command("id", "aggregate2Id"))
                .expectEvents(new Aggregate2CreatedEvent("aggregate2Id"), new Aggregate1CreatedEvent("id"))
@@ -61,7 +61,7 @@ public class FixtureTest_SpawningNewAggregate {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testFixtureWithRepositoryProviderInjected() throws Exception {
+    void testFixtureWithRepositoryProviderInjected() throws Exception {
         RepositoryProvider repositoryProvider = mock(RepositoryProvider.class);
         Repository<Aggregate2> aggregate2Repository = mock(Repository.class);
         AggregateModel<Aggregate2> aggregate2Model = AnnotatedAggregateMetaModelFactory
@@ -101,7 +101,7 @@ public class FixtureTest_SpawningNewAggregate {
             return id;
         }
 
-        public String getAggregate2Id() {
+        String getAggregate2Id() {
             return aggregate2Id;
         }
     }
@@ -197,7 +197,7 @@ public class FixtureTest_SpawningNewAggregate {
         public Aggregate2() {
         }
 
-        public Aggregate2(String id) {
+        Aggregate2(String id) {
             apply(new Aggregate2CreatedEvent(id));
         }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -20,36 +20,36 @@ import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.hamcrest.CoreMatchers.any;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
-public class FixtureTest_StateStorage {
+class FixtureTest_StateStorage {
 
     private FixtureConfiguration<StateStoredAggregate> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new AggregateTestFixture<>(StateStoredAggregate.class);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         if (CurrentUnitOfWork.isStarted()) {
             fail("A unit of work is still running");
         }
     }
 
     @Test
-    public void testCreateStateStoredAggregate() {
+    void testCreateStateStoredAggregate() {
         fixture.givenState(() -> new StateStoredAggregate("id", "message"))
                .when(new SetMessageCommand("id", "message2"))
                .expectEvents(new StubDomainEvent())
@@ -57,7 +57,7 @@ public class FixtureTest_StateStorage {
     }
 
     @Test
-    public void testEmittedEventsFromExpectStateAreNotStored() {
+    void testEmittedEventsFromExpectStateAreNotStored() {
         fixture.givenState(() -> new StateStoredAggregate("id", "message"))
                .when(new SetMessageCommand("id", "message2"))
                .expectEvents(new StubDomainEvent())
@@ -66,23 +66,20 @@ public class FixtureTest_StateStorage {
                    assertEquals("message2", aggregate.getMessage());
                })
                .expectEvents(new StubDomainEvent())
-               .expectState(Assert::assertNotNull);
+               .expectState(Assertions::assertNotNull);
     }
 
     @Test
-    public void testCreateStateStoredAggregate_ErrorInChanges() {
+    void testCreateStateStoredAggregate_ErrorInChanges() {
         ResultValidator<StateStoredAggregate> result =
                 fixture.givenState(() -> new StateStoredAggregate("id", "message"))
                        .when(new ErrorCommand("id", "message2"))
                        .expectException(any(Exception.class))
                        .expectNoEvents();
-        try {
-            result.expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
-            fail("Expected an exception");
-        } catch (IllegalStateException e) {
-            assertTrue("Wrong message: " + e.getMessage(), e.getMessage().contains("Unit of Work"));
-            assertTrue("Wrong message: " + e.getMessage(), e.getMessage().contains("rolled back"));
-        }
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> result.expectState(aggregate -> assertEquals("message2", aggregate.getMessage())));
+        assertTrue(e.getMessage().contains("Unit of Work"), "Wrong message: " + e.getMessage());
+        assertTrue(e.getMessage().contains("rolled back"), "Wrong message: " + e.getMessage());
     }
 
     private static class InitializeCommand {
@@ -151,7 +148,7 @@ public class FixtureTest_StateStorage {
 
         private String message;
 
-        public StateStoredAggregate(String id, String message) {
+        StateStoredAggregate(String id, String message) {
             this.id = id;
             this.message = message;
         }
@@ -183,7 +180,7 @@ public class FixtureTest_StateStorage {
 
     private static class StubDomainEvent {
 
-        public StubDomainEvent() {
+        StubDomainEvent() {
         }
     }
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -19,51 +19,52 @@ package org.axonframework.test.aggregate;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.matchers.MatchAllFieldFilter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Collections.*;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ResultValidatorImplTest {
+class ResultValidatorImplTest {
 
     private ResultValidator<?> validator = new ResultValidatorImpl<>(actualEvents(),
                                                                      new MatchAllFieldFilter(emptyList()),
                                                                      () -> null,
                                                                      null);
 
-    @Test(expected = AxonAssertionError.class)
-    public void shouldCompareValuesForEquality() {
+    @Test
+    void shouldCompareValuesForEquality() {
         EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("key1", "otherValue"));
 
-        validator.expectEvents(expected);
-    }
-
-    @Test(expected = AxonAssertionError.class)
-    public void shouldCompareKeysForEquality() {
-        EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("KEY1", "value1"));
-
-        validator.expectEvents(expected);
+        assertThrows(AxonAssertionError.class, () -> validator.expectEvents(expected));
     }
 
     @Test
-    public void shouldSuccesfullyCompareEqualMetadata() {
+    void shouldCompareKeysForEquality() {
+        EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("KEY1", "value1"));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectEvents(expected));
+    }
+
+    @Test
+    void shouldSuccesfullyCompareEqualMetadata() {
         EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("key1", "value1"));
 
         validator.expectEvents(expected);
     }
 
     @Test
-    public void shouldConsiderExplicitEqualsBeforeCheckingFields() {
+    void shouldConsiderExplicitEqualsBeforeCheckingFields() {
         String s1 = "0";
         validator = new ResultValidatorImpl<>(singletonList(asEventMessage(s1)),
                                               new MatchAllFieldFilter(emptyList()),
                                               () -> null,
                                               null);
         String s2 = String.valueOf(0);
-        Assert.assertEquals(s1, s2);
+        assertEquals(s1, s2);
 
         // the hash code is cached in a String
         int ignored = s1.hashCode();

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
@@ -16,42 +16,44 @@
 
 package org.axonframework.test.aggregate;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class StubAggregateLifecycleTest {
+class StubAggregateLifecycleTest {
     private StubAggregateLifecycle testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new StubAggregateLifecycle();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         testSubject.close();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testLifecycleIsNotRegisteredAutomatically() {
-        apply("test");
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testApplyingEventsAfterDeactivationFails() {
-        testSubject.activate();
-        testSubject.close();
-        apply("test");
     }
 
     @Test
-    public void testAppliedEventsArePassedToActiveLifecycle() {
+    void testLifecycleIsNotRegisteredAutomatically() {
+        assertThrows(IllegalStateException.class, () -> apply("test"));
+    }
+
+    @Test
+    void testApplyingEventsAfterDeactivationFails() {
+        testSubject.activate();
+        testSubject.close();
+
+        assertThrows(IllegalStateException.class, () -> apply("test"));
+    }
+
+    @Test
+    void testAppliedEventsArePassedToActiveLifecycle() {
         testSubject.activate();
         apply("test");
 
@@ -61,7 +63,7 @@ public class StubAggregateLifecycleTest {
     }
 
     @Test
-    public void testMarkDeletedIsRegisteredWithActiveLifecycle() {
+    void testMarkDeletedIsRegisteredWithActiveLifecycle() {
         testSubject.activate();
         markDeleted();
 

--- a/test/src/test/java/org/axonframework/test/deadline/StubDeadlineManagerTest.java
+++ b/test/src/test/java/org/axonframework/test/deadline/StubDeadlineManagerTest.java
@@ -19,27 +19,27 @@ package org.axonframework.test.deadline;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.messaging.Scope;
 import org.axonframework.messaging.ScopeDescriptor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class StubDeadlineManagerTest {
+class StubDeadlineManagerTest {
 
     private StubDeadlineManager testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new StubDeadlineManager();
     }
 
     @Test
-    public void testMessagesCarryTriggerTimestamp() throws Exception {
+    void testMessagesCarryTriggerTimestamp() throws Exception {
         Instant triggerTime = Instant.now().plusSeconds(60);
         MockScope.execute(() ->
                                   testSubject.schedule(triggerTime, "gone")

--- a/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
+++ b/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
@@ -18,10 +18,8 @@ package org.axonframework.test.eventscheduler;
 
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -29,31 +27,29 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Allard Buijze
  */
-public class StubEventSchedulerTest {
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class StubEventSchedulerTest {
 
     private StubEventScheduler testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new StubEventScheduler();
     }
 
     @Test
-    public void testScheduleEvent() {
+    void testScheduleEvent() {
         testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
         assertEquals(1, testSubject.getScheduledItems().size());
     }
 
     @Test
-    public void testEventContainsTimestampOfScheduledTime() {
+    void testEventContainsTimestampOfScheduledTime() {
         Instant triggerTime = Instant.now().plusSeconds(60);
         testSubject.schedule(triggerTime, "gone");
         List<EventMessage<?>> triggered = new ArrayList<>();
@@ -64,10 +60,11 @@ public class StubEventSchedulerTest {
     }
 
     @Test
-    public void testInitializeAtDateTimeAfterSchedulingEvent() {
+    void testInitializeAtDateTimeAfterSchedulingEvent() {
         testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
-        exception.expect(IllegalStateException.class);
-        testSubject.initializeAt(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+        assertThrows(IllegalStateException.class, () ->
+                        testSubject.initializeAt(Instant.now().minus(10, ChronoUnit.MINUTES)));
     }
 
     private EventMessage<MockEvent> event(MockEvent mockEvent) {

--- a/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
@@ -19,61 +19,61 @@ package org.axonframework.test.matchers;
 import org.axonframework.test.aggregate.MyEvent;
 import org.axonframework.test.aggregate.MyOtherEvent;
 import org.hamcrest.StringDescription;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
-public class EqualFieldsMatcherTest {
+class EqualFieldsMatcherTest {
 
     private EqualFieldsMatcher<MyEvent> testSubject;
     private MyEvent expectedEvent;
     private String aggregateId = "AggregateId";
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         expectedEvent = new MyEvent(aggregateId, 1);
         testSubject = Matchers.equalTo(expectedEvent);
     }
 
     @Test
-    public void testMatches_SameInstance() {
+    void testMatches_SameInstance() {
         assertTrue(testSubject.matches(expectedEvent));
     }
 
     @Test
-    public void testMatches_EqualInstance() {
+    void testMatches_EqualInstance() {
         assertTrue(testSubject.matches(new MyEvent(aggregateId, 1)));
     }
 
     @Test
-    public void testMatches_WrongEventType() {
+    void testMatches_WrongEventType() {
         assertFalse(testSubject.matches(new MyOtherEvent()));
     }
 
     @Test
-    public void testMatches_WrongFieldValue() {
+    void testMatches_WrongFieldValue() {
         assertFalse(testSubject.matches(new MyEvent(aggregateId, 2)));
         assertEquals("someValue", testSubject.getFailedField().getName());
     }
 
     @Test
-    public void testMatches_WrongFieldValueInIgnoredField() {
+    void testMatches_WrongFieldValueInIgnoredField() {
         testSubject = Matchers.equalTo(expectedEvent, field -> !field.getName().equals("someValue"));
         assertTrue(testSubject.matches(new MyEvent(aggregateId, 2)));
     }
 
     @Test
-    public void testMatches_WrongFieldValueInArray() {
+    void testMatches_WrongFieldValueInArray() {
         assertFalse(testSubject.matches(new MyEvent(aggregateId, 1, new byte[]{1, 2})));
         assertEquals("someBytes", testSubject.getFailedField().getName());
     }
 
     @Test
-    public void testDescription_AfterSuccess() {
+    void testDescription_AfterSuccess() {
         testSubject.matches(expectedEvent);
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
@@ -81,7 +81,7 @@ public class EqualFieldsMatcherTest {
     }
 
     @Test
-    public void testDescription_AfterMatchWithWrongType() {
+    void testDescription_AfterMatchWithWrongType() {
         testSubject.matches(new MyOtherEvent());
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
@@ -89,7 +89,7 @@ public class EqualFieldsMatcherTest {
     }
 
     @Test
-    public void testDescription_AfterMatchWithWrongFieldValue() {
+    void testDescription_AfterMatchWithWrongFieldValue() {
         testSubject.matches(new MyEvent(aggregateId, 2));
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);

--- a/test/src/test/java/org/axonframework/test/matchers/ExactSequenceOfEventsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ExactSequenceOfEventsMatcherTest.java
@@ -20,8 +20,8 @@ import org.axonframework.eventhandling.EventMessage;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -30,13 +30,13 @@ import java.util.List;
 
 import static org.axonframework.test.matchers.Matchers.andNoMore;
 import static org.axonframework.test.matchers.Matchers.exactSequenceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class ExactSequenceOfEventsMatcherTest {
+class ExactSequenceOfEventsMatcherTest {
 
     private Matcher<EventMessage<?>> mockMatcher1;
     private Matcher<EventMessage<?>> mockMatcher2;
@@ -47,8 +47,8 @@ public class ExactSequenceOfEventsMatcherTest {
     private StubEvent stubEvent3;
 
     @SuppressWarnings({"unchecked"})
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockMatcher1 = mock(Matcher.class);
         mockMatcher2 = mock(Matcher.class);
         mockMatcher3 = mock(Matcher.class);
@@ -62,7 +62,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatch() {
+    void testMatch_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -79,7 +79,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatchAndNoMore() {
+    void testMatch_FullMatchAndNoMore() {
         testSubject = exactSequenceOf(mockMatcher1, mockMatcher2, mockMatcher3, andNoMore());
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3)));
 
@@ -97,7 +97,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_ExcessIsRefused() {
+    void testMatch_ExcessIsRefused() {
         testSubject = exactSequenceOf(mockMatcher1, mockMatcher2, mockMatcher3, andNoMore());
         assertFalse(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3, new StubEvent())));
 
@@ -115,7 +115,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatchWithGaps() {
+    void testMatch_FullMatchWithGaps() {
         reset(mockMatcher2);
         when(mockMatcher2.matches(any())).thenReturn(false);
 
@@ -133,7 +133,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_MoreMatchersThanEvents() {
+    void testMatch_MoreMatchersThanEvents() {
         when(mockMatcher3.matches(null)).thenReturn(false);
         assertFalse(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
@@ -147,7 +147,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_ExcessEventsIgnored() {
+    void testMatch_ExcessEventsIgnored() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3, new StubEvent())));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -160,7 +160,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testDescribe() {
+    void testDescribe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -173,7 +173,7 @@ public class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testDescribe_OneMatcherFailed() {
+    void testDescribe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(true);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);
@@ -192,7 +192,7 @@ public class ExactSequenceOfEventsMatcherTest {
     private static class DescribingAnswer implements Answer<Object> {
         private String description;
 
-        public DescribingAnswer(String description) {
+        DescribingAnswer(String description) {
             this.description = description;
         }
 

--- a/test/src/test/java/org/axonframework/test/matchers/IgnoreFieldTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/IgnoreFieldTest.java
@@ -17,35 +17,36 @@
 package org.axonframework.test.matchers;
 
 import org.axonframework.test.FixtureExecutionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Allard Buijze
  */
-public class IgnoreFieldTest {
+class IgnoreFieldTest {
 
     @SuppressWarnings("unused") private String field;
     @SuppressWarnings("unused") private String ignoredField;
 
     @Test
-    public void testAcceptOtherFields_ClassStringConstructor() throws Exception {
+    void testAcceptOtherFields_ClassStringConstructor() throws Exception {
         IgnoreField testSubject = new IgnoreField(IgnoreFieldTest.class, "ignoredField");
         assertTrue(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("field")));
         assertFalse(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("ignoredField")));
     }
 
     @Test
-    public void testAcceptOtherFields_FieldConstructor() throws Exception {
+    void testAcceptOtherFields_FieldConstructor() throws Exception {
         IgnoreField testSubject = new IgnoreField(IgnoreFieldTest.class.getDeclaredField("ignoredField"));
         assertTrue(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("field")));
         assertFalse(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("ignoredField")));
     }
 
-    @Test(expected = FixtureExecutionException.class)
-    public void testRejectNonExistentField() {
-        new IgnoreField(IgnoreFieldTest.class, "nonExistent");
+    @Test
+    void testRejectNonExistentField() {
+        assertThrows(FixtureExecutionException.class, () -> new IgnoreField(IgnoreFieldTest.class, "nonExistent"));
     }
 }

--- a/test/src/test/java/org/axonframework/test/matchers/ListWithAllOfMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ListWithAllOfMatcherTest.java
@@ -20,8 +20,8 @@ import org.axonframework.eventhandling.EventMessage;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -29,13 +29,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.axonframework.test.matchers.Matchers.listWithAllOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class ListWithAllOfMatcherTest {
+class ListWithAllOfMatcherTest {
 
     private Matcher<EventMessage<?>> mockMatcher1;
     private Matcher<EventMessage<?>> mockMatcher2;
@@ -45,8 +45,8 @@ public class ListWithAllOfMatcherTest {
     private StubEvent stubEvent2;
 
     @SuppressWarnings({"unchecked"})
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockMatcher1 = mock(Matcher.class);
         mockMatcher2 = mock(Matcher.class);
         mockMatcher3 = mock(Matcher.class);
@@ -59,7 +59,7 @@ public class ListWithAllOfMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatch() {
+    void testMatch_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -71,7 +71,7 @@ public class ListWithAllOfMatcherTest {
     }
 
     @Test
-    public void testMatch_OnlyOneEventMatches() {
+    void testMatch_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -87,7 +87,7 @@ public class ListWithAllOfMatcherTest {
     }
 
     @Test
-    public void testMatch_OneMatcherDoesNotMatch() {
+    void testMatch_OneMatcherDoesNotMatch() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -99,7 +99,7 @@ public class ListWithAllOfMatcherTest {
     }
 
     @Test
-    public void testDescribe() {
+    void testDescribe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -112,7 +112,7 @@ public class ListWithAllOfMatcherTest {
     }
 
     @Test
-    public void testDescribe_OneMatcherFailed() {
+    void testDescribe_OneMatcherFailed() {
         when(mockMatcher2.matches(any())).thenReturn(false);
 
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
@@ -129,7 +129,7 @@ public class ListWithAllOfMatcherTest {
     private static class DescribingAnswer implements Answer<Object> {
         private String description;
 
-        public DescribingAnswer(String description) {
+        DescribingAnswer(String description) {
             this.description = description;
         }
 

--- a/test/src/test/java/org/axonframework/test/matchers/ListWithAnyOfMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ListWithAnyOfMatcherTest.java
@@ -20,8 +20,8 @@ import org.axonframework.eventhandling.EventMessage;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -29,13 +29,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.axonframework.test.matchers.Matchers.listWithAnyOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class ListWithAnyOfMatcherTest {
+class ListWithAnyOfMatcherTest {
 
     private Matcher<EventMessage<?>> mockMatcher1;
     private Matcher<EventMessage<?>> mockMatcher2;
@@ -45,8 +45,8 @@ public class ListWithAnyOfMatcherTest {
     private StubEvent stubEvent2;
 
     @SuppressWarnings({"unchecked"})
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockMatcher1 = mock(Matcher.class);
         mockMatcher2 = mock(Matcher.class);
         mockMatcher3 = mock(Matcher.class);
@@ -59,7 +59,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatch() {
+    void testMatch_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -71,7 +71,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testMatch_OnlyOneEventMatches() {
+    void testMatch_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -87,7 +87,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testMatch_NoMatches() {
+    void testMatch_NoMatches() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);
@@ -103,7 +103,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testMatch_OneMatcherDoesNotMatch() {
+    void testMatch_OneMatcherDoesNotMatch() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -119,7 +119,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testDescribe() {
+    void testDescribe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -132,7 +132,7 @@ public class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    public void testDescribe_OneMatcherFailed() {
+    void testDescribe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);

--- a/test/src/test/java/org/axonframework/test/matchers/MapEntryMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/MapEntryMatcherTest.java
@@ -1,7 +1,7 @@
 package org.axonframework.test.matchers;
 
 import org.hamcrest.StringDescription;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,9 +10,10 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.*;
 import static org.axonframework.test.matchers.EqualsMatcher.equalTo;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class MapEntryMatcherTest {
+class MapEntryMatcherTest {
 
     private static final Map<String, Object> EXPECTED = new HashMap<>();
 
@@ -25,19 +26,19 @@ public class MapEntryMatcherTest {
     private final MapEntryMatcher matcher = new MapEntryMatcher(EXPECTED);
 
     @Test
-    public void nullSafe() {
+    void nullSafe() {
         assertFalse(matcher.matches(null));
     }
 
     @Test
-    public void testExpectedEntriesNotPresent() {
+    void testExpectedEntriesNotPresent() {
         assertFalse(matcher.matches(singletonMap("a", new ValueItem("a"))));
 
         assertThat(matcher.getMissingEntries(), equalTo(newHashMap("b", new ValueItem("b"), "c", new ValueItem("c"))));
     }
 
     @Test
-    public void testTooManyEntries() {
+    void testTooManyEntries() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "c", new ValueItem("c"),
                                                "d", new ValueItem("d"), "e", new ValueItem("e"))));
 
@@ -45,7 +46,7 @@ public class MapEntryMatcherTest {
     }
 
     @Test
-    public void testIncorrectValue() {
+    void testIncorrectValue() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "c", new ValueItem("CCCC"))));
 
         assertThat(matcher.getAdditionalEntries(), equalTo(newHashMap("c", new ValueItem("CCCC"))));
@@ -57,7 +58,7 @@ public class MapEntryMatcherTest {
     }
 
     @Test
-    public void testIncorrectKey() {
+    void testIncorrectKey() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "CCCC", new ValueItem("c"))));
 
         assertThat(matcher.getAdditionalEntries(), equalTo(newHashMap("CCCC", new ValueItem("c"))));
@@ -69,8 +70,8 @@ public class MapEntryMatcherTest {
     }
 
     @Test
-    public void testAnyOrder() {
-        TreeMap<String, Object> sortedMap = new TreeMap();
+    void testAnyOrder() {
+        TreeMap<String, Object> sortedMap = new TreeMap<>();
         sortedMap.putAll(EXPECTED);
 
         assertTrue(matcher.matches(sortedMap));
@@ -78,23 +79,23 @@ public class MapEntryMatcherTest {
     }
 
     @Test
-    public void matchEmptyMap() {
+    void matchEmptyMap() {
         assertTrue(new MapEntryMatcher(emptyMap()).matches(emptyMap()));
     }
 
     @Test
-    public void testNull() {
+    void testNull() {
         assertFalse(new MapEntryMatcher(emptyMap()).matches(null));
     }
 
     @Test
-    public void testNonMapType() {
+    void testNonMapType() {
         assertFalse(new MapEntryMatcher(emptyMap()).matches(new Object()));
         assertFalse(new MapEntryMatcher(emptyMap()).matches(emptySet()));
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         StringDescription description = new StringDescription();
         matcher.describeTo(description);
         assertEquals(description.toString(), "map containing " + String.format("[<%s=%s>,<%s=%s>,<%s=%s>]", EXPECTED.entrySet().stream().flatMap(entry -> Stream.of(entry.getKey(), entry.getValue())).toArray()));
@@ -115,7 +116,7 @@ public class MapEntryMatcherTest {
 
         private String name;
 
-        public ValueItem(String name) {
+        ValueItem(String name) {
             this.name = name;
         }
 

--- a/test/src/test/java/org/axonframework/test/matchers/MatchAllFieldFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/MatchAllFieldFilterTest.java
@@ -16,37 +16,37 @@
 
 package org.axonframework.test.matchers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Allard Buijze
  */
-public class MatchAllFieldFilterTest {
+class MatchAllFieldFilterTest {
 
     @SuppressWarnings("unused")
     private String field;
 
     @Test
-    public void testAcceptWhenEmpty() throws Exception {
+    void testAcceptWhenEmpty() throws Exception {
         assertTrue(new MatchAllFieldFilter(Collections.emptyList())
                            .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));
     }
 
     @Test
-    public void testAcceptWhenAllAccept() throws Exception {
+    void testAcceptWhenAllAccept() throws Exception {
         assertTrue(new MatchAllFieldFilter(Arrays.asList(AllFieldsFilter.instance(),
                                                          AllFieldsFilter.instance()))
                            .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));
     }
 
     @Test
-    public void testRejectWhenOneRejects() throws Exception {
+    void testRejectWhenOneRejects() throws Exception {
         assertFalse(new MatchAllFieldFilter(Arrays.asList(AllFieldsFilter.instance(),
                                                           field -> false))
                             .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));

--- a/test/src/test/java/org/axonframework/test/matchers/NonStaticFieldsFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NonStaticFieldsFilterTest.java
@@ -1,11 +1,11 @@
 package org.axonframework.test.matchers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NonStaticFieldsFilterTest {
+class NonStaticFieldsFilterTest {
 
     @SuppressWarnings("unused")
     private static String staticField;
@@ -13,13 +13,13 @@ public class NonStaticFieldsFilterTest {
     private String nonStaticField;
 
     @Test
-    public void testAcceptNonTransientField() throws Exception {
+    void testAcceptNonTransientField() throws Exception {
         assertTrue(NonStaticFieldsFilter.instance()
                            .accept(getClass().getDeclaredField("nonStaticField")));
     }
 
     @Test
-    public void testRejectTransientField() throws Exception {
+    void testRejectTransientField() throws Exception {
         assertFalse(NonStaticFieldsFilter.instance()
                             .accept(getClass().getDeclaredField("staticField")));
     }

--- a/test/src/test/java/org/axonframework/test/matchers/NonTransientFieldsFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NonTransientFieldsFilterTest.java
@@ -16,15 +16,15 @@
 
 package org.axonframework.test.matchers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Allard Buijze
  */
-public class NonTransientFieldsFilterTest {
+class NonTransientFieldsFilterTest {
 
     @SuppressWarnings("unused")
     private transient String transientField;
@@ -32,13 +32,13 @@ public class NonTransientFieldsFilterTest {
     private String nonTransientField;
 
     @Test
-    public void testAcceptNonTransientField() throws Exception {
+    void testAcceptNonTransientField() throws Exception {
         assertTrue(NonTransientFieldsFilter.instance()
                                            .accept(getClass().getDeclaredField("nonTransientField")));
     }
 
     @Test
-    public void testRejectTransientField() throws Exception {
+    void testRejectTransientField() throws Exception {
         assertFalse(NonTransientFieldsFilter.instance()
                                             .accept(getClass().getDeclaredField("transientField")));
     }

--- a/test/src/test/java/org/axonframework/test/matchers/NullOrVoidMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NullOrVoidMatcherTest.java
@@ -16,19 +16,19 @@
 
 package org.axonframework.test.matchers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.axonframework.test.matchers.Matchers.nothing;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Allard Buijze
  */
-public class NullOrVoidMatcherTest {
+class NullOrVoidMatcherTest {
 
     @Test
-    public void testMatcherMatchesVoidAndNull() {
+    void testMatcherMatchesVoidAndNull() {
         assertTrue(nothing().matches(Void.class));
         assertTrue(nothing().matches(null));
         assertFalse(nothing().matches(new Object()));

--- a/test/src/test/java/org/axonframework/test/matchers/SequenceOfEventsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/SequenceOfEventsMatcherTest.java
@@ -20,15 +20,15 @@ import org.axonframework.eventhandling.EventMessage;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -47,8 +47,8 @@ public class SequenceOfEventsMatcherTest {
     private Matcher<List<EventMessage<?>>> testSubject;
 
     @SuppressWarnings({"unchecked"})
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockMatcher1 = mock(Matcher.class);
         mockMatcher2 = mock(Matcher.class);
         mockMatcher3 = mock(Matcher.class);
@@ -64,7 +64,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatch() {
+    void testMatch_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3,
                                                      stubEvent4, stubEvent5)));
 
@@ -88,7 +88,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_FullMatchWithGaps() {
+    void testMatch_FullMatchWithGaps() {
         reset(mockMatcher2);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent5)).thenReturn(true);
@@ -117,7 +117,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_OnlyOneEventMatches() {
+    void testMatch_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -136,7 +136,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testMatch_NoMatches() {
+    void testMatch_NoMatches() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);
@@ -152,7 +152,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testDescribe() {
+    void testDescribe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -165,7 +165,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    public void testDescribe_OneMatcherFailed() {
+    void testDescribe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(true);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.test.matchers.Matchers;
 import org.axonframework.test.utils.CallbackBehavior;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -32,17 +32,17 @@ import java.util.UUID;
 
 import static org.axonframework.test.matchers.Matchers.*;
 import static org.hamcrest.CoreMatchers.any;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**
  * @author Allard Buijze
  */
-public class AnnotatedSagaTest {
+class AnnotatedSagaTest {
 
     @Test
-    public void testFixtureApi_WhenEventOccurs() {
+    void testFixtureApi_WhenEventOccurs() {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -72,7 +72,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_AggregatePublishedEvent_NoHistoricActivity() {
+    void testFixtureApi_AggregatePublishedEvent_NoHistoricActivity() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenAggregate("id").publishes(new TriggerSagaStartEvent("id"))
@@ -82,7 +82,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_AggregatePublishedEventWithMetaData_NoHistoricActivity() {
+    void testFixtureApi_AggregatePublishedEventWithMetaData_NoHistoricActivity() {
         String extraIdentifier = UUID.randomUUID().toString();
         Map<String, String> metaData = new HashMap<>();
         metaData.put("extraIdentifier", extraIdentifier);
@@ -97,24 +97,21 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_NonTransientResourceInjected() {
+    void testFixtureApi_NonTransientResourceInjected() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerResource(new NonTransientResource());
         fixture.givenNoPriorActivity();
-        try {
-            fixture.whenAggregate("id")
-                   .publishes(new TriggerSagaStartEvent("id"))
-                   .expectNoScheduledDeadlines();
-            fail("Expected error");
-        } catch (AssertionError e) {
-            assertTrue("Got unexpected error: " + e.getMessage(),
-                       e.getMessage().contains("StubSaga.nonTransientResource"));
-            assertTrue("Got unexpected error: " + e.getMessage(), e.getMessage().contains("transient"));
-        }
+        AssertionError e = assertThrows(AssertionError.class, () ->
+                fixture.whenAggregate("id")
+                       .publishes(new TriggerSagaStartEvent("id"))
+                       .expectNoScheduledDeadlines());
+        assertTrue(e.getMessage().contains("StubSaga.nonTransientResource"),
+                "Got unexpected error: " + e.getMessage());
+        assertTrue(e.getMessage().contains("transient"), "Got unexpected error: " + e.getMessage());
     }
 
     @Test
-    public void testFixtureApi_NonTransientResourceInjected_CheckDisabled() {
+    void testFixtureApi_NonTransientResourceInjected_CheckDisabled() {
         FixtureConfiguration fixture = new SagaTestFixture<>(StubSaga.class)
                 .withTransienceCheckDisabled();
         fixture.registerResource(new NonTransientResource());
@@ -125,7 +122,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test // testing issue AXON-279
-    public void testFixtureApi_PublishedEvent_NoHistoricActivity() {
+    void testFixtureApi_PublishedEvent_NoHistoricActivity() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenPublishingA(new GenericEventMessage<>(new TriggerSagaStartEvent("id")))
@@ -135,7 +132,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_PublishedEventWithMetaData_NoHistoricActivity() {
+    void testFixtureApi_PublishedEventWithMetaData_NoHistoricActivity() {
         String extraIdentifier = UUID.randomUUID().toString();
         Map<String, String> metaData = new HashMap<>();
         metaData.put("extraIdentifier", extraIdentifier);
@@ -150,7 +147,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WithApplicationEvents() throws Exception {
+    void testFixtureApi_WithApplicationEvents() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -169,7 +166,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenEventIsPublishedToEventBus() {
+    void testFixtureApi_WhenEventIsPublishedToEventBus() {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -189,7 +186,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() throws Exception {
+    void testFixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         FixtureExecutionResult validator = fixture
@@ -215,7 +212,7 @@ public class AnnotatedSagaTest {
 
 
     @Test
-    public void testFixtureApi_WhenTimeElapses_UsingMockGateway() {
+    void testFixtureApi_WhenTimeElapses_UsingMockGateway() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -239,7 +236,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testSchedulingEventsAsMessage() {
+    void testSchedulingEventsAsMessage() {
         UUID identifier = UUID.randomUUID();
         SagaTestFixture fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerCommandGateway(StubGateway.class);
@@ -252,7 +249,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testSchedulingEventsAsDomainEventMessage() {
+    void testSchedulingEventsAsDomainEventMessage() {
         UUID identifier = UUID.randomUUID();
         SagaTestFixture fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerCommandGateway(StubGateway.class);
@@ -265,7 +262,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testScheduledEventsInPastAsDomainEventMessage() {
+    void testScheduledEventsInPastAsDomainEventMessage() {
         UUID identifier = UUID.randomUUID();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerCommandGateway(StubGateway.class);
@@ -277,7 +274,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testScheduledEventsInPastAsEventMessage() {
+    void testScheduledEventsInPastAsEventMessage() {
         UUID identifier = UUID.randomUUID();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerCommandGateway(StubGateway.class);
@@ -289,7 +286,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_givenCurrentTime() {
+    void testFixtureApi_givenCurrentTime() {
         String identifier = UUID.randomUUID().toString();
         Instant fourDaysAgo = Instant.now().minus(4, ChronoUnit.DAYS);
         Instant fourDaysMinusTenMinutesAgo = fourDaysAgo.plus(10, ChronoUnit.MINUTES);
@@ -302,7 +299,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenTimeElapses_UsingDefaults() {
+    void testFixtureApi_WhenTimeElapses_UsingDefaults() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -322,7 +319,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenTimeElapses_UsingCallbackBehavior() throws Exception {
+    void testFixtureApi_WhenTimeElapses_UsingCallbackBehavior() throws Exception {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -346,7 +343,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testFixtureApi_WhenTimeAdvances() {
+    void testFixtureApi_WhenTimeAdvances() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -365,7 +362,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testLastResourceEvaluatedFirst() {
+    void testLastResourceEvaluatedFirst() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -387,7 +384,7 @@ public class AnnotatedSagaTest {
     }
 
     @Test
-    public void testPublishEventFromSecondFixtureCall() {
+    void testPublishEventFromSecondFixtureCall() {
         String identifier = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.whenAggregate(identifier).publishes(new TriggerSagaStartEvent(identifier))

--- a/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
@@ -5,46 +5,47 @@ import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.utils.RecordingCommandBus;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CommandValidatorTest {
+class CommandValidatorTest {
 
     private CommandValidator testSubject;
 
     private RecordingCommandBus commandBus;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         commandBus = mock(RecordingCommandBus.class);
         testSubject = new CommandValidator(commandBus, AllFieldsFilter.instance());
     }
 
     @Test
-    public void testAssertEmptyDispatchedEqualTo() {
+    void testAssertEmptyDispatchedEqualTo() {
         when(commandBus.getDispatchedCommands()).thenReturn(emptyCommandMessageList());
 
         testSubject.assertDispatchedEqualTo();
     }
 
     @Test
-    public void testAssertNonEmptyDispatchedEqualTo() {
+    void testAssertNonEmptyDispatchedEqualTo() {
         when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage("command"));
 
         testSubject.assertDispatchedEqualTo("command");
     }
 
-    @Test(expected = AxonAssertionError.class)
-    public void testMatchWithUnexpectedNullValue() {
+    @Test
+    void testMatchWithUnexpectedNullValue() {
         when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage(new SomeCommand(null)));
 
-        testSubject.assertDispatchedEqualTo(new SomeCommand("test"));
+        assertThrows(AxonAssertionError.class, () -> testSubject.assertDispatchedEqualTo(new SomeCommand("test")));
     }
 
     private List<CommandMessage<?>> emptyCommandMessageList() {

--- a/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -6,43 +6,45 @@ import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.aggregate.MyOtherEvent;
 import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.matchers.Matchers;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-public class EventValidatorTest {
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EventValidatorTest {
 
     private EventValidator testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new EventValidator(null, AllFieldsFilter.instance());
     }
 
     @Test
-    public void testAssertPublishedEventsWithNoEventsMatcherIfNoEventWasPublished() {
-        testSubject.assertPublishedEventsMatching(Matchers.noEvents());
-    }
-
-    @Test(expected = AxonAssertionError.class)
-    public void testAssertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() {
-        testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
-
+    void testAssertPublishedEventsWithNoEventsMatcherIfNoEventWasPublished() {
         testSubject.assertPublishedEventsMatching(Matchers.noEvents());
     }
 
     @Test
-    public void testAssertPublishedEventsIfNoEventWasPublished() {
-        testSubject.assertPublishedEvents();
-    }
-
-    @Test(expected = AxonAssertionError.class)
-    public void testAssertPublishedEventsThrowsAssertionErrorIfEventWasPublished() {
+    void testAssertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() {
         testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
 
+        assertThrows(AxonAssertionError.class, () -> testSubject.assertPublishedEventsMatching(Matchers.noEvents()));
+    }
+
+    @Test
+    void testAssertPublishedEventsIfNoEventWasPublished() {
         testSubject.assertPublishedEvents();
     }
 
     @Test
-    public void testAssertPublishedEventsForEventMessages() {
+    void testAssertPublishedEventsThrowsAssertionErrorIfEventWasPublished() {
+        testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
+
+        assertThrows(AxonAssertionError.class, testSubject::assertPublishedEvents);
+    }
+
+    @Test
+    void testAssertPublishedEventsForEventMessages() {
         EventMessage<MyOtherEvent> testEventMessage = GenericEventMessage.asEventMessage(new MyOtherEvent());
         testSubject.handle(testEventMessage);
 

--- a/test/src/test/java/org/axonframework/test/saga/SagaDeadlineSchedulingTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/SagaDeadlineSchedulingTest.java
@@ -22,8 +22,8 @@ import org.axonframework.deadline.annotation.DeadlineHandler;
 import org.axonframework.eventhandling.Timestamp;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -34,19 +34,19 @@ import java.time.Instant;
  * @author Milan Savic
  * @author Steven van Beelen
  */
-public class SagaDeadlineSchedulingTest {
+class SagaDeadlineSchedulingTest {
 
     private static final int TRIGGER_DURATION_MINUTES = 10;
 
     private SagaTestFixture<MySaga> fixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new SagaTestFixture<>(MySaga.class);
     }
 
     @Test
-    public void testDeadlineScheduling() {
+    void testDeadlineScheduling() {
         fixture.givenNoPriorActivity()
                .whenAggregate("id").publishes(new TriggerSagaStartEvent("id"))
                .expectActiveSagas(1)
@@ -55,7 +55,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineSchedulingTypeMatching() {
+    void testDeadlineSchedulingTypeMatching() {
         fixture.givenNoPriorActivity()
                .whenAggregate("id").publishes(new TriggerSagaStartEvent("id"))
                .expectActiveSagas(1)
@@ -64,7 +64,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineMet() {
+    void testDeadlineMet() {
         fixture.givenAggregate("id").published(new TriggerSagaStartEvent("id"))
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
                .expectActiveSagas(1)
@@ -73,7 +73,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineCancelled() {
+    void testDeadlineCancelled() {
         fixture.givenAggregate("id")
                .published(new TriggerSagaStartEvent("id"))
                .whenPublishingA(new ResetTriggerEvent("id"))
@@ -83,7 +83,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineWhichCancelsAll() {
+    void testDeadlineWhichCancelsAll() {
         fixture.givenAggregate("id")
                .published(new TriggerSagaStartEvent("id"))
                .whenPublishingA(new ResetAllTriggeredEvent("id"))
@@ -93,7 +93,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineDispatchInterceptor() {
+    void testDeadlineDispatchInterceptor() {
         fixture.registerDeadlineDispatchInterceptor(
                 messages -> (i, m) -> GenericDeadlineMessage
                         .asDeadlineMessage(m.getDeadlineName(), "fakeDeadlineDetails", m.getTimestamp()))
@@ -105,7 +105,7 @@ public class SagaDeadlineSchedulingTest {
     }
 
     @Test
-    public void testDeadlineHandlerInterceptor() {
+    void testDeadlineHandlerInterceptor() {
         fixture.registerDeadlineHandlerInterceptor((uow, chain) -> {
                     uow.transformMessage(deadlineMessage -> GenericDeadlineMessage
                             .asDeadlineMessage(deadlineMessage.getDeadlineName(), "fakeDeadlineDetails", deadlineMessage.getTimestamp()));

--- a/test/src/test/java/org/axonframework/test/saga/SagaTestFixtureRegistrationTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/SagaTestFixtureRegistrationTest.java
@@ -3,32 +3,33 @@ package org.axonframework.test.saga;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Duration.ofSeconds;
 import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class dedicated to validating custom registered components on a {@link SagaTestFixture} instance.
  */
-public class SagaTestFixtureRegistrationTest {
+class SagaTestFixtureRegistrationTest {
 
     private SagaTestFixture<SomeTestSaga> fixture;
     private AtomicInteger startRecordingCount;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         fixture = new SagaTestFixture<>(SomeTestSaga.class);
         startRecordingCount = new AtomicInteger();
         fixture.registerStartRecordingCallback(startRecordingCount::getAndIncrement);
     }
 
     @Test
-    public void startRecordingCallbackIsInvokedOnWhenPublishingAnEvent() {
+    void startRecordingCallbackIsInvokedOnWhenPublishingAnEvent() {
         fixture.givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
 
@@ -37,7 +38,7 @@ public class SagaTestFixtureRegistrationTest {
     }
 
     @Test
-    public void startRecordingCallbackIsInvokedOnWhenTimeAdvances() {
+    void startRecordingCallbackIsInvokedOnWhenTimeAdvances() {
         fixture.givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
 
@@ -46,7 +47,7 @@ public class SagaTestFixtureRegistrationTest {
     }
 
     @Test
-    public void startRecordingCallbackIsInvokedOnWhenTimeElapses() {
+    void startRecordingCallbackIsInvokedOnWhenTimeElapses() {
         fixture.givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
 
@@ -55,7 +56,7 @@ public class SagaTestFixtureRegistrationTest {
     }
 
     @Test
-    public void testCustomListenerInvocationErrorHandlerIsUsed() {
+    void testCustomListenerInvocationErrorHandlerIsUsed() {
         SomeTestSaga.SomeEvent testEvent = new SomeTestSaga.SomeEvent("some-id", true);
 
         ListenerInvocationErrorHandler testSubject = (exception, event, eventHandler) ->
@@ -96,7 +97,7 @@ public class SagaTestFixtureRegistrationTest {
                 return id;
             }
 
-            public Boolean shouldThrowException() {
+            Boolean shouldThrowException() {
                 return shouldThrowException;
             }
 

--- a/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
+++ b/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
@@ -19,37 +19,36 @@ package org.axonframework.test.utils;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.MessageHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze
  */
-public class RecordingCommandBusTest {
+class RecordingCommandBusTest {
 
     private RecordingCommandBus testSubject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testSubject = new RecordingCommandBus();
     }
 
     @Test
-    public void testPublishCommand() {
+    void testPublishCommand() {
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("First"));
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("Second"),
                              (commandMessage, commandResultMessage) -> {
                                  if (commandResultMessage.isExceptional()) {
                                      fail("Didn't expect handling to fail");
                                  }
-                                 assertNull("Expected default callback behavior to invoke onResult(null)",
-                                            commandResultMessage.getPayload());
+                                 assertNull(commandResultMessage.getPayload(),
+                                         "Expected default callback behavior to invoke onResult(null)");
                              });
-        //noinspection AssertEqualsBetweenInconvertibleTypes
         List<CommandMessage<?>> actual = testSubject.getDispatchedCommands();
         assertEquals(2, actual.size());
         assertEquals("First", actual.get(0).getPayload());
@@ -57,7 +56,7 @@ public class RecordingCommandBusTest {
     }
 
     @Test
-    public void testPublishCommandWithCallbackBehavior() {
+    void testPublishCommandWithCallbackBehavior() {
         testSubject.setCallbackBehavior((commandPayload, commandMetaData) -> "callbackResult");
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("First"));
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("Second"),
@@ -67,7 +66,6 @@ public class RecordingCommandBusTest {
                                  }
                                  assertEquals("callbackResult", commandResultMessage.getPayload());
                              });
-        //noinspection AssertEqualsBetweenInconvertibleTypes
         List<CommandMessage<?>> actual = testSubject.getDispatchedCommands();
         assertEquals(2, actual.size());
         assertEquals("First", actual.get(0).getPayload());
@@ -75,7 +73,7 @@ public class RecordingCommandBusTest {
     }
 
     @Test
-    public void testRegisterHandler() {
+    void testRegisterHandler() {
         MessageHandler<? super CommandMessage<?>> handler = command -> {
             fail("Did not expect handler to be invoked");
             return null;


### PR DESCRIPTION
migrate module test to JUnit5
All test was migrated, except StubAggregateLifecycleRuleTest (because it is JUnit4-specific)