### PR TITLE
[#1252] Expose token replay info in EventTrackerStatus

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
@@ -76,12 +76,11 @@ public class FakeEventTrackerStatus implements EventTrackerStatus {
 
     @Override
     public OptionalLong getCurrentPosition() {
-        return (trackingToken!=null) ? trackingToken.position() : OptionalLong.empty();
+        return (trackingToken != null) ? trackingToken.position() : OptionalLong.empty();
     }
 
     @Override
     public OptionalLong getResetPosition() {
         return ReplayToken.getTokenAtReset(trackingToken);
     }
-
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class FakeEventTrackerStatus implements EventTrackerStatus {
     }
 
     @Override
-    public OptionalLong getResetTokenPosition() {
+    public OptionalLong getResetPosition() {
         return ReplayToken.getTokenAtReset(trackingToken);
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
@@ -75,8 +75,8 @@ public class FakeEventTrackerStatus implements EventTrackerStatus {
     }
 
     @Override
-    public OptionalLong getReplayPosition() {
-        return (replaying) ? trackingToken.position() : OptionalLong.empty();
+    public OptionalLong getCurrentPosition() {
+        return (trackingToken!=null) ? trackingToken.position() : OptionalLong.empty();
     }
 
     @Override

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
@@ -17,8 +17,11 @@
 package org.axonframework.axonserver.connector.processor.grpc;
 
 import org.axonframework.eventhandling.EventTrackerStatus;
+import org.axonframework.eventhandling.ReplayToken;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.TrackingToken;
+
+import java.util.OptionalLong;
 
 /**
  * Created by Sara Pellegrini on 01/08/2018.
@@ -70,4 +73,15 @@ public class FakeEventTrackerStatus implements EventTrackerStatus {
     public Throwable getError() {
         return exception;
     }
+
+    @Override
+    public OptionalLong getReplayPosition() {
+        return (replaying) ? trackingToken.position() : OptionalLong.empty();
+    }
+
+    @Override
+    public OptionalLong getResetTokenPosition() {
+        return ReplayToken.getTokenAtReset(trackingToken);
+    }
+
 }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -700,8 +700,12 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(0, 4), handled.subList(4, 8));
         assertEquals(handled.subList(4, 8), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
+        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(5, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
     }
 
     @Test
@@ -732,8 +736,12 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(2, 4), handled.subList(4, 6));
         assertEquals(handled.subList(4, 6), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
+        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(5, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
     }
 
     @Test
@@ -781,8 +789,12 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(0, 2), handled.subList(2, 4));
         assertEquals(handled.subList(2, 4), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
+        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
     }
 
     @Test
@@ -806,6 +818,8 @@ class TrackingEventProcessorTest {
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(4, handled.size()));
         assertEquals(0, handledInRedelivery.size());
         assertFalse(testSubject.processingStatus().get(0).isReplaying());
+        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
     }
 
     @SuppressWarnings("unchecked")

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -701,11 +701,11 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(4, 8), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
-        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
-        assertWithin(5, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
     }
 
     @Test
@@ -737,11 +737,11 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(4, 6), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
-        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
-        assertWithin(5, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
     }
 
     @Test
@@ -790,11 +790,11 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(2, 4), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
         assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
-        assertTrue(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
         eventBus.publish(createEvents(1));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
     }
 
     @Test
@@ -818,8 +818,8 @@ class TrackingEventProcessorTest {
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(4, handled.size()));
         assertEquals(0, handledInRedelivery.size());
         assertFalse(testSubject.processingStatus().get(0).isReplaying());
-        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
-        assertFalse(testSubject.processingStatus().get(0).getResetTokenPosition().isPresent());
+        assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent());
     }
 
     @SuppressWarnings("unchecked")

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -700,12 +700,16 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(0, 4), handled.subList(4, 8));
         assertEquals(handled.subList(4, 8), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
-        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent());
         assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
+
+        long resetPositionAtReplay = testSubject.processingStatus().get(0).getCurrentPosition().getAsLong();
         eventBus.publish(createEvents(1));
+
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().getAsLong() > resetPositionAtReplay));
     }
 
     @Test
@@ -736,12 +740,16 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(2, 4), handled.subList(4, 6));
         assertEquals(handled.subList(4, 6), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
-        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent());
         assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
+
+        long resetPositionAtReplay = testSubject.processingStatus().get(0).getResetPosition().getAsLong();
         eventBus.publish(createEvents(1));
+
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().getAsLong() > resetPositionAtReplay));
     }
 
     @Test
@@ -789,12 +797,16 @@ class TrackingEventProcessorTest {
         assertEquals(handled.subList(0, 2), handled.subList(2, 4));
         assertEquals(handled.subList(2, 4), handledInRedelivery);
         assertTrue(testSubject.processingStatus().get(0).isReplaying());
-        assertTrue(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent());
         assertTrue(testSubject.processingStatus().get(0).getResetPosition().isPresent());
+
+        long resetPositionAtReplay = testSubject.processingStatus().get(0).getResetPosition().getAsLong();
         eventBus.publish(createEvents(1));
+
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).isReplaying()));
-        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent()));
         assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent()));
+        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().getAsLong() > resetPositionAtReplay));
     }
 
     @Test
@@ -813,13 +825,15 @@ class TrackingEventProcessorTest {
         }).when(mockHandler).handle(any());
 
         testSubject.resetTokens();
+
         testSubject.start();
         eventBus.publish(createEvents(4));
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(4, handled.size()));
         assertEquals(0, handledInRedelivery.size());
         assertFalse(testSubject.processingStatus().get(0).isReplaying());
-        assertFalse(testSubject.processingStatus().get(0).getReplayPosition().isPresent());
         assertFalse(testSubject.processingStatus().get(0).getResetPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().isPresent());
+        assertTrue(testSubject.processingStatus().get(0).getCurrentPosition().getAsLong() > 0);
     }
 
     @SuppressWarnings("unchecked")

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,19 +78,19 @@ public interface EventTrackerStatus {
     Throwable getError();
 
     /**
-     * Return the estimated relative position this tracking token represents for the event tracker status whether this Segment is still replaying.
-     * In case no estimation can be given or no replay an {@code OptionalLong.empty()} will be returned.
+     * Return the estimated relative replay position this Segment represents.
+     * In case no estimation can be given or no replay is active, an {@code OptionalLong.empty()} will be returned.
      *
-     * @return the estimated relative position this tracking token represents for the event tracker status whether this Segment is still replaying
+     * @return return the estimated relative replay position this Segment represents
      */
     OptionalLong getReplayPosition();
 
     /**
-     * Return the relative position at which a reset was triggered whether this Segment is still replaying.
-     * In case of a replay ended or no replay an {@code OptionalLong.empty()} will be returned.
+     * Return the relative position at which a reset was triggered for this Segment.
+     * In case a replay finished or no replay is active, an {@code OptionalLong.empty()} will be returned.
      *
-     * @return the relative position at which a reset was triggered whether this Segment is still replaying
+     * @return the relative position at which a reset was triggered for this Segment
      */
-    OptionalLong getResetTokenPosition();
+    OptionalLong getResetPosition();
 
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -78,12 +78,13 @@ public interface EventTrackerStatus {
     Throwable getError();
 
     /**
-     * Return the estimated relative replay position this Segment represents.
-     * In case no estimation can be given or no replay is active, an {@code OptionalLong.empty()} will be returned.
+     * Return the estimated relative current token position this Segment represents.
+     * In case no estimation can be given an {@code OptionalLong.empty()} will be returned.
+     * In case of replay is active, return the estimated relative replay position.
      *
-     * @return return the estimated relative replay position this Segment represents
+     * @return return the estimated relative current token position this Segment represents
      */
-    OptionalLong getReplayPosition();
+    OptionalLong getCurrentPosition();
 
     /**
      * Return the relative position at which a reset was triggered for this Segment.

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -18,6 +18,8 @@ package org.axonframework.eventhandling;
 
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 
+import java.util.OptionalLong;
+
 /**
  * Interface describing the status of a Segment of a TrackingProcessor.
  */
@@ -74,4 +76,21 @@ public interface EventTrackerStatus {
      * @return the exception that caused processing to fail, or {@code null} when processing normally
      */
     Throwable getError();
+
+    /**
+     * Return the estimated relative position this tracking token represents for the event tracker status whether this Segment is still replaying.
+     * In case no estimation can be given or no replay an {@code OptionalLong.empty()} will be returned.
+     *
+     * @return the estimated relative position this tracking token represents for the event tracker status whether this Segment is still replaying
+     */
+    OptionalLong getReplayPosition();
+
+    /**
+     * Return the relative position at which a reset was triggered whether this Segment is still replaying.
+     * In case of a replay ended or no replay an {@code OptionalLong.empty()} will be returned.
+     *
+     * @return the relative position at which a reset was triggered whether this Segment is still replaying
+     */
+    OptionalLong getResetTokenPosition();
+
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -100,6 +100,18 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
     }
 
     /**
+     * Return the relative position at which a reset was triggered whether this Segment is still replaying.
+     * In case of a replay ended or no replay an {@code OptionalLong.empty()} will be returned.
+     *
+     * @return the relative position at which a reset was triggered whether this Segment is still replaying
+     */
+    public static OptionalLong getTokenAtReset(TrackingToken trackingToken) {
+        return WrappedToken.unwrap(trackingToken, ReplayToken.class)
+                           .map(rt -> rt.getTokenAtReset().position())
+                .orElse(OptionalLong.empty());
+    }
+
+    /**
      * Initialize a ReplayToken, using the given {@code tokenAtReset} to represent the position at which a reset was
      * triggered. The current token is reset to the initial position.
      * <p>
@@ -253,4 +265,5 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
         }
         return OptionalLong.empty();
     }
+
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,10 +100,10 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
     }
 
     /**
-     * Return the relative position at which a reset was triggered whether this Segment is still replaying.
-     * In case of a replay ended or no replay an {@code OptionalLong.empty()} will be returned.
+     * Return the relative position at which a reset was triggered for this Segment.
+     * In case a replay finished or no replay is active, an {@code OptionalLong.empty()} will be returned.
      *
-     * @return the relative position at which a reset was triggered whether this Segment is still replaying
+     * @return the relative position at which a reset was triggered for this Segment
      */
     public static OptionalLong getTokenAtReset(TrackingToken trackingToken) {
         return WrappedToken.unwrap(trackingToken, ReplayToken.class)

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
@@ -862,6 +863,16 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
         @Override
         public Throwable getError() {
             return errorState;
+        }
+
+        @Override
+        public OptionalLong getReplayPosition() {
+            return trackingToken.position();
+        }
+
+        @Override
+        public OptionalLong getResetTokenPosition() {
+            return ReplayToken.getTokenAtReset(trackingToken);
         }
 
         private TrackingToken getInternalTrackingToken() {

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -866,10 +866,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
         }
 
         /**
-         * Return the estimated relative replay position this Segment represents.
-         * In case no estimation can be given or no replay is active, an {@code OptionalLong.empty()} will be returned.
-         *
-         * @return return the estimated relative replay position this Segment represents
+         * {@inheritDoc}
          */
         @Override
         public OptionalLong getCurrentPosition() {

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -865,11 +865,21 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
             return errorState;
         }
 
+        /**
+         * Return the estimated relative replay position this Segment represents.
+         * In case no estimation can be given or no replay is active, an {@code OptionalLong.empty()} will be returned.
+         *
+         * @return return the estimated relative replay position this Segment represents
+         */
         @Override
-        public OptionalLong getReplayPosition() {
-            return WrappedToken.unwrap(trackingToken, ReplayToken.class)
-                               .map(ReplayToken::position)
-                               .orElse(OptionalLong.empty());
+        public OptionalLong getCurrentPosition() {
+            if (isReplaying()) {
+                return  WrappedToken.unwrap(trackingToken, ReplayToken.class)
+                                   .map(ReplayToken::position)
+                                   .orElse(OptionalLong.empty());
+            }
+
+            return (trackingToken == null) ? OptionalLong.empty() : trackingToken.position();
         }
 
         @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -867,11 +867,13 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
 
         @Override
         public OptionalLong getReplayPosition() {
-            return trackingToken.position();
+            return WrappedToken.unwrap(trackingToken, ReplayToken.class)
+                               .map(ReplayToken::position)
+                               .orElse(OptionalLong.empty());
         }
 
         @Override
-        public OptionalLong getResetTokenPosition() {
+        public OptionalLong getResetPosition() {
             return ReplayToken.getTokenAtReset(trackingToken);
         }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -73,4 +73,12 @@ class ReplayTokenTest {
         TrackingToken replayToken = ReplayToken.createReplayToken(innerToken);
         assertFalse(replayToken.position().isPresent());
     }
+
+    @Test
+    void testGetTokenAtReset() {
+        ReplayToken testSubject = new ReplayToken(innerToken);
+        TrackingToken actual = testSubject.advancedTo(GapAwareTrackingToken.newInstance(6, emptySet()));
+        assertTrue(actual instanceof ReplayToken);
+        assertEquals(testSubject.getTokenAtReset(), innerToken);
+    }
 }


### PR DESCRIPTION
This PR will solve issue #1252 

User can now have more information on an ongoing reply token status, knowing the estimated position of current replay token and the reset token position until the replay will be processed.