### PR TITLE
[#1311] Remove unnecessary use of generics in Cache

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/caching/Cache.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package org.axonframework.common.caching;
 import org.axonframework.common.Registration;
 
 /**
- * Abstraction for a Caching mechanism. All Axon component rely on this abstraction, so that different
- * providers can be plugged in. In future versions, this abstraction may be replaced with the {@code javax.cache}
- * api, as soon as that api is final.
+ * Abstraction for a Caching mechanism. All Axon component rely on this abstraction, so that different providers can be
+ * plugged in. In future versions, this abstraction may be replaced with the {@code javax.cache} api, as soon as that
+ * api is final.
  *
  * @author Allard Buijze
  * @since 2.1.2
@@ -39,46 +39,39 @@ public interface Cache {
     <K, V> V get(K key);
 
     /**
-     * Stores the given {@code value} in the cache, under given {@code key}. If an item already exists,
-     * it is updated with the new value.
+     * Stores the given {@code value} in the cache, under given {@code key}. If an item already exists, it is updated
+     * with the new value.
      *
      * @param key   The key under which to store the item
      * @param value The item to cache
-     * @param <K>   The type of key used
-     * @param <V>   The type of value stored
      */
-    <K, V> void put(K key, V value);
+    void put(Object key, Object value);
 
     /**
-     * Stores the given {@code value} in the cache, under given {@code key}, if no element is yet available
-     * under that key. This operation is performed atomically.
+     * Stores the given {@code value} in the cache, under given {@code key}, if no element is yet available under that
+     * key. This operation is performed atomically.
      *
      * @param key   The key under which to store the item
      * @param value The item to cache
-     * @param <K>   The type of key used
-     * @param <V>   The type of value stored
      * @return {@code true} if no value was previously assigned to the key, {@code false} otherwise.
      */
-    <K, V> boolean putIfAbsent(K key, V value);
+    boolean putIfAbsent(Object key, Object value);
 
     /**
      * Removes the entry stored under given {@code key}. If no such entry exists, nothing happens.
      *
      * @param key The key under which the item was stored
-     * @param <K> The type of key used
-     * @return {@code true} if a value was previously assigned to the key and has been removed, {@code false}
-     * otherwise.
+     * @return {@code true} if a value was previously assigned to the key and has been removed, {@code false} otherwise.
      */
-    <K> boolean remove(K key);
+    boolean remove(Object key);
 
     /**
      * Indicates whether there is an item stored under given {@code key}.
      *
      * @param key The key to check
-     * @param <K> The type of key
      * @return {@code true} if an item is available under that key, {@code false} otherwise.
      */
-    <K> boolean containsKey(K key);
+    boolean containsKey(Object key);
 
     /**
      * Registers the given {@code cacheEntryListener} to listen for Cache changes.
@@ -137,7 +130,6 @@ public interface Cache {
          * java.lang.Cloneable} to indicate it supports cloning.
          *
          * @return a copy of this instance
-         *
          * @throws CloneNotSupportedException if cloning is not supported
          * @see java.lang.Cloneable
          */

--- a/messaging/src/main/java/org/axonframework/common/caching/EhCacheAdapter.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/EhCacheAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,26 +49,25 @@ public class EhCacheAdapter extends AbstractCacheAdapter<CacheEventListener> {
     }
 
     @Override
-    public <K, V> void put(K key, V value) {
+    public void put(Object key, Object value) {
         ehCache.put(new Element(key, value));
     }
 
     @Override
-    public <K, V> boolean putIfAbsent(K key, V value) {
+    public boolean putIfAbsent(Object key, Object value) {
         return ehCache.putIfAbsent(new Element(key, value)) == null;
     }
 
     @Override
-    public <K> boolean remove(K key) {
+    public boolean remove(Object key) {
         return ehCache.remove(key);
     }
 
     @Override
-    public <K> boolean containsKey(K key) {
+    public boolean containsKey(Object key) {
         return ehCache.isKeyInCache(key);
     }
 
-    @SuppressWarnings("ClassEscapesDefinedScope")
     @Override
     protected EhCacheAdapter.CacheEventListenerAdapter createListenerAdapter(EntryListener cacheEntryListener) {
         return new EhCacheAdapter.CacheEventListenerAdapter(ehCache, cacheEntryListener);
@@ -80,7 +79,6 @@ public class EhCacheAdapter extends AbstractCacheAdapter<CacheEventListener> {
         return () -> ehCache.getCacheEventNotificationService().unregisterListener(listenerAdapter);
     }
 
-    @SuppressWarnings("unchecked")
     private static class CacheEventListenerAdapter implements CacheEventListener, Cloneable {
 
         private Ehcache ehCache;

--- a/messaging/src/main/java/org/axonframework/common/caching/JCacheAdapter.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/JCacheAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,17 @@ package org.axonframework.common.caching;
 
 import org.axonframework.common.Registration;
 
+import java.io.Serializable;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;
-import javax.cache.event.*;
-import java.io.Serializable;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryEventFilter;
+import javax.cache.event.CacheEntryExpiredListener;
+import javax.cache.event.CacheEntryListener;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.event.CacheEntryRemovedListener;
+import javax.cache.event.CacheEntryUpdatedListener;
 
 /**
  * Cache adapter implementation that allows providers implementing the JCache abstraction to be used.
@@ -29,52 +36,52 @@ import java.io.Serializable;
  * @author Allard Buijze
  * @since 2.1.2
  */
-@SuppressWarnings("unchecked")
-public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfiguration> {
+public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfiguration<Object, Object>> {
 
-    private final javax.cache.Cache jCache;
+    private final javax.cache.Cache<Object, Object> jCache;
 
     /**
      * Initialize the adapter to forward call to the given {@code jCache} instance
      *
      * @param jCache The cache to forward all calls to
      */
-    public JCacheAdapter(javax.cache.Cache jCache) {
+    public JCacheAdapter(javax.cache.Cache<Object, Object> jCache) {
         this.jCache = jCache;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <K, V> V get(K key) {
         return (V) jCache.get(key);
     }
 
     @Override
-    public <K, V> void put(K key, V value) {
+    public void put(Object key, Object value) {
         jCache.put(key, value);
     }
 
     @Override
-    public <K, V> boolean putIfAbsent(K key, V value) {
+    public boolean putIfAbsent(Object key, Object value) {
         return jCache.putIfAbsent(key, value);
     }
 
     @Override
-    public <K> boolean remove(K key) {
+    public boolean remove(Object key) {
         return jCache.remove(key);
     }
 
     @Override
-    public <K> boolean containsKey(K key) {
+    public boolean containsKey(Object key) {
         return jCache.containsKey(key);
     }
 
     @Override
-    protected CacheEntryListenerConfiguration createListenerAdapter(EntryListener cacheEntryListener) {
-        return new JCacheListenerAdapter(cacheEntryListener);
+    protected CacheEntryListenerConfiguration<Object, Object> createListenerAdapter(EntryListener cacheEntryListener) {
+        return new JCacheListenerAdapter<>(cacheEntryListener);
     }
 
     @Override
-    protected Registration doRegisterListener(CacheEntryListenerConfiguration listenerAdapter) {
+    protected Registration doRegisterListener(CacheEntryListenerConfiguration<Object, Object> listenerAdapter) {
         jCache.registerCacheEntryListener(listenerAdapter);
         return () -> {
             jCache.deregisterCacheEntryListener(listenerAdapter);
@@ -96,7 +103,7 @@ public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfig
         @Override
         public void onCreated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent event : cacheEntryEvents) {
+            for (CacheEntryEvent<?, ?> event : cacheEntryEvents) {
                 delegate.onEntryCreated(event.getKey(), event.getValue());
             }
         }
@@ -104,7 +111,7 @@ public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfig
         @Override
         public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> iterable)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent event : iterable) {
+            for (CacheEntryEvent<?, ?> event : iterable) {
                 delegate.onEntryExpired(event.getKey());
             }
         }
@@ -132,7 +139,7 @@ public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfig
         @Override
         public void onRemoved(Iterable<CacheEntryEvent<? extends K, ? extends V>> iterable)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent event : iterable) {
+            for (CacheEntryEvent<?, ?> event : iterable) {
                 delegate.onEntryRemoved(event.getKey());
             }
         }
@@ -140,13 +147,13 @@ public class JCacheAdapter extends AbstractCacheAdapter<CacheEntryListenerConfig
         @Override
         public void onUpdated(Iterable<CacheEntryEvent<? extends K, ? extends V>> iterable)
                 throws CacheEntryListenerException {
-            for (CacheEntryEvent event : iterable) {
+            for (CacheEntryEvent<?, ?> event : iterable) {
                 delegate.onEntryUpdated(event.getKey(), event.getValue());
             }
         }
 
         @Override
-        public CacheEntryListener create() {
+        public CacheEntryListener<K, V> create() {
             return this;
         }
     }

--- a/messaging/src/main/java/org/axonframework/common/caching/WeakReferenceCache.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/WeakReferenceCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * Values are Weakly referenced, which means they are not eligible for removal as long as any other references to the
  * value exist.
  * <p/>
- * Items expire once the garbage collector has removed them. Some time after they have been removed, the entry
- * listeners are being notified thereof. Note that notification are emitted when the cache is being accessed (either
- * for reading or writing). If the cache is not being accessed for a longer period of time, it may occur that listeners
- * are not notified.
+ * Items expire once the garbage collector has removed them. Some time after they have been removed, the entry listeners
+ * are being notified thereof. Note that notification are emitted when the cache is being accessed (either for reading
+ * or writing). If the cache is not being accessed for a longer period of time, it may occur that listeners are not
+ * notified.
  *
  * @author Allard Buijze
  * @author Henrique Sena
@@ -72,7 +72,7 @@ public class WeakReferenceCache implements Cache {
     }
 
     @Override
-    public <K, V> void put(K key, V value) {
+    public void put(Object key, Object value) {
         if (value == null) {
             throw new IllegalArgumentException("Null values not supported");
         }
@@ -90,7 +90,7 @@ public class WeakReferenceCache implements Cache {
     }
 
     @Override
-    public <K, V> boolean putIfAbsent(K key, V value) {
+    public boolean putIfAbsent(Object key, Object value) {
         if (value == null) {
             throw new IllegalArgumentException("Null values not supported");
         }
@@ -105,7 +105,7 @@ public class WeakReferenceCache implements Cache {
     }
 
     @Override
-    public <K> boolean remove(K key) {
+    public boolean remove(Object key) {
         if (cache.remove(key) != null) {
             for (EntryListener adapter : adapters) {
                 adapter.onEntryRemoved(key);
@@ -116,7 +116,7 @@ public class WeakReferenceCache implements Cache {
     }
 
     @Override
-    public <K> boolean containsKey(K key) {
+    public boolean containsKey(Object key) {
         Assert.nonNull(key, () -> "Key may not be null");
         purgeItems();
         final Reference<Object> entry = cache.get(key);


### PR DESCRIPTION
The `Cache` interface utilizes unnecessary generics for the `put`, `putIfAbsent`, `remove` and `containsKey` methods. 
This pull request replaces those generics for `Object` instead, to simplify the `Cache` interface.
The implementation `EhCacheAdapter`, `JCacheAdapter` and `WeakReferenceCache` have been adjusted accordingly too.

This pull request resolves #1311