### PR TITLE
Changes to ensure certain handlers take priority over others

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -18,7 +18,14 @@ package org.axonframework.messaging.annotation;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -201,16 +208,8 @@ public class AnnotatedHandlerInspector<T> {
     }
 
     private void registerHandler(Class<?> type, MessageHandlingMember<? super T> handler) {
-        handlers.compute(type, (key, value) -> {
-            if (value == null) {
-                SortedSet<MessageHandlingMember<? super T>> handlers = new TreeSet<>(HandlerComparator.instance());
-                handlers.add(handler);
-                return handlers;
-            } else {
-                value.add(handler);
-                return value;
-            }
-        });
+        handlers.computeIfAbsent(type, t -> new TreeSet<>(HandlerComparator.instance()))
+                .add(handler);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
@@ -21,7 +21,11 @@ import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.Message;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,11 +84,6 @@ public class AnnotatedMessageHandlingMember<T> implements MessageHandlingMember<
     @Override
     public Class<?> payloadType() {
         return payloadType;
-    }
-
-    @Override
-    public int priority() {
-        return parameterCount;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
@@ -26,13 +26,19 @@ import java.util.function.ToIntFunction;
  */
 public final class HandlerComparator {
 
-    private static final Comparator<MessageHandlingMember<?>> INSTANCE = Comparator
-            .comparing((Function<MessageHandlingMember<?>, Class<?>>) MessageHandlingMember::payloadType,
-                       HandlerComparator::compareHierarchy)
-            .thenComparing(
-                    Comparator.comparingInt((ToIntFunction<MessageHandlingMember<?>>) MessageHandlingMember::priority)
-                            .reversed())
-            .thenComparing(m -> m.unwrap(Executable.class).map(Executable::toGenericString).orElse(m.toString()));
+    private static final Comparator<MessageHandlingMember<?>> INSTANCE =
+            Comparator.comparingInt((ToIntFunction<MessageHandlingMember<?>>) MessageHandlingMember::priority)
+                      .reversed()
+                      .thenComparing(
+                              (Function<MessageHandlingMember<?>, Class<?>>) MessageHandlingMember::payloadType,
+                              HandlerComparator::compareHierarchy)
+                      .thenComparing(
+                              Comparator.comparingInt((ToIntFunction<MessageHandlingMember<?>>)
+                                                              m -> m.unwrap(Executable.class)
+                                                                    .map(Executable::getParameterCount)
+                                                                    .orElse(1))
+                                        .reversed())
+                      .thenComparing(m -> m.unwrap(Executable.class).map(Executable::toGenericString).orElse(m.toString()));
 
     // prevent construction
     private HandlerComparator() {

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerComparator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,18 @@ import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
 /**
- * Comparator used by {@link AnnotatedHandlerInspector} to sort {@link MessageHandlingMember entity members}.
+ * Comparator used by {@link AnnotatedHandlerInspector} to sort {@link MessageHandlingMember} entity members.
+ * <p>
+ * The ordering among {@code MessageHandlingMember}s through this comparator is defined as follows:
+ * <ol type="1">
+ * <li>The {@link MessageHandlingMember#priority()}, favoring the largest number</li>
+ * <li>The class hierarchy of the {@link MessageHandlingMember#payloadType()}, favoring the most specific handler.</li>
+ * <li>The parameter count on the actual message handling function, favoring the highest number as the most specific handler.</li>
+ * <li>As a final tie breaker, the {@link Executable#toGenericString()} of the actual message handling function</li>
+ * </ol>
+ *
+ * @author Allard Buijze
+ * @since 3.0
  */
 public final class HandlerComparator {
 
@@ -31,17 +42,22 @@ public final class HandlerComparator {
                       .reversed()
                       .thenComparing(
                               (Function<MessageHandlingMember<?>, Class<?>>) MessageHandlingMember::payloadType,
-                              HandlerComparator::compareHierarchy)
+                              HandlerComparator::compareHierarchy
+                      )
+                      .thenComparing(Comparator.comparingInt(
+                              (ToIntFunction<MessageHandlingMember<?>>) m -> m.unwrap(Executable.class)
+                                                                              .map(Executable::getParameterCount)
+                                                                              .orElse(1)
+                                     ).reversed()
+                      )
                       .thenComparing(
-                              Comparator.comparingInt((ToIntFunction<MessageHandlingMember<?>>)
-                                                              m -> m.unwrap(Executable.class)
-                                                                    .map(Executable::getParameterCount)
-                                                                    .orElse(1))
-                                        .reversed())
-                      .thenComparing(m -> m.unwrap(Executable.class).map(Executable::toGenericString).orElse(m.toString()));
+                              m -> m.unwrap(Executable.class)
+                                    .map(Executable::toGenericString)
+                                    .orElse(m.toString())
+                      );
 
-    // prevent construction
     private HandlerComparator() {
+        // Utility class
     }
 
     /**
@@ -54,7 +70,7 @@ public final class HandlerComparator {
     }
 
     private static int compareHierarchy(Class<?> o1, Class<?> o2) {
-        if (o1.isInterface() && !o2.isInterface()){
+        if (o1.isInterface() && !o2.isInterface()) {
             return 1;
         } else if (!o1.isInterface() && o2.isInterface()) {
             return -1;
@@ -81,5 +97,4 @@ public final class HandlerComparator {
         }
         return depth;
     }
-
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
@@ -50,7 +50,9 @@ public interface MessageHandlingMember<T> {
      *
      * @return Number indicating the priority of this handler over other handlers
      */
-    int priority();
+    default int priority() {
+        return 0;
+    }
 
     /**
      * Checks if this handler is capable of handling the given {@code message}.

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
@@ -21,9 +21,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HandlerComparatorTest {
 
@@ -31,6 +38,7 @@ class HandlerComparatorTest {
     private MessageHandlingMember<?> objectHandler;
     private MessageHandlingMember<?> longHandler;
     private MessageHandlingMember<?> numberHandler;
+    private MessageHandlingMember<?> priorityHandler;
 
     private Comparator<MessageHandlingMember<?>> testSubject;
 
@@ -39,7 +47,8 @@ class HandlerComparatorTest {
         stringHandler = new StubMessageHandlingMember(String.class, 0);
         objectHandler = new StubMessageHandlingMember(Object.class, 0);
         longHandler = new StubMessageHandlingMember(Long.class, 0);
-        numberHandler = new StubMessageHandlingMember(Number.class, 1);
+        numberHandler = new StubMessageHandlingMember(Number.class, 0);
+        priorityHandler = new StubMessageHandlingMember(Object.class, 1);
 
         testSubject = HandlerComparator.instance();
     }
@@ -65,12 +74,14 @@ class HandlerComparatorTest {
         assertEquals(0, testSubject.compare(objectHandler, objectHandler));
         assertEquals(0, testSubject.compare(longHandler, longHandler));
         assertEquals(0, testSubject.compare(numberHandler, numberHandler));
+        assertEquals(0, testSubject.compare(priorityHandler, priorityHandler));
 
         assertNotEquals(0, testSubject.compare(stringHandler, objectHandler));
         assertNotEquals(0, testSubject.compare(longHandler, stringHandler));
         assertNotEquals(0, testSubject.compare(numberHandler, stringHandler));
         assertNotEquals(0, testSubject.compare(objectHandler, longHandler));
         assertNotEquals(0, testSubject.compare(objectHandler, numberHandler));
+        assertNotEquals(0, testSubject.compare(priorityHandler, numberHandler));
     }
 
     @Test
@@ -84,8 +95,8 @@ class HandlerComparatorTest {
 
     @Test
     void testNotInSameHierarchyUsesPriorityBasedEvaluation() {
-        assertTrue(testSubject.compare(numberHandler, stringHandler) < 0, "Number should appear before String based on priority");
-        assertTrue(testSubject.compare(stringHandler, numberHandler) > 0, "Number should appear before String based on priority");
+        assertTrue(testSubject.compare(priorityHandler, stringHandler) < 0, "priorityHandler should appear before String based on priority");
+        assertTrue(testSubject.compare(stringHandler, priorityHandler) > 0, "priorityHandler should appear before String based on priority");
     }
 
     private static class StubMessageHandlingMember implements MessageHandlingMember<Object> {


### PR DESCRIPTION
Mainly the explicit priority of handlers must be taken into account before looking at payload types or parameter count. This allows handlers for specific Message types to be evaluated before handlers of more generic Message types.