### PR TITLE
Lazily initialize the JpaSagaStore

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import java.sql.SQLException;
 import javax.persistence.EntityManagerFactory;
@@ -64,6 +65,7 @@ public class JpaAutoConfiguration {
                             .build();
     }
 
+    @Lazy
     @Bean
     @ConditionalOnMissingBean(SagaStore.class)
     public JpaSagaStore sagaStore(Serializer serializer, EntityManagerProvider entityManagerProvider) {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationLazySagaStoreTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationLazySagaStoreTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot;
+
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.modelling.saga.repository.SagaStore;
+import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.junit.jupiter.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests JPA auto-configuration lazy initializes the provided {@link SagaStore} bean by verifying that the mocked {@link
+ * EntityManager} is not used until the {@code SagaStore} is retrieved from the {@link ApplicationContext}.
+ *
+ * @author Steven van Beelen
+ */
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@ContextConfiguration(classes = JpaAutoConfigurationLazySagaStoreTest.TestContext.class)
+@EnableAutoConfiguration
+@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+class JpaAutoConfigurationLazySagaStoreTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    /**
+     * The last {@link org.mockito.Mockito#verify(Object)} operation checks whether the {@code
+     * JpaSagaStore#addNamedQueriesTo(EntityManager)} operation is called, signaling that the {@code JpaSagaStore} is
+     * being initialized.
+     */
+    @Test
+    void testContextInitialization() {
+        EntityManagerProvider entityManagerProvider = applicationContext.getBean(EntityManagerProvider.class);
+        EntityManager entityManager = entityManagerProvider.getEntityManager();
+        verifyZeroInteractions(entityManager);
+
+        SagaStore<?> sagaStore = applicationContext.getBean(SagaStore.class);
+        assertTrue(sagaStore instanceof JpaSagaStore);
+
+        verify(entityManager).getEntityManagerFactory();
+    }
+
+    static class TestContext {
+
+        @Bean
+        public EntityManagerProvider entityManagerProvider() {
+            EntityManager entityManager = mock(EntityManager.class);
+            when(entityManager.getEntityManagerFactory()).thenReturn(mock(EntityManagerFactory.class));
+
+            EntityManagerProvider entityManagerProvider = mock(EntityManagerProvider.class);
+            when(entityManagerProvider.getEntityManager()).thenReturn(entityManager);
+
+            return entityManagerProvider;
+        }
+    }
+}


### PR DESCRIPTION
Currently the `JpaSagaStore` will eagerly create named queries for the `saga_entry` table. 
However, if the `saga_entry` entity is not required/desired, this approach will still enforce it being available. 

Changing this behavior to lazily initialize, by adding `@Lazy` to the `JpaSagaStore` bean creation method will allow ignoring the `saga_entry` entity altogether.

This pull request is a follow up from [this](https://groups.google.com/forum/#!topic/axonframework/VnCsbuMt0FU) user group issue.