### PR TITLE
JdbcSagaStore should not insert Saga after zero updates

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -215,8 +215,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
         }
 
         if (updateCount == 0) {
-            logger.warn("Expected to be able to update a Saga instance, but no rows were found. Inserting instead.");
-            insertSaga(sagaType, sagaIdentifier, saga, associationValues.asSet());
+            logger.warn("Expected to be able to update a Saga instance, but no rows were found.");
         }
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStoreTest.java
@@ -97,4 +97,11 @@ class JdbcSagaStoreTest {
         Set<String> actual = testSubject.findSagas(StubSaga.class, new AssociationValue("key", "value"));
         assertEquals(singleton("123"), actual);
     }
+
+    @Test
+    void testUpdateSagaWhenDeleted() {
+        AssociationValues associationsValues = new AssociationValuesImpl(singleton(new AssociationValue("key", "value")));
+        testSubject.updateSaga(StubSaga.class, "123456", new StubSaga(), associationsValues);
+        assertNull(testSubject.loadSaga(StubSaga.class, "123456"));
+    }
 }


### PR DESCRIPTION
Updated `JdbcSagaStore` so it does not persist the saga when an update fails.

Inspired by this Axon google group question: https://groups.google.com/forum/#!topic/axonframework/xAiMAmsbgiE

Currently the `JdbcSagaStore` persists a saga if an update fails, but it seems like it should do nothing when this occurs which would be consistent with the `JpaSagaStore`.