### PR TITLE
Complete request stream when response stream completes or errors

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -420,7 +420,7 @@ public class AxonServerConnectionManager {
                     @Override
                     public void onError(Throwable throwable) {
                         logger.warn("Lost instruction stream from [{}] - {}", name, throwable.getMessage());
-
+                        completeRequestStream();
                         notifyConnectionChange(disconnectListeners, context);
                         if (throwable instanceof StatusRuntimeException) {
                             StatusRuntimeException sre = (StatusRuntimeException) throwable;
@@ -434,6 +434,7 @@ public class AxonServerConnectionManager {
                     @Override
                     public void onCompleted() {
                         logger.info("Closed instruction stream to [{}]", name);
+                        completeRequestStream();
                         notifyConnectionChange(disconnectListeners, context);
                         scheduleReconnect(context, true);
                     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -789,12 +789,14 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
                 @Override
                 public void onError(Throwable ex) {
                     logger.warn("Command Inbound Stream closed with error", ex);
+                    completeRequestStream();
                     subscriberStreamObserver = null;
                 }
 
                 @Override
                 public void onCompleted() {
                     logger.info("Received completed from server.");
+                    completeRequestStream();
                     subscriberStreamObserver = null;
                 }
             };

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -719,11 +719,14 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                 @Override
                 public void onError(Throwable ex) {
                     logger.warn("Query Inbound Stream closed with error", ex);
+                    completeRequestStream();
+                    outboundStreamObserver = null;
                 }
 
                 @Override
                 public void onCompleted() {
                     logger.info("Received completed from server.");
+                    completeRequestStream();
                     outboundStreamObserver = null;
                 }
             };

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/UpstreamAwareStreamObserver.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/UpstreamAwareStreamObserver.java
@@ -27,4 +27,18 @@ public abstract class UpstreamAwareStreamObserver<ResT> implements ClientRespons
     public ClientCallStreamObserver<?> getRequestStream() {
         return requestStream;
     }
+
+    /**
+     * Completes the request steam related to this stream observer. Ignores exceptions that may occur (for instance if
+     * the request stream is already half-closed).
+     */
+    protected void completeRequestStream() {
+         if( requestStream != null) {
+             try {
+                 requestStream.onCompleted();
+             } catch (Exception ex) {
+                // Ignore exceptions on completing the request stream, may already have been closed
+             }
+         }
+    }
 }


### PR DESCRIPTION
Keeping the request stream alive may lead to memory leak.