### PR TITLE
[#894] Add registerResourceInjector method to SagaTestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -218,10 +218,14 @@ public interface FixtureConfiguration {
      * sagas.
      * <p>
      * The provided {@code resourceInjector} will be paired with the fixture's default {@code ResourceInjector} to keep
-     * supporting the {@link #registerResource(Object)} and {@link #withTransienceCheckDisabled()} methods. Note that
+     * support for the {@link #registerResource(Object)} and {@link #withTransienceCheckDisabled()} methods. Note that
      * <b>first</b> the default injector is called, and after that the given {@code resourceInjector}. This approach
      * ensures the fixture's correct workings for default provided resources, like the {@link EventBus} and {@link
-     * CommandBus}}.
+     * CommandBus}}, whilst allowing the capability to append and/or override with the given {@code resourceInjector}.
+     * <p>
+     * Care should be taken if the custom {@code resourceInjector} overrides default resources like the {@code EventBus}
+     * and {@code CommandBus}, as the fixture uses specialized versions of the default sources to support all testing
+     * functionality.
      *
      * @param resourceInjector the {@link ResourceInjector} to register within this fixture
      * @return the current FixtureConfiguration, for fluent interfacing

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -27,6 +27,7 @@ import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolver;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.aggregate.ResultValidator;
 import org.axonframework.test.matchers.FieldFilter;
@@ -210,6 +211,22 @@ public interface FixtureConfiguration {
      */
     FixtureConfiguration registerListenerInvocationErrorHandler(
             ListenerInvocationErrorHandler listenerInvocationErrorHandler);
+
+    /**
+     * Registers a {@link ResourceInjector} within this fixture. This approach can be used if a custom {@code
+     * ResourceInjector} has been built for a project which the user wants to take into account when testing it's
+     * sagas.
+     * <p>
+     * The provided {@code resourceInjector} will be paired with the fixture's default {@code ResourceInjector} to keep
+     * supporting the {@link #registerResource(Object)} and {@link #withTransienceCheckDisabled()} methods. Note that
+     * <b>first</b> the default injector is called, and after that the given {@code resourceInjector}. This approach
+     * ensures the fixture's correct workings for default provided resources, like the {@link EventBus} and {@link
+     * CommandBus}}.
+     *
+     * @param resourceInjector the {@link ResourceInjector} to register within this fixture
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    FixtureConfiguration registerResourceInjector(ResourceInjector resourceInjector);
 
     /**
      * Sets the instance that defines the behavior of the Command Bus when a command is dispatched with a callback.

--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -57,8 +57,8 @@ public interface FixtureConfiguration {
     FixtureConfiguration withTransienceCheckDisabled();
 
     /**
-     * Registers the given {@code resource}. When a Saga is created, all resources are injected on that instance
-     * before any Events are passed onto it.
+     * Registers the given {@code resource}. When a Saga is created, all resources are injected on that instance before
+     * any Events are passed onto it.
      * <p/>
      * Note that a CommandBus, EventBus and EventScheduler are already registered as resources, and need not be
      * registered again.
@@ -71,8 +71,8 @@ public interface FixtureConfiguration {
     void registerResource(Object resource);
 
     /**
-     * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
-     * will be added to the other parameter resolver factories introduced through {@link
+     * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory} will
+     * be added to the other parameter resolver factories introduced through {@link
      * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link
      * org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory} adding the registered resources
      * (with {@link #registerResource(Object)}. The type of the saga under test is used as input for the {@code
@@ -85,9 +85,9 @@ public interface FixtureConfiguration {
     FixtureConfiguration registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory);
 
     /**
-     * Creates a Command Gateway for the given {@code gatewayInterface} and registers that as a resource. The
-     * gateway will dispatch commands on the Command Bus contained in this Fixture, so that you can validate commands
-     * using {@link FixtureExecutionResult#expectDispatchedCommands(Object...)} and {@link
+     * Creates a Command Gateway for the given {@code gatewayInterface} and registers that as a resource. The gateway
+     * will dispatch commands on the Command Bus contained in this Fixture, so that you can validate commands using
+     * {@link FixtureExecutionResult#expectDispatchedCommands(Object...)} and {@link
      * FixtureExecutionResult#expectDispatchedCommandsMatching(org.hamcrest.Matcher)}.
      * <p/>
      * Note that you need to use {@link #setCallbackBehavior(org.axonframework.test.utils.CallbackBehavior)} to defined
@@ -101,14 +101,14 @@ public interface FixtureConfiguration {
     <T> T registerCommandGateway(Class<T> gatewayInterface);
 
     /**
-     * Creates a Command Gateway for the given {@code gatewayInterface} and registers that as a resource. The
-     * gateway will dispatch commands on the Command Bus contained in this Fixture, so that you can validate commands
-     * using {@link FixtureExecutionResult#expectDispatchedCommands(Object...)} and {@link
+     * Creates a Command Gateway for the given {@code gatewayInterface} and registers that as a resource. The gateway
+     * will dispatch commands on the Command Bus contained in this Fixture, so that you can validate commands using
+     * {@link FixtureExecutionResult#expectDispatchedCommands(Object...)} and {@link
      * FixtureExecutionResult#expectDispatchedCommandsMatching(org.hamcrest.Matcher)}.
      * <p/>
-     * The behavior of the created gateway is defined by the given {@code stubImplementation}, if not null.
-     * Dispatched Commands are still recorded for verification. Note that only commands executed in the "when" phase
-     * are recorded, while the stub implementation may record activity during the "given" phase as well.
+     * The behavior of the created gateway is defined by the given {@code stubImplementation}, if not null. Dispatched
+     * Commands are still recorded for verification. Note that only commands executed in the "when" phase are recorded,
+     * while the stub implementation may record activity during the "given" phase as well.
      *
      * @param gatewayInterface   The interface describing the gateway
      * @param stubImplementation The stub or mock implementation defining behavior of the gateway
@@ -118,9 +118,9 @@ public interface FixtureConfiguration {
     <T> T registerCommandGateway(Class<T> gatewayInterface, T stubImplementation);
 
     /**
-     * Registers the given {@code fieldFilter}, which is used to define which Fields are used when comparing
-     * objects. The {@link ResultValidator#expectEvents(Object...)} and
-     * {@link ResultValidator#expectResultMessage(CommandResultMessage)}, for example, use this filter.
+     * Registers the given {@code fieldFilter}, which is used to define which Fields are used when comparing objects.
+     * The {@link ResultValidator#expectEvents(Object...)} and {@link ResultValidator#expectResultMessage(CommandResultMessage)},
+     * for example, use this filter.
      * <p/>
      * When multiple filters are registered, a Field must be accepted by all registered filters in order to be
      * accepted.
@@ -133,13 +133,12 @@ public interface FixtureConfiguration {
     FixtureConfiguration registerFieldFilter(FieldFilter fieldFilter);
 
     /**
-     * Indicates that a field with given {@code fieldName}, which is declared in given {@code declaringClass}
-     * is ignored when performing deep equality checks.
+     * Indicates that a field with given {@code fieldName}, which is declared in given {@code declaringClass} is ignored
+     * when performing deep equality checks.
      *
      * @param declaringClass The class declaring the field
      * @param fieldName      The name of the field
      * @return the current FixtureConfiguration, for fluent interfacing
-     *
      * @throws FixtureExecutionException when no such field is declared
      */
     FixtureConfiguration registerIgnoredField(Class<?> declaringClass, String fieldName);
@@ -201,9 +200,8 @@ public interface FixtureConfiguration {
 
     /**
      * Registers a {@link ListenerInvocationErrorHandler} to be set for the Saga to deal with exceptions being thrown
-     * from within Saga Event Handlers. Will be given to the
-     * {@link org.axonframework.modelling.saga.AnnotatedSagaManager} for the defined Saga type. Defaults to a
-     * {@link org.axonframework.eventhandling.LoggingErrorHandler}.
+     * from within Saga Event Handlers. Will be given to the {@link org.axonframework.modelling.saga.AnnotatedSagaManager}
+     * for the defined Saga type. Defaults to a {@link org.axonframework.eventhandling.LoggingErrorHandler}.
      *
      * @param listenerInvocationErrorHandler to be set for the Saga to deal with exceptions being thrown from within
      *                                       Saga Event Handlers
@@ -242,8 +240,7 @@ public interface FixtureConfiguration {
     /**
      * Use this method to indicate that an aggregate with given identifier published certain events.
      * <p/>
-     * Can be chained to build natural sentences:<br/>
-     * {@code andThenAggregate(someIdentifier).published(someEvents)}
+     * Can be chained to build natural sentences:<br/> {@code andThenAggregate(someIdentifier).published(someEvents)}
      *
      * @param aggregateIdentifier The identifier of the aggregate the events should appear to come from
      * @return an object that allows registration of the actual events to send
@@ -251,8 +248,8 @@ public interface FixtureConfiguration {
     GivenAggregateEventPublisher givenAggregate(String aggregateIdentifier);
 
     /**
-     * Use this method to indicate a specific moment as the initial current time "known" by the fixture at the start
-     * of the given state.
+     * Use this method to indicate a specific moment as the initial current time "known" by the fixture at the start of
+     * the given state.
      *
      * @param currentTime The simulated "current time" at which the given state is initialized
      * @return an object that allows chaining of more given state
@@ -272,14 +269,12 @@ public interface FixtureConfiguration {
      * Indicates that no relevant activity has occurred in the past.
      *
      * @return an object that allows the definition of the activity to measure Saga behavior
-     *
      * @since 2.1.1
      */
     WhenState givenNoPriorActivity();
 
     /**
-     * Returns the time as "known" by the fixture. This is the time at which the fixture was created, plus the amount
-     * of
+     * Returns the time as "known" by the fixture. This is the time at which the fixture was created, plus the amount of
      * time the fixture was told to simulate a "wait".
      * <p/>
      * This time can be used to predict calculations that the saga may have made based on timestamps from the events it
@@ -291,8 +286,8 @@ public interface FixtureConfiguration {
 
     /**
      * Returns the event bus used by this fixture. The event bus is provided for wiring purposes only, for example to
-     * allow command handlers to publish events other than Domain Events. Events published on the returned event bus
-     * are recorded an evaluated in the {@link ResultValidator} operations.
+     * allow command handlers to publish events other than Domain Events. Events published on the returned event bus are
+     * recorded an evaluated in the {@link ResultValidator} operations.
      *
      * @return the event bus used by this fixture
      */

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -46,6 +46,7 @@ import org.axonframework.messaging.annotation.SimpleResourceParameterResolverFac
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.modelling.saga.AnnotatedSagaManager;
 import org.axonframework.modelling.saga.SagaRepository;
+import org.axonframework.modelling.saga.SimpleResourceInjector;
 import org.axonframework.modelling.saga.repository.AnnotatedSagaRepository;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.axonframework.test.FixtureExecutionException;
@@ -53,7 +54,6 @@ import org.axonframework.test.deadline.StubDeadlineManager;
 import org.axonframework.test.eventscheduler.StubEventScheduler;
 import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.matchers.IgnoreField;
-import org.axonframework.test.utils.AutowiredResourceInjector;
 import org.axonframework.test.utils.CallbackBehavior;
 import org.axonframework.test.utils.RecordingCommandBus;
 
@@ -570,7 +570,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
         }
     }
 
-    private class TransienceValidatingResourceInjector extends AutowiredResourceInjector {
+    private class TransienceValidatingResourceInjector extends SimpleResourceInjector {
 
         public TransienceValidatingResourceInjector() {
             super(registeredResources);

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,8 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     private ResourceInjector getResourceInjector() {
-        TransienceValidatingResourceInjector defaultResourceInjector = new TransienceValidatingResourceInjector();
+        TransienceValidatingResourceInjector defaultResourceInjector =
+                new TransienceValidatingResourceInjector(registeredResources, transienceCheckEnabled);
         return resourceInjector != null
                 ? new WrappingResourceInjector(resourceInjector, defaultResourceInjector)
                 : defaultResourceInjector;
@@ -585,10 +586,15 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
         }
     }
 
-    private class TransienceValidatingResourceInjector extends SimpleResourceInjector {
+    private static class TransienceValidatingResourceInjector extends SimpleResourceInjector {
 
-        public TransienceValidatingResourceInjector() {
+        private final List<Object> registeredResources;
+        private final boolean transienceCheckEnabled;
+
+        public TransienceValidatingResourceInjector(List<Object> registeredResources, boolean transienceCheckEnabled) {
             super(registeredResources);
+            this.registeredResources = registeredResources;
+            this.transienceCheckEnabled = transienceCheckEnabled;
         }
 
         @Override
@@ -621,7 +627,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
      * resources, as well as potentially override resources already injected by the {@code
      * TransienceValidatingResourceInjector}.
      */
-    private class WrappingResourceInjector implements ResourceInjector {
+    private static class WrappingResourceInjector implements ResourceInjector {
 
         private final ResourceInjector customResourceInjector;
         private final TransienceValidatingResourceInjector defaultResourceInjector;

--- a/test/src/main/java/org/axonframework/test/utils/AutowiredResourceInjector.java
+++ b/test/src/main/java/org/axonframework/test/utils/AutowiredResourceInjector.java
@@ -16,41 +16,27 @@
 
 package org.axonframework.test.utils;
 
-import org.axonframework.modelling.saga.AbstractResourceInjector;
-
-import java.util.Optional;
+import org.axonframework.modelling.saga.SimpleResourceInjector;
 
 /**
- * Resource injector that uses setter methods to inject resources. All methods and fields annotated with
- * {@code @Inject} are evaluated. If that method has a single parameter, a Resource of that type
- * is injected into it, if present.
+ * Resource injector that uses setter methods to inject resources. All methods and fields annotated with {@code @Inject}
+ * are evaluated. If that method has a single parameter, a Resource of that type is injected into it, if present.
  * <p>
  * Unlike the SimpleResourceInjector, changes in the provided {@link Iterable} are reflected in this injector.
  *
  * @author Allard Buijze
  * @since 1.1
+ * @deprecated in favor of the {@link SimpleResourceInjector}
  */
-public class AutowiredResourceInjector extends AbstractResourceInjector {
-
-    private final Iterable<?> resources;
+@Deprecated
+public class AutowiredResourceInjector extends SimpleResourceInjector {
 
     /**
      * Initializes the resource injector to inject to given {@code resources}.
      *
-     * @param resources The resources to inject
+     * @param resources the resources to inject
      */
-    public AutowiredResourceInjector(Iterable<?> resources) {
-        this.resources = resources;
+    public AutowiredResourceInjector(Iterable<Object> resources) {
+        super(resources);
     }
-
-    @Override
-    protected <R> Optional<R> findResource(Class<R> requiredType) {
-        for (Object resource : resources) {
-            if (requiredType.isInstance(resource)) {
-                return Optional.of(requiredType.cast(resource));
-            }
-        }
-        return Optional.empty();
-    }
-
 }


### PR DESCRIPTION
This pull request introduces the `SagaTestFixture#registerResourceInjector(ResourceInjector)` method, which allows the registration of custom `ResourceInjector` instances a user might have defined in their application.

To keep supporting the fixtures `SagaTestFixture#registerResource(Object)` and `SagaTestFixture#withTransienceCheckDisabled` methods, we have decided that the `registerResourceInjector(ResourceInjector)` *does not* replace the fixtures default `ResourceInjector`. Instead, the registered custom injector is paired with the default provided in the fixture. Firstly, the default will be called for resource injection and secondly the custom one.

Through this approach we ensure that `registerResource` and `withTransienceCheckDisabled` work as intended, whilst the `registerResourceInjector` can be appended in saga test fixtures to include the custom injector (which for example injects additional values on `@Value` annotated fields).

Additionally, this pull request deprecates the `AutowiredResourceInjector`, as it's a duplicate of the `SimpleResourceInjector`, with the additional drawback it's only available in the `axon-test` module. 

This pull request resolves #894 