### PR TITLE
[#1050] Register Parameter Resolvers in Test Fixtures

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -134,7 +134,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     private long sequenceNumber = 0;
     private boolean reportIllegalStateChange = true;
     private boolean explicitCommandHandlersSet;
-    private final List<ParameterResolverFactory> registeredParameterResolverFactories = new ArrayList<>();
+    private final LinkedList<ParameterResolverFactory> registeredParameterResolverFactories = new LinkedList<>();
     private final LinkedList<HandlerDefinition> registeredHandlerDefinitions = new LinkedList<>();
     private final LinkedList<HandlerEnhancerDefinition> registeredHandlerEnhancerDefinitions = new LinkedList<>();
     private CommandTargetResolver commandTargetResolver;
@@ -224,7 +224,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public FixtureConfiguration<T> registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory) {
-        this.registeredParameterResolverFactories.add(parameterResolverFactory);
+        this.registeredParameterResolverFactories.addFirst(parameterResolverFactory);
         return this;
     }
 

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -162,11 +162,11 @@ public interface FixtureConfiguration<T> {
 
     /**
      * Registers a resource that is eligible for injection in handler method (e.g. methods annotated with {@link
-     * CommandHandler @CommandHandler}, {@link EventSourcingHandler @EventSourcingHandler} and {@link EventHandler
+     * CommandHandler @CommandHandler}, {@link EventSourcingHandler @EventSourcingHandler} and {@link EventHandler}.
+     * These resource must be registered <em>before</em> registering any command handler.
      *
      * @param resource the resource eligible for injection
      * @return the current FixtureConfiguration, for fluent interfacing
-     * @EventHandler}. These resource must be registered <em>before</em> registering any command handler.
      */
     FixtureConfiguration<T> registerInjectableResource(Object resource);
 

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -172,7 +172,7 @@ public interface FixtureConfiguration<T> {
 
     /**
      * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
-     * should be added to the other parameter resolver factories introduced through {@link
+     * will be added to the other parameter resolver factories introduced through {@link
      * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link
      * org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory} adding the registered resources
      * (with {@link #registerInjectableResource(Object)}. The generic {@code T} is used as input for the {@code

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -32,6 +32,8 @@ import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.modelling.command.CommandTargetResolver;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.command.RepositoryProvider;
@@ -160,15 +162,27 @@ public interface FixtureConfiguration<T> {
 
     /**
      * Registers a resource that is eligible for injection in handler method (e.g. methods annotated with {@link
-     * CommandHandler @CommandHandler}, {@link
-     * EventSourcingHandler @EventSourcingHandler} and {@link
-     * EventHandler @EventHandler}. These resource must be
-     * registered <em>before</em> registering any command handler.
+     * CommandHandler @CommandHandler}, {@link EventSourcingHandler @EventSourcingHandler} and {@link EventHandler
      *
-     * @param resource The resource eligible for injection
+     * @param resource the resource eligible for injection
      * @return the current FixtureConfiguration, for fluent interfacing
+     * @EventHandler}. These resource must be registered <em>before</em> registering any command handler.
      */
     FixtureConfiguration<T> registerInjectableResource(Object resource);
+
+    /**
+     * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
+     * should be added to the other parameter resolver factories introduced through {@link
+     * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link
+     * org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory} adding the registered resources
+     * (with {@link #registerInjectableResource(Object)}. The generic {@code T} is used as input for the {@code
+     * ClasspathParameterResolverFactory#forClass(Class)} operation.
+     *
+     * @param parameterResolverFactory the {@link ParameterResolver} to register within this fixture
+     * @return the current FixtureConfiguration, for fluent interfacing
+     * @see #registerInjectableResource(Object)
+     */
+    FixtureConfiguration<T> registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory);
 
     /**
      * Register a command dispatch interceptor which will always be invoked before a command is dispatched on the

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -25,6 +25,8 @@ import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.aggregate.ResultValidator;
 import org.axonframework.test.matchers.FieldFilter;
@@ -66,6 +68,20 @@ public interface FixtureConfiguration {
      * @param resource the resource to register.
      */
     void registerResource(Object resource);
+
+    /**
+     * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
+     * should be added to the other parameter resolver factories introduced through {@link
+     * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link
+     * org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory} adding the registered resources
+     * (with {@link #registerResource(Object)}. The type of the saga under test is used as input for the {@code
+     * ClasspathParameterResolverFactory#forClass(Class)} operation.
+     *
+     * @param parameterResolverFactory the {@link ParameterResolver} to register within this fixture
+     * @return the current FixtureConfiguration, for fluent interfacing
+     * @see #registerResource(Object)
+     */
+    FixtureConfiguration registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory);
 
     /**
      * Creates a Command Gateway for the given {@code gatewayInterface} and registers that as a resource. The

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,7 +71,7 @@ public interface FixtureConfiguration {
 
     /**
      * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
-     * should be added to the other parameter resolver factories introduced through {@link
+     * will be added to the other parameter resolver factories introduced through {@link
      * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link
      * org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory} adding the registered resources
      * (with {@link #registerResource(Object)}. The type of the saga under test is used as input for the {@code

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -88,7 +88,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     private EventBus eventBus;
     private final StubEventScheduler eventScheduler;
     private final StubDeadlineManager deadlineManager;
-    private final List<ParameterResolverFactory> registeredParameterResolverFactories = new ArrayList<>();
+    private final LinkedList<ParameterResolverFactory> registeredParameterResolverFactories = new LinkedList<>();
     private final LinkedList<HandlerDefinition> registeredHandlerDefinitions = new LinkedList<>();
     private final LinkedList<HandlerEnhancerDefinition> registeredHandlerEnhancerDefinitions = new LinkedList<>();
     private ListenerInvocationErrorHandler listenerInvocationErrorHandler;
@@ -242,7 +242,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
     @Override
     public FixtureConfiguration registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory) {
-        this.registeredParameterResolverFactories.add(parameterResolverFactory);
+        this.registeredParameterResolverFactories.addFirst(parameterResolverFactory);
         return this;
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/ParameterResolvedEvent.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ParameterResolvedEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Event payload dedicated to triggering the resolution of parameters through a custom {@link
+ * org.axonframework.messaging.annotation.ParameterResolverFactory}.
+ *
+ * @author Steven van Beelen
+ */
+public class ParameterResolvedEvent {
+
+    private final Object aggregateIdentifier;
+    private final AtomicBoolean assertion;
+
+    ParameterResolvedEvent(Object aggregateIdentifier, AtomicBoolean assertion) {
+        this.aggregateIdentifier = aggregateIdentifier;
+        this.assertion = assertion;
+    }
+
+    public Object getAggregateIdentifier() {
+        return aggregateIdentifier;
+    }
+
+    public AtomicBoolean getAssertion() {
+        return assertion;
+    }
+}

--- a/test/src/test/java/org/axonframework/test/aggregate/ResolveParameterCommand.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResolveParameterCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+/**
+ * Command payload dedicated to triggering the resolution of parameters through a custom {@link
+ * org.axonframework.messaging.annotation.ParameterResolverFactory}.
+ *
+ * @author Steven van Beelen
+ */
+public class ResolveParameterCommand {
+
+    @TargetAggregateIdentifier
+    private final Object aggregateIdentifier;
+
+    ResolveParameterCommand(Object aggregateIdentifier) {
+        this.aggregateIdentifier = aggregateIdentifier;
+    }
+
+    public Object getAggregateIdentifier() {
+        return aggregateIdentifier;
+    }
+}

--- a/test/src/test/java/org/axonframework/test/saga/ParameterResolvedEvent.java
+++ b/test/src/test/java/org/axonframework/test/saga/ParameterResolvedEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.saga;
+
+/**
+ * Event payload dedicated to triggering the resolution of parameters through a custom {@link
+ * org.axonframework.messaging.annotation.ParameterResolverFactory}.
+ *
+ * @author Steven van Beelen
+ */
+public class ParameterResolvedEvent {
+
+    private final Object identifier;
+
+    ParameterResolvedEvent(Object identifier) {
+        this.identifier = identifier;
+    }
+
+    public Object getIdentifier() {
+        return identifier;
+    }
+}

--- a/test/src/test/java/org/axonframework/test/saga/ResolveParameterCommand.java
+++ b/test/src/test/java/org/axonframework/test/saga/ResolveParameterCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.saga;
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Command payload dedicated to triggering the resolution of parameters through a custom {@link
+ * org.axonframework.messaging.annotation.ParameterResolverFactory}.
+ *
+ * @author Steven van Beelen
+ */
+public class ResolveParameterCommand {
+
+    @TargetAggregateIdentifier
+    private final Object identifier;
+    private final AtomicBoolean assertion;
+
+    ResolveParameterCommand(Object identifier, AtomicBoolean assertion) {
+        this.identifier = identifier;
+        this.assertion = assertion;
+    }
+
+    public Object getIdentifier() {
+        return identifier;
+    }
+
+    public AtomicBoolean getAssertion() {
+        return assertion;
+    }
+}


### PR DESCRIPTION
This pull request introduces the `registerParameterResolverFactory(ParameterResolverFactory)` method to the `AggregateTestFixture` and `SagaTestFixture` classes. Doing so allows an easy handle for users to register custom `ParameterResolverFactories` they might have added to their project.

Next to providing test cases for the added functionality, IDE warnings in the touched classes have been resolved.

This pull request resolves #1050  