### PR TITLE
Introduce an EventTypeUpcaster

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.SimpleSerializedType;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A {@link SingleEventUpcaster} implementation which allows for type upcasting only. This could be used if the event's
+ * class name did not follow the desired naming convention or if an event's package name has been adjusted.
+ * <p>
+ * Note that this upcaster <b>should not</b> be used to change the semantic meaning of an event. Such a requirement
+ * points towards a new event type instead of adjusting an existing one.
+ *
+ * @author Steven van Beelen
+ * @since 4.3
+ */
+public abstract class EventTypeUpcaster extends SingleEventUpcaster {
+
+    /**
+     * Retrieve the expected event payload type this upcaster should react on.
+     *
+     * @return the expected event payload type this upcaster should react on
+     */
+    public abstract String expectedPayloadType();
+
+    /**
+     * Retrieve the expected event revision this upcaster should react on.
+     *
+     * @return the expected event revision this upcaster should react on
+     */
+    public abstract String expectedRevision();
+
+    /**
+     * Retrieve the event payload type to upcast towards.
+     *
+     * @return the event payload type to upcast towards
+     */
+    public abstract String upcastedPayloadType();
+
+    /**
+     * Retrieve the event revision to upcast towards.
+     *
+     * @return the event revision to upcast towards
+     */
+    public abstract String upcastedRevision();
+
+    @Override
+    protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation) {
+        SerializedType serializedType = intermediateRepresentation.getType();
+        return isExpectedPayloadType(serializedType.getName()) && isExpectedRevision(serializedType.getRevision());
+    }
+
+    /**
+     * Check whether the given {@code payloadType} matches the outcome of {@link #expectedPayloadType()}.
+     *
+     * @param payloadType the event payload type received by this upcaster in the {@link #canUpcast(IntermediateEventRepresentation)}
+     *                    method
+     * @return {@code true} if the given {@code payloadType} matches the result of {@link #expectedPayloadType()},
+     * {@code false} otherwise
+     */
+    protected boolean isExpectedPayloadType(String payloadType) {
+        return Objects.equals(payloadType, expectedPayloadType());
+    }
+
+    /**
+     * Check whether the given {@code revision} matches the outcome of {@link #expectedRevision()}.
+     *
+     * @param revision the event payload type received by this upcaster in the {@link #canUpcast(IntermediateEventRepresentation)}
+     *                 method
+     * @return {@code true} if the given {@code revision} matches the result of {@link #expectedRevision()}, {@code
+     * false} otherwise
+     */
+    protected boolean isExpectedRevision(String revision) {
+        return Objects.equals(revision, expectedRevision());
+    }
+
+    @Override
+    protected IntermediateEventRepresentation doUpcast(IntermediateEventRepresentation intermediateRepresentation) {
+        return intermediateRepresentation.upcastPayload(upcastedType(), Object.class, Function.identity());
+    }
+
+    /**
+     * Retrieve the upcasted event {@link SerializedType}. Returns a {@link SimpleSerializedType} using {@link
+     * #upcastedPayloadType()} and {@link #upcastedRevision()} as constructor inputs
+     *
+     * @return the event {@link SerializedType} to upcast to
+     */
+    protected SerializedType upcastedType() {
+        return new SimpleSerializedType(upcastedPayloadType(), upcastedRevision());
+    }
+}

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
@@ -32,35 +32,31 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @since 4.3
  */
-public abstract class EventTypeUpcaster extends SingleEventUpcaster {
+public class EventTypeUpcaster extends SingleEventUpcaster {
+
+    private final String expectedPayloadType;
+    private final String expectedRevision;
+    private final String upcastedPayloadType;
+    private final String upcastedRevision;
 
     /**
-     * Retrieve the expected event payload type this upcaster should react on.
+     * Instantiate an {@link EventTypeUpcaster} using the given expected and upcasted payload types and revisions.
+     * <b>Note</b> that the payload type normally represents the fully qualified class name of the event to upcast.
      *
-     * @return the expected event payload type this upcaster should react on
+     * @param expectedPayloadType the expected event payload type this upcaster should react on
+     * @param expectedRevision    the expected event revision this upcaster should react on
+     * @param upcastedPayloadType the event payload type to upcast towards
+     * @param upcastedRevision    the event revision to upcast towards
      */
-    public abstract String expectedPayloadType();
-
-    /**
-     * Retrieve the expected event revision this upcaster should react on.
-     *
-     * @return the expected event revision this upcaster should react on
-     */
-    public abstract String expectedRevision();
-
-    /**
-     * Retrieve the event payload type to upcast towards.
-     *
-     * @return the event payload type to upcast towards
-     */
-    public abstract String upcastedPayloadType();
-
-    /**
-     * Retrieve the event revision to upcast towards.
-     *
-     * @return the event revision to upcast towards
-     */
-    public abstract String upcastedRevision();
+    public EventTypeUpcaster(String expectedPayloadType,
+                             String expectedRevision,
+                             String upcastedPayloadType,
+                             String upcastedRevision) {
+        this.expectedPayloadType = expectedPayloadType;
+        this.expectedRevision = expectedRevision;
+        this.upcastedPayloadType = upcastedPayloadType;
+        this.upcastedRevision = upcastedRevision;
+    }
 
     @Override
     protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation) {
@@ -69,27 +65,27 @@ public abstract class EventTypeUpcaster extends SingleEventUpcaster {
     }
 
     /**
-     * Check whether the given {@code payloadType} matches the outcome of {@link #expectedPayloadType()}.
+     * Check whether the given {@code payloadType} matches the outcome of {@code expectedPayloadType}.
      *
      * @param payloadType the event payload type received by this upcaster in the {@link #canUpcast(IntermediateEventRepresentation)}
      *                    method
-     * @return {@code true} if the given {@code payloadType} matches the result of {@link #expectedPayloadType()},
-     * {@code false} otherwise
+     * @return {@code true} if the given {@code payloadType} matches the result of {@code expectedPayloadType}, {@code
+     * false} otherwise
      */
     protected boolean isExpectedPayloadType(String payloadType) {
-        return Objects.equals(payloadType, expectedPayloadType());
+        return Objects.equals(payloadType, expectedPayloadType);
     }
 
     /**
-     * Check whether the given {@code revision} matches the outcome of {@link #expectedRevision()}.
+     * Check whether the given {@code revision} matches the outcome of {@code expectedRevision}.
      *
      * @param revision the event payload type received by this upcaster in the {@link #canUpcast(IntermediateEventRepresentation)}
      *                 method
-     * @return {@code true} if the given {@code revision} matches the result of {@link #expectedRevision()}, {@code
-     * false} otherwise
+     * @return {@code true} if the given {@code revision} matches the result of {@code expectedRevision}, {@code false}
+     * otherwise
      */
     protected boolean isExpectedRevision(String revision) {
-        return Objects.equals(revision, expectedRevision());
+        return Objects.equals(revision, expectedRevision);
     }
 
     @Override
@@ -98,12 +94,12 @@ public abstract class EventTypeUpcaster extends SingleEventUpcaster {
     }
 
     /**
-     * Retrieve the upcasted event {@link SerializedType}. Returns a {@link SimpleSerializedType} using {@link
-     * #upcastedPayloadType()} and {@link #upcastedRevision()} as constructor inputs
+     * Retrieve the upcasted event {@link SerializedType}. Returns a {@link SimpleSerializedType} using {@code
+     * upcastedPayloadType} and {@code upcastedRevision} as constructor inputs
      *
      * @return the event {@link SerializedType} to upcast to
      */
     protected SerializedType upcastedType() {
-        return new SimpleSerializedType(upcastedPayloadType(), upcastedRevision());
+        return new SimpleSerializedType(upcastedPayloadType, upcastedRevision);
     }
 }

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
@@ -40,29 +40,10 @@ class EventTypeUpcasterTest {
     public static final String UPCASTED_PAYLOAD_TYPE = "upcasted-payload-type";
     public static final String UPCASTED_REVISION = "2";
 
-    private final TestEventTypeUpcaster testSubject = new TestEventTypeUpcaster();
+    private final EventTypeUpcaster testSubject =
+            new EventTypeUpcaster(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
 
     private final Serializer serializer = XStreamSerializer.defaultSerializer();
-
-    @Test
-    void testExpectedPayloadType() {
-        assertEquals(EXPECTED_PAYLOAD_TYPE, testSubject.expectedPayloadType());
-    }
-
-    @Test
-    void testExpectedRevision() {
-        assertEquals(EXPECTED_REVISION, testSubject.expectedRevision());
-    }
-
-    @Test
-    void testUpcastedPayloadType() {
-        assertEquals(UPCASTED_PAYLOAD_TYPE, testSubject.upcastedPayloadType());
-    }
-
-    @Test
-    void testUpcastedRevision() {
-        assertEquals(UPCASTED_REVISION, testSubject.upcastedRevision());
-    }
 
     @Test
     void testCanUpcastReturnsTrueForMatchingPayloadTypeAndRevision() {
@@ -115,29 +96,6 @@ class EventTypeUpcasterTest {
     void testUpcastedType() {
         SerializedType expectedType = new SimpleSerializedType(UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
         assertEquals(expectedType, testSubject.upcastedType());
-    }
-
-    private static class TestEventTypeUpcaster extends EventTypeUpcaster {
-
-        @Override
-        public String expectedPayloadType() {
-            return EXPECTED_PAYLOAD_TYPE;
-        }
-
-        @Override
-        public String expectedRevision() {
-            return EXPECTED_REVISION;
-        }
-
-        @Override
-        public String upcastedPayloadType() {
-            return UPCASTED_PAYLOAD_TYPE;
-        }
-
-        @Override
-        public String upcastedRevision() {
-            return UPCASTED_REVISION;
-        }
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
@@ -67,7 +67,7 @@ class EventTypeUpcasterTest {
     @Test
     void testCanUpcastReturnsTrueForMatchingPayloadTypeAndRevision() {
         EventData<?> testEventData = new TestEventEntry(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
-        InitialEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
+        IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
 
         assertTrue(testSubject.canUpcast(testRepresentation));
     }
@@ -75,7 +75,7 @@ class EventTypeUpcasterTest {
     @Test
     void testCanUpcastReturnsFalseForIncorrectPayloadType() {
         EventData<?> testEventData = new TestEventEntry("some-non-matching-payload-type", EXPECTED_REVISION);
-        InitialEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
+        IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
 
         assertFalse(testSubject.canUpcast(testRepresentation));
     }
@@ -83,7 +83,7 @@ class EventTypeUpcasterTest {
     @Test
     void testCanUpcastReturnsFalseForIncorrectRevision() {
         EventData<?> testEventData = new TestEventEntry(EXPECTED_PAYLOAD_TYPE, "some-non-matching-revision");
-        InitialEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
+        IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
 
         assertFalse(testSubject.canUpcast(testRepresentation));
     }


### PR DESCRIPTION
On the user group a [request](https://groups.google.com/forum/#!topic/axonframework/jyg73R-2sXU) came in for insights into an upcaster which purely allowed for upcasting the event type. From the pseudo code I provided in, I went further and drafted an actual implementation.

Thus, this pull request introduced the `EventTypeUpcaster`. This is an implementation of the
`SingleEventUpcaster`, which in the constructor requires the expected and upcasted payload type / revision.

The `SingleEventUpcaster#canUpcast(IntermediateEventRepresentation)` and `SingleEventUpcaster#doUpcast(IntermediateEventRepresentation)` call `protected` methods, which allow for more fine grained control by the end user.