### PR TITLE
Allow disabling AxonServer AutoConfiguration through property

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -40,6 +40,14 @@ public class AxonServerConfiguration {
     private static final String DEFAULT_CONTEXT = "default";
 
     /**
+     * Whether (automatic) configuration of the AxonServer Connector is enabled. When {@code false}, the connector will
+     * not be implicitly be configured. Defaults to {@code true}.
+     * <p>
+     * Note that this setting will only affect automatic configuration by Application Containers (such as Spring).
+     */
+    private boolean enabled = true;
+
+    /**
      * Comma separated list of AxonServer servers. Each element is hostname or hostname:grpcPort. When no grpcPort is
      * specified, default port 8123 is used.
      */
@@ -222,6 +230,14 @@ public class AxonServerConfiguration {
     public AxonServerConfiguration() {
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
     public String getServers() {
         return servers;
     }
@@ -316,7 +332,7 @@ public class AxonServerConfiguration {
         return Arrays.stream(serverArr).map(server -> {
             String[] s = server.trim().split(":");
             if (s.length > 1) {
-                return NodeInfo.newBuilder().setHostName(s[0]).setGrpcPort(Integer.valueOf(s[1])).build();
+                return NodeInfo.newBuilder().setHostName(s[0]).setGrpcPort(Integer.parseInt(s[1])).build();
             }
             return NodeInfo.newBuilder().setHostName(s[0]).setGrpcPort(DEFAULT_GRPC_PORT).build();
         }).collect(Collectors.toList());

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -49,7 +49,6 @@ import org.axonframework.springboot.TagsConfigurationProperties;
 import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -71,6 +70,7 @@ import org.springframework.context.annotation.Primary;
 @AutoConfigureBefore(AxonAutoConfiguration.class)
 @ConditionalOnClass(AxonServerConfiguration.class)
 @EnableConfigurationProperties(TagsConfigurationProperties.class)
+@ConditionalOnProperty(name = "axon.axonserver.enabled", matchIfMissing = true)
 public class AxonServerAutoConfiguration implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;

--- a/spring-boot-autoconfigure/src/main/resources/application-disable-axon-server.properties
+++ b/spring-boot-autoconfigure/src/main/resources/application-disable-axon-server.properties
@@ -1,1 +1,0 @@
-spring.autoconfigure.exclude=org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -22,10 +22,11 @@ import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
+import org.axonframework.eventhandling.EventBus;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,7 +40,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -97,6 +99,20 @@ class AxonServerAutoConfigurationTest {
                                                  .isExactlyInstanceOf(AxonServerCommandBus.class);
                               assertThat(context).getBean("commandBus")
                                                  .isExactlyInstanceOf(SimpleCommandBus.class);
+                          });
+    }
+
+    @Test
+    void testAxonServerDefaultConfiguration_AxonServerDisabled() {
+        this.contextRunner.withPropertyValues("axon.axonserver.enabled=false")
+                          .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+                          .run(context -> {
+                              assertThat(context).getBeanNames(CommandBus.class)
+                                                 .hasSize(1);
+                              assertThat(context).doesNotHaveBean("axonServerCommandBus");
+                              assertThat(context).getBean("commandBus")
+                                                 .isExactlyInstanceOf(SimpleCommandBus.class);
+                              assertThat(context).hasSingleBean(EventBus.class);
                           });
     }
 


### PR DESCRIPTION
This PR introduces the ability to define a Spring property that disables AutoConfiguration for the AxonServer connector altogether. When set, none of the autoconfigured beans related to the AxonServer Connector is configured.