### PR TITLE
EventTypeUpcaster Builder

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.axonframework.common;
 
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Utility class containing reusable functionality for implementing the Builder Pattern in (infrastructure) components.
@@ -27,6 +26,8 @@ import java.util.function.Supplier;
  * @since 4.0
  */
 public abstract class BuilderUtils {
+
+    private static final String EMPTY_STRING = "";
 
     private BuilderUtils() {
         // Utility class
@@ -39,8 +40,8 @@ public abstract class BuilderUtils {
      * @param value            a {@code T} specifying the value to assert
      * @param assertion        a {@link Predicate} to test {@code value} against
      * @param exceptionMessage The message for the exception.
-     * @param <T>              a generic specifying the type of the {@code value}, which is the input for the
-     *                         {@code assertion}
+     * @param <T>              a generic specifying the type of the {@code value}, which is the input for the {@code
+     *                         assertion}
      * @throws AxonConfigurationException if the {@code value} asserts to {@code false} by the {@code assertion}
      */
     public static <T> void assertThat(T value,
@@ -55,8 +56,8 @@ public abstract class BuilderUtils {
      *
      * @param value            a {@code T} specifying the value to assert
      * @param exceptionMessage The message for the exception.
-     * @param <T>              a generic specifying the type of the {@code value}, which is the input for the
-     *                         {@code assertion}
+     * @param <T>              a generic specifying the type of the {@code value}, which is the input for the {@code
+     *                         assertion}
      * @throws AxonConfigurationException if the {@code value} equals {@code null}
      */
     public static <T> void assertNonNull(T value, String exceptionMessage) throws AxonConfigurationException {
@@ -64,8 +65,8 @@ public abstract class BuilderUtils {
     }
 
     /**
-     * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an
-     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an {@link
+     * AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
      * @param i                the value to assert
      * @param exceptionMessage the message for the exception
@@ -75,8 +76,8 @@ public abstract class BuilderUtils {
     }
 
     /**
-     * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an
-     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     * Assert that the given {@code value} is positive, meaning greater than, or equal to, zero. If not, an {@link
+     * AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
      * @param l                the value to assert
      * @param exceptionMessage the message for the exception
@@ -86,8 +87,8 @@ public abstract class BuilderUtils {
     }
 
     /**
-     * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an
-     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an {@link
+     * AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
      * @param i                the value to assert
      * @param exceptionMessage the message for the exception.
@@ -97,13 +98,24 @@ public abstract class BuilderUtils {
     }
 
     /**
-     * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an
-     * {@link AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
+     * Assert that the given {@code value} is strictly positive, meaning greater than zero. If not, an {@link
+     * AxonConfigurationException} is thrown containing the provided {code exceptionMessage}.
      *
      * @param l                the value to assert
      * @param exceptionMessage the message for the exception.
      */
     public static void assertStrictPositive(long l, String exceptionMessage) {
         assertThat(l, number -> number > 0L, exceptionMessage);
+    }
+
+    /**
+     * Assert that the given {@code string} is not null and does not equal an empty String. If not, an {@link
+     * AxonConfigurationException} is thrown containing the provided {@code exceptionMessage}.
+     *
+     * @param string           the value to assert
+     * @param exceptionMessage the message for the exception.
+     */
+    public static void assertNonEmpty(String string, String exceptionMessage) {
+        assertThat(string, s -> Objects.nonNull(s) && !EMPTY_STRING.equals(s), exceptionMessage);
     }
 }

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
@@ -22,6 +22,9 @@ import org.axonframework.serialization.SimpleSerializedType;
 import java.util.Objects;
 import java.util.function.Function;
 
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+
 /**
  * A {@link SingleEventUpcaster} implementation which allows for type upcasting only. This could be used if the event's
  * class name did not follow the desired naming convention or if an event's package name has been adjusted.
@@ -38,6 +41,33 @@ public class EventTypeUpcaster extends SingleEventUpcaster {
     private final String expectedRevision;
     private final String upcastedPayloadType;
     private final String upcastedRevision;
+
+    /**
+     * Instantiate a {@link EventTypeUpcaster.Builder} which should upcast "from" the given {@code payloadType} and
+     * {@code revision}. This method will use the fully qualified class name of the given {@code payloadType} as the
+     * {@code expectedPayloadType}.
+     *
+     * @param payloadType the payload type the upcaster should upcast "from"
+     * @param revision    the revision the upcaster should upcast "from"
+     * @return the current Builder instance, for fluent interfacing
+     */
+    public static Builder from(Class<?> payloadType, String revision) {
+        assertNonNull(payloadType, "The payloadType may not be null");
+        return from(payloadType.getName(), revision);
+    }
+
+    /**
+     * Instantiate a {@link EventTypeUpcaster.Builder} which should upcast "from" the given {@code payloadType} and
+     * {@code revision}.
+     *
+     * @param payloadType the payload type the upcaster should upcast "from"
+     * @param revision    the revision the upcaster should upcast "from"
+     * @return the current Builder instance, for fluent interfacing
+     */
+    public static Builder from(String payloadType, String revision) {
+        assertNonEmpty(payloadType, "The payloadType may not be null or empty");
+        return new Builder(payloadType, revision);
+    }
 
     /**
      * Instantiate an {@link EventTypeUpcaster} using the given expected and upcasted payload types and revisions.
@@ -101,5 +131,51 @@ public class EventTypeUpcaster extends SingleEventUpcaster {
      */
     protected SerializedType upcastedType() {
         return new SimpleSerializedType(upcastedPayloadType, upcastedRevision);
+    }
+
+    /**
+     * Builder class to instantiate an {@link EventTypeUpcaster}.
+     */
+    public static class Builder {
+
+        private final String expectedPayloadType;
+        private final String expectedRevision;
+
+        /**
+         * Instantiate a {@link Builder} as a shorthand to create an {@link EventTypeUpcaster}.
+         *
+         * @param expectedPayloadType the expected event payload type this upcaster should react on
+         * @param expectedRevision    the expected event revision this upcaster should react on
+         */
+        public Builder(String expectedPayloadType, String expectedRevision) {
+            this.expectedPayloadType = expectedPayloadType;
+            this.expectedRevision = expectedRevision;
+        }
+
+        /**
+         * Create an {@link EventTypeUpcaster} which upcasts "to" the given {@code payloadType} and {@code revision}.
+         * This method will use the fully qualified class name of the given {@code payloadType} as the {@code
+         * upcastedPayloadType}.
+         *
+         * @param payloadType the payload type the upcaster should upcast "to"
+         * @param revision    the revision the upcaster should upcast "to"
+         * @return an {@link EventTypeUpcaster} upcasting "to" the given {@code payloadType} and {@code revision}
+         */
+        public EventTypeUpcaster to(Class<?> payloadType, String revision) {
+            assertNonNull(payloadType, "The payloadType may not be null");
+            return to(payloadType.getName(), revision);
+        }
+
+        /**
+         * Create an {@link EventTypeUpcaster} which upcasts "to" the given {@code payloadType} and {@code revision}.
+         *
+         * @param payloadType the payload type the upcaster should upcast "to"
+         * @param revision    the revision the upcaster should upcast "to"
+         * @return an {@link EventTypeUpcaster} upcasting "to" the given {@code payloadType} and {@code revision}
+         */
+        public EventTypeUpcaster to(String payloadType, String revision) {
+            assertNonEmpty(payloadType, "The payloadType may not be null or empty");
+            return new EventTypeUpcaster(expectedPayloadType, expectedRevision, payloadType, revision);
+        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/BuilderUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/BuilderUtilsTest.java
@@ -1,13 +1,33 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.common;
 
 import org.junit.jupiter.api.*;
 
 import java.util.Random;
 
-import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.BuilderUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating all the methods in the {@link BuilderUtils}.
+ *
+ * @author Bert Laverman
+ */
 class BuilderUtilsTest {
 
     private static final int NUMBER_OF_RANDOM_NUMBERS = 256;
@@ -31,7 +51,7 @@ class BuilderUtilsTest {
 
     @Test
     void testAssertNonNull() {
-        BuilderUtils.assertNonNull(this, "This is not null");
+        assertNonNull(this, "This is not null");
 
         testAssertFails(() -> assertNonNull(null, "Null should be null"),
                         "BuilderUtils.assertNonNull() should have failed on value null.");
@@ -117,5 +137,14 @@ class BuilderUtilsTest {
                 testAssertFails(() -> assertStrictPositive(value, "fail"), "Value " + value + " is negative.");
             }
         }
+    }
+
+    @Test
+    void testAssertNonEmpty() {
+        assertNonEmpty("some-text", "Reacts fine on some text");
+        testAssertFails(() -> assertNonEmpty(null, "Should fail on null"),
+                        "BuilderUtils.assertNonEmpty() should have failed on value null.");
+        testAssertFails(() -> assertNonEmpty("", "Should fail on an empty string"),
+                        "BuilderUtils.assertNonEmpty() should have failed on an empty string.");
     }
 }

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.serialization.upcasting.event;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.AbstractEventEntry;
 import org.axonframework.eventhandling.EventData;
 import org.axonframework.serialization.SerializedType;
@@ -44,6 +45,51 @@ class EventTypeUpcasterTest {
             new EventTypeUpcaster(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
 
     private final Serializer serializer = XStreamSerializer.defaultSerializer();
+
+    @Test
+    void testUpcasterBuilderFailsForNullExpectedPayloadTypeClass() {
+        assertThrows(
+                AxonConfigurationException.class, () -> EventTypeUpcaster.from((Class<?>) null, EXPECTED_REVISION)
+        );
+    }
+
+    @Test
+    void testUpcasterBuilderFailsForNullExpectedPayloadType() {
+        assertThrows(
+                AxonConfigurationException.class, () -> EventTypeUpcaster.from((String) null, EXPECTED_REVISION)
+        );
+    }
+
+    @Test
+    void testUpcasterBuilderFailsForEmptyExpectedPayloadType() {
+        assertThrows(
+                AxonConfigurationException.class, () -> EventTypeUpcaster.from("", EXPECTED_REVISION)
+        );
+    }
+
+    @Test
+    void testUpcasterBuilderFailsForNullUpcastedPayloadTypeClass() {
+        EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
+        assertThrows(
+                AxonConfigurationException.class, () -> testSubject.to((Class<?>) null, UPCASTED_REVISION)
+        );
+    }
+
+    @Test
+    void testUpcasterBuilderFailsForNullUpcastedPayloadType() {
+        EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
+        assertThrows(
+                AxonConfigurationException.class, () -> testSubject.to((String) null, UPCASTED_REVISION)
+        );
+    }
+
+    @Test
+    void testUpcasterBuilderFailsForEmptyUpcastedPayloadType() {
+        EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
+        assertThrows(
+                AxonConfigurationException.class, () -> testSubject.to("", UPCASTED_REVISION)
+        );
+    }
 
     @Test
     void testCanUpcastReturnsTrueForMatchingPayloadTypeAndRevision() {


### PR DESCRIPTION
This pull request introduces a static `EventTypeUpcaster#from(String, String)` and `EventTypeUpcaster.Builder#to(String, String)` method to allow creation of an `EventTypeUpcaster`.

This builder approach looks cleaner from a usage perspective then the constructor of the `EventTypeUpcaster`. I've also provided a `from(Class, String)` and `to(Class, String)` method, which will use the fully qualified class name of the given class as the expected/upcasted payload type of the `EventTypeUpcaster`.

Lastly, I've added the `assertNonEmpty(String, String)` method to the `BuilderUtils` class, as I wanted to assure the given payload type is non null and empty at all times.