### PR TITLE
Easier configuration of lenient serialization

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MetaData;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -267,9 +268,10 @@ public abstract class AbstractXStreamSerializer implements Serializer {
     public abstract static class Builder {
 
         private XStream xStream;
-        private Charset charset = Charset.forName("UTF-8");
+        private Charset charset = StandardCharsets.UTF_8;
         private RevisionResolver revisionResolver = new AnnotationRevisionResolver();
         private Converter converter = new ChainingConverter();
+        private boolean lenientDeserialization = false;
 
         /**
          * Sets the {@link XStream} used to perform the serialization of objects to XML, and vice versa.
@@ -327,6 +329,17 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         }
 
         /**
+         * Configures the underlying XStream instance to be lenient when deserializing data into Java objects.
+         * Specifically sets the {@link XStream#ignoreUnknownElements()}.
+         *
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder lenientDeserialization() {
+            this.lenientDeserialization = true;
+            return this;
+        }
+
+        /**
          * Validates whether the fields contained in this Builder are set accordingly.
          *
          * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
@@ -334,6 +347,9 @@ public abstract class AbstractXStreamSerializer implements Serializer {
          */
         protected void validate() throws AxonConfigurationException {
             assertNonNull(xStream, "The XStream is a hard requirement and should be provided");
+            if (lenientDeserialization) {
+                xStream.ignoreUnknownElements();
+            }
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,7 @@
 package org.axonframework.serialization.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -265,6 +266,7 @@ public class JacksonSerializer implements Serializer {
         private RevisionResolver revisionResolver = new AnnotationRevisionResolver();
         private Converter converter = new ChainingConverter();
         private ObjectMapper objectMapper = new ObjectMapper();
+        private boolean lenientDeserialization = false;
 
         /**
          * Sets the {@link RevisionResolver} used to resolve the revision from an object to be serialized. Defaults to
@@ -326,11 +328,29 @@ public class JacksonSerializer implements Serializer {
         }
 
         /**
+         * Configures the underlying ObjectMapper to be lenient when deserializing JSON into Java objects. Specifically,
+         * enables the {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} and
+         * {@link DeserializationFeature#UNWRAP_SINGLE_VALUE_ARRAYS}, and disables
+         * {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES}.
+         *
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder lenientDeserialization() {
+            lenientDeserialization = true;
+            return this;
+        }
+
+        /**
          * Initializes a {@link JacksonSerializer} as specified through this Builder.
          *
          * @return a {@link JacksonSerializer} as specified through this Builder
          */
         public JacksonSerializer build() {
+            if (lenientDeserialization) {
+                objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+                objectMapper.enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS);
+                objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            }
             return new JacksonSerializer(this);
         }
 

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,6 +179,12 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
         @Override
         public Builder converter(Converter converter) {
             super.converter(converter);
+            return this;
+        }
+
+        @Override
+        public Builder lenientDeserialization() {
+            super.lenientDeserialization();
             return this;
         }
 

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -269,7 +269,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testDeserializeLienientIgnoresUnknownValues() {
+    void testDeserializeLenientIgnoresUnknownValues() {
         testSubject = JacksonSerializer.builder().lenientDeserialization().objectMapper(objectMapper).build();
         SerializedObject<JsonNode> serialized = testSubject.serialize(new ComplexObject("one", "two", 3), JsonNode.class);
         ObjectNode data = (ObjectNode) serialized.getData();

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.*;
+import org.axonframework.serialization.AnnotationRevisionResolver;
+import org.axonframework.serialization.ChainingConverter;
+import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.RevisionResolver;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.UnknownSerializedType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +43,15 @@ import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Allard Buijze
@@ -249,6 +266,20 @@ class JacksonSerializerTest {
     void testDeserializeEmptyBytes() {
         assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
         assertNull(testSubject.deserialize(new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())));
+    }
+
+    @Test
+    void testDeserializeLienientIgnoresUnknownValues() {
+        testSubject = JacksonSerializer.builder().lenientDeserialization().objectMapper(objectMapper).build();
+        SerializedObject<JsonNode> serialized = testSubject.serialize(new ComplexObject("one", "two", 3), JsonNode.class);
+        ObjectNode data = (ObjectNode) serialized.getData();
+        JsonNodeFactory nf = objectMapper.getNodeFactory();
+        data.set("newField", nf.textNode("newValue"));
+        ArrayNode arrayNode = nf.arrayNode().add(data);
+        ComplexObject actual = testSubject.deserialize(new SimpleSerializedObject<>(arrayNode, JsonNode.class, serialized.getType()));
+        assertEquals("one", actual.getValue1());
+        assertEquals("two", actual.getValue2());
+        assertEquals(3, actual.getValue3());
     }
 
     public static class ComplexObject {


### PR DESCRIPTION
This PR adds a method to the builders of the XStreamSerializer and JacksonSerializer that instructs them to be lenient towards missing properties when deserializing into Java Objects.
For distributed systems, lenience is considered good practice, as it allows producers to make slight changes to the serialized structure, without impacting consumers of these messages.