### PR TITLE
AggregateCreationPolicy.ALWAYS returns an NPE if set on a non-constructor method

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -140,7 +140,10 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
                                aggregateModel.type()
                                        + ": Static methods/constructors can only use creationPolicy ALWAYS");
                     aggregateCreationPolicy.set(AggregateCreationPolicy.ALWAYS);
+                }else if (!aggregateCreationPolicy.get().equals(AggregateCreationPolicy.NEVER)){
+                    aggregateCreationPolicy.set(AggregateCreationPolicy.CREATE_IF_MISSING);
                 }
+
                 switch (aggregateCreationPolicy.get()) {
                     case ALWAYS:
                         handlersFound.add(new AggregateConstructorCommandHandler(handler));

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -715,6 +715,13 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
             return aggregate;
         }
 
+        @Override
+        public Aggregate<T> loadOrCreate(String aggregateIdentifier,Callable<T> factoryMethod) throws Exception{
+            CurrentUnitOfWork.get().onRollback(u -> this.rolledBack = true);
+            aggregate = delegate.loadOrCreate(aggregateIdentifier,factoryMethod);
+            return aggregate;
+        }
+
         private void validateIdentifier(String aggregateIdentifier, Aggregate<T> aggregate) {
             if (aggregateIdentifier != null && !aggregateIdentifier.equals(aggregate.identifierAsString())) {
                 throw new AssertionError(String.format(


### PR DESCRIPTION
Hi,

I have modeled a Simple Aggregate and used the Always policy on a non-constructor method as follows. 

   ```
@CommandHandler
    @CreationPolicy(AggregateCreationPolicy.ALWAYS)
    public void handle(SimpleCreateCommand cmd) {
        apply(new SimpleEventCreated(cmd.getCommandId(), cmd.getCommandData()));
    }
```


When I attempt to test this, returns a Null Pointer Exception,

```
java.lang.NullPointerException: null
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.axonframework.messaging.annotation.AnnotatedMessageHandlingMember.handle(AnnotatedMessageHandlingMember.java:133)
	at org.axonframework.messaging.annotation.WrappedMessageHandlingMember.handle(WrappedMessageHandlingMember.java:61)
	at org.axonframework.messaging.annotation.WrappedMessageHandlingMember.handle(WrappedMessageHandlingMember.java:61)
	at org.axonframework.modelling.command.AggregateAnnotationCommandHandler$AggregateConstructorCommandHandler.lambda$handle$0(AggregateAnnotationCommandHandler.java:377)
	at org.axonframework.messaging.Scope.executeWithResult(Scope.java:111)
	at org.axonframework.modelling.command.inspection.AnnotatedAggregate.registerRoot(AnnotatedAggregate.java:283)
	at org.axonframework.eventsourcing.EventSourcedAggregate.initialize(EventSourcedAggregate.java:120)
	at org.axonframework.eventsourcing.EventSourcingRepository.doCreateNewForLock(EventSourcingRepository.java:171)
	at org.axonframework.eventsourcing.EventSourcingRepository.doCreateNewForLock(EventSourcingRepository.java:52)
	at org.axonframework.modelling.command.LockingRepository.doCreateNew(LockingRepository.java:81)
	at org.axonframework.modelling.command.LockingRepository.doCreateNew(LockingRepository.java:52)
	at org.axonframework.modelling.command.AbstractRepository.newInstance(AbstractRepository.java:90)
	at org.axonframework.test.aggregate.AggregateTestFixture$IdentifierValidatingRepository.newInstance(AggregateTestFixture.java:699)
	at org.axonframework.modelling.command.AggregateAnnotationCommandHandler$AggregateConstructorCommandHandler.handle(AggregateAnnotationCommandHandler.java:377)
	at org.axonframework.modelling.command.AggregateAnnotationCommandHandler$AggregateConstructorCommandHandler.handle(AggregateAnnotationCommandHandler.java:364)
	at org.axonframework.modelling.command.AggregateAnnotationCommandHandler.handle(AggregateAnnotationCommandHandler.java:173)
	at org.axonframework.modelling.command.AggregateAnnotationCommandHandler.handle(AggregateAnnotationCommandHandler.java:59)
```

This is because as part of the default execution chain, the _AggregateAnnotationCommandHandler_ assigns the _AggregateConstructorCommandHandler_ as the handler instead of the _AggregateCreateOrUpdateCommandHandler_ . So when the _AggregateConstructorCommandHandler_ tries to handle the message by executing the _handle()_ method on the delegate _AnnotatedMessageHandlingMember_ it results in an NPE because it expects the _executable_ to be of type method but since the target is null (set by the _AggregateConstructorCommandHandler_) it results in an NPE (_AnnotatedMessageHandlingMember_  -> Line 133)

Probably there exists a better way of fixing (e.g. a executable type name) or maybe I am doing something wrong ?