### PR TITLE
Flow control per message type

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -85,17 +85,17 @@ public class AxonServerConfiguration {
     private FlowControlConfiguration defaultFlowControl = new FlowControlConfiguration();
 
     /**
-     * specific flow control settings for the event message stream
+     * Specific flow control settings for the event message stream
      */
     private FlowControlConfiguration eventFlowControl;
 
     /**
-     * specific flow control settings for the queue message stream
+     * Specific flow control settings for the queue message stream
      */
     private FlowControlConfiguration queryFlowControl;
 
     /**
-     * specific flow control settings for the command message stream
+     * Specific flow control settings for the command message stream
      */
     private FlowControlConfiguration commandFlowControl;
 
@@ -470,6 +470,7 @@ public class AxonServerConfiguration {
     }
 
     public static class FlowControlConfiguration {
+
         /**
          * Initial number of permits send for message streams (events, commands, queries)
          */

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -518,7 +518,9 @@ public class AxonServerConfiguration {
         }
 
         /**
-         * Initialize flow control with initialNrOfPermits, nrOfNewPermits en newPermitsThreshold
+         * @param initialNrOfPermits    Initial nr of new permits
+         * @param nrOfNewPermits        Additional number of permits when applictation is ready for message
+         * @param newPermitsThreshold   Threshold at which application sends new permits to server
          */
         public FlowControlConfiguration(Integer initialNrOfPermits, Integer nrOfNewPermits, Integer newPermitsThreshold) {
             this.initialNrOfPermits = initialNrOfPermits;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -518,7 +518,7 @@ public class AxonServerConfiguration {
         }
 
         /**
-         * initialize flow control with initialNrOfPermits, nrOfNewPermits en newPermitsThreshold
+         * Initialize flow control with initialNrOfPermits, nrOfNewPermits en newPermitsThreshold
          */
         public FlowControlConfiguration(Integer initialNrOfPermits, Integer nrOfNewPermits, Integer newPermitsThreshold) {
             this.initialNrOfPermits = initialNrOfPermits;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -79,9 +79,24 @@ public class AxonServerConfiguration {
     private boolean sslEnabled;
 
 
+    /**
+     * Default flow control settings.
+     */
     private FlowControlConfiguration defaultFlowControl = new FlowControlConfiguration();
+
+    /**
+     * specific flow control settings for the event message stream
+     */
     private FlowControlConfiguration eventFlowControl;
+
+    /**
+     * specific flow control settings for the queue message stream
+     */
     private FlowControlConfiguration queryFlowControl;
+
+    /**
+     * specific flow control settings for the command message stream
+     */
     private FlowControlConfiguration commandFlowControl;
 
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -563,18 +563,18 @@ public class AxonServerConfiguration {
             return this;
         }
 
-        public Builder commandFlowControl(FlowControlConfiguration flowControlConfiguration) {
-            instance.setCommandFlowControl(flowControlConfiguration);
+        public Builder commandFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setCommandFlowControl(new FlowControlConfiguration(initialNrOfPermits,nrOfNewPermits,newPermitsThreshold));
             return this;
         }
 
-        public Builder queryFlowControl(FlowControlConfiguration flowControlConfiguration) {
-            instance.setQueryFlowControl(flowControlConfiguration);
+        public Builder queryFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setQueryFlowControl(new FlowControlConfiguration(initialNrOfPermits,nrOfNewPermits,newPermitsThreshold));
             return this;
         }
 
-        public Builder eventFlowControl(FlowControlConfiguration flowControlConfiguration) {
-            instance.setEventFlowControl(flowControlConfiguration);
+        public Builder eventFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setEventFlowControl(new FlowControlConfiguration(initialNrOfPermits,nrOfNewPermits,newPermitsThreshold));
             return this;
         }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -450,7 +450,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getEventFlowControl() {
         if (eventFlowControl == null) {
-            eventFlowControl = new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return eventFlowControl;
     }
@@ -461,7 +461,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getQueryFlowControl() {
         if (queryFlowControl == null) {
-            queryFlowControl = new FlowControlConfiguration(getInitialNrOfPermits(),getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getInitialNrOfPermits(),getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return queryFlowControl;
     }
@@ -472,7 +472,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getCommandFlowControl() {
         if (commandFlowControl == null) {
-            commandFlowControl = new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return commandFlowControl;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -778,7 +778,8 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
 
             subscriberStreamObserver = new FlowControllingStreamObserver<>(
                     streamObserver,
-                    configuration,
+                    configuration.getClientId(),
+                    configuration.getCommandFlowControl(),
                     flowControl -> CommandProviderOutbound.newBuilder().setFlowControl(flowControl).build(),
                     t -> t.getRequestCase().equals(CommandProviderOutbound.RequestCase.COMMAND_RESPONSE)
             ).sendInitialPermits();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -479,7 +479,8 @@ public class AxonServerEventStore extends AbstractEventStore {
                     });
             FlowControllingStreamObserver<GetEventsRequest> observer = new FlowControllingStreamObserver<>(
                     requestStream,
-                    configuration,
+                    configuration.getClientId(),
+                    configuration.getEventFlowControl(),
                     t -> GetEventsRequest.newBuilder().setNumberOfPermits(t.getPermits()).build(),
                     t -> false
             );
@@ -536,7 +537,8 @@ public class AxonServerEventStore extends AbstractEventStore {
                     });
             FlowControllingStreamObserver<QueryEventsRequest> observer = new FlowControllingStreamObserver<>(
                     requestStream,
-                    configuration,
+                    configuration.getClientId(),
+                    configuration.getEventFlowControl(),
                     t -> QueryEventsRequest.newBuilder().setNumberOfPermits(t.getPermits()).build(),
                     t -> false
             );

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -691,7 +691,8 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
 
             outboundStreamObserver = new FlowControllingStreamObserver<>(
                     streamObserver,
-                    configuration,
+                    configuration.getClientId(),
+                    configuration.getQueryFlowControl(),
                     flowControl -> QueryProviderOutbound.newBuilder().setFlowControl(flowControl).build(),
                     t -> t.getRequestCase().equals(QueryProviderOutbound.RequestCase.QUERY_RESPONSE)
             ).sendInitialPermits();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResult.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResult.java
@@ -17,12 +17,7 @@
 package org.axonframework.axonserver.connector.query.subscription;
 
 import io.axoniq.axonserver.grpc.FlowControl;
-import io.axoniq.axonserver.grpc.query.QueryResponse;
-import io.axoniq.axonserver.grpc.query.QueryUpdate;
-import io.axoniq.axonserver.grpc.query.QueryUpdateCompleteExceptionally;
-import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
-import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
-import io.axoniq.axonserver.grpc.query.SubscriptionQueryResponse;
+import io.axoniq.axonserver.grpc.query.*;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.ErrorCode;
@@ -90,10 +85,10 @@ public class AxonServerSubscriptionQueryResult implements Supplier<SubscriptionQ
         Function<FlowControl, SubscriptionQueryRequest> requestMapping =
                 flowControl -> newBuilder().setFlowControl(
                         SubscriptionQuery.newBuilder(this.subscriptionQuery)
-                                         .setNumberOfPermits(flowControl.getPermits())
+                                .setNumberOfPermits(flowControl.getPermits())
                 ).build();
         requestObserver = new FlowControllingStreamObserver<>(
-                subscriptionStreamObserver, configuration, requestMapping, t -> false
+                subscriptionStreamObserver, configuration.getClientId(), configuration.getQueryFlowControl(), requestMapping, t -> false
         );
         requestObserver.sendInitialPermits();
         requestObserver.onNext(newBuilder().setSubscribe(this.subscriptionQuery).build());

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
@@ -5,17 +5,13 @@ import org.junit.jupiter.api.Test;
 import static org.axonframework.axonserver.connector.AxonServerConfiguration.builder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Test Axon Server Configuration
+ * Testing falling back to defaults for Flow Control per message type
+ *
+ */
 class AxonServerConfigurationTest {
 
-    @Test
-    void testDefaultFlowControl() {
-
-        AxonServerConfiguration axonServerConfiguration = new AxonServerConfiguration();
-        axonServerConfiguration.setInitialNrOfPermits(1000);
-
-        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
-        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
-    }
 
     @Test
     void testEventsFlowControl() {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
@@ -1,0 +1,62 @@
+package org.axonframework.axonserver.connector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.axonframework.axonserver.connector.AxonServerConfiguration.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AxonServerConfigurationTest {
+
+    @Test
+    void testDefaultFlowControl() {
+
+        AxonServerConfiguration axonServerConfiguration = new AxonServerConfiguration();
+        axonServerConfiguration.setInitialNrOfPermits(1000);
+
+        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+    }
+
+    @Test
+    void testEventsFlowControl() {
+
+        AxonServerConfiguration axonServerConfiguration = builder().eventFlowControl(10, 20, 30).build();
+
+        assertEquals(10, axonServerConfiguration.getEventFlowControl().getInitialNrOfPermits());
+        assertEquals(20, axonServerConfiguration.getEventFlowControl().getNrOfNewPermits());
+        assertEquals(30, axonServerConfiguration.getEventFlowControl().getNewPermitsThreshold());
+        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+
+    }
+
+    @Test
+    void testCommandFlowControl() {
+
+        AxonServerConfiguration axonServerConfiguration = builder().commandFlowControl(10, 20, 30).build();
+
+        assertEquals(10, axonServerConfiguration.getCommandFlowControl().getInitialNrOfPermits());
+        assertEquals(20, axonServerConfiguration.getCommandFlowControl().getNrOfNewPermits());
+        assertEquals(30, axonServerConfiguration.getCommandFlowControl().getNewPermitsThreshold());
+        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+
+    }
+
+    @Test
+    void testQueryFlowControl() {
+
+        AxonServerConfiguration axonServerConfiguration = builder().queryFlowControl(10, 20, 30).build();
+
+        assertEquals(10, axonServerConfiguration.getQueryFlowControl().getInitialNrOfPermits());
+        assertEquals(20, axonServerConfiguration.getQueryFlowControl().getNrOfNewPermits());
+        assertEquals(30, axonServerConfiguration.getQueryFlowControl().getNewPermitsThreshold());
+        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+
+    }
+
+}


### PR DESCRIPTION
We would like to separate the flow control settings for each message type. This way we can use the flow control for back-pressure control of commands to a certain component, while letting it accepting the events with a greater (default settings) flow. The handing of commands in this component is far more time consuming than the event handling.