### PR TITLE
Several minor resolution around Shutdown Order

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -726,6 +726,7 @@ public class AxonServerConnectionManager {
     @ShutdownHandler(phase = Phase.EXTERNAL_CONNECTIONS)
     public void shutdown() {
         shutdown = true;
+        instructionStreams.values().forEach(StreamObserver::onCompleted);
         disconnect();
         scheduler.shutdown();
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -819,7 +819,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
 
         private void unsubscribeAll() {
             if (subscriberStreamObserver != null) {
-                subscribedCommands.forEach(this::removeAndUnsubscribe);
+                subscribedCommands.forEach(this::unsubscribe);
             }
         }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -385,9 +385,9 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     /**
      * Disconnect the command bus for receiving commands from Axon Server, by unsubscribing all registered command
      * handlers. After this the connection will be closed, waiting until all command processing tasks have been
-     * resolved. This shutdown operation is performed in the {@link Phase#INBOUND_COMMAND_CONNECTOR} phase.
+     * resolved. This shutdown operation is performed in the {@link Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
      */
-    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
     public void disconnect() {
         commandProcessor.unsubscribeAll();
         commandProcessor.disconnect();
@@ -396,11 +396,11 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     /**
      * Shutdown the command bus asynchronously for dispatching commands to Axon Server. This process will wait for
      * dispatched commands which have not received a response yet. This shutdown operation is performed in the {@link
-     * Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
+     * Phase#INBOUND_COMMAND_CONNECTOR} phase.
      *
      * @return a completable future which is resolved once all command dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
     public CompletableFuture<Void> shutdownDispatching() {
         commandProcessor.removeLocalSubscriptions();
         return shutdownLatch.initiateShutdown();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -860,10 +860,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         }
 
         void disconnect() {
-            if (subscriberStreamObserver != null) {
-                subscriberStreamObserver.onCompleted();
-            }
-
+            running = false;
             commandExecutor.shutdown();
             try {
                 if (!commandExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
@@ -878,7 +875,10 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
                 commandExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
-            running = false;
+
+            if (subscriberStreamObserver != null) {
+                subscriberStreamObserver.onCompleted();
+            }
         }
 
         /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -360,7 +360,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         commandProcessor.subscribe(commandName);
         return new AxonServerRegistration(
                 registration,
-                () -> commandProcessor.unsubscribeAndRemove(commandName)
+                () -> commandProcessor.removeAndUnsubscribe(commandName)
         );
     }
 
@@ -818,17 +818,15 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         }
 
         private void unsubscribeAll() {
-            StreamObserver<CommandProviderOutbound> out = subscriberStreamObserver;
-            if (out != null) {
-                subscriberStreamObserver = null;
-                subscribedCommands.forEach(this::unsubscribe);
-                out.onCompleted();
+            if (subscriberStreamObserver != null) {
+                subscribedCommands.forEach(this::removeAndUnsubscribe);
             }
         }
 
-        public void unsubscribeAndRemove(String command) {
-            subscribedCommands.remove(command);
-            unsubscribe(command);
+        public void removeAndUnsubscribe(String command) {
+            if (subscribedCommands.remove(command)) {
+                unsubscribe(command);
+            }
         }
 
         private void unsubscribe(String command) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -385,9 +385,9 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     /**
      * Disconnect the command bus for receiving commands from Axon Server, by unsubscribing all registered command
      * handlers. After this the connection will be closed, waiting until all command processing tasks have been
-     * resolved. This shutdown operation is performed in the {@link Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
+     * resolved. This shutdown operation is performed in the {@link Phase#INBOUND_COMMAND_CONNECTOR} phase.
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
     public void disconnect() {
         commandProcessor.unsubscribeAll();
         commandProcessor.disconnect();
@@ -396,11 +396,11 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     /**
      * Shutdown the command bus asynchronously for dispatching commands to Axon Server. This process will wait for
      * dispatched commands which have not received a response yet. This shutdown operation is performed in the {@link
-     * Phase#INBOUND_COMMAND_CONNECTOR} phase.
+     * Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
      *
      * @return a completable future which is resolved once all command dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
     public CompletableFuture<Void> shutdownDispatching() {
         commandProcessor.removeLocalSubscriptions();
         return shutdownLatch.initiateShutdown();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -530,9 +530,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     /**
      * Disconnect the query bus from Axon Server, by unsubscribing all known query handlers. After this the connection
      * will be closed, waiting nicely until all query processing tasks have been resolved. This shutdown operation is
-     * performed in the {@link Phase#OUTBOUND_QUERY_CONNECTORS} phase.
+     * performed in the {@link Phase#INBOUND_QUERY_CONNECTOR} phase.
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_QUERY_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
     public void disconnect() {
         queryProcessor.unsubscribeAll();
         queryProcessor.disconnect();
@@ -541,11 +541,11 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     /**
      * Shutdown the query bus asynchronously for dispatching queries to Axon Server. This process will wait for
      * dispatched queries which have not received a response yet and will close off running subscription queries. This
-     * shutdown operation is performed in the {@link Phase#INBOUND_QUERY_CONNECTOR} phase.
+     * shutdown operation is performed in the {@link Phase#OUTBOUND_QUERY_CONNECTORS} phase.
      *
      * @return a completable future which is resolved once all query dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_QUERY_CONNECTORS)
     public CompletableFuture<Void> shutdownDispatching() {
         queryProcessor.removeLocalSubscriptions();
         return shutdownLatch.initiateShutdown();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -530,9 +530,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     /**
      * Disconnect the query bus from Axon Server, by unsubscribing all known query handlers. After this the connection
      * will be closed, waiting nicely until all query processing tasks have been resolved. This shutdown operation is
-     * performed in the {@link Phase#INBOUND_QUERY_CONNECTOR} phase.
+     * performed in the {@link Phase#OUTBOUND_QUERY_CONNECTORS} phase.
      */
-    @ShutdownHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_QUERY_CONNECTORS)
     public void disconnect() {
         queryProcessor.unsubscribeAll();
         queryProcessor.disconnect();
@@ -541,11 +541,11 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     /**
      * Shutdown the query bus asynchronously for dispatching queries to Axon Server. This process will wait for
      * dispatched queries which have not received a response yet and will close off running subscription queries. This
-     * shutdown operation is performed in the {@link Phase#OUTBOUND_QUERY_CONNECTORS} phase.
+     * shutdown operation is performed in the {@link Phase#INBOUND_QUERY_CONNECTOR} phase.
      *
      * @return a completable future which is resolved once all query dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_QUERY_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
     public CompletableFuture<Void> shutdownDispatching() {
         queryProcessor.removeLocalSubscriptions();
         return shutdownLatch.initiateShutdown();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -756,7 +756,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
 
         private void unsubscribeAll() {
             if (outboundStreamObserver != null) {
-                subscribedQueries.keySet().forEach(this::removeAndUnsubscribe);
+                subscribedQueries.keySet().forEach(this::unsubscribe);
             }
         }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -789,10 +789,6 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
         }
 
         void disconnect() {
-            if (outboundStreamObserver != null) {
-                outboundStreamObserver.onCompleted();
-            }
-
             running = false;
             queryExecutor.shutdown();
             try {
@@ -809,7 +805,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                 Thread.currentThread().interrupt();
             }
 
-            Optional.ofNullable(this.outboundStreamObserver).ifPresent(StreamObserver::onCompleted);
+            if (outboundStreamObserver != null) {
+                outboundStreamObserver.onCompleted();
+            }
         }
 
         private QuerySubscription buildQuerySubscription(QueryDefinition queryDefinition, int nrHandlers) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -507,9 +507,12 @@ class AxonServerCommandBusTest {
     void testAfterShutdownDispatchingAnShutdownInProgressExceptionIsThrownOnDispatchInvocation() {
         testSubject.shutdownDispatching();
 
-        assertThrows(
-                ShutdownInProgressException.class,
-                () -> testSubject.dispatch(new GenericCommandMessage<>("some-command"))
+        assertWithin(
+                50, TimeUnit.MILLISECONDS,
+                () -> assertThrows(
+                        ShutdownInProgressException.class,
+                        () -> testSubject.dispatch(new GenericCommandMessage<>("some-command"))
+                )
         );
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -42,9 +42,7 @@ import org.axonframework.messaging.MessageHandler;
 import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -60,21 +58,10 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.axonframework.axonserver.connector.ErrorCode.UNSUPPORTED_INSTRUCTION;
 import static org.axonframework.axonserver.connector.TestTargetContextResolver.BOUNDED_CONTEXT;
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit test class to cover all the operations performed by the {@link AxonServerCommandBus}.
@@ -506,7 +493,7 @@ class AxonServerCommandBusTest {
         try {
             inboundStreamObserverRef.get().onNext(testCommandMessage);
         } finally {
-            disconnected = CompletableFuture.runAsync(testSubject::disconnect);
+            disconnected = testSubject.shutdownDispatching();
             slowHandlerLock.unlock();
         }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -409,7 +409,7 @@ class AxonServerQueryBusTest {
         assertNotNull(dummyMessagePlatformServer.subscriptions(TEST_QUERY, String.class.getName()));
 
         //noinspection unchecked
-        verify(axonServerConnectionManager, times(2)).getQueryStream(eq(BOUNDED_CONTEXT), any(StreamObserver.class));
+        verify(axonServerConnectionManager).getQueryStream(eq(BOUNDED_CONTEXT), any(StreamObserver.class));
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -480,11 +480,13 @@ class AxonServerQueryBusTest {
 
     @Test
     void testAfterShutdownDispatchingAnShutdownInProgressExceptionOnQueryInvocation() {
+        QueryMessage<String, String> testQuery = new GenericQueryMessage<>("some-query", instanceOf(String.class));
+
         testSubject.shutdownDispatching();
 
-        assertThrows(
-                ShutdownInProgressException.class,
-                () -> testSubject.query(new GenericQueryMessage<>("some-query", ResponseTypes.instanceOf(String.class)))
+        assertWithin(
+                50, TimeUnit.MILLISECONDS,
+                () -> assertThrows(ShutdownInProgressException.class, () -> testSubject.query(testQuery))
         );
     }
 
@@ -494,7 +496,13 @@ class AxonServerQueryBusTest {
 
         testSubject.shutdownDispatching();
 
-        assertThrows(ShutdownInProgressException.class, () -> testSubject.scatterGather(testQuery, 1, TimeUnit.SECONDS));
+        assertWithin(
+                50, TimeUnit.MILLISECONDS,
+                () -> assertThrows(
+                        ShutdownInProgressException.class,
+                        () -> testSubject.scatterGather(testQuery, 1, TimeUnit.SECONDS)
+                )
+        );
     }
 
     @Test
@@ -504,7 +512,13 @@ class AxonServerQueryBusTest {
 
         testSubject.shutdownDispatching();
 
-        assertThrows(ShutdownInProgressException.class, () -> testSubject.subscriptionQuery(testSubscriptionQuery));
+        assertWithin(
+                50, TimeUnit.MILLISECONDS,
+                () -> assertThrows(
+                        ShutdownInProgressException.class,
+                        () -> testSubject.subscriptionQuery(testSubscriptionQuery)
+                )
+        );
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -44,9 +44,7 @@ import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -67,21 +65,10 @@ import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWit
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.messaging.responsetypes.ResponseTypes.instanceOf;
 import static org.axonframework.messaging.responsetypes.ResponseTypes.optionalInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit test suite to verify the {@link AxonServerQueryBus}.
@@ -481,7 +468,7 @@ class AxonServerQueryBusTest {
         try {
             inboundStreamObserver.get().onNext(testQueryMessage);
         } finally {
-            disconnected = CompletableFuture.runAsync(testSubject::disconnect);
+            disconnected = testSubject.shutdownDispatching();
             slowHandlerLock.unlock();
         }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,9 +106,9 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
 
     /**
      * Disconnect the command bus for receiving new commands, by unsubscribing all registered command handlers. This
-     * shutdown operation is performed in the {@link Phase#INBOUND_COMMAND_CONNECTOR} phase.
+     * shutdown operation is performed in the {@link Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
      */
-    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
     public void disconnect() {
         commandRouter.updateMembership(loadFactor, DenyAll.INSTANCE);
     }
@@ -116,11 +116,11 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
     /**
      * Shutdown the command bus asynchronously for dispatching commands to other instances. This process will wait for
      * dispatched commands which have not received a response yet. This shutdown operation is performed in the {@link
-     * Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
+     * Phase#INBOUND_COMMAND_CONNECTOR} phase.
      *
      * @return a completable future which is resolved once all command dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
     public CompletableFuture<Void> shutdownDispatching() {
         return connector.initiateShutdown();
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,9 +106,9 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
 
     /**
      * Disconnect the command bus for receiving new commands, by unsubscribing all registered command handlers. This
-     * shutdown operation is performed in the {@link Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
+     * shutdown operation is performed in the {@link Phase#INBOUND_COMMAND_CONNECTOR} phase.
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
+    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
     public void disconnect() {
         commandRouter.updateMembership(loadFactor, DenyAll.INSTANCE);
     }
@@ -116,11 +116,11 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
     /**
      * Shutdown the command bus asynchronously for dispatching commands to other instances. This process will wait for
      * dispatched commands which have not received a response yet. This shutdown operation is performed in the {@link
-     * Phase#INBOUND_COMMAND_CONNECTOR} phase.
+     * Phase#OUTBOUND_COMMAND_CONNECTORS} phase.
      *
      * @return a completable future which is resolved once all command dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.INBOUND_COMMAND_CONNECTOR)
+    @ShutdownHandler(phase = Phase.OUTBOUND_COMMAND_CONNECTORS)
     public CompletableFuture<Void> shutdownDispatching() {
         return connector.initiateShutdown();
     }

--- a/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
@@ -36,34 +36,34 @@ public abstract class Phase {
      */
     public static final int EXTERNAL_CONNECTIONS = Integer.MIN_VALUE >> 4;
     /**
+     * Phase to start or shutdown outbound event connectors. It is targeted towards connectors which can send events out
+     * to external applications.
+     */
+    public static final int OUTBOUND_EVENT_CONNECTORS = -10;
+    /**
      * Phase to register or cancel the registration of any local message handler.
      */
     public static final int LOCAL_MESSAGE_HANDLER_REGISTRATIONS = 0;
     /**
-     * Phase to start or shutdown inbound command connectors. It is targeted towards connectors which
-     * receive commands from external applications.
+     * Phase to start or shutdown outbound command and/or query connectors. It is targeted towards connectors which send
+     * commands and/or queries out to external applications.
      */
-    public static final int INBOUND_COMMAND_CONNECTOR = 0;
-    /**
-     * Phase to start or shutdown inbound query connectors. It is targeted towards connectors which
-     * receive queries from external applications.
-     */
-    public static final int INBOUND_QUERY_CONNECTOR = 0;
-    /**
-     * Phase to start or shutdown outbound event connectors. It is targeted towards connectors which can send events out
-     * to external applications.
-     */
-    public static final int OUTBOUND_EVENT_CONNECTORS = Integer.MAX_VALUE >> 3;
+    public static final int OUTBOUND_COMMAND_CONNECTORS = 0;
     /**
      * Phase to start or shutdown outbound command and/or query connectors. It is targeted towards connectors which send
      * commands and/or queries out to external applications.
      */
-    public static final int OUTBOUND_COMMAND_CONNECTORS = Integer.MAX_VALUE >> 2;
+    public static final int OUTBOUND_QUERY_CONNECTORS = 0;
     /**
-     * Phase to start or shutdown outbound command and/or query connectors. It is targeted towards connectors which send
-     * commands and/or queries out to external applications.
+     * Phase to start or shutdown inbound command connectors. It is targeted towards connectors which receive commands
+     * from external applications.
      */
-    public static final int OUTBOUND_QUERY_CONNECTORS = Integer.MAX_VALUE >> 2;
+    public static final int INBOUND_COMMAND_CONNECTOR = Integer.MAX_VALUE >> 2;
+    /**
+     * Phase to start or shutdown inbound query connectors. It is targeted towards connectors which receive queries from
+     * external applications.
+     */
+    public static final int INBOUND_QUERY_CONNECTOR = Integer.MAX_VALUE >> 2;
     /**
      * Phase to start or shutdown inbound event connectors. It is targeted towards connectors which can receive events
      * from external sources.


### PR DESCRIPTION
This pull request resolves a number of issues around the shutdown order process, being:

- Ensure the instruction streams are closed on the `AxonServerConnectionManager`.
- Switch around the "inbound" and "outbound" command-/query-connector phases, value wise. These were accidentally the wrong way around.
- Move the `Phase#OUTBOUND_EVENT_CONNECTORS` to -10
- Move the command/query Executor `disconnect()` call from the inbound to the outbound phase. The inbound shutdown handler should _only_ remove message handler registration from the outside world.
- Adjust the way handlers are removed/unregistered from the `AxonServerCommandBus` and `AxonServerQueryBus`, to ensure those operations aren't sent twice.