### PR TITLE
[#1365] Adjust mysql-connector-java

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore.jdbc;
 
-import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import com.mysql.cj.jdbc.MysqlDataSource;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <javax.validation-api.version>1.1.0.Final</javax.validation-api.version>
         <javax.jaxb-api.version>2.3.0</javax.jaxb-api.version>
         <disruptor.version>3.4.2</disruptor.version>
-        <mysql-connector-java.version>5.1.31</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.19</mysql-connector-java.version>
         <ehcache.version>2.10.6</ehcache.version>
         <quartz.version>2.3.0</quartz.version>
         <c3p0.version>0.9.1.2</c3p0.version>


### PR DESCRIPTION
This PR changes the `mysql-connector-java` version from 5.1.31 to 8.0.19 to resolve a "common vulnerabilities and exposures) somewhere down the call hierarchy, as mentioned in #1365.

As such, this pull request resolves #1365 