### PR TITLE
Fixed timing of message monitor on the SimpleEventBus

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
@@ -34,10 +34,12 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.messaging.unitofwork.UnitOfWork.Phase.*;
+import static org.axonframework.messaging.unitofwork.UnitOfWork.Phase.AFTER_COMMIT;
+import static org.axonframework.messaging.unitofwork.UnitOfWork.Phase.COMMIT;
+import static org.axonframework.messaging.unitofwork.UnitOfWork.Phase.PREPARE_COMMIT;
 
 /**
  * Base class for the Event Bus. In case events are published while a Unit of Work is active the Unit of Work root
@@ -109,7 +111,8 @@ public abstract class AbstractEventBus implements EventBus {
 
     @Override
     public void publish(List<? extends EventMessage<?>> events) {
-        Stream<MessageMonitor.MonitorCallback> ingested = events.stream().map(messageMonitor::onMessageIngested);
+        List<MessageMonitor.MonitorCallback> ingested = events.stream().map(messageMonitor::onMessageIngested)
+                                                              .collect(Collectors.toList());
 
         if (CurrentUnitOfWork.isStarted()) {
             UnitOfWork<?> unitOfWork = CurrentUnitOfWork.get();


### PR DESCRIPTION
The SimpleEventBus used a Stream to create a MessageMonitorCallback for each published message. Due to the lazy initialization of streams, this caused the messages to only be marked as "ingested" by the time they we actually dispatched. For monitors performing timing, it may seem that the publication of messages is done in near-0 time.

This commit fixes that, ensuring messages are marked as ingested as soon as they arrive on the Event Bus, and marked as completed (or failed) when the Unit of Work is committed.