### PR TITLE
Adds debug logging for thrown exception

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -1139,6 +1139,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
                 } catch (Exception e) {
                     logger.warn("Fetch Segments for Processor '{}' failed: {}. Preparing for retry in {}s",
                                 processorName, e.getMessage(), waitTime);
+                    logger.debug("Fetch Segments failed because:", e);
                     doSleepFor(SECONDS.toMillis(waitTime));
                     waitTime = Math.min(waitTime * 2, 60);
 


### PR DESCRIPTION
On our project, we are moving from MariaDB to CockroachDB. While migrating our code, we saw a lot of `Fetch Segments for Processor: ...` errors, with no further explanation. We were unable to figure out what the problem was without access to the underlying exception, which was not logged. With the modification proposed in this PR, the underlying issue was immediately clear: a silly casing issue in our SQL scripts. (CockroachDB is case sensitive, MariaDB is not.)

I'm opening this PR because I think it can be valuable for others as well to be able to see the underlying issue to this class of errors. I've set it to the "DEBUG" level because it's probably too chatty if it  were logged all of the time. This way users can opt-in to this message.