### PR TITLE
[#680]  Expect Scheduled Deadline based on Deadline name

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -212,6 +212,15 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectScheduledDeadlineOfType(Duration duration, Class<?> deadlineType);
 
     /**
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     *
+     * @param duration     the time to wait before the deadline is met
+     * @param deadlineName the name of the expected deadline
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectScheduledDeadlineWithName(Duration duration, String deadlineName);
+
+    /**
      * Asserts that a deadline matching the given {@code matcher} has been scheduled at the given {@code
      * scheduledTime}.
      * <p/>
@@ -248,6 +257,15 @@ public interface ResultValidator<T> {
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType);
+
+    /**
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     *
+     * @param scheduledTime the time at which the deadline is scheduled
+     * @param deadlineName  the name of the expected deadline
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
 
     /**
      * Asserts that no deadlines are scheduled. This means that either no deadlines were scheduled at all, all schedules

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -257,7 +257,8 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType);
 
     /**
-     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled at the given {@code
+     * scheduledTime}.
      *
      * @param scheduledTime the time at which the deadline is scheduled
      * @param deadlineName  the name of the expected deadline

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -28,11 +28,9 @@ import java.util.function.Consumer;
 
 /**
  * Interface describing the operations available on the "validate result" (a.k.a. "then") stage of the test execution.
- * The underlying fixture expects a test to have been executed succesfully using a {@link
- * TestExecutor}.
+ * The underlying fixture expects a test to have been executed successfully using a {@link TestExecutor}.
  * <p>
- * There are several things to validate:<ul><li>the published events,<li>the stored events, and<li>the command
- * handler's
+ * There are several things to validate:<ul><li>the published events,<li>the stored events, and<li>the command handler's
  * execution result, which is one of <ul><li>a regular return value,<li>a {@code void} return value, or<li>an
  * exception.</ul></ul>
  *
@@ -67,7 +65,7 @@ public interface ResultValidator<T> {
      * @param expectedEvents The expected events, in the exact order they are expected to be dispatched and stored.
      * @return the current ResultValidator, for fluent interfacing
      */
-    ResultValidator<T> expectEvents(EventMessage... expectedEvents);
+    ResultValidator<T> expectEvents(EventMessage<?>... expectedEvents);
 
     /**
      * Expect no events to have been published from the command.
@@ -115,7 +113,7 @@ public interface ResultValidator<T> {
      * @param expectedResultMessage The expected result message of the command execution
      * @return the current ResultValidator, for fluent interfacing
      */
-    ResultValidator<T> expectResultMessage(CommandResultMessage expectedResultMessage);
+    ResultValidator<T> expectResultMessage(CommandResultMessage<?> expectedResultMessage);
 
     /**
      * Expect the command handler to return a value that matches the given {@code matcher} after execution.

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -90,7 +90,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (Object expectedEvent : expectedEvents) {
-            EventMessage actualEvent = iterator.next();
+            EventMessage<?> actualEvent = iterator.next();
             if (!verifyPayloadEquality(expectedEvent, actualEvent.getPayload())) {
                 reporter.reportWrongEvent(publishedEvents, Arrays.asList(expectedEvents), actualException);
             }
@@ -99,12 +99,12 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     }
 
     @Override
-    public ResultValidator<T> expectEvents(EventMessage... expectedEvents) {
+    public ResultValidator<T> expectEvents(EventMessage<?>... expectedEvents) {
         this.expectEvents(Stream.of(expectedEvents).map(Message::getPayload).toArray());
 
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
-        for (EventMessage expectedEvent : expectedEvents) {
-            EventMessage actualEvent = iterator.next();
+        for (EventMessage<?> expectedEvent : expectedEvents) {
+            EventMessage<?> actualEvent = iterator.next();
             if (!verifyMetaDataEquality(expectedEvent.getPayloadType(),
                                         expectedEvent.getMetaData(),
                                         actualEvent.getMetaData())) {
@@ -245,7 +245,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     }
 
     @Override
-    public ResultValidator<T> expectResultMessage(CommandResultMessage expectedResultMessage) {
+    public ResultValidator<T> expectResultMessage(CommandResultMessage<?> expectedResultMessage) {
         expectResultMessagePayload(expectedResultMessage.getPayload());
 
         StringDescription expectedDescription = new StringDescription();
@@ -299,7 +299,6 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
         return expectExceptionMessage(equalTo(exceptionMessage));
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
     public ResultValidator<T> expectException(Class<? extends Throwable> expectedException) {
         return expectException(instanceOf(expectedException));

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -27,17 +27,26 @@ import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.deadline.DeadlineManagerValidator;
 import org.axonframework.test.deadline.StubDeadlineManager;
-import org.axonframework.test.matchers.*;
+import org.axonframework.test.matchers.EqualFieldsMatcher;
+import org.axonframework.test.matchers.FieldFilter;
+import org.axonframework.test.matchers.MapEntryMatcher;
+import org.axonframework.test.matchers.Matchers;
+import org.axonframework.test.matchers.PayloadMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static org.axonframework.test.matchers.Matchers.matches;
 import static org.axonframework.test.matchers.Matchers.messageWithPayload;
 import static org.hamcrest.CoreMatchers.*;
 
@@ -153,6 +162,14 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     }
 
     @Override
+    public ResultValidator<T> expectScheduledDeadlineWithName(Duration duration, String deadlineName) {
+        return expectScheduledDeadlineMatching(
+                duration,
+                matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
+        );
+    }
+
+    @Override
     public ResultValidator<T> expectScheduledDeadlineMatching(Instant scheduledTime,
                                                               Matcher<? super DeadlineMessage<?>> matcher) {
         deadlineManagerValidator.assertScheduledDeadlineMatching(scheduledTime, matcher);
@@ -168,6 +185,14 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     @Override
     public ResultValidator<T> expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType) {
         return expectScheduledDeadlineMatching(scheduledTime, messageWithPayload(any(deadlineType)));
+    }
+
+    @Override
+    public ResultValidator<T> expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName) {
+        return expectScheduledDeadlineMatching(
+                scheduledTime,
+                matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
+        );
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -128,6 +128,15 @@ public interface FixtureExecutionResult {
     FixtureExecutionResult expectScheduledDeadlineOfType(Duration duration, Class<?> deadlineType);
 
     /**
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     *
+     * @param duration     the time to wait before the deadline is met
+     * @param deadlineName the name of the expected deadline
+     * @return the FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectScheduledDeadlineWithName(Duration duration, String deadlineName);
+
+    /**
      * Asserts that an event matching the given {@code matcher} has been scheduled to be published at the given
      * {@code scheduledTime}.
      * <p/>
@@ -208,6 +217,15 @@ public interface FixtureExecutionResult {
      * @return the FixtureExecutionResult for method chaining
      */
     FixtureExecutionResult expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType);
+
+    /**
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     *
+     * @param scheduledTime the time at which the deadline is scheduled
+     * @param deadlineName the name of the expected deadline
+     * @return the FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
 
     /**
      * Asserts that the given commands have been dispatched in exactly the order given. The command objects are

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -219,10 +219,11 @@ public interface FixtureExecutionResult {
     FixtureExecutionResult expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType);
 
     /**
-     * Asserts that a deadline with the given {@code deadlineName} has been scheduled after the given {@code duration}.
+     * Asserts that a deadline with the given {@code deadlineName} has been scheduled at the given {@code
+     * scheduledTime}.
      *
      * @param scheduledTime the time at which the deadline is scheduled
-     * @param deadlineName the name of the expected deadline
+     * @param deadlineName  the name of the expected deadline
      * @return the FixtureExecutionResult for method chaining
      */
     FixtureExecutionResult expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -35,8 +35,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.axonframework.test.matchers.Matchers.equalTo;
-import static org.axonframework.test.matchers.Matchers.messageWithPayload;
+import static org.axonframework.test.matchers.Matchers.*;
 import static org.hamcrest.CoreMatchers.any;
 
 /**
@@ -121,7 +120,8 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
 
 
     @Override
-    public FixtureExecutionResult expectScheduledEventMatching(Duration duration, Matcher<? super EventMessage<?>> matcher) {
+    public FixtureExecutionResult expectScheduledEventMatching(Duration duration,
+                                                               Matcher<? super EventMessage<?>> matcher) {
         eventSchedulerValidator.assertScheduledEventMatching(duration, matcher);
         return this;
     }
@@ -154,7 +154,16 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
     }
 
     @Override
-    public FixtureExecutionResult expectScheduledEventMatching(Instant scheduledTime, Matcher<? super EventMessage<?>> matcher) {
+    public FixtureExecutionResult expectScheduledDeadlineWithName(Duration duration, String deadlineName) {
+        return expectScheduledDeadlineMatching(
+                duration,
+                matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
+        );
+    }
+
+    @Override
+    public FixtureExecutionResult expectScheduledEventMatching(Instant scheduledTime,
+                                                               Matcher<? super EventMessage<?>> matcher) {
         eventSchedulerValidator.assertScheduledEventMatching(scheduledTime, matcher);
         return this;
     }
@@ -184,6 +193,14 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
     @Override
     public FixtureExecutionResult expectScheduledDeadlineOfType(Instant scheduledTime, Class<?> deadlineType) {
         return expectScheduledDeadlineMatching(scheduledTime, messageWithPayload(any(deadlineType)));
+    }
+
+    @Override
+    public FixtureExecutionResult expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName) {
+        return expectScheduledDeadlineMatching(
+                scheduledTime,
+                matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
+        );
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces two methods to both the `AggregateTestFixture` and `SagaTestFixture` validation phase:

1. `expectScheduledDeadlineWithName(Duration duration, String deadlineName)`
2. `expectScheduledDeadlineWithName(Instant scheduledTime, String deadlineName)`

This methods are beneficial to include, as users are able to schedule deadlines without any form of payload, but with a _deadline name_. In those scenarios, one would still want to verify through test cases if such a deadline was scheduled.

Alongside this addition, I've resolved warnings I encountered in the touched files.

This pull request resolves #680 