### PR TITLE
Removed autoconfiguration of EventStore when EventBus is present

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jdbc.UnitOfWorkAwareConnectionProviderWrapper;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
@@ -53,7 +54,7 @@ import javax.sql.DataSource;
 public class JdbcAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean({EventStorageEngine.class, EventStore.class})
+    @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
     public EventStorageEngine eventStorageEngine(Serializer defaultSerializer,
                                                  PersistenceExceptionResolver persistenceExceptionResolver,
                                                  @Qualifier("eventSerializer") Serializer eventSerializer,

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -19,8 +19,8 @@ package org.axonframework.springboot.autoconfig;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.config.AxonConfiguration;
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 import javax.persistence.EntityManagerFactory;
 
 @ConditionalOnBean(EntityManagerFactory.class)
-@ConditionalOnMissingBean({EventStorageEngine.class, EventStore.class})
+@ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventsourcing.eventstore.jpa"
 })

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.springboot;
 
+import org.axonframework.common.jdbc.ConnectionProvider;
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.axonframework.common.jdbc.UnitOfWorkAwareConnectionProviderWrapper;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.SimpleEventBus;
@@ -25,6 +28,7 @@ import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
@@ -66,6 +70,8 @@ public class JdbcAutoConfigurationTest {
                     assertThat(context).getBean(TokenStore.class).isInstanceOf(JdbcTokenStore.class);
                     assertThat(context).getBean(SagaStore.class).isInstanceOf(JdbcSagaStore.class);
                     assertThat(context).getBean(TokenStore.class).isEqualTo(context.getBean(EventProcessingConfiguration.class).tokenStore("test"));
+                    assertThat(context).getBean(PersistenceExceptionResolver.class).isInstanceOf(JdbcSQLErrorCodesResolver.class);
+                    assertThat(context).getBean(ConnectionProvider.class).isInstanceOf(UnitOfWorkAwareConnectionProviderWrapper.class);
                 });
     }
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,38 +16,35 @@
 
 package org.axonframework.springboot;
 
-import org.axonframework.common.jdbc.ConnectionProvider;
-import org.axonframework.common.jdbc.PersistenceExceptionResolver;
-import org.axonframework.common.jdbc.UnitOfWorkAwareConnectionProviderWrapper;
 import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jdbc.JdbcTokenStore;
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jdbc.JdbcSagaStore;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.context.ApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import javax.sql.DataSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,39 +53,38 @@ import static org.mockito.Mockito.when;
  *
  * @author Milan Savic
  */
-@ExtendWith(SpringExtension.class)
-@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-@ContextConfiguration(classes = JdbcAutoConfigurationTest.Context.class)
-@EnableAutoConfiguration(exclude = {
-        JpaRepositoriesAutoConfiguration.class,
-        HibernateJpaAutoConfiguration.class,
-        AxonServerAutoConfiguration.class
-})
 public class JdbcAutoConfigurationTest {
 
-    @Autowired
-    private ApplicationContext applicationContext;
-
     @Test
-    void testContextInitialization() {
-        assertNotNull(applicationContext);
-
-        assertTrue(applicationContext.getBean(EventStorageEngine.class) instanceof JdbcEventStorageEngine);
-        assertTrue(applicationContext.getBean(PersistenceExceptionResolver.class) instanceof JdbcSQLErrorCodesResolver);
-        assertTrue(
-                applicationContext.getBean(ConnectionProvider.class) instanceof UnitOfWorkAwareConnectionProviderWrapper
-        );
-        assertTrue(applicationContext.getBean(TokenStore.class) instanceof JdbcTokenStore);
-        assertTrue(applicationContext.getBean(SagaStore.class) instanceof JdbcSagaStore);
-
-        assertEquals(
-                applicationContext.getBean(TokenStore.class),
-                applicationContext.getBean(EventProcessingConfiguration.class).tokenStore("test")
-        );
+    void testAllJdbcComponentsAutoConfigured() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(JdbcEventStorageEngine.class);
+                    assertThat(context).getBean(EventStorageEngine.class).isInstanceOf(JdbcEventStorageEngine.class);
+                    assertThat(context).getBean(EventStore.class).isInstanceOf(EmbeddedEventStore.class);
+                    assertThat(context).getBean(TokenStore.class).isInstanceOf(JdbcTokenStore.class);
+                    assertThat(context).getBean(SagaStore.class).isInstanceOf(JdbcSagaStore.class);
+                    assertThat(context).getBean(TokenStore.class).isEqualTo(context.getBean(EventProcessingConfiguration.class).tokenStore("test"));
+                });
     }
 
-    @Configuration
-    public static class Context {
+    @Test
+    void testConfigurationOfEventBusPreventsEventStoreDefinition() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class, ExplicitEventBusContext.class)
+                .run(context -> assertThat(context).doesNotHaveBean(EventStorageEngine.class)
+                                                   .doesNotHaveBean(EventStore.class));
+    }
+
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    @ContextConfiguration
+    @EnableAutoConfiguration(exclude = {
+            JpaRepositoriesAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            AxonServerAutoConfiguration.class
+    })
+    static class Context {
 
         @Bean
         public DataSource dataSource() throws SQLException {
@@ -99,6 +95,15 @@ public class JdbcAutoConfigurationTest {
             DataSource dataSource = mock(DataSource.class);
             when(dataSource.getConnection()).thenReturn(connection);
             return dataSource;
+        }
+    }
+
+    @Configuration
+    static class ExplicitEventBusContext {
+
+        @Bean
+        public EventBus eventBus() {
+            return SimpleEventBus.builder().build();
         }
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
@@ -1,20 +1,37 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.springboot;
 
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests JPA EventStore auto-configuration
@@ -22,21 +39,44 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Sara Pellegrini
  */
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
-@EnableAutoConfiguration(exclude = {AxonServerAutoConfiguration.class})
-@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
-
-    @Autowired
-    private EventStorageEngine eventStorageEngine;
-
-    @Autowired
-    private EventStore eventStore;
 
     @Test
     void testEventStore() {
-        assertTrue(eventStorageEngine instanceof JpaEventStorageEngine);
-        assertTrue(eventStore instanceof EmbeddedEventStore);
+        new ApplicationContextRunner()
+                .withUserConfiguration(TestContext.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(JpaEventStorageEngine.class);
+                    assertThat(context).getBean(JpaEventStorageEngine.class).isInstanceOf(JpaEventStorageEngine.class);
+                    assertThat(context).getBean(EventStore.class).isInstanceOf(EmbeddedEventStore.class);
+                });
+    }
+
+    @Test
+    void testEventBusOverridesEventStoreDefinition() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(EventBusContext.class,
+                                       TestContext.class)
+                .run(context -> {
+                    assertThat(context).hasBean("simpleEventBus");
+                    assertThat(context).getBean(EventBus.class).isInstanceOf(SimpleEventBus.class);
+                    assertThat(context).doesNotHaveBean(EventStore.class);
+                    assertThat(context).doesNotHaveBean(EventStorageEngine.class);
+                });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration(exclude = {AxonServerAutoConfiguration.class})
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class TestContext {
+
+    }
+
+    private static class EventBusContext {
+
+        @Bean
+        public EventBus simpleEventBus() {
+            return SimpleEventBus.builder().build();
+        }
     }
 }


### PR DESCRIPTION
When explicitly defining an EventBus in the configuration, that should be interpreted as an attempt to suppress Event Sourcing.

Resolves #1395