### PR TITLE
Remove duplicate Apache license in headers and add a missing one

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/DistributedCommandBusProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/DistributedCommandBusProperties.java
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/EventProcessorProperties.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot;
 
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/MetricsProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/MetricsProperties.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/SerializerProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/SerializerProperties.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.springboot.autoconfig;
 
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/MetricsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/MetricsAutoConfiguration.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.autoconfig;
 
 import com.codahale.metrics.MetricRegistry;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/TransactionAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/TransactionAutoConfiguration.java
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.autoconfig;
 
 import org.axonframework.common.transaction.TransactionManager;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/AbstractQualifiedBeanCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/AbstractQualifiedBeanCondition.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.util;
 
 import org.slf4j.Logger;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/ConditionalOnMissingQualifiedBean.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/ConditionalOnMissingQualifiedBean.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.util;
 
 import org.springframework.beans.factory.BeanFactory;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/ConditionalOnQualifiedBean.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/ConditionalOnQualifiedBean.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2017. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.util;
 
 import org.springframework.beans.factory.BeanFactory;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/jpa/ContainerManagedEntityManagerProvider.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/jpa/ContainerManagedEntityManagerProvider.java
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright (c) 2010-2018. Axon Framework
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.axonframework.springboot.util.jpa;
 
 import org.axonframework.common.jpa.EntityManagerProvider;


### PR DESCRIPTION
I found a few cases where the apache license had been duplicated in the file headers. I also found a case where a file didn't have the license in its header.

This PR cleans up the aforementioned cases. 

It does look like the years are inconsistent, however. For example, some say 2010-2017, 2010-2018 etc etc. I would more than happy to update them all to say 2020 if that would be beneficial. 

Cheers