### PR TITLE
Migrate module "axon-server-connector" to JUnit5

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -23,7 +23,7 @@ import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.event.StubServer;
 import org.axonframework.config.TagsConfiguration;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.axonframework.axonserver.connector.ErrorCode.UNSUPPORTED_INSTRUCTION;
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -42,25 +42,25 @@ import static org.mockito.Mockito.*;
  *
  * @author Milan Savic
  */
-public class AxonServerConnectionManagerTest {
+class AxonServerConnectionManagerTest {
 
     private StubServer stubServer = new StubServer(18124, 9657);
     private StubServer secondNode = new StubServer(9657, 9657);
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
         stubServer.start();
         secondNode.start();
     }
 
-    @After
-    public void tearDown() throws InterruptedException {
+    @AfterEach
+    void tearDown() throws InterruptedException {
         stubServer.shutdown();
         secondNode.shutdown();
     }
 
     @Test
-    public void checkWhetherConnectionPreferenceIsSent() {
+    void checkWhetherConnectionPreferenceIsSent() {
         TagsConfiguration tags = new TagsConfiguration(Collections.singletonMap("key", "value"));
         AxonServerConfiguration configuration = AxonServerConfiguration.builder().servers("localhost:" + stubServer.getPort()).build();
         AxonServerConnectionManager axonServerConnectionManager =
@@ -91,7 +91,7 @@ public class AxonServerConnectionManagerTest {
     }
 
     @Test
-    public void testConnectionTimeout() throws IOException, InterruptedException {
+    void testConnectionTimeout() throws IOException, InterruptedException {
         String version = "4.2.1";
         stubServer.shutdown();
         stubServer = new StubServer(stubServer.getPort(), new PlatformService(secondNode.getPort()){
@@ -118,7 +118,7 @@ public class AxonServerConnectionManagerTest {
     }
 
     @Test
-    public void testFrameworkVersionSent() {
+    void testFrameworkVersionSent() {
         String version = "4.2.1";
         AxonServerConfiguration configuration = AxonServerConfiguration.builder().servers("localhost:" + stubServer.getPort()).build();
         AxonServerConnectionManager axonServerConnectionManager =
@@ -137,7 +137,7 @@ public class AxonServerConnectionManagerTest {
     }
 
     @Test
-    public void unsupportedInstruction() {
+    void unsupportedInstruction() {
         AxonServerConfiguration configuration = AxonServerConfiguration.builder().servers("localhost:" + stubServer.getPort()).build();
         TestStreamObserver<PlatformInboundInstruction> requestStream = new TestStreamObserver<>();
         AxonServerConnectionManager axonServerConnectionManager =
@@ -167,7 +167,7 @@ public class AxonServerConnectionManagerTest {
     }
 
     @Test
-    public void unsupportedInstructionWithoutInstructionId() {
+    void unsupportedInstructionWithoutInstructionId() {
         AxonServerConfiguration configuration = AxonServerConfiguration.builder().servers("localhost:" + stubServer.getPort()).build();
         TestStreamObserver<PlatformInboundInstruction> requestStream = new TestStreamObserver<>();
         AxonServerConnectionManager axonServerConnectionManager =

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/DispatchInterceptorsTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/DispatchInterceptorsTest.java
@@ -17,22 +17,21 @@ package org.axonframework.axonserver.connector;
 
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
-import org.axonframework.axonserver.connector.DispatchInterceptors;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by Sara Pellegrini on 03/04/2018.
  * sara.pellegrini@gmail.com
  */
-public class DispatchInterceptorsTest {
+class DispatchInterceptorsTest {
 
     @Test
-    public void registerInterceptors() {
+    void registerInterceptors() {
         List<String> results = new ArrayList<>();
         DispatchInterceptors<Message<?>> dispatchInterceptors = new DispatchInterceptors<>();
         dispatchInterceptors.registerDispatchInterceptor(messages -> (a, b) -> {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -24,14 +24,14 @@ import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class ServerConnectorConfigurerModuleTest {
+class ServerConnectorConfigurerModuleTest {
 
     @Test
-    public void testAxonServerConfiguredInDefaultConfiguration() {
+    void testAxonServerConfiguredInDefaultConfiguration() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration()
                                                      .buildConfiguration();
 
@@ -60,7 +60,7 @@ public class ServerConnectorConfigurerModuleTest {
     }
 
     @Test
-    public void testQueryUpdateEmitterIsTakenFromConfiguration() {
+    void testQueryUpdateEmitterIsTakenFromConfiguration() {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .buildConfiguration();
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -40,7 +40,7 @@ import org.axonframework.common.Registration;
 import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.axonframework.axonserver.connector.ErrorCode.UNSUPPORTED_INSTRUCTION;
 import static org.axonframework.axonserver.connector.TestTargetContextResolver.BOUNDED_CONTEXT;
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Marc Gathier
  */
-public class AxonServerCommandBusTest {
+class AxonServerCommandBusTest {
 
     private DummyMessagePlatformServer dummyMessagePlatformServer;
 
@@ -76,8 +76,8 @@ public class AxonServerCommandBusTest {
 
     private AxonServerCommandBus testSubject;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         dummyMessagePlatformServer = new DummyMessagePlatformServer(4344);
         dummyMessagePlatformServer.start();
 
@@ -103,15 +103,15 @@ public class AxonServerCommandBusTest {
                                           .build();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         dummyMessagePlatformServer.stop();
         axonServerConnectionManager.shutdown();
         testSubject.disconnect();
     }
 
     @Test
-    public void dispatch() throws Exception {
+    void dispatch() throws Exception {
         CommandMessage<String> commandMessage = new GenericCommandMessage<>("this is the payload");
         CountDownLatch waiter = new CountDownLatch(1);
         AtomicReference<String> resultHolder = new AtomicReference<>();
@@ -135,7 +135,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void fireAndForgetUsesDefaultCallback() throws InterruptedException {
+    void fireAndForgetUsesDefaultCallback() throws InterruptedException {
         testSubject.disconnect();
         //noinspection unchecked
         CommandCallback<Object, Object> mockDefaultCommandCallback = mock(CommandCallback.class);
@@ -158,12 +158,12 @@ public class AxonServerCommandBusTest {
 
         testSubject.dispatch(commandMessage);
 
-        assertTrue("Expected default callback to have been invoked", cdl.await(1, TimeUnit.SECONDS));
+        assertTrue(cdl.await(1, TimeUnit.SECONDS), "Expected default callback to have been invoked");
         verify(mockDefaultCommandCallback).onResult(eq(commandMessage), any());
     }
 
     @Test
-    public void dispatchWhenChannelThrowsAnException() throws InterruptedException {
+    void dispatchWhenChannelThrowsAnException() throws InterruptedException {
         CommandMessage<String> commandMessage = new GenericCommandMessage<>("this is the payload");
         CountDownLatch waiter = new CountDownLatch(1);
         AtomicBoolean failure = new AtomicBoolean(false);
@@ -189,7 +189,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void dispatchWithError() throws Exception {
+    void dispatchWithError() throws Exception {
         CommandMessage<String> commandMessage = new GenericCommandMessage<>("this is an error request");
         CountDownLatch waiter = new CountDownLatch(1);
         AtomicReference<String> resultHolder = new AtomicReference<>();
@@ -212,7 +212,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void dispatchWithConcurrencyException() throws Exception {
+    void dispatchWithConcurrencyException() throws Exception {
         CommandMessage<String> commandMessage = new GenericCommandMessage<>("this is a concurrency issue");
         CountDownLatch waiter = new CountDownLatch(1);
         AtomicReference<CommandResultMessage<? extends String>> resultHolder = new AtomicReference<>();
@@ -231,7 +231,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void dispatchWithExceptionFromHandler() throws Exception {
+    void dispatchWithExceptionFromHandler() throws Exception {
         CommandMessage<String> commandMessage = new GenericCommandMessage<>("give me an exception");
         CountDownLatch waiter = new CountDownLatch(1);
         AtomicReference<CommandResultMessage<? extends String>> resultHolder = new AtomicReference<>();
@@ -254,7 +254,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void subscribe() {
+    void subscribe() {
         Registration registration = testSubject.subscribe(String.class.getName(), c -> "Done");
         assertWithin(100, TimeUnit.MILLISECONDS, () ->
                 assertNotNull(dummyMessagePlatformServer.subscriptions(String.class.getName())));
@@ -264,7 +264,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void processCommand() {
+    void processCommand() {
         AxonServerConnectionManager mockAxonServerConnectionManager = mock(AxonServerConnectionManager.class);
         AtomicReference<StreamObserver<CommandProviderInbound>> inboundStreamObserverRef = new AtomicReference<>();
         doAnswer(invocationOnMock -> {
@@ -303,7 +303,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void unsupportedCommandInstruction() {
+    void unsupportedCommandInstruction() {
         AxonServerConnectionManager mockAxonServerConnectionManager = mock(AxonServerConnectionManager.class);
         AtomicReference<StreamObserver<CommandProviderInbound>> inboundStreamObserverRef = new AtomicReference<>();
         doAnswer(invocationOnMock -> {
@@ -363,7 +363,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void resubscribe() throws Exception {
+    void resubscribe() throws Exception {
         testSubject.subscribe(String.class.getName(), c -> "Done");
         assertWithin(
                 1,
@@ -388,7 +388,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void dispatchInterceptor() {
+    void dispatchInterceptor() {
         List<Object> results = new LinkedList<>();
         testSubject.registerDispatchInterceptor(messages -> (a, b) -> {
             results.add(b.getPayload());
@@ -400,7 +400,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void reconnectAfterConnectionLost() {
+    void reconnectAfterConnectionLost() {
         testSubject.subscribe(String.class.getName(), c -> "Done");
         assertWithin(
                 1,
@@ -422,7 +422,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void subscribeWithLoadFactor() {
+    void subscribeWithLoadFactor() {
         testSubject.subscribe(String.class.getName(), c -> "Done");
         assertWithin(2, TimeUnit.SECONDS, () -> {
             Optional<CommandSubscription> subscription = dummyMessagePlatformServer.subscriptionForCommand(String.class
@@ -433,7 +433,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void resubscribeWithLoadFactor() throws IOException {
+    void resubscribeWithLoadFactor() throws IOException {
         testSubject.subscribe(String.class.getName(), c -> "Done");
         assertWithin(2, TimeUnit.SECONDS, () -> {
             Optional<CommandSubscription> subscription = dummyMessagePlatformServer.subscriptionForCommand(String.class
@@ -455,7 +455,7 @@ public class AxonServerCommandBusTest {
     }
 
     @Test
-    public void testLocalSegmentReturnsLocalCommandBus() {
+    void testLocalSegmentReturnsLocalCommandBus() {
         assertEquals(localSegment, testSubject.localSegment());
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
@@ -23,41 +23,34 @@ import io.axoniq.axonserver.grpc.command.CommandResponse;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.commandhandling.*;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.*;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Author: marc
  */
-@RunWith(Parameterized.class)
-public class CommandSerializerTest {
+class CommandSerializerTest {
 
-    private final CommandSerializer testSubject;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<?> data() {
-        return Arrays.asList(new Object[]{"JacksonSerializer", JacksonSerializer.defaultSerializer()},
-                             new Object[]{"XStreamSerializer", XStreamSerializer.defaultSerializer()});
-    }
-
-    public CommandSerializerTest(@SuppressWarnings("unused") String name, Serializer serializer) {
+    public static Stream<CommandSerializer> data() {
         AxonServerConfiguration configuration = new AxonServerConfiguration() {{
             this.setClientId("client");
             this.setComponentName("component");
         }};
-        testSubject = new CommandSerializer(serializer, configuration);
+        return Stream.of(JacksonSerializer.defaultSerializer(),
+                         XStreamSerializer.defaultSerializer())
+                .map(serializer -> new CommandSerializer(serializer, configuration));
     }
 
-    @Test
-    public void testSerializeRequest() {
+    @MethodSource("data")
+    @ParameterizedTest
+    public void testSerializeRequest(CommandSerializer testSubject) {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");
@@ -73,8 +66,9 @@ public class CommandSerializerTest {
         assertEquals(message.getPayload(), deserialize.getPayload());
     }
 
-    @Test
-    public void testSerializeResponse() {
+    @MethodSource("data")
+    @ParameterizedTest
+    void testSerializeResponse(CommandSerializer testSubject) {
         CommandResultMessage response = new GenericCommandResultMessage<>("response",
                                                                           MetaData.with("test", "testValue"));
         CommandProviderOutbound outbound = testSubject.serialize(response, "requestIdentifier");
@@ -87,8 +81,9 @@ public class CommandSerializerTest {
         assertFalse(response.optionalExceptionResult().isPresent());
     }
 
-    @Test
-    public void testSerializeExceptionalResponse() {
+    @MethodSource("data")
+    @ParameterizedTest
+    void testSerializeExceptionalResponse(CommandSerializer testSubject) {
         RuntimeException exception = new RuntimeException("oops");
         CommandResultMessage response = new GenericCommandResultMessage<>(exception,
                                                                           MetaData.with("test", "testValue"));
@@ -102,8 +97,9 @@ public class CommandSerializerTest {
         assertEquals(exception.getMessage(), deserialize.exceptionResult().getMessage());
     }
 
-    @Test
-    public void testSerializeExceptionalResponseWithDetails() {
+    @MethodSource("data")
+    @ParameterizedTest
+    void testSerializeExceptionalResponseWithDetails(CommandSerializer testSubject) {
         Exception exception = new CommandExecutionException("oops", null, "Details");
         CommandResultMessage<?> response = new GenericCommandResultMessage<>(exception,
                                                                              MetaData.with("test", "testValue"));
@@ -121,8 +117,9 @@ public class CommandSerializerTest {
         assertEquals("Details", ((CommandExecutionException) actual).getDetails().orElse("None"));
     }
 
-    @Test
-    public void testDeserializeResponseWithoutPayload() {
+    @MethodSource("data")
+    @ParameterizedTest
+    void testDeserializeResponseWithoutPayload(CommandSerializer testSubject) {
         CommandResponse response = CommandResponse.newBuilder()
                                                   .setRequestIdentifier("requestId")
                                                   .putAllMetaData(Collections.singletonMap("meta-key", MetaDataValue.newBuilder().setTextValue("meta-value").build()))

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
@@ -50,7 +50,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    public void testSerializeRequest(CommandSerializer testSubject) {
+    void testSerializeRequest(CommandSerializer testSubject) {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/GrpcBackedCommandMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/GrpcBackedCommandMessageTest.java
@@ -23,11 +23,11 @@ import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test all the functions provided on the {@link GrpcBackedCommandMessage}. The {@link Command} to be passed to a
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcBackedCommandMessageTest {
+class GrpcBackedCommandMessageTest {
 
     private static final TestCommand TEST_COMMAND = new TestCommand("aggregateId", 42);
     private static final String ROUTING_KEY = "someRoutingKey";
@@ -46,7 +46,7 @@ public class GrpcBackedCommandMessageTest {
             new CommandSerializer(serializer, new AxonServerConfiguration());
 
     @Test
-    public void testGetCommandNameReturnsTheNameOfTheCommandAsSpecifiedInTheGrpcCommand() {
+    void testGetCommandNameReturnsTheNameOfTheCommandAsSpecifiedInTheGrpcCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -55,7 +55,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheGrpcCommand() {
+    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheGrpcCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -64,7 +64,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheGrpcCommand() {
+    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheGrpcCommand() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(expectedMetaData);
@@ -75,7 +75,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheGrpcCommand() {
+    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheGrpcCommand() {
         TestCommand expectedCommand = TEST_COMMAND;
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(expectedCommand);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
@@ -85,7 +85,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsTheTypeOfTheInsertedCommand() {
+    void testGetPayloadTypeReturnsTheTypeOfTheInsertedCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -94,7 +94,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(testMetaData);
@@ -110,7 +110,7 @@ public class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    public void testAndMetaDataAppendsToTheExistingMetaData() {
+    void testAndMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClientTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStoreClientTest.java
@@ -10,7 +10,7 @@ import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.TestStreamObserver;
 import org.axonframework.axonserver.connector.command.DummyMessagePlatformServer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.time.Instant;
 
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Steven van Beelen
  */
-public class AxonServerEventStoreClientTest {
+class AxonServerEventStoreClientTest {
 
     private static final String BOUNDED_CONTEXT = "not-important";
 
@@ -32,8 +32,8 @@ public class AxonServerEventStoreClientTest {
 
     private AxonServerEventStoreClient testSubject;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         dummyMessagePlatformServer = new DummyMessagePlatformServer(4344);
         dummyMessagePlatformServer.start();
 
@@ -52,14 +52,14 @@ public class AxonServerEventStoreClientTest {
         testSubject = new AxonServerEventStoreClient(configuration, axonServerConnectionManager);
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         dummyMessagePlatformServer.stop();
         axonServerConnectionManager.shutdown();
     }
 
     @Test
-    public void testListAggregateEvents() {
+    void testListAggregateEvents() {
         GetAggregateEventsRequest testRequest = GetAggregateEventsRequest.getDefaultInstance();
 
         testSubject.listAggregateEvents(testRequest);
@@ -68,7 +68,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testListAggregateEventsWithContext() {
+    void testListAggregateEventsWithContext() {
         GetAggregateEventsRequest testRequest = GetAggregateEventsRequest.getDefaultInstance();
 
         testSubject.listAggregateEvents(BOUNDED_CONTEXT, testRequest);
@@ -77,7 +77,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testListEvents() {
+    void testListEvents() {
         StreamObserver<EventWithToken> testStreamObserver = new TestStreamObserver<>();
 
         testSubject.listEvents(testStreamObserver);
@@ -86,7 +86,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testListEventsWithContext() {
+    void testListEventsWithContext() {
         StreamObserver<EventWithToken> testStreamObserver = new TestStreamObserver<>();
 
         testSubject.listEvents(BOUNDED_CONTEXT, testStreamObserver);
@@ -95,7 +95,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testAppendSnapshot() {
+    void testAppendSnapshot() {
         Event testSnapshotEvent = Event.getDefaultInstance();
 
         testSubject.appendSnapshot(testSnapshotEvent);
@@ -104,7 +104,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testAppendSnapshotWithContext() {
+    void testAppendSnapshotWithContext() {
         Event testSnapshotEvent = Event.getDefaultInstance();
 
         testSubject.appendSnapshot(BOUNDED_CONTEXT, testSnapshotEvent);
@@ -113,35 +113,35 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testGetLastToken() {
+    void testGetLastToken() {
         testSubject.getLastToken();
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testGetLastTokenWithContext() {
+    void testGetLastTokenWithContext() {
         testSubject.getLastToken(BOUNDED_CONTEXT);
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testGetFirstToken() {
+    void testGetFirstToken() {
         testSubject.getFirstToken();
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testGetFirstTokenWithContext() {
+    void testGetFirstTokenWithContext() {
         testSubject.getFirstToken(BOUNDED_CONTEXT);
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testGetTokenAt() {
+    void testGetTokenAt() {
         Instant testInstant = Instant.now();
 
         testSubject.getTokenAt(testInstant);
@@ -150,7 +150,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testGetTokenAtWithContext() {
+    void testGetTokenAtWithContext() {
         Instant testInstant = Instant.now();
 
         testSubject.getTokenAt(BOUNDED_CONTEXT, testInstant);
@@ -159,21 +159,21 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testCreateAppendEventConnection() {
+    void testCreateAppendEventConnection() {
         testSubject.createAppendEventConnection();
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testCreateAppendEventConnectionWithContext() {
+    void testCreateAppendEventConnectionWithContext() {
         testSubject.createAppendEventConnection(BOUNDED_CONTEXT);
 
         verify(axonServerConnectionManager).getChannel(BOUNDED_CONTEXT);
     }
 
     @Test
-    public void testQuery() {
+    void testQuery() {
         StreamObserver<QueryEventsResponse> testSreamObserver = new TestStreamObserver<>();
 
         testSubject.query(testSreamObserver);
@@ -182,7 +182,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testQueryWithContext() {
+    void testQueryWithContext() {
         StreamObserver<QueryEventsResponse> testSreamObserver = new TestStreamObserver<>();
 
         testSubject.query(BOUNDED_CONTEXT, testSreamObserver);
@@ -191,7 +191,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testLastSequenceNumberFor() {
+    void testLastSequenceNumberFor() {
         String testAggregateId = "some-id";
 
         testSubject.lastSequenceNumberFor(testAggregateId);
@@ -200,7 +200,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testLastSequenceNumberForWithContext() {
+    void testLastSequenceNumberForWithContext() {
         String testAggregateId = "some-id";
 
         testSubject.lastSequenceNumberFor(BOUNDED_CONTEXT, testAggregateId);
@@ -209,7 +209,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testListAggregateSnapshots() {
+    void testListAggregateSnapshots() {
         GetAggregateSnapshotsRequest testRequest = GetAggregateSnapshotsRequest.getDefaultInstance();
 
         testSubject.listAggregateSnapshots(testRequest);
@@ -218,7 +218,7 @@ public class AxonServerEventStoreClientTest {
     }
 
     @Test
-    public void testListAggregateSnapshotsWithContext() {
+    void testListAggregateSnapshotsWithContext() {
         GetAggregateSnapshotsRequest testRequest = GetAggregateSnapshotsRequest.getDefaultInstance();
 
         testSubject.listAggregateSnapshots(BOUNDED_CONTEXT, testRequest);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -31,9 +31,9 @@ import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,18 +41,18 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class AxonServerEventStoreTest {
+class AxonServerEventStoreTest {
 
     private StubServer server;
     private AxonServerEventStore testSubject;
     private EventUpcaster upcasterChain;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         server = new StubServer(6123);
         server.start();
         upcasterChain = mock(EventUpcaster.class);
@@ -75,13 +75,13 @@ public class AxonServerEventStoreTest {
                                           .build();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         server.shutdown();
     }
 
     @Test
-    public void testPublishAndConsumeEvents() throws Exception {
+    void testPublishAndConsumeEvents() throws Exception {
         UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         testSubject.publish(GenericEventMessage.asEventMessage("Test1"),
                             GenericEventMessage.asEventMessage("Test2"),
@@ -100,7 +100,7 @@ public class AxonServerEventStoreTest {
     }
 
     @Test
-    public void testLoadEventsWithMultiUpcaster() {
+    void testLoadEventsWithMultiUpcaster() {
         reset(upcasterChain);
         when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
             Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
@@ -122,7 +122,7 @@ public class AxonServerEventStoreTest {
     }
 
     @Test
-    public void testLoadSnapshotAndEventsWithMultiUpcaster() {
+    void testLoadSnapshotAndEventsWithMultiUpcaster() {
         reset(upcasterChain);
         when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
             Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
@@ -142,13 +142,13 @@ public class AxonServerEventStoreTest {
         assertFalse(actual.hasNext());
     }
 
-    @Test(expected = EventStoreException.class)
-    public void testLastSequenceNumberFor() {
-        testSubject.lastSequenceNumberFor("Agg1");
+    @Test
+    void testLastSequenceNumberFor() {
+        assertThrows(EventStoreException.class, () -> testSubject.lastSequenceNumberFor("Agg1"));
     }
 
     @Test
-    public void testCreateStreamableMessageSourceForContext() {
+    void testCreateStreamableMessageSourceForContext() {
         assertNotNull(testSubject.createStreamableMessageSourceForContext("some-context"));
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/ErrorCodeTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/ErrorCodeTest.java
@@ -21,19 +21,19 @@ import org.axonframework.axonserver.connector.AxonServerException;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.common.AxonException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**
  * Author: marc
  */
-public class ErrorCodeTest {
+class ErrorCodeTest {
 
     @Test
-    public void testConvert4002FromCodeAndMessage() {
+    void testConvert4002FromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("AXONIQ-4002");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build(), () -> "myCustomObject");
         assertTrue(exception instanceof CommandExecutionException);
@@ -42,7 +42,7 @@ public class ErrorCodeTest {
     }
 
     @Test
-    public void testConvertUnknownFromCodeAndMessage() {
+    void testConvertUnknownFromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("????????");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build());
         assertTrue(exception instanceof AxonServerException);
@@ -50,7 +50,7 @@ public class ErrorCodeTest {
     }
 
     @Test
-    public void testConvertWithoutSource() {
+    void testConvertWithoutSource() {
         RuntimeException exception = new RuntimeException("oops");
         AxonException axonException = ErrorCode.getFromCode("AXONIQ-4002").convert(exception);
         assertEquals(exception.getMessage(), axonException.getMessage());

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
@@ -26,7 +26,8 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.stubbing.*;
 
 import java.util.UUID;
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.*;
  * @author Marc Gathier
  * @author Steven van Beelen
  */
-public class EventBufferTest {
+class EventBufferTest {
 
     private EventUpcaster stubUpcaster;
     private XStreamSerializer serializer;
@@ -54,8 +55,8 @@ public class EventBufferTest {
 
     private org.axonframework.serialization.SerializedObject<byte[]> serializedObject;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         stubUpcaster = mock(EventUpcaster.class);
         //noinspection unchecked
         when(stubUpcaster.upcast(any()))
@@ -70,7 +71,7 @@ public class EventBufferTest {
     }
 
     @Test
-    public void testDataUpcastAndDeserialized() throws InterruptedException {
+    void testDataUpcastAndDeserialized() throws InterruptedException {
         assertFalse(testSubject.hasNextAvailable());
         testSubject.push(createEventData(1L));
         assertTrue(testSubject.hasNextAvailable());
@@ -91,7 +92,7 @@ public class EventBufferTest {
     }
 
     @Test
-    public void testConsumptionIsRecorded() {
+    void testConsumptionIsRecorded() {
         testSubject = new EventBuffer(stream -> stream.filter(i -> false), serializer);
 
         testSubject.push(createEventData(1));
@@ -105,8 +106,9 @@ public class EventBufferTest {
         assertEquals(3, consumed.get());
     }
 
-    @Test(timeout = 2000)
-    public void testNextAvailableDoesNotBlockIndefinitelyIfTheStreamIsClosedExceptionally()
+    @Test
+    @Timeout(value = 2)
+    void testNextAvailableDoesNotBlockIndefinitelyIfTheStreamIsClosedExceptionally()
             throws InterruptedException {
         RuntimeException expected = new RuntimeException("Some Exception");
         AtomicReference<Exception> result = new AtomicReference<>();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/util/EventCipherTests.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/util/EventCipherTests.java
@@ -18,21 +18,21 @@ package org.axonframework.axonserver.connector.event.util;
 import com.google.protobuf.ByteString;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.SerializedObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class EventCipherTests {
+class EventCipherTests {
 
     /**
      * Most basic test of a simple encryption scenario.
      */
     @Test
-    public void smoke() {
+    void smoke() {
         String message = "Hello World! AxonIQ Rulez!";
         String aggregateIdentifier = "1234";
         byte[] clearPayload = message.getBytes(StandardCharsets.UTF_8);
@@ -58,7 +58,7 @@ public class EventCipherTests {
     }
 
     @Test
-    public void defaultEventCipherShouldNotEncrypt() {
+    void defaultEventCipherShouldNotEncrypt() {
         String message = "Hello World! AxonIQ Rulez!";
         String aggregateIdentifier = "1234";
         byte[] clearPayload = message.getBytes(StandardCharsets.UTF_8);
@@ -80,7 +80,7 @@ public class EventCipherTests {
     }
 
     @Test
-    public void encryptionShouldBeRandom() {
+    void encryptionShouldBeRandom() {
         String message = "Hello World! AxonIQ Rulez!";
         String aggregateIdentifier = "1234";
         byte[] clearPayload = message.getBytes(StandardCharsets.UTF_8);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatConnectionCheckerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatConnectionCheckerTest.java
@@ -2,24 +2,24 @@ package org.axonframework.axonserver.connector.heartbeat;
 
 import org.axonframework.axonserver.connector.utils.FakeClock;
 import org.axonframework.axonserver.connector.heartbeat.connection.checker.HeartbeatConnectionChecker;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link HeartbeatConnectionChecker}.
  *
  * @author Sara Pellegrini
  */
-public class HeartbeatConnectionCheckerTest {
+class HeartbeatConnectionCheckerTest {
 
     @Test
-    public void testHeartbeatNeverReceived() {
+    void testHeartbeatNeverReceived() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
                                                                       r -> {
@@ -31,7 +31,7 @@ public class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    public void testHeartbeatProperlyReceived() {
+    void testHeartbeatProperlyReceived() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
@@ -44,7 +44,7 @@ public class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    public void testHeartbeatReceivedLate() {
+    void testHeartbeatReceivedLate() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
@@ -57,7 +57,7 @@ public class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    public void testDelegateDetectsBrokenConnection() {
+    void testDelegateDetectsBrokenConnection() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitorTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitorTest.java
@@ -1,21 +1,21 @@
 package org.axonframework.axonserver.connector.heartbeat;
 
 import org.axonframework.axonserver.connector.utils.FakeScheduler;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link HeartbeatMonitor}
  *
  * @author Sara Pellegrini
  */
-public class HeartbeatMonitorTest {
+class HeartbeatMonitorTest {
 
     @Test
-    public void testConnectionAlive() {
+    void testConnectionAlive() {
         FakeScheduler fakeScheduler = new FakeScheduler();
         AtomicBoolean reconnect = new AtomicBoolean(false);
         HeartbeatMonitor monitor = new HeartbeatMonitor(() -> reconnect.set(true),
@@ -32,7 +32,7 @@ public class HeartbeatMonitorTest {
     }
 
     @Test
-    public void testDisconnection() {
+    void testDisconnection() {
         FakeScheduler fakeScheduler = new FakeScheduler();
         AtomicBoolean reconnect = new AtomicBoolean(false);
         HeartbeatMonitor monitor = new HeartbeatMonitor(() -> reconnect.set(true),

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -17,7 +17,7 @@
 package org.axonframework.axonserver.connector.processor;
 
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.function.Consumer;
 
@@ -25,13 +25,13 @@ import static io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction.Requ
 import static org.axonframework.axonserver.connector.TestTargetContextResolver.BOUNDED_CONTEXT;
 import static org.mockito.Mockito.*;
 
-public class EventProcessorControlServiceTest {
+class EventProcessorControlServiceTest {
 
     private final AxonServerConnectionManager axonServerConnectionManager = mock(AxonServerConnectionManager.class);
     private final EventProcessorController eventProcessorController = mock(EventProcessorController.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(axonServerConnectionManager.getDefaultContext()).thenReturn(BOUNDED_CONTEXT);
 
         EventProcessorControlService testSubject =
@@ -41,7 +41,7 @@ public class EventProcessorControlServiceTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testStartAddOutboundInstructionToTheAxonServerConnectionManager() {
+    void testStartAddOutboundInstructionToTheAxonServerConnectionManager() {
         verify(axonServerConnectionManager).onOutboundInstruction(
                 eq(BOUNDED_CONTEXT), eq(PAUSE_EVENT_PROCESSOR), any(Consumer.class)
         );

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControllerTest.java
@@ -20,15 +20,15 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class EventProcessorControllerTest {
+class EventProcessorControllerTest {
 
     private static final String TRACKING_PROCESSOR_NAME = "some-event-processor-name";
     private static final String SUBSCRIBING_PROCESSOR_NAME = "some-other-processor";
@@ -41,8 +41,8 @@ public class EventProcessorControllerTest {
     private final TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
     private final SubscribingEventProcessor testSubscribingProcessor = mock(SubscribingEventProcessor.class);
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(eventProcessingConfiguration.eventProcessor(TRACKING_PROCESSOR_NAME))
                 .thenReturn(Optional.of(testTrackingProcessor));
         when(eventProcessingConfiguration.eventProcessor(SUBSCRIBING_PROCESSOR_NAME))
@@ -53,47 +53,47 @@ public class EventProcessorControllerTest {
     }
 
     @Test
-    public void testGetEventProcessorReturnsAnEventProcessor() {
+    void testGetEventProcessorReturnsAnEventProcessor() {
         EventProcessor result = testSubject.getEventProcessor(TRACKING_PROCESSOR_NAME);
 
         assertEquals(testTrackingProcessor, result);
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testGetEventProcessorThrowsRuntimeExceptionForNonExistingProcessor() {
-        testSubject.getEventProcessor("non-existing-processor");
+    @Test
+    void testGetEventProcessorThrowsRuntimeExceptionForNonExistingProcessor() {
+        assertThrows(RuntimeException.class, () -> testSubject.getEventProcessor("non-existing-processor"));
     }
 
     @Test
-    public void testPauseProcessorCallsShutdownOnAnEventProcessor() {
+    void testPauseProcessorCallsShutdownOnAnEventProcessor() {
         testSubject.pauseProcessor(TRACKING_PROCESSOR_NAME);
 
         verify(testTrackingProcessor).shutDown();
     }
 
     @Test
-    public void testStartProcessorCallsStartOnAnEventProcessor() {
+    void testStartProcessorCallsStartOnAnEventProcessor() {
         testSubject.startProcessor(TRACKING_PROCESSOR_NAME);
 
         verify(testTrackingProcessor).start();
     }
 
     @Test
-    public void testReleaseSegmentCallsReleaseSegmentOnAnEventProcessor() {
+    void testReleaseSegmentCallsReleaseSegmentOnAnEventProcessor() {
         testSubject.releaseSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
 
         verify(testTrackingProcessor).releaseSegment(SEGMENT_ID);
     }
 
     @Test
-    public void testReleaseSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+    void testReleaseSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
         testSubject.releaseSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
 
         verifyZeroInteractions(testSubscribingProcessor);
     }
 
     @Test
-    public void testSplitSegmentCallSplitOnAnEventProcessor() {
+    void testSplitSegmentCallSplitOnAnEventProcessor() {
         boolean result = testSubject.splitSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
 
         verify(testTrackingProcessor).splitSegment(SEGMENT_ID);
@@ -101,15 +101,15 @@ public class EventProcessorControllerTest {
     }
 
     @Test
-    public void testSplitSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+    void testSplitSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
         boolean result = testSubject.splitSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
 
         verifyZeroInteractions(testSubscribingProcessor);
         assertFalse(result);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testSplitSegmentThrowsAnExceptionIfSplittingFails() {
+    @Test
+    void testSplitSegmentThrowsAnExceptionIfSplittingFails() {
         String testEventProcessorName = "failing-event-processor";
         TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
 
@@ -117,11 +117,11 @@ public class EventProcessorControllerTest {
                 .thenReturn(Optional.of(testTrackingProcessor));
         when(testTrackingProcessor.splitSegment(SEGMENT_ID)).thenThrow(new IllegalStateException("some-exception"));
 
-        testSubject.splitSegment(testEventProcessorName, SEGMENT_ID);
+        assertThrows(IllegalStateException.class, () -> testSubject.splitSegment(testEventProcessorName, SEGMENT_ID));
     }
 
     @Test
-    public void testMergeSegmentCallMergeOnAnEventProcessor() {
+    void testMergeSegmentCallMergeOnAnEventProcessor() {
         boolean result = testSubject.mergeSegment(TRACKING_PROCESSOR_NAME, SEGMENT_ID);
 
         verify(testTrackingProcessor).mergeSegment(SEGMENT_ID);
@@ -129,15 +129,15 @@ public class EventProcessorControllerTest {
     }
 
     @Test
-    public void testMergeSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
+    void testMergeSegmentDoesNothingIfTheEventProcessorIsNotOfTypeTracking() {
         boolean result = testSubject.mergeSegment(SUBSCRIBING_PROCESSOR_NAME, SEGMENT_ID);
 
         verifyZeroInteractions(testSubscribingProcessor);
         assertFalse(result);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testMergeSegmentThrowsAnExceptionIfMergingFails() {
+    @Test
+    void testMergeSegmentThrowsAnExceptionIfMergingFails() {
         String testEventProcessorName = "failing-event-processor";
         TrackingEventProcessor testTrackingProcessor = mock(TrackingEventProcessor.class);
 
@@ -145,6 +145,6 @@ public class EventProcessorControllerTest {
                 .thenReturn(Optional.of(testTrackingProcessor));
         when(testTrackingProcessor.mergeSegment(SEGMENT_ID)).thenThrow(new IllegalStateException("some-exception"));
 
-        testSubject.mergeSegment(testEventProcessorName, SEGMENT_ID);
+        assertThrows(IllegalStateException.class, () -> testSubject.mergeSegment(testEventProcessorName, SEGMENT_ID));
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSourceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/GrpcEventProcessorInfoSourceTest.java
@@ -6,7 +6,7 @@ import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Map;
 
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcEventProcessorInfoSourceTest {
+class GrpcEventProcessorInfoSourceTest {
 
     private static final String BOUNDED_CONTEXT = "some-context";
 
@@ -29,7 +29,7 @@ public class GrpcEventProcessorInfoSourceTest {
     );
 
     @Test
-    public void testNotifyInformation() {
+    void testNotifyInformation() {
         EventProcessor mockEventProcessor = mock(TrackingEventProcessor.class);
         when(mockEventProcessor.getName()).thenReturn("eventProcessor");
         Map<String, EventProcessor> testEventProcessors = ImmutableMap.of("eventProcessor", mockEventProcessor);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/TrackingEventProcessorInfoMessageTest.java
@@ -20,35 +20,31 @@ import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
 import org.axonframework.eventhandling.EventTrackerStatus;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.axonframework.eventhandling.Segment.ROOT_SEGMENT;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by Sara Pellegrini on 01/08/2018.
  * sara.pellegrini@gmail.com
  */
-@RunWith(MockitoJUnitRunner.class)
-public class TrackingEventProcessorInfoMessageTest {
-
-    @Mock
-    private TrackingEventProcessor trackingEventProcessor;
-
+@ExtendWith(MockitoExtension.class)
+class TrackingEventProcessorInfoMessageTest {
     private Map<Integer, EventTrackerStatus> processingStatus = new HashMap<Integer, EventTrackerStatus>(){{
         this.put(0, new FakeEventTrackerStatus(ROOT_SEGMENT.split()[0], true, false, new GlobalSequenceTrackingToken(100), null));
         this.put(1, new FakeEventTrackerStatus(ROOT_SEGMENT.split()[1], true, false, new GlobalSequenceTrackingToken(100), new RuntimeException("Testing")));
     }};
 
     @Test
-    public void instruction() {
+    void instruction(@Mock TrackingEventProcessor trackingEventProcessor) {
         when(trackingEventProcessor.processingStatus()).thenReturn(processingStatus);
         when(trackingEventProcessor.getName()).thenReturn("ProcessorName");
         when(trackingEventProcessor.activeProcessorThreads()).thenReturn(3);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/schedule/ScheduledEventProcessorInfoSourceTest.java
@@ -18,36 +18,36 @@ package org.axonframework.axonserver.connector.processor.schedule;
 
 import org.axonframework.axonserver.connector.processor.FakeEventProcessorInfoSource;
 import org.axonframework.axonserver.connector.utils.AssertUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by Sara Pellegrini on 23/03/2018.
  * sara.pellegrini@gmail.com
  */
-public class ScheduledEventProcessorInfoSourceTest {
+class ScheduledEventProcessorInfoSourceTest {
 
     private ScheduledEventProcessorInfoSource scheduled;
     private FakeEventProcessorInfoSource delegate;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         delegate = new FakeEventProcessorInfoSource();
         scheduled = new ScheduledEventProcessorInfoSource(50, 30, delegate);
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         scheduled.shutdown();
     }
 
     @Test
-    public void notifyInformation() throws InterruptedException {
+    void notifyInformation() throws InterruptedException {
         scheduled.start();
         TimeUnit.MILLISECONDS.sleep(50);
         AssertUtils.assertWithin(100, TimeUnit.MILLISECONDS, () -> assertEquals(2, delegate.notifyCalls()));

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -41,7 +41,7 @@ import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -59,7 +59,7 @@ import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWit
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.messaging.responsetypes.ResponseTypes.instanceOf;
 import static org.axonframework.messaging.responsetypes.ResponseTypes.optionalInstanceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
@@ -69,7 +69,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Marc Gathier
  */
-public class AxonServerQueryBusTest {
+class AxonServerQueryBusTest {
 
     private DummyMessagePlatformServer dummyMessagePlatformServer;
 
@@ -81,8 +81,8 @@ public class AxonServerQueryBusTest {
 
     private AxonServerQueryBus testSubject;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         dummyMessagePlatformServer = new DummyMessagePlatformServer(4343);
         dummyMessagePlatformServer.start();
 
@@ -109,15 +109,15 @@ public class AxonServerQueryBusTest {
                                         .build();
     }
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         dummyMessagePlatformServer.stop();
         axonServerConnectionManager.shutdown();
         testSubject.disconnect();
     }
 
     @Test
-    public void subscribe() throws Exception {
+    void subscribe() throws Exception {
         Registration result = testSubject.subscribe("testQuery", String.class, q -> "test");
 
         Thread.sleep(1000);
@@ -139,7 +139,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void query() throws Exception {
+    void query() throws Exception {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class));
 
         assertEquals("test", testSubject.query(testQuery).get().getPayload());
@@ -148,7 +148,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void queryWhenQueryServiceStubFails() {
+    void queryWhenQueryServiceStubFails() {
         AxonServerConnectionManager axonServerConnectionManager =
                 AxonServerConnectionManager.builder()
                                            .axonServerConfiguration(configuration)
@@ -185,7 +185,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void testQueryReportsCorrectException() throws ExecutionException, InterruptedException {
+    void testQueryReportsCorrectException() throws ExecutionException, InterruptedException {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class))
                 .andMetaData(Collections.singletonMap("errorCode", ErrorCode.QUERY_EXECUTION_ERROR.errorCode()));
 
@@ -205,7 +205,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void processQuery() {
+    void processQuery() {
         AxonServerQueryBus testSubject = AxonServerQueryBus.builder()
                                                            .axonServerConnectionManager(axonServerConnectionManager)
                                                            .configuration(configuration)
@@ -229,7 +229,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void unsupportedQueryInstruction() {
+    void unsupportedQueryInstruction() {
         TestStreamObserver<QueryProviderOutbound> requestStream = new TestStreamObserver<>();
         AxonServerQueryBus testSubject = AxonServerQueryBus.builder()
                                                            .axonServerConnectionManager(axonServerConnectionManager)
@@ -266,7 +266,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void unsupportedQueryInstructionWithoutInstructionId() {
+    void unsupportedQueryInstructionWithoutInstructionId() {
         TestStreamObserver<QueryProviderOutbound> requestStream = new TestStreamObserver<>();
         AxonServerQueryBus testSubject = AxonServerQueryBus.builder()
                                                            .axonServerConnectionManager(axonServerConnectionManager)
@@ -293,7 +293,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void scatterGather() {
+    void scatterGather() {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class))
                 .andMetaData(MetaData.with("repeat", 10).and("interval", 10));
 
@@ -303,7 +303,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void queryForOptionalWillRequestInstanceOfFromRemoteDestination() {
+    void queryForOptionalWillRequestInstanceOfFromRemoteDestination() {
         QueryMessage<String, Optional<String>> testQuery = new GenericQueryMessage<>("Hello, World", optionalInstanceOf(String.class))
                 .andMetaData(MetaData.with("repeat", 10).and("interval", 10));
 
@@ -316,7 +316,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void scatterGatherTimeout() {
+    void scatterGatherTimeout() {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class))
                 .andMetaData(MetaData.with("repeat", 10).and("interval", 100));
 
@@ -326,7 +326,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void testSubscriptionQueryIsHandledByDispatchInterceptors() {
+    void testSubscriptionQueryIsHandledByDispatchInterceptors() {
         AtomicInteger counter = new AtomicInteger(0);
 
         // Add a dispatch interceptor which increase the counter, to check whether it was called during a sub.query
@@ -347,7 +347,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void dispatchInterceptor() {
+    void dispatchInterceptor() {
         List<Object> results = new LinkedList<>();
         testSubject.registerDispatchInterceptor(messages -> (a, b) -> {
             results.add(b.getPayload());
@@ -360,7 +360,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void handlerInterceptor() {
+    void handlerInterceptor() {
         AxonServerQueryBus testSubject = AxonServerQueryBus.builder()
                                                            .axonServerConnectionManager(axonServerConnectionManager)
                                                            .configuration(configuration)
@@ -388,7 +388,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void reconnectAfterConnectionLost() throws InterruptedException {
+    void reconnectAfterConnectionLost() throws InterruptedException {
         testSubject.subscribe("testQuery", String.class, q -> "test");
 
         Thread.sleep(50);
@@ -403,7 +403,7 @@ public class AxonServerQueryBusTest {
     }
 
     @Test
-    public void testLocalSegmentReturnsLocalQueryBus() {
+    void testLocalSegmentReturnsLocalQueryBus() {
         assertEquals(localSegment, testSubject.localSegment());
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
@@ -25,11 +25,11 @@ import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test all the functions provided on the {@link GrpcBackedQueryMessage}. The {@link QueryRequest} to be passed to a
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcBackedQueryMessageTest {
+class GrpcBackedQueryMessageTest {
 
     private static final TestQuery TEST_QUERY = new TestQuery("aggregateId", 42);
     private static final ResponseType<String> RESPONSE_TYPE = ResponseTypes.instanceOf(String.class);
@@ -50,7 +50,7 @@ public class GrpcBackedQueryMessageTest {
             new QuerySerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    public void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheQueryRequest() {
+    void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -61,7 +61,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheQueryRequest() {
+    void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheQueryRequest() {
         ResponseType<String> expectedResponseType = RESPONSE_TYPE;
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, expectedResponseType);
         QueryRequest testQueryRequest =
@@ -75,7 +75,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryRequest() {
+    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -86,7 +86,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryRequest() {
+    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryRequest() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(expectedMetaData);
@@ -99,7 +99,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
+    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
         TestQuery expectedQuery = TEST_QUERY;
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(expectedQuery, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
@@ -111,7 +111,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryRequest() {
+    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -122,7 +122,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(testMetaData);
@@ -140,7 +140,7 @@ public class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    public void testAndMetaDataAppendsToTheExistingMetaData() {
+    void testAndMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
@@ -23,14 +23,14 @@ import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class GrpcBackedResponseMessageTest {
+class GrpcBackedResponseMessageTest {
 
     private static final TestQueryResponse TEST_QUERY_RESPONSE = new TestQueryResponse("aggregateId", 42);
     private static final String REQUEST_MESSAGE_ID = "request-message-id";
@@ -40,7 +40,7 @@ public class GrpcBackedResponseMessageTest {
             new QuerySerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    public void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryResponseMessage() {
+    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TEST_QUERY_RESPONSE);
         QueryResponse testQueryResponse =
@@ -52,7 +52,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryResponseMessage() {
+    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryResponseMessage() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)
@@ -66,7 +66,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
+    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
         TestQueryResponse expectedQuery = TEST_QUERY_RESPONSE;
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(expectedQuery);
@@ -79,7 +79,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
+    void testGetPayloadReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -93,7 +93,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryResponseMessage() {
+    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TEST_QUERY_RESPONSE);
         QueryResponse testQueryResponse =
@@ -105,7 +105,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
+    void testGetPayloadTypeReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -119,7 +119,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testIsExceptionalReturnsTrueForAnExceptionalQueryResponseMessage() {
+    void testIsExceptionalReturnsTrueForAnExceptionalQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -133,7 +133,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testOptionalExceptionResultReturnsTheExceptionAsAsInsertedThroughTheQueryResponseMessage() {
+    void testOptionalExceptionResultReturnsTheExceptionAsAsInsertedThroughTheQueryResponseMessage() {
         IllegalArgumentException expectedException = new IllegalArgumentException("some-exception");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TestQueryResponse.class, expectedException);
@@ -148,7 +148,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)
@@ -167,7 +167,7 @@ public class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    public void testAndMetaDataAppendsToTheExistingMetaData() {
+    void testAndMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
@@ -24,21 +24,21 @@ import org.axonframework.queryhandling.*;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.axonframework.messaging.responsetypes.ResponseTypes.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by Sara Pellegrini on 28/06/2018.
  * sara.pellegrini@gmail.com
  */
-public class QuerySerializerTest {
+class QuerySerializerTest {
 
     private final Serializer xStreamSerializer = XStreamSerializer.builder().build();
 
@@ -52,7 +52,7 @@ public class QuerySerializerTest {
     private final QuerySerializer testSubject = new QuerySerializer(jacksonSerializer, xStreamSerializer, configuration);
 
     @Test
-    public void testSerializeRequest() {
+    void testSerializeRequest() {
         QueryMessage<String, Integer> message = new GenericQueryMessage<>("Test", "MyQueryName", instanceOf(int.class));
         QueryRequest queryRequest = testSubject.serializeRequest(message, 5, 10, 1);
         QueryMessage<Object, Object> deserialized = testSubject.deserializeRequest(queryRequest);
@@ -66,7 +66,7 @@ public class QuerySerializerTest {
     }
 
     @Test
-    public void testSerializeResponse() {
+    void testSerializeResponse() {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");
@@ -82,7 +82,7 @@ public class QuerySerializerTest {
     }
 
     @Test
-    public void testSerializeExceptionalResponse() {
+    void testSerializeExceptionalResponse() {
         RuntimeException exception = new RuntimeException("oops");
         GenericQueryResponseMessage responseMessage = new GenericQueryResponseMessage<>(
                 String.class,
@@ -100,7 +100,7 @@ public class QuerySerializerTest {
     }
 
     @Test
-    public void testSerializeExceptionalResponseWithDetails() {
+    void testSerializeExceptionalResponseWithDetails() {
         Exception exception = new QueryExecutionException("oops", null, "Details");
         GenericQueryResponseMessage responseMessage = new GenericQueryResponseMessage<>(
                 String.class,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
@@ -19,21 +19,20 @@ package org.axonframework.axonserver.connector.query.subscription;
 import io.axoniq.axonserver.grpc.query.*;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.queryhandling.SubscriptionQueryBackpressure;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.FluxSink;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by Sara Pellegrini on 18/06/2018.
  * sara.pellegrini@gmail.com
  */
-public class AxonServerSubscriptionQueryResultTest {
-
+class AxonServerSubscriptionQueryResultTest {
 
     private SubscriptionQuery queryMessage;
 
@@ -46,8 +45,8 @@ public class AxonServerSubscriptionQueryResultTest {
     private SubscriptionQueryResponse initialResult;
 
 
-    @Before
-    public void setUp(){
+    @BeforeEach
+    void setUp(){
         requestObserver = new FakeStreamObserver<>();
         queryMessage = SubscriptionQuery.newBuilder().build();
         update = SubscriptionQueryResponse.newBuilder().setUpdate(QueryUpdate.newBuilder()).build();
@@ -59,7 +58,7 @@ public class AxonServerSubscriptionQueryResultTest {
     }
 
     @Test
-    public void testSubscribeUpdates() {
+    void testSubscribeUpdates() {
         SubscriptionQueryBackpressure backPressure = new SubscriptionQueryBackpressure(FluxSink.OverflowStrategy.ERROR);
         AxonServerSubscriptionQueryResult target = new AxonServerSubscriptionQueryResult(
                 queryMessage, responseStream -> requestObserver, configuration, backPressure, 10, () -> {});
@@ -71,7 +70,7 @@ public class AxonServerSubscriptionQueryResultTest {
     }
 
     @Test
-    public void testSubscribeInitialResponse() {
+    void testSubscribeInitialResponse() {
         SubscriptionQueryBackpressure backPressure = new SubscriptionQueryBackpressure(FluxSink.OverflowStrategy.ERROR);
         AxonServerSubscriptionQueryResult target = new AxonServerSubscriptionQueryResult(
                 queryMessage, responseStream -> requestObserver, configuration, backPressure, 10, () -> {});
@@ -83,7 +82,7 @@ public class AxonServerSubscriptionQueryResultTest {
     }
 
     @Test
-    public void testErrorOverflowStrategy() {
+    void testErrorOverflowStrategy() {
         SubscriptionQueryBackpressure backPressure = new SubscriptionQueryBackpressure(FluxSink.OverflowStrategy.ERROR);
         AxonServerSubscriptionQueryResult target = new AxonServerSubscriptionQueryResult(
                 queryMessage, responseStream -> requestObserver, configuration, backPressure, 2, () -> {});

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
@@ -23,11 +23,11 @@ import org.axonframework.queryhandling.GenericSubscriptionQueryUpdateMessage;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test all the functions provided on the {@link GrpcBackedQueryUpdateMessage}. The {@link QueryUpdate} to be passed to
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcBackedQueryUpdateMessageTest {
+class GrpcBackedQueryUpdateMessageTest {
 
     private static final TestQueryUpdate TEST_QUERY_UPDATE = new TestQueryUpdate("aggregateId", 42);
     private static final String SUBSCRIPTION_ID = "subscription-id";
@@ -45,7 +45,7 @@ public class GrpcBackedQueryUpdateMessageTest {
             new SubscriptionMessageSerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    public void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryUpdate() {
+    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryUpdate() {
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE);
         QueryUpdate testQueryUpdate =
@@ -59,7 +59,7 @@ public class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    public void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryUpdate() {
+    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryUpdate() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(expectedMetaData);
@@ -74,7 +74,7 @@ public class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
+    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
         TestQueryUpdate expectedQueryUpdate = TEST_QUERY_UPDATE;
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(expectedQueryUpdate);
@@ -89,7 +89,7 @@ public class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryUpdate() {
+    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryUpdate() {
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE);
         QueryUpdate testQueryUpdate =
@@ -103,7 +103,7 @@ public class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    public void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(testMetaData);
@@ -123,7 +123,7 @@ public class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    public void testAndMetaDataAppendsToTheExistingMetaData() {
+    void testAndMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
@@ -25,11 +25,11 @@ import org.axonframework.queryhandling.GenericSubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test all the functions provided on the {@link GrpcBackedSubscriptionQueryMessage}. The {@link SubscriptionQuery} to
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcBackedSubscriptionQueryMessageTest {
+class GrpcBackedSubscriptionQueryMessageTest {
 
     private static final TestQuery TEST_QUERY = new TestQuery("aggregateId", 42);
     private static final ResponseType<String> RESPONSE_TYPE = ResponseTypes.instanceOf(String.class);
@@ -47,7 +47,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
             new SubscriptionMessageSerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    public void testGetUpdateResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
+    void testGetUpdateResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
         ResponseType<String> expectedUpdateResponseType = RESPONSE_TYPE;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, expectedUpdateResponseType);
@@ -62,7 +62,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheSubscriptionQuery() {
+    void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -73,7 +73,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
+    void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
         ResponseType<String> expectedResponseType = RESPONSE_TYPE;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, expectedResponseType, RESPONSE_TYPE);
@@ -87,7 +87,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheSubscriptionQuery() {
+    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -98,7 +98,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheSubscriptionQuery() {
+    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheSubscriptionQuery() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)
@@ -111,7 +111,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
+    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
         TestQuery expectedQuery = TEST_QUERY;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(expectedQuery, RESPONSE_TYPE, RESPONSE_TYPE);
@@ -123,7 +123,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testGetPayloadTypeReturnsTheTypeOfTheInsertedSubscriptionQuery() {
+    void testGetPayloadTypeReturnsTheTypeOfTheInsertedSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -134,7 +134,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)
@@ -152,7 +152,7 @@ public class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    public void testAndMetaDataAppendsToTheExistingMetaData() {
+    void testAndMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
@@ -32,7 +32,7 @@ import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,12 +40,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.axonframework.messaging.responsetypes.ResponseTypes.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Sara Pellegrini
  */
-public class SubscriptionMessageSerializerTest {
+class SubscriptionMessageSerializerTest {
 
     private final Serializer xStreamSerializer = XStreamSerializer.builder().build();
 
@@ -60,7 +60,7 @@ public class SubscriptionMessageSerializerTest {
             new SubscriptionMessageSerializer(jacksonSerializer, xStreamSerializer, configuration);
 
     @Test
-    public void testInitialResponse() {
+    void testInitialResponse() {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");
@@ -77,7 +77,7 @@ public class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    public void testUpdate() {
+    void testUpdate() {
         List<String> payload = new ArrayList<>();
         payload.add("A");
         payload.add("B");
@@ -93,7 +93,7 @@ public class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    public void testSubscriptionQueryMessage() {
+    void testSubscriptionQueryMessage() {
         GenericSubscriptionQueryMessage<String, Integer, Integer> message = new GenericSubscriptionQueryMessage<>(
                 "query",
                 "MyQueryName",
@@ -112,13 +112,13 @@ public class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    public void testComplete() {
+    void testComplete() {
         QueryProviderOutbound grpcMessage = testSubject.serializeComplete("subscriptionId");
         assertEquals("subscriptionId", grpcMessage.getSubscriptionQueryResponse().getSubscriptionIdentifier());
     }
 
     @Test
-    public void testCompleteExceptionally() {
+    void testCompleteExceptionally() {
         QueryProviderOutbound grpcMessage = testSubject.serializeCompleteExceptionally("subscriptionId",
                                                                                        new RuntimeException("Error"));
         SubscriptionQueryResponse subscriptionQueryResponse = grpcMessage.getSubscriptionQueryResponse();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/AxonFrameworkVersionResolverTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/AxonFrameworkVersionResolverTest.java
@@ -1,19 +1,19 @@
 package org.axonframework.axonserver.connector.util;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link AxonFrameworkVersionResolver}
  *
  * @author Sara Pellegrini
  */
-public class AxonFrameworkVersionResolverTest {
+class AxonFrameworkVersionResolverTest {
 
 
     @Test
-    public void testMavenPriorityOverEnvProperty() {
+    void testMavenPriorityOverEnvProperty() {
         AxonFrameworkVersionResolver testSubject = new AxonFrameworkVersionResolver(
                 () -> "4.2.1",
                 property -> property.equals("AXON_FRAMEWORK_VERSION") ? "3.5" : null);
@@ -22,7 +22,7 @@ public class AxonFrameworkVersionResolverTest {
     }
 
     @Test
-    public void testEnvPropertyUsedAsFallback() {
+    void testEnvPropertyUsedAsFallback() {
         AxonFrameworkVersionResolver testSubject = new AxonFrameworkVersionResolver(
                 () -> null,
                 property -> property.equals("AXON_FRAMEWORK_VERSION") ? "3.5" : null);
@@ -31,7 +31,7 @@ public class AxonFrameworkVersionResolverTest {
     }
 
     @Test
-    public void testEmptyStringAsFallback() {
+    void testEmptyStringAsFallback() {
         AxonFrameworkVersionResolver testSubject = new AxonFrameworkVersionResolver(() -> null, property -> null);
 
         assertEquals("", testSubject.get());

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/BufferingSpliteratorTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/BufferingSpliteratorTest.java
@@ -16,7 +16,8 @@
 
 package org.axonframework.axonserver.connector.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.time.Instant;
 import java.util.List;
@@ -26,26 +27,28 @@ import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Author: marc
  */
-public class BufferingSpliteratorTest {
+class BufferingSpliteratorTest {
 
     private static final Consumer<Object> IGNORE = s -> {};
 
-    @Test(timeout = 1000)
-    public void testTimeout() {
+    @Test
+    @Timeout(value = 1)
+    void testTimeout() {
         BufferingSpliterator<String> bufferingSpliterator = new BufferingSpliterator<>(Instant.now().plusMillis(250));
         long t1 = System.currentTimeMillis();
         assertFalse(bufferingSpliterator.tryAdvance(IGNORE));
         long t2 = System.currentTimeMillis();
-        assertTrue("Expected at least 150 millis to have elapsed", t2 - t1 > 150);
+        assertTrue(t2 - t1 > 150, "Expected at least 150 millis to have elapsed");
     }
 
-    @Test(timeout = 10000)
-    public void testCompleteWithNull() {
+    @Test
+    @Timeout(value = 10)
+    void testCompleteWithNull() {
         BufferingSpliterator<String> bufferingSpliterator = new BufferingSpliterator<>(Instant.now().plusSeconds(10));
         Thread queueListener = new Thread(() -> bufferingSpliterator.tryAdvance(IGNORE));
         queueListener.start();
@@ -54,15 +57,10 @@ public class BufferingSpliteratorTest {
     }
 
     @Test
-    public void testCompleteWithValues() {
+    void testCompleteWithValues() {
         BufferingSpliterator<String> bufferingSpliterator = new BufferingSpliterator<>(Instant.now().plusSeconds(1));
         List<String> items = new CopyOnWriteArrayList<>();
-        Thread queueListener = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                StreamSupport.stream(bufferingSpliterator, false).forEach(items::add);
-            }
-        });
+        Thread queueListener = new Thread(() -> StreamSupport.stream(bufferingSpliterator, false).forEach(items::add));
         queueListener.start();
         bufferingSpliterator.put("One");
         bufferingSpliterator.put("Two");

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ExceptionSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ExceptionSerializerTest.java
@@ -1,16 +1,16 @@
 package org.axonframework.axonserver.connector.util;
 
 import io.axoniq.axonserver.grpc.ErrorMessage;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Author: marc
  */
-public class ExceptionSerializerTest {
+class ExceptionSerializerTest {
     @Test
-    public void serializeNullClient() {
+    void serializeNullClient() {
         ErrorMessage result = ExceptionSerializer.serialize(null,
                                                             new RuntimeException(
                                                                     "Something went wrong"));
@@ -18,7 +18,7 @@ public class ExceptionSerializerTest {
     }
 
     @Test
-    public void serializeNonNullClient() {
+    void serializeNonNullClient() {
         ErrorMessage result = ExceptionSerializer.serialize("Client",
                                                             new RuntimeException(
                                                                     "Something went wrong"));

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcBufferingInterceptorTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcBufferingInterceptorTest.java
@@ -20,23 +20,23 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class GrpcBufferingInterceptorTest {
+class GrpcBufferingInterceptorTest {
 
     private CallOptions mockCallOptions;
     private Channel mockChannel;
     private ClientCall.Listener<Object> mockResponseListener;
     private ClientCall<Object, Object> mockCall;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         mockCallOptions = CallOptions.DEFAULT;
         mockChannel = mock(Channel.class);
         mockResponseListener = mock(ClientCall.Listener.class);
@@ -46,7 +46,7 @@ public class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    public void testInterceptClientCall_BiDiStreaming() {
+    void testInterceptClientCall_BiDiStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -60,7 +60,7 @@ public class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    public void testInterceptClientCall_ServerStreaming() {
+    void testInterceptClientCall_ServerStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.SERVER_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -74,7 +74,7 @@ public class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    public void testInterceptClientCall_ClientStreaming() {
+    void testInterceptClientCall_ClientStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.CLIENT_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -88,7 +88,7 @@ public class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    public void testInterceptClientCall_NoStreaming() {
+    void testInterceptClientCall_NoStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.UNARY);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -102,7 +102,7 @@ public class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    public void testInterceptClientCall_ZeroBuffer() {
+    void testInterceptClientCall_ZeroBuffer() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(0);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
@@ -5,11 +5,11 @@ import io.axoniq.axonserver.grpc.SerializedObject;
 import org.axonframework.serialization.Revision;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -19,13 +19,13 @@ import static org.mockito.Mockito.*;
  *
  * @author Steven van Beelen
  */
-public class GrpcMetaDataConverterTest {
+class GrpcMetaDataConverterTest {
 
     private final Serializer serializer = spy(XStreamSerializer.defaultSerializer());
     private final GrpcMetaDataConverter testSubject = new GrpcMetaDataConverter(serializer);
 
     @Test
-    public void testConvertStringToMetaDataValue() {
+    void testConvertStringToMetaDataValue() {
         String testValue = "some-text";
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -34,7 +34,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertDoubleToMetaDataValue() {
+    void testConvertDoubleToMetaDataValue() {
         double testValue = 10d;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -43,7 +43,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFloatToMetaDataValue() {
+    void testConvertFloatToMetaDataValue() {
         float testValue = 10f;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -52,7 +52,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertIntegerToMetaDataValue() {
+    void testConvertIntegerToMetaDataValue() {
         int testValue = 10;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -61,7 +61,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertLongToMetaDataValue() {
+    void testConvertLongToMetaDataValue() {
         long testValue = 10L;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -70,14 +70,14 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertBooleanToMetaDataValue() {
+    void testConvertBooleanToMetaDataValue() {
         MetaDataValue result = testSubject.convertToMetaDataValue(true);
 
         assertTrue(result.getBooleanValue());
     }
 
     @Test
-    public void testConvertObjectToMetaDataValueUsesSerializer() {
+    void testConvertObjectToMetaDataValueUsesSerializer() {
         TestObject testObject = new TestObject("some-text");
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
@@ -91,7 +91,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertObjectWithRevisionToMetaDataValue() {
+    void testConvertObjectWithRevisionToMetaDataValue() {
         RevisionTestObject testObject = new RevisionTestObject("some-text");
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
@@ -105,7 +105,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertNullToMetaDataValue() {
+    void testConvertNullToMetaDataValue() {
         MetaDataValue result = testSubject.convertToMetaDataValue(null);
 
         verify(serializer).serialize(null, byte[].class);
@@ -114,7 +114,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromTextMetaDataValue() {
+    void testConvertFromTextMetaDataValue() {
         String expected = "some-text";
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setTextValue(expected)
@@ -128,7 +128,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromBytesMetaDataValue() {
+    void testConvertFromBytesMetaDataValue() {
         TestObject testObject = new TestObject("some-text");
         MetaDataValue testMetaData = testSubject.convertToMetaDataValue(testObject);
 
@@ -140,14 +140,14 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromBytesMetaDataValueOfTypeEmptyReturnsNull() {
+    void testConvertFromBytesMetaDataValueOfTypeEmptyReturnsNull() {
         MetaDataValue testMetaData = testSubject.convertToMetaDataValue(null);
 
         assertNull(testSubject.convertFromMetaDataValue(testMetaData));
     }
 
     @Test
-    public void testConvertFromDoubleMetaDataValue() {
+    void testConvertFromDoubleMetaDataValue() {
         @SuppressWarnings("WrapperTypeMayBePrimitive")
         Double expected = 10d;
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
@@ -162,7 +162,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromNumberMetaDataValue() {
+    void testConvertFromNumberMetaDataValue() {
         @SuppressWarnings("WrapperTypeMayBePrimitive")
         Long expected = 10L;
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
@@ -177,7 +177,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromBooleanMetaDataValue() {
+    void testConvertFromBooleanMetaDataValue() {
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setBooleanValue(true)
                                                   .build();
@@ -190,7 +190,7 @@ public class GrpcMetaDataConverterTest {
     }
 
     @Test
-    public void testConvertFromDataNotSetMetaDataValue() {
+    void testConvertFromDataNotSetMetaDataValue() {
         MetaDataValue testMetaData = MetaDataValue.getDefaultInstance();
 
         assertNull(testSubject.convertFromMetaDataValue(testMetaData));

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -23,9 +23,9 @@ import org.axonframework.eventsourcing.NoSnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.modelling.command.Repository;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -42,7 +42,7 @@ public class AggregateConfigurerTest {
 
     private AggregateConfigurer<TestAggregate> testSubject;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockConfiguration = mock(Configuration.class);
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
@@ -25,7 +25,6 @@ import org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.hsqldb.jdbc.JDBCDataSource;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +50,7 @@ import java.time.Duration;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ContextConfiguration
@@ -157,15 +157,15 @@ public class JdbcTokenStoreTest {
 
         transactionManager.executeInTransaction(() -> {
             final int[] segments = tokenStore.fetchSegments("proc1");
-            Assert.assertThat(segments.length, is(2));
+            assertThat(segments.length, is(2));
         });
         transactionManager.executeInTransaction(() -> {
             final int[] segments = tokenStore.fetchSegments("proc2");
-            Assert.assertThat(segments.length, is(2));
+            assertThat(segments.length, is(2));
         });
         transactionManager.executeInTransaction(() -> {
             final int[] segments = tokenStore.fetchSegments("proc3");
-            Assert.assertThat(segments.length, is(0));
+            assertThat(segments.length, is(0));
         });
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -27,7 +27,6 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.hsqldb.jdbc.JDBCDataSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,6 +58,7 @@ import java.util.List;
 import java.util.concurrent.*;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -235,16 +235,16 @@ public class JpaTokenStoreTest {
 
         {
             final int[] segments = jpaTokenStore.fetchSegments("proc1");
-            Assert.assertThat(segments.length, is(2));
+            assertThat(segments.length, is(2));
         }
         {
             final int[] segments = jpaTokenStore.fetchSegments("proc2");
-            Assert.assertThat(segments.length, is(1));
+            assertThat(segments.length, is(1));
         }
 
         {
             final int[] segments = jpaTokenStore.fetchSegments("proc3");
-            Assert.assertThat(segments.length, is(0));
+            assertThat(segments.length, is(0));
         }
 
 

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ConvertingResponseMessageTest {
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -189,11 +189,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -201,11 +196,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -467,11 +457,19 @@
                 <version>${junit4.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Migrate module "axon-server-connector" to JUnit5 + migrate some tests in other modules.
Exclude JUnit 4 from dependencies except the module `test`