### PR TITLE
Fixed exception occurring with BeanFactory that is null

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -110,8 +110,8 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
      * {@link <a href="https://github.com/spring-cloud/spring-cloud-aws/blob/12c785a52d935d307f7caffe7894b04742229d17/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java#L80">NullBean example</a>}
      * @see org.springframework.beans.factory.support.NullBean#equals
      *
-     * @param bean bean to check
-     * @return true if bean is NullBean
+     * @param bean the {@link Object} to verify if it is a {@link org.springframework.beans.factory.support.NullBean}
+     * @return {@code true} if the given {@code bean} is of type {@link org.springframework.beans.factory.support.NullBean} and {@code false} otherwise
      */
     private boolean isNullBean(final Object bean) {
         return bean.equals(null);

--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -70,7 +70,7 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
      */
     @Override
     public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
-        if (beanName != null && beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName)) {
+        if (beanName != null && !isNullBean(bean) && beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName)) {
             return bean;
         }
 
@@ -101,6 +101,20 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
             }
         }
         return bean;
+    }
+        
+    /**
+     * Verify if the given {@code bean} is a {@link org.springframework.beans.factory.support.NullBean} instance.
+     * If this is the case, a call to {@link org.springframework.beans.factory.support.NullBean#equals} using {@code null} will return {@code true}.
+     *
+     * {@link <a href="https://github.com/spring-cloud/spring-cloud-aws/blob/12c785a52d935d307f7caffe7894b04742229d17/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java#L80">NullBean example</a>}
+     * @see org.springframework.beans.factory.support.NullBean#equals
+     *
+     * @param bean bean to check
+     * @return true if bean is NullBean
+     */
+    private boolean isNullBean(final Object bean) {
+        return bean.equals(null);
     }
 
     private boolean isInstance(Object bean, Class<?>[] adapterInterfaces) {


### PR DESCRIPTION
Axon's spring BeanPostProcessor doesn't tolerate null BeanFactories.
In conjunction with spring-cloud-aws-autoconfigure it breaks entire application boot.
The culprit is null BeanFactory returned from @Bean method. Code is here: https://github.com/spring-cloud/spring-cloud-aws/blob/v2.2.1.RELEASE/spring-cloud-aws-autoconfigure/src/main/java/org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.java#L80
As a result `org.axonframework.spring.config.AbstractAnnotationHandlerBeanPostProcessor#postProcessAfterInitialization` gets `org.springframework.beans.factory.support.NullBean` instance and on `beanFactory.isSingleton(beanName)` throws exception.

`org.axonframework.spring.config.AbstractAnnotationHandlerBeanPostProcessor#postProcessAfterInitialization` Produces following exception:

`2020-02-26 12:33:19.061  WARN 10135 --- [  restartedMain] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.cloud.aws.core.env.ResourceIdResolver.BEAN_NAME': Invocation of init method failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'stackResourceRegistryFactoryBean' defined in class path resource [org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.class]: Initialization of bean failed; nested exception is java.lang.ClassCastException: class org.springframework.beans.factory.support.NullBean cannot be cast to class org.springframework.beans.factory.FactoryBean (org.springframework.beans.factory.support.NullBean and org.springframework.beans.factory.FactoryBean are in unnamed module of loader 'app')
2020-02-`

Entire application fails later:
```
2020-02-26 12:33:22.197 ERROR 10135 --- [  restartedMain] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.cloud.aws.core.env.ResourceIdResolver.BEAN_NAME': Invocation of init method failed; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'stackResourceRegistryFactoryBean' defined in class path resource [org/springframework/cloud/aws/autoconfigure/context/ContextStackAutoConfiguration.class]: Initialization of bean failed; nested exception is java.lang.ClassCastException: class org.springframework.beans.factory.support.NullBean cannot be cast to class org.springframework.beans.factory.FactoryBean (org.springframework.beans.factory.support.NullBean and org.springframework.beans.factory.FactoryBean are in unnamed module of loader 'app')
```