### PR TITLE
[#1212] TrackingProcessor should rethrow exceptions when shutting down in error state

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -1296,8 +1296,8 @@ public class TrackingEventProcessorTest {
 
         assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(testSubject.isError()));
         assertWithin(
-                2, TimeUnit.SECONDS,
-                () -> assertTrue(thrownException.get().getClass().isAssignableFrom(TestError.class))
+                15, TimeUnit.SECONDS,
+                () -> assertTrue(thrownException.get() instanceof TestError)
         );
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -187,6 +188,10 @@ public class TrackingEventProcessorTest {
                                                          .andEventAvailabilityTimeout(100, TimeUnit.MILLISECONDS));
     }
 
+    private void initProcessor(TrackingEventProcessorConfiguration config) {
+        initProcessor(config, UnaryOperator.identity());
+    }
+
     private void initProcessor(TrackingEventProcessorConfiguration config,
                                UnaryOperator<TrackingEventProcessor.Builder> customization) {
         TrackingEventProcessor.Builder eventProcessorBuilder =
@@ -206,10 +211,6 @@ public class TrackingEventProcessorTest {
                 }
             }
         };
-    }
-
-    private void initProcessor(TrackingEventProcessorConfiguration config) {
-        initProcessor(config, UnaryOperator.identity());
     }
 
     @After
@@ -1268,6 +1269,38 @@ public class TrackingEventProcessorTest {
         assertFalse("Expected merge to be rejected", actual.join());
     }
 
+    /**
+     * This test is a follow up from issue https://github.com/AxonFramework/AxonFramework/issues/1212
+     */
+    @Test
+    public void testThrownErrorBubblesUp() {
+        AtomicReference<Throwable> thrownException = new AtomicReference<>();
+
+        EventHandlerInvoker eventHandlerInvoker = mock(EventHandlerInvoker.class);
+        when(eventHandlerInvoker.canHandle(any(), any())).thenThrow(new TestError());
+
+        initProcessor(
+                TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
+                                                   .andThreadFactory(name -> runnableForThread -> new Thread(() -> {
+                                                       try {
+                                                           runnableForThread.run();
+                                                       } catch (Throwable t) {
+                                                           thrownException.set(t);
+                                                       }
+                                                   })),
+                builder -> builder.eventHandlerInvoker(eventHandlerInvoker)
+        );
+
+        eventBus.publish(createEvents(1));
+        testSubject.start();
+
+        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(testSubject.isError()));
+        assertWithin(
+                2, TimeUnit.SECONDS,
+                () -> assertTrue(thrownException.get().getClass().isAssignableFrom(TestError.class))
+        );
+    }
+
     private void waitForStatus(String description,
                                long time,
                                TimeUnit unit,
@@ -1352,5 +1385,9 @@ public class TrackingEventProcessorTest {
         public void close() {
 
         }
+    }
+
+    private static class TestError extends Error {
+
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -1093,6 +1093,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
             } catch (Throwable e) {
                 logger.error("Processing loop ended due to uncaught exception. Pausing processor in Error State.", e);
                 state.set(State.PAUSED_ERROR);
+                throw e;
             } finally {
                 activeSegments.remove(segment.getSegmentId());
                 logger.info("Worker for segment {} stopped.", segment);


### PR DESCRIPTION
This PR adds a rethrow of the exception caught in the `TrackingSegmentWorker` after the `TrackingEventProcessor` it's state has been set to `PAUSED_ERROR`.
As such this pull request resolves #1212