### PR TITLE
Fix resubscribe of Query Handlers on Resource Exhausted exception

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -719,6 +719,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                 @Override
                 public void onError(Throwable ex) {
                     logger.warn("Query Inbound Stream closed with error", ex);
+                    outboundStreamObserver = null;
                 }
 
                 @Override


### PR DESCRIPTION
Set stream observer to `null` on error, which fixes resubscribe on `RESOURCE_EXHAUSTED` exception.

This pull request resolves #1384.