### PR TITLE
Fix for the IdentifierValidationRepository not implementing the loado…

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -715,6 +715,13 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
             return aggregate;
         }
 
+        @Override
+        public Aggregate<T> loadOrCreate(String aggregateIdentifier,Callable<T> factoryMethod) throws Exception{
+            CurrentUnitOfWork.get().onRollback(u -> this.rolledBack = true);
+            aggregate = delegate.loadOrCreate(aggregateIdentifier,factoryMethod);
+            return aggregate;
+        }
+
         private void validateIdentifier(String aggregateIdentifier, Aggregate<T> aggregate) {
             if (aggregateIdentifier != null && !aggregateIdentifier.equals(aggregate.identifierAsString())) {
                 throw new AssertionError(String.format(


### PR DESCRIPTION
A command handler within an aggregate is modeled with the new Aggregate Creation Policy capability _AggregateCreationPolicy.CREATE_IF_MISSING_

When we try to run the  AggregateTestFixture class to test this scenario, the fixture fails with the message _loadOrCreate not implemented on this repository_ . This is because the IdentifierValidatingRepository which is the repository implementation used by the _AggregateTestFixture_ class does not override the _loadOrCreate_ method which results in the default implementation of the _Repository_ class to kick in, causing the test fixture to fail.

This fix provides an overriding implementation by calling the underlying delegate's loadorcreate method. The test fixture passes and we are able to test the scenario above.