### PR TITLE
[#1219] Allow resource injection for State-Stored Aggregates

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -306,7 +306,11 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         clearGivenWhenState();
         DefaultUnitOfWork.startAndGet(null).execute(() -> {
             if (repository == null) {
-                registerRepository(new InMemoryRepository<>(aggregateType, eventStore, getRepositoryProvider()));
+                registerRepository(new InMemoryRepository<>(aggregateType,
+                                                            eventStore,
+                                                            getParameterResolverFactory(),
+                                                            getHandlerDefinition(),
+                                                            getRepositoryProvider()));
             }
             try {
                 repository.newInstance(aggregate::get);
@@ -725,8 +729,14 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         private final AggregateModel<T> aggregateModel;
         private AnnotatedAggregate<T> storedAggregate;
 
-        protected InMemoryRepository(Class<T> aggregateType, EventBus eventBus, RepositoryProvider repositoryProvider) {
-            this.aggregateModel = AnnotatedAggregateMetaModelFactory.inspectAggregate(aggregateType);
+        protected InMemoryRepository(Class<T> aggregateType,
+                                     EventBus eventBus,
+                                     ParameterResolverFactory parameterResolverFactory,
+                                     HandlerDefinition handlerDefinition,
+                                     RepositoryProvider repositoryProvider) {
+            this.aggregateModel = AnnotatedAggregateMetaModelFactory.inspectAggregate(
+                    aggregateType, parameterResolverFactory, handlerDefinition
+            );
             this.eventBus = eventBus;
             this.repositoryProvider = repositoryProvider;
         }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,27 @@
 package org.axonframework.test.aggregate;
 
 import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.modelling.command.TargetAggregateIdentifier;
-import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+import org.junit.jupiter.api.*;
+
+import java.util.function.Supplier;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.hamcrest.CoreMatchers.any;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
+ * Test class intended to validate the {@link AggregateTestFixture}'s inner workings after a {@link
+ * AggregateTestFixture#givenState(Supplier)}.
+ *
  * @author Allard Buijze
  */
 class FixtureTest_StateStorage {
+
+    private static final String AGGREGATE_ID = "id";
 
     private FixtureConfiguration<StateStoredAggregate> fixture;
 
@@ -50,16 +55,16 @@ class FixtureTest_StateStorage {
 
     @Test
     void testCreateStateStoredAggregate() {
-        fixture.givenState(() -> new StateStoredAggregate("id", "message"))
-               .when(new SetMessageCommand("id", "message2"))
+        fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
+               .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                .expectEvents(new StubDomainEvent())
                .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
     }
 
     @Test
     void testEmittedEventsFromExpectStateAreNotStored() {
-        fixture.givenState(() -> new StateStoredAggregate("id", "message"))
-               .when(new SetMessageCommand("id", "message2"))
+        fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
+               .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                .expectEvents(new StubDomainEvent())
                .expectState(aggregate -> {
                    apply(new StubDomainEvent());
@@ -72,14 +77,32 @@ class FixtureTest_StateStorage {
     @Test
     void testCreateStateStoredAggregate_ErrorInChanges() {
         ResultValidator<StateStoredAggregate> result =
-                fixture.givenState(() -> new StateStoredAggregate("id", "message"))
-                       .when(new ErrorCommand("id", "message2"))
+                fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
+                       .when(new ErrorCommand(AGGREGATE_ID, "message2"))
                        .expectException(any(Exception.class))
                        .expectNoEvents();
-        IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> result.expectState(aggregate -> assertEquals("message2", aggregate.getMessage())));
+        IllegalStateException e = assertThrows(
+                IllegalStateException.class,
+                () -> result.expectState(aggregate -> assertEquals("message2", aggregate.getMessage()))
+        );
         assertTrue(e.getMessage().contains("Unit of Work"), "Wrong message: " + e.getMessage());
         assertTrue(e.getMessage().contains("rolled back"), "Wrong message: " + e.getMessage());
+    }
+
+    /**
+     * Follow up on GitHub issue https://github.com/AxonFramework/AxonFramework/issues/1219
+     */
+    @Test
+    void testStateStoredAggregateCanAttachRegisteredResource() {
+        String expectedMessage = "state stored resource injection works";
+        HardToCreateResource testResource = spy(new HardToCreateResource());
+
+        fixture.registerInjectableResource(testResource)
+               .givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
+               .when(new HandleWithResourceCommand(AGGREGATE_ID, expectedMessage))
+               .expectEvents(new StubDomainEvent());
+
+        verify(testResource).difficultOperation(expectedMessage);
     }
 
     private static class InitializeCommand {
@@ -141,6 +164,27 @@ class FixtureTest_StateStorage {
         }
     }
 
+    private static class HandleWithResourceCommand {
+
+        @TargetAggregateIdentifier
+        private final String id;
+        private final String messageToLog;
+
+        private HandleWithResourceCommand(String id, String messageToLog) {
+            this.id = id;
+            this.messageToLog = messageToLog;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getMessageToLog() {
+            return messageToLog;
+        }
+    }
+
+    @SuppressWarnings("unused")
     public static class StateStoredAggregate {
 
         @AggregateIdentifier
@@ -172,10 +216,15 @@ class FixtureTest_StateStorage {
             throw new RuntimeException("Stub");
         }
 
+        @CommandHandler
+        public void handle(HandleWithResourceCommand command, HardToCreateResource resource) {
+            resource.difficultOperation(command.getMessageToLog());
+            apply(new StubDomainEvent());
+        }
+
         public String getMessage() {
             return message;
         }
-
     }
 
     private static class StubDomainEvent {

--- a/test/src/test/java/org/axonframework/test/aggregate/HardToCreateResource.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/HardToCreateResource.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2013. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,26 @@
 
 package org.axonframework.test.aggregate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+
 /**
+ * Stub resource used for validating resource injection for the {@link AggregateTestFixture}.
+ *
  * @author Allard Buijze
  */
 public class HardToCreateResource {
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /**
+     * Some operation to spy/verify on during tests
+     *
+     * @param p a {@link String} which will become debug logging
+     */
+    public void difficultOperation(String p) {
+        logger.debug("Performing a difficult operation using [{}]", p);
+    }
 }


### PR DESCRIPTION
The `InMemoryRepository` used in the `AggregateTestFixture` for state-stored aggregate testing did not utilize any of the resources added through `AggregateTestFixture#registerInjectableResource(Object)`.

This followed from the fact that the `AggregateModel` created in the `InMemoryRepository` used the default `ParameterResolverFactory` instead of the one registered in the `AggregateTestFixture` which includes the registered resource.
Added, the registered `HandlerDefinition`/`HandlerEnhancerDefinition` was also not taken into account by the `InMemoryRepository`.

To thus resolve this bug, I've simply added the `ParameterResolverFactory` and `HandlerDefinition` to the `InMemoryRepository` which did the trick.

This issue resolves #1219