### PR TITLE
Store message timestamp as string in JobData

### DIFF
--- a/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
@@ -291,7 +291,9 @@ public class DeadlineJob implements Job {
 
         private static Instant retrieveDeadlineTimestamp(JobDataMap jobDataMap) {
             Object timestamp = jobDataMap.get(MESSAGE_TIMESTAMP);
-            if (timestamp instanceof String) return Instant.parse(timestamp.toString());
+            if (timestamp instanceof String) {
+                return Instant.parse(timestamp.toString());
+            }
             return Instant.ofEpochMilli((long) timestamp);
         }
 

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
@@ -223,7 +223,7 @@ public class DeadlineJob implements Job {
                                                Serializer serializer) {
             jobData.put(DEADLINE_NAME, deadlineMessage.getDeadlineName());
             jobData.put(MESSAGE_ID, deadlineMessage.getIdentifier());
-            jobData.put(MESSAGE_TIMESTAMP, deadlineMessage.getTimestamp().toEpochMilli());
+            jobData.put(MESSAGE_TIMESTAMP, deadlineMessage.getTimestamp().toString());
 
             SerializedObject<byte[]> serializedDeadlinePayload =
                     serializer.serialize(deadlineMessage.getPayload(), byte[].class);
@@ -290,7 +290,9 @@ public class DeadlineJob implements Job {
         }
 
         private static Instant retrieveDeadlineTimestamp(JobDataMap jobDataMap) {
-            return Instant.ofEpochMilli((long) jobDataMap.get(MESSAGE_TIMESTAMP));
+            Object timestamp = jobDataMap.get(MESSAGE_TIMESTAMP);
+            if (timestamp instanceof String) return Instant.parse(timestamp.toString());
+            return Instant.ofEpochMilli((long) timestamp);
         }
 
         /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -240,7 +240,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
             EventMessage eventMessage = (EventMessage) event;
 
             jobData.put(MESSAGE_ID, eventMessage.getIdentifier());
-            jobData.put(MESSAGE_TIMESTAMP, eventMessage.getTimestamp().toEpochMilli());
+            jobData.put(MESSAGE_TIMESTAMP, eventMessage.getTimestamp().toString());
 
             SerializedObject<byte[]> serializedPayload =
                     serializer.serialize(eventMessage.getPayload(), byte[].class);
@@ -305,7 +305,9 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         }
 
         private Instant retrieveDeadlineTimestamp(JobDataMap jobDataMap) {
-            return Instant.ofEpochMilli((long) jobDataMap.get(MESSAGE_TIMESTAMP));
+            Object timestamp = jobDataMap.get(MESSAGE_TIMESTAMP);
+            if (timestamp instanceof String) return Instant.parse(timestamp.toString());
+            return Instant.ofEpochMilli((long) timestamp);
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -306,7 +306,9 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
 
         private Instant retrieveDeadlineTimestamp(JobDataMap jobDataMap) {
             Object timestamp = jobDataMap.get(MESSAGE_TIMESTAMP);
-            if (timestamp instanceof String) return Instant.parse(timestamp.toString());
+            if (timestamp instanceof String) {
+                return Instant.parse(timestamp.toString());
+            }
             return Instant.ofEpochMilli((long) timestamp);
         }
     }

--- a/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
@@ -94,7 +94,7 @@ class DeadlineJobDataBinderTest {
 
         assertEquals(TEST_DEADLINE_NAME, result.get(DEADLINE_NAME));
         assertEquals(testDeadlineMessage.getIdentifier(), result.get(MESSAGE_ID));
-        assertEquals(testDeadlineMessage.getTimestamp().toEpochMilli(), result.get(MESSAGE_TIMESTAMP));
+        assertEquals(testDeadlineMessage.getTimestamp().toString(), result.get(MESSAGE_TIMESTAMP));
         String expectedPayloadType = expectedSerializedClassType.apply(testDeadlineMessage.getPayloadType());
         assertEquals(expectedPayloadType, result.get(MESSAGE_TYPE));
         Object resultRevision = result.get(MESSAGE_REVISION);

--- a/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
@@ -124,7 +124,7 @@ class DeadlineJobDataBinderTest {
 
         assertEquals(testDeadlineMessage.getDeadlineName(), result.getDeadlineName());
         assertEquals(testDeadlineMessage.getIdentifier(), result.getIdentifier());
-        assertEquals(testDeadlineMessage.getTimestamp().truncatedTo(ChronoUnit.MILLIS), result.getTimestamp());
+        assertEquals(testDeadlineMessage.getTimestamp(), result.getTimestamp());
         assertEquals(testDeadlineMessage.getPayload(), result.getPayload());
         assertEquals(testDeadlineMessage.getPayloadType(), result.getPayloadType());
         assertEquals(testDeadlineMessage.getMetaData(), result.getMetaData());

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -96,7 +96,7 @@ class DirectEventJobDataBinderTest {
         JobDataMap result = testSubject.toJobData(testEventMessage);
 
         assertEquals(testEventMessage.getIdentifier(), result.get(MESSAGE_ID));
-        assertEquals(testEventMessage.getTimestamp().toEpochMilli(), result.get(MESSAGE_TIMESTAMP));
+        assertEquals(testEventMessage.getTimestamp().toString(), result.get(MESSAGE_TIMESTAMP));
         String expectedPayloadType = expectedSerializedClassType.apply(testEventMessage.getPayloadType());
         assertEquals(expectedPayloadType, result.get(MESSAGE_TYPE));
         Object resultRevision = result.get(MESSAGE_REVISION);

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -127,7 +127,7 @@ class DirectEventJobDataBinderTest {
         EventMessage<String> resultEventMessage = (EventMessage<String>) result;
 
         assertEquals(testEventMessage.getIdentifier(), resultEventMessage.getIdentifier());
-        assertEquals(testEventMessage.getTimestamp().truncatedTo(ChronoUnit.MILLIS), resultEventMessage.getTimestamp());
+        assertEquals(testEventMessage.getTimestamp(), resultEventMessage.getTimestamp());
         assertEquals(testEventMessage.getPayload(), resultEventMessage.getPayload());
         assertEquals(testEventMessage.getPayloadType(), resultEventMessage.getPayloadType());
         assertEquals(testEventMessage.getMetaData(), resultEventMessage.getMetaData());


### PR DESCRIPTION
Converting timestamp represented by `Instant` to `Long` using `.toEpochMillis()` loses timestamp precision. Injecting such timestamp using `@Timestamp` to `@DeadlineHandler` may cause unpredicted behavior.

This PR translates timestamp using `Instant.toString()`. When reading timestamp it attempts both old way `Long` and new way `String`. Thus change is non intrusive.

This pull request resolves issue #1302 