### PR TITLE
Prevent null pointer exception in MultiSourceTrackingToken

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
@@ -76,9 +76,11 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
 
         Map<String, TrackingToken> tokenMap = new HashMap<>();
 
-        otherMultiToken.trackingTokens.forEach((tokenSourceName, otherToken) ->
-                                                       tokenMap.put(tokenSourceName,
-                                                                    trackingTokens.get(tokenSourceName).lowerBound(otherToken))
+        otherMultiToken.trackingTokens
+                .forEach((tokenSourceName, otherToken) ->
+                                 tokenMap.put(tokenSourceName, trackingTokens.get(tokenSourceName) == null ?
+                                                    null :
+                                                    trackingTokens.get(tokenSourceName).lowerBound(otherToken))
         );
 
         return new MultiSourceTrackingToken(tokenMap);
@@ -104,8 +106,11 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
 
         Map<String, TrackingToken> tokenMap = new HashMap<>();
 
-        otherMultiToken.trackingTokens.forEach((tokenSourceName, otherToken) ->
-                                                       tokenMap.put(tokenSourceName, trackingTokens.get(tokenSourceName).upperBound(otherToken))
+        otherMultiToken.trackingTokens
+                .forEach((tokenSourceName, otherToken) ->
+                                 tokenMap.put(tokenSourceName, trackingTokens.get(tokenSourceName) == null ?
+                                                    otherToken :
+                                                    trackingTokens.get(tokenSourceName).upperBound(otherToken))
         );
 
         return new MultiSourceTrackingToken(tokenMap);
@@ -214,6 +219,10 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
 
         for (Map.Entry<String, TrackingToken> trackingTokenEntry : trackingTokens.entrySet()) {
             try {
+                if ( trackingTokenEntry.getValue() == null  && that.trackingTokens.get(trackingTokenEntry.getKey()) == null) {
+                    return true;
+                }
+
                 if (!trackingTokenEntry.getValue().equals(that.trackingTokens.get(trackingTokenEntry.getKey()))) {
                     return false;
                 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
@@ -217,21 +217,10 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
             return false;
         }
 
-        for (Map.Entry<String, TrackingToken> trackingTokenEntry : trackingTokens.entrySet()) {
-            try {
-                if ( trackingTokenEntry.getValue() == null  && that.trackingTokens.get(trackingTokenEntry.getKey()) == null) {
-                    return true;
-                }
-
-                if (!trackingTokenEntry.getValue().equals(that.trackingTokens.get(trackingTokenEntry.getKey()))) {
-                    return false;
-                }
-            } catch (NullPointerException ex) {
-                logger.warn("A constituent token has not been initialized");
-                return false;
-            }
-        }
-        return true;
+        return trackingTokens.entrySet()
+                             .stream()
+                             .allMatch(trackingTokenEntry -> Objects.equals(trackingTokenEntry.getValue(),
+                                                                            that.trackingTokens.get(trackingTokenEntry.getKey())));
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
@@ -186,11 +186,12 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
     public OptionalLong position() {
 
         //If all delegated tokens are empty then return empty
-        if (trackingTokens.entrySet().stream().noneMatch(token -> token.getValue().position().isPresent())) {
+        if (trackingTokens.entrySet().stream().noneMatch(token -> token.getValue() != null && token.getValue().position().isPresent())) {
             return OptionalLong.empty();
         }
 
         long sumOfTokens = trackingTokens.values().stream()
+                                         .filter(Objects::nonNull)
                                          .mapToLong(trackingToken -> trackingToken.position().orElse(0L))
                                          .sum();
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
@@ -71,6 +71,27 @@ class MultiSourceTrackingTokenTest {
 
         assertEquals(new MultiSourceTrackingToken(expectedTokens), newMultiToken);
     }
+    @Test
+    void lowerBoundWithNull() {
+        Map<String, TrackingToken> tokenMap = new HashMap<>();
+        tokenMap.put("token1", new GlobalSequenceTrackingToken(2));
+        tokenMap.put("token2", null);
+
+        testSubject = new MultiSourceTrackingToken(tokenMap);
+
+        Map<String, TrackingToken> newTokens = new HashMap<>();
+        newTokens.put("token1", new GlobalSequenceTrackingToken(1));
+        newTokens.put("token2", new GlobalSequenceTrackingToken(2));
+
+        Map<String, TrackingToken> expectedTokens = new HashMap<>();
+        expectedTokens.put("token1", new GlobalSequenceTrackingToken(1));
+        expectedTokens.put("token2", null);
+
+        MultiSourceTrackingToken newMultiToken = (MultiSourceTrackingToken) testSubject
+                .lowerBound(new MultiSourceTrackingToken(newTokens));
+
+        assertEquals(new MultiSourceTrackingToken(expectedTokens), newMultiToken);
+    }
 
     @Test
     void lowerBoundMismatchTokens() {
@@ -111,6 +132,23 @@ class MultiSourceTrackingTokenTest {
         assertEquals(new MultiSourceTrackingToken(newTokens), newMultiToken);
     }
 
+    @Test
+    void upperBoundWithNull() {
+        Map<String, TrackingToken> tokenMap = new HashMap<>();
+        tokenMap.put("token1", new GlobalSequenceTrackingToken(0));
+        tokenMap.put("token2", null);
+
+        testSubject = new MultiSourceTrackingToken(tokenMap);
+        Map<String, TrackingToken> newTokens = new HashMap<>();
+
+        newTokens.put("token1", new GlobalSequenceTrackingToken(1));
+        newTokens.put("token2", new GlobalSequenceTrackingToken(2));
+
+        MultiSourceTrackingToken newMultiToken = (MultiSourceTrackingToken) testSubject
+                .upperBound(new MultiSourceTrackingToken(newTokens));
+
+        assertEquals(new MultiSourceTrackingToken(newTokens), newMultiToken);
+    }
 
     @Test
     void upperBoundMismatchTokens() {

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
@@ -199,6 +199,28 @@ class MultiSourceTrackingTokenTest {
     }
 
     @Test
+    void positionWithNullValue() {
+        Map<String, TrackingToken> tokenMap = new HashMap<>();
+        tokenMap.put("token1", new GlobalSequenceTrackingToken(10));
+        tokenMap.put("token2", null);
+
+        MultiSourceTrackingToken newMultiToken = new MultiSourceTrackingToken(tokenMap);
+
+        assertEquals(10, newMultiToken.position().orElse(-1));
+    }
+
+    @Test
+    void positionWithNullValue2() {
+        Map<String, TrackingToken> tokenMap = new HashMap<>();
+        tokenMap.put("token1", null);
+        tokenMap.put("token2", new GlobalSequenceTrackingToken(10));
+
+        MultiSourceTrackingToken newMultiToken = new MultiSourceTrackingToken(tokenMap);
+
+        assertEquals(10, newMultiToken.position().orElse(-1));
+    }
+
+    @Test
     void equals() {
         Map<String, TrackingToken> tokenMap = new HashMap<>();
         tokenMap.put("token1", new GlobalSequenceTrackingToken(0));


### PR DESCRIPTION
Handled null for empty streams as members of the MultiSourceTrackingToken.
Affected operations position/upperBound/lowerBound.

This PR resolves #1398.