### PR TITLE
Adjust retrieval of Query Name in the QueryGateway

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,8 @@ import java.util.Map;
  * If a GenericMessage is created while a {@link org.axonframework.messaging.unitofwork.UnitOfWork} is active it copies
  * over the correlation data of the UnitOfWork to the created message.
  *
- * @author Rene de Waele
+ * @author Allard Buijze
+ * @since 2.0
  */
 public class GenericMessage<T> extends AbstractMessage<T> {
 
@@ -57,6 +58,23 @@ public class GenericMessage<T> extends AbstractMessage<T> {
     }
 
     /**
+     * Extracts the message name from the given {@code payloadOrMessage}. If the given {@code payloadOrMessage} is an
+     * instance of {@link Message}, {@link Message#getPayloadType()} is used. Otherwise we expect the given {@link
+     * Object} to be the payload directly. The return value will be the result of {@link Class#getName()}, either from
+     * the {@code Message}'s {@code payloadType} or from the payload's class.
+     *
+     * @param payloadOrMessage the payload to extract the {@link Class#getName()} from, or an instance of {@link
+     *                         Message}
+     * @return the {@link Class#getName()} result from the payload, or from the {@link Message#getPayloadType()} if the
+     * given {@code payloadOrMessage} is an instance of {@link Message}
+     */
+    public static String messageName(Object payloadOrMessage) {
+        return Message.class.isAssignableFrom(payloadOrMessage.getClass())
+                ? ((Message<?>) payloadOrMessage).getPayloadType().getName()
+                : payloadOrMessage.getClass().getName();
+    }
+
+    /**
      * Constructs a Message for the given {@code payload} using the correlation data of the current Unit of Work, if
      * present.
      *
@@ -67,21 +85,20 @@ public class GenericMessage<T> extends AbstractMessage<T> {
     }
 
     /**
-     * Constructs a Message for the given {@code payload} and {@code meta data}. The given {@code metaData} is
-     * merged with the MetaData from the correlation data of the current unit of work, if present.
-     * In case the {@code payload == null}, {@link Void} will be used as the {@code payloadType}.
+     * Constructs a Message for the given {@code payload} and {@code meta data}. The given {@code metaData} is merged
+     * with the MetaData from the correlation data of the current unit of work, if present. In case the {@code payload
+     * == null}, {@link Void} will be used as the {@code payloadType}.
      *
      * @param payload  The payload for the message as a generic {@code T}
      * @param metaData The meta data {@link Map} for the message
      */
-    @SuppressWarnings("unchecked")
     public GenericMessage(T payload, Map<String, ?> metaData) {
         this(getDeclaredPayloadType(payload), payload, metaData);
     }
 
     /**
-     * Constructs a Message for the given {@code payload} and {@code meta data}. The given {@code metaData} is
-     * merged with the MetaData from the correlation data of the current unit of work, if present.
+     * Constructs a Message for the given {@code payload} and {@code meta data}. The given {@code metaData} is merged
+     * with the MetaData from the correlation data of the current unit of work, if present.
      *
      * @param declaredPayloadType The declared type of message payload
      * @param payload             The payload for the message
@@ -93,24 +110,23 @@ public class GenericMessage<T> extends AbstractMessage<T> {
     }
 
     /**
-     * Constructor to reconstruct a Message using existing data. Note that no correlation data
-     * from a UnitOfWork is attached when using this constructor. If you're constructing a new
-     * Message, use {@link #GenericMessage(Object, Map)} instead.
+     * Constructor to reconstruct a Message using existing data. Note that no correlation data from a UnitOfWork is
+     * attached when using this constructor. If you're constructing a new Message, use {@link #GenericMessage(Object,
+     * Map)} instead.
      *
      * @param identifier The identifier of the Message
      * @param payload    The payload of the message
      * @param metaData   The meta data of the message
      * @throws NullPointerException when the given {@code payload} is {@code null}.
      */
-    @SuppressWarnings("unchecked")
     public GenericMessage(String identifier, T payload, Map<String, ?> metaData) {
         this(identifier, getDeclaredPayloadType(payload), payload, metaData);
     }
 
     /**
-     * Constructor to reconstruct a Message using existing data. Note that no correlation data
-     * from a UnitOfWork is attached when using this constructor. If you're constructing a new
-     * Message, use {@link #GenericMessage(Object, Map)} instead
+     * Constructor to reconstruct a Message using existing data. Note that no correlation data from a UnitOfWork is
+     * attached when using this constructor. If you're constructing a new Message, use {@link #GenericMessage(Object,
+     * Map)} instead
      *
      * @param identifier          The identifier of the Message
      * @param declaredPayloadType The declared type of message payload

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -58,23 +58,6 @@ public class GenericMessage<T> extends AbstractMessage<T> {
     }
 
     /**
-     * Extracts the message name from the given {@code payloadOrMessage}. If the given {@code payloadOrMessage} is an
-     * instance of {@link Message}, {@link Message#getPayloadType()} is used. Otherwise we expect the given {@link
-     * Object} to be the payload directly. The return value will be the result of {@link Class#getName()}, either from
-     * the {@code Message}'s {@code payloadType} or from the payload's class.
-     *
-     * @param payloadOrMessage the payload to extract the {@link Class#getName()} from, or an instance of {@link
-     *                         Message}
-     * @return the {@link Class#getName()} result from the payload, or from the {@link Message#getPayloadType()} if the
-     * given {@code payloadOrMessage} is an instance of {@link Message}
-     */
-    public static String messageName(Object payloadOrMessage) {
-        return Message.class.isAssignableFrom(payloadOrMessage.getClass())
-                ? ((Message<?>) payloadOrMessage).getPayloadType().getName()
-                : payloadOrMessage.getClass().getName();
-    }
-
-    /**
      * Constructs a Message for the given {@code payload} using the correlation data of the current Unit of Work, if
      * present.
      *

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.axonframework.messaging.GenericMessage.messageName;
+import static org.axonframework.queryhandling.QueryMessage.queryName;
 
 /**
  * Interface towards the Query Handling components of an application. This interface provides a friendlier API toward
@@ -51,7 +51,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * {@code responseType}
      */
     default <R, Q> CompletableFuture<R> query(Q query, Class<R> responseType) {
-        return query(messageName(query), query, responseType);
+        return query(queryName(query), query, responseType);
     }
 
     /**
@@ -84,7 +84,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * {@code responseType}
      */
     default <R, Q> CompletableFuture<R> query(Q query, ResponseType<R> responseType) {
-        return query(messageName(query), query, responseType);
+        return query(queryName(query), query, responseType);
     }
 
     /**
@@ -117,7 +117,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @return A stream of results.
      */
     default <R, Q> Stream<R> scatterGather(Q query, ResponseType<R> responseType, long timeout, TimeUnit timeUnit) {
-        return scatterGather(messageName(query), query, responseType, timeout, timeUnit);
+        return scatterGather(queryName(query), query, responseType, timeout, timeUnit);
     }
 
     /**
@@ -158,7 +158,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      */
     default <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(Q query, Class<I> initialResponseType,
                                                                       Class<U> updateResponseType) {
-        return subscriptionQuery(messageName(query), query, initialResponseType, updateResponseType);
+        return subscriptionQuery(queryName(query), query, initialResponseType, updateResponseType);
     }
 
     /**
@@ -212,7 +212,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      */
     default <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(Q query, ResponseType<I> initialResponseType,
                                                                       ResponseType<U> updateResponseType) {
-        return subscriptionQuery(messageName(query),
+        return subscriptionQuery(queryName(query),
                                  query,
                                  initialResponseType,
                                  updateResponseType,

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static org.axonframework.messaging.GenericMessage.messageName;
+
 /**
  * Interface towards the Query Handling components of an application. This interface provides a friendlier API toward
  * the query bus.
@@ -38,8 +40,8 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
 
     /**
      * Sends given {@code query} over the {@link org.axonframework.queryhandling.QueryBus}, expecting a response with
-     * the given {@code responseType} from a single source. The query name will be derived from the provided
-     * {@code query}. Execution may be asynchronous, depending on the QueryBus implementation.
+     * the given {@code responseType} from a single source. The query name will be derived from the provided {@code
+     * query}. Execution may be asynchronous, depending on the QueryBus implementation.
      *
      * @param query        The {@code query} to be sent
      * @param responseType A {@link java.lang.Class} describing the desired response type
@@ -49,7 +51,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * {@code responseType}
      */
     default <R, Q> CompletableFuture<R> query(Q query, Class<R> responseType) {
-        return query(query.getClass().getName(), query, responseType);
+        return query(messageName(query), query, responseType);
     }
 
     /**
@@ -71,8 +73,8 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
 
     /**
      * Sends given {@code query} over the {@link org.axonframework.queryhandling.QueryBus}, expecting a response in the
-     * form of {@code responseType} from a single source. The query name will be derived from the provided
-     * {@code query}. Execution may be asynchronous, depending on the QueryBus implementation.
+     * form of {@code responseType} from a single source. The query name will be derived from the provided {@code
+     * query}. Execution may be asynchronous, depending on the QueryBus implementation.
      *
      * @param query        The {@code query} to be sent
      * @param responseType The {@link ResponseType} used for this query
@@ -82,7 +84,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * {@code responseType}
      */
     default <R, Q> CompletableFuture<R> query(Q query, ResponseType<R> responseType) {
-        return query(query.getClass().getName(), query, responseType);
+        return query(messageName(query), query, responseType);
     }
 
     /**
@@ -115,7 +117,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @return A stream of results.
      */
     default <R, Q> Stream<R> scatterGather(Q query, ResponseType<R> responseType, long timeout, TimeUnit timeUnit) {
-        return scatterGather(query.getClass().getName(), query, responseType, timeout, timeUnit);
+        return scatterGather(messageName(query), query, responseType, timeout, timeUnit);
     }
 
     /**
@@ -151,16 +153,12 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @param <I>                 The type of the initial response
      * @param <U>                 The type of the incremental update
      * @return registration which can be used to cancel receiving updates
-     *
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */
     default <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(Q query, Class<I> initialResponseType,
                                                                       Class<U> updateResponseType) {
-        return subscriptionQuery(query.getClass().getName(),
-                                 query,
-                                 initialResponseType,
-                                 updateResponseType);
+        return subscriptionQuery(messageName(query), query, initialResponseType, updateResponseType);
     }
 
     /**
@@ -180,7 +178,6 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @param <I>                 The type of the initial response
      * @param <U>                 The type of the incremental update
      * @return registration which can be used to cancel receiving updates
-     *
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */
@@ -210,13 +207,12 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @param <I>                 The type of the initial response
      * @param <U>                 The type of the incremental update
      * @return registration which can be used to cancel receiving updates
-     *
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */
     default <Q, I, U> SubscriptionQueryResult<I, U> subscriptionQuery(Q query, ResponseType<I> initialResponseType,
                                                                       ResponseType<U> updateResponseType) {
-        return subscriptionQuery(query.getClass().getName(),
+        return subscriptionQuery(messageName(query),
                                  query,
                                  initialResponseType,
                                  updateResponseType,
@@ -241,7 +237,6 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @param <I>                 The type of the initial response
      * @param <U>                 The type of the incremental update
      * @return registration which can be used to cancel receiving updates
-     *
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */
@@ -277,7 +272,6 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @param <I>                 The type of the initial response
      * @param <U>                 The type of the incremental update
      * @return registration which can be used to cancel receiving updates
-     *
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage)
      * @see QueryBus#subscriptionQuery(SubscriptionQueryMessage, SubscriptionQueryBackpressure, int)
      */

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,27 @@ public interface QueryMessage<T, R> extends Message<T> {
     String getQueryName();
 
     /**
+     * Extracts the {@code queryName} from the given {@code payloadOrMessage}, with three possible outcomes:
+     * <ul>
+     * <li>The {@code payloadOrMessage} is an instance of {@link QueryMessage} - {@link QueryMessage#getQueryName()} is returned.</li>
+     * <li>The {@code payloadOrMessage} is an instance of {@link Message} - the name of {@link Message#getPayloadType()} is returned.</li>
+     * <li>The {@code payloadOrMessage} is the query payload - {@link Class#getName()} is returned.</li>
+     * </ul>
+     *
+     * @param payloadOrMessage the object to base the {@code queryName} on
+     * @return the {@link QueryMessage#getQueryName()}, the name of {@link Message#getPayloadType()} or the result of {@link
+     * Class#getName()}, depending on the type of the {@code payloadOrMessage}
+     */
+    static String queryName(Object payloadOrMessage) {
+        if (payloadOrMessage instanceof QueryMessage) {
+            return ((QueryMessage<?, ?>) payloadOrMessage).getQueryName();
+        } else if (payloadOrMessage instanceof Message) {
+            return ((Message<?>) payloadOrMessage).getPayloadType().getName();
+        }
+        return payloadOrMessage.getClass().getName();
+    }
+
+    /**
      * The type of response expected by the sender of the query
      *
      * @return the type of response expected by the sender of the query
@@ -54,8 +75,8 @@ public interface QueryMessage<T, R> extends Message<T> {
     QueryMessage<T, R> withMetaData(Map<String, ?> metaData);
 
     /**
-     * Returns a copy of this QueryMessage with its MetaData merged with given {@code metaData}. The payload
-     * remains unchanged.
+     * Returns a copy of this QueryMessage with its MetaData merged with given {@code metaData}. The payload remains
+     * unchanged.
      *
      * @param additionalMetaData The MetaData to merge into the QueryMessage
      * @return a copy of this message with the given additional MetaData

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
  */
 class GenericMessageTest {
 
-    private Map<String, ?> correlationData = MetaData.from(Collections.singletonMap("foo", "bar"));
+    private final Map<String, ?> correlationData = MetaData.from(Collections.singletonMap("foo", "bar"));
 
     @BeforeEach
     void setUp() {
@@ -91,5 +91,24 @@ class GenericMessageTest {
 
         assertNotEquals(testPayload, result);
         assertEquals(testPayload, result.getPayload());
+    }
+
+    @Test
+    void testMessageNameResemblesPayloadClassName() {
+        String testPayload = "payload";
+
+        String result = GenericMessage.messageName(testPayload);
+
+        assertEquals(String.class.getName(), result);
+    }
+
+    @Test
+    void testMessageNameResemblesMessagePayloadTypeClassName() {
+        String testPayload = "payload";
+        Message<?> testMessage = GenericMessage.asMessage(testPayload);
+
+        String result = GenericMessage.messageName(testMessage);
+
+        assertEquals(String.class.getName(), result);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -92,23 +92,4 @@ class GenericMessageTest {
         assertNotEquals(testPayload, result);
         assertEquals(testPayload, result.getPayload());
     }
-
-    @Test
-    void testMessageNameResemblesPayloadClassName() {
-        String testPayload = "payload";
-
-        String result = GenericMessage.messageName(testPayload);
-
-        assertEquals(String.class.getName(), result);
-    }
-
-    @Test
-    void testMessageNameResemblesMessagePayloadTypeClassName() {
-        String testPayload = "payload";
-        Message<?> testMessage = GenericMessage.asMessage(testPayload);
-
-        String result = GenericMessage.messageName(testMessage);
-
-        assertEquals(String.class.getName(), result);
-    }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -19,6 +19,7 @@ package org.axonframework.queryhandling;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.responsetypes.InstanceResponseType;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -61,132 +62,199 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testDispatchSingleResultQuery() throws Exception {
+    void testPointToPointQuery() throws Exception {
         when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
 
-        CompletableFuture<String> actual = testSubject.query("query", String.class);
-        assertEquals("answer", actual.get());
+        CompletableFuture<String> queryResponse = testSubject.query("query", String.class);
+        assertEquals("answer", queryResponse.get());
 
-        verify(mockBus).query(
-                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "query".equals(x.getPayload()))
-        );
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).query(queryMessageCaptor.capture());
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("query", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
     }
 
     @Test
-    void testDispatchMessageWithMetaData() {
-        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
-
+    void testPointToPointQueryWithMetaData() throws Exception {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
 
-        testSubject.query(
-                new GenericMessage<>("Query", MetaData.with(expectedMetaDataKey, expectedMetaDataValue)),
-                instanceOf(String.class)
-        );
+        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
 
-        verify(mockBus).query(
-                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "Query".equals(x.getPayload())
-                        && expectedMetaDataValue.equals(x.getMetaData().get(expectedMetaDataKey)))
-        );
+        GenericMessage<String> testQuery =
+                new GenericMessage<>("query", MetaData.with(expectedMetaDataKey, expectedMetaDataValue));
+
+        CompletableFuture<String> queryResponse = testSubject.query(testQuery, instanceOf(String.class));
+        assertEquals("answer", queryResponse.get());
+
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).query(queryMessageCaptor.capture());
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("query", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        MetaData resultMetaData = result.getMetaData();
+        assertTrue(resultMetaData.containsKey(expectedMetaDataKey));
+        assertTrue(resultMetaData.containsValue(expectedMetaDataValue));
     }
 
     @Test
-    void testDispatchSingleResultQueryWhenBusReportsAnError() throws Exception {
+    void testPointToPointQueryWhenQueryBusReportsAnError() throws Exception {
         Throwable expected = new Throwable("oops");
         when(mockBus.query(anyMessage(String.class, String.class)))
                 .thenReturn(completedFuture(new GenericQueryResponseMessage<>(String.class, expected)));
 
         CompletableFuture<String> result = testSubject.query("query", String.class);
+
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
         assertEquals(expected.getMessage(), result.exceptionally(Throwable::getMessage).get());
     }
 
     @Test
-    void testDispatchSingleResultQueryWhenBusThrowsException() throws Exception {
+    void testPointToPointQueryWhenQueryBusThrowsException() throws Exception {
         Throwable expected = new Throwable("oops");
-        CompletableFuture<QueryResponseMessage<String>> queryResponseMessageCompletableFuture = new CompletableFuture<>();
-        queryResponseMessageCompletableFuture.completeExceptionally(expected);
-        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(queryResponseMessageCompletableFuture);
+        CompletableFuture<QueryResponseMessage<String>> queryResponseCompletableFuture = new CompletableFuture<>();
+        queryResponseCompletableFuture.completeExceptionally(expected);
+        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(queryResponseCompletableFuture);
+
         CompletableFuture<String> result = testSubject.query("query", String.class);
+
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
         assertEquals(expected.getMessage(), result.exceptionally(Throwable::getMessage).get());
     }
 
     @Test
-    void testDispatchMultiResultQuery() {
+    void testScatterGatherQuery() {
+        long expectedTimeout = 1L;
+        TimeUnit expectedTimeUnit = TimeUnit.SECONDS;
+
         when(mockBus.scatterGather(anyMessage(String.class, String.class), anyLong(), any()))
                 .thenReturn(Stream.of(answer));
 
-        Stream<String> actual = testSubject.scatterGather(
-                "query", instanceOf(String.class), 1, TimeUnit.SECONDS
-        );
-        Optional<String> firstResult = actual.findFirst();
+        Stream<String> queryResponse =
+                testSubject.scatterGather("scatterGather", instanceOf(String.class), expectedTimeout, expectedTimeUnit);
+        Optional<String> firstResult = queryResponse.findFirst();
         assertTrue(firstResult.isPresent());
         assertEquals("answer", firstResult.get());
-        verify(mockBus).scatterGather(
-                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "query".equals(x.getPayload())),
-                eq(1L),
-                eq(TimeUnit.SECONDS)
-        );
+
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).scatterGather(queryMessageCaptor.capture(), eq(expectedTimeout), eq(expectedTimeUnit));
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("scatterGather", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
     }
 
     @Test
-    void testDispatchMultiResultQueryWithMetaData() {
+    void testScatterGatherQueryWithMetaData() {
+        String expectedMetaDataKey = "key";
+        String expectedMetaDataValue = "value";
+        long expectedTimeout = 1L;
+        TimeUnit expectedTimeUnit = TimeUnit.SECONDS;
+
         when(mockBus.scatterGather(anyMessage(String.class, String.class), anyLong(), any()))
                 .thenReturn(Stream.of(answer));
 
-        String expectedMetaDataKey = "key";
-        String expectedMetaDataValue = "value";
+        GenericMessage<String> testQuery =
+                new GenericMessage<>("scatterGather", MetaData.with(expectedMetaDataKey, expectedMetaDataValue));
 
-        testSubject.scatterGather(
-                new GenericMessage<>("scatterGather", MetaData.with(expectedMetaDataKey, expectedMetaDataValue)),
-                instanceOf(String.class), 1, TimeUnit.SECONDS
-        );
+        Stream<String> queryResponse =
+                testSubject.scatterGather(testQuery, instanceOf(String.class), expectedTimeout, expectedTimeUnit);
+        Optional<String> firstResult = queryResponse.findFirst();
+        assertTrue(firstResult.isPresent());
+        assertEquals("answer", firstResult.get());
 
-        verify(mockBus).scatterGather(
-                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "scatterGather".equals(x.getPayload())
-                        && expectedMetaDataValue.equals(x.getMetaData().get(expectedMetaDataKey))),
-                eq(1L),
-                eq(TimeUnit.SECONDS)
-        );
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).scatterGather(queryMessageCaptor.capture(), eq(expectedTimeout), eq(expectedTimeUnit));
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("scatterGather", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        MetaData resultMetaData = result.getMetaData();
+        assertTrue(resultMetaData.containsKey(expectedMetaDataKey));
+        assertTrue(resultMetaData.containsValue(expectedMetaDataValue));
     }
 
     @Test
-    void testDispatchSubscriptionQuery() {
+    void testSubscriptionQuery() {
         when(mockBus.subscriptionQuery(any(), any(), anyInt()))
                 .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
 
-        testSubject.subscriptionQuery("query",
-                                      instanceOf(String.class),
-                                      instanceOf(String.class));
-        verify(mockBus)
-                .subscriptionQuery(argThat((ArgumentMatcher<SubscriptionQueryMessage<String, String, String>>)
-                                                   x -> "query".equals(x.getPayload())), any(), anyInt());
+        testSubject.subscriptionQuery("subscription", instanceOf(String.class), instanceOf(String.class));
+
+        //noinspection unchecked
+        ArgumentCaptor<SubscriptionQueryMessage<String, String, String>> queryMessageCaptor =
+                ArgumentCaptor.forClass(SubscriptionQueryMessage.class);
+
+        verify(mockBus).subscriptionQuery(queryMessageCaptor.capture(), any(), anyInt());
+
+        SubscriptionQueryMessage<String, String, String> result = queryMessageCaptor.getValue();
+        assertEquals("subscription", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getUpdateResponseType().getClass()));
+        assertEquals(String.class, result.getUpdateResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
     }
 
     @Test
-    void testDispatchSubscriptionQueryWithMetaData() {
-        when(mockBus.subscriptionQuery(any(), any(), anyInt()))
-                .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
-
+    void testSubscriptionQueryWithMetaData() {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
 
-        testSubject.subscriptionQuery(
-                new GenericMessage<>("subscription", MetaData.with(expectedMetaDataKey, expectedMetaDataValue)),
-                instanceOf(String.class), instanceOf(String.class)
-        );
+        when(mockBus.subscriptionQuery(any(), any(), anyInt()))
+                .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
 
-        verify(mockBus).subscriptionQuery(
-                argThat((ArgumentMatcher<SubscriptionQueryMessage<String, String, String>>) x ->
-                        "subscription".equals(x.getPayload())
-                                && expectedMetaDataValue.equals(x.getMetaData().get(expectedMetaDataKey))
-                ),
-                any(),
-                anyInt()
-        );
+
+        GenericMessage<String> testQuery =
+                new GenericMessage<>("subscription", MetaData.with(expectedMetaDataKey, expectedMetaDataValue));
+        testSubject.subscriptionQuery(testQuery, instanceOf(String.class), instanceOf(String.class));
+
+        //noinspection unchecked
+        ArgumentCaptor<SubscriptionQueryMessage<String, String, String>> queryMessageCaptor =
+                ArgumentCaptor.forClass(SubscriptionQueryMessage.class);
+
+        verify(mockBus).subscriptionQuery(queryMessageCaptor.capture(), any(), anyInt());
+
+        SubscriptionQueryMessage<String, String, String> result = queryMessageCaptor.getValue();
+        assertEquals("subscription", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getUpdateResponseType().getClass()));
+        assertEquals(String.class, result.getUpdateResponseType().getExpectedResponseType());
+        MetaData resultMetaData = result.getMetaData();
+        assertTrue(resultMetaData.containsKey(expectedMetaDataKey));
+        assertTrue(resultMetaData.containsValue(expectedMetaDataValue));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -83,6 +83,29 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
+    void testPointToPointQuerySpecifyingQueryName() throws Exception {
+        String expectedQueryName = "myQueryName";
+
+        when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
+
+        CompletableFuture<String> queryResponse = testSubject.query(expectedQueryName, "query", String.class);
+        assertEquals("answer", queryResponse.get());
+
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).query(queryMessageCaptor.capture());
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("query", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(expectedQueryName, result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
+    }
+
+    @Test
     void testPointToPointQueryWithMetaData() throws Exception {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
@@ -167,6 +190,36 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
+    void testScatterGatherQuerySpecifyingQueryName() {
+        String expectedQueryName = "myQueryName";
+        long expectedTimeout = 1L;
+        TimeUnit expectedTimeUnit = TimeUnit.SECONDS;
+
+        when(mockBus.scatterGather(anyMessage(String.class, String.class), anyLong(), any()))
+                .thenReturn(Stream.of(answer));
+
+        Stream<String> queryResponse = testSubject.scatterGather(
+                expectedQueryName, "scatterGather", instanceOf(String.class), expectedTimeout, expectedTimeUnit
+        );
+        Optional<String> firstResult = queryResponse.findFirst();
+        assertTrue(firstResult.isPresent());
+        assertEquals("answer", firstResult.get());
+
+        //noinspection unchecked
+        ArgumentCaptor<QueryMessage<String, String>> queryMessageCaptor = ArgumentCaptor.forClass(QueryMessage.class);
+
+        verify(mockBus).scatterGather(queryMessageCaptor.capture(), eq(expectedTimeout), eq(expectedTimeUnit));
+
+        QueryMessage<String, String> result = queryMessageCaptor.getValue();
+        assertEquals("scatterGather", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(expectedQueryName, result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
+    }
+
+    @Test
     void testScatterGatherQueryWithMetaData() {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
@@ -218,6 +271,32 @@ class DefaultQueryGatewayTest {
         assertEquals("subscription", result.getPayload());
         assertEquals(String.class, result.getPayloadType());
         assertEquals(String.class.getName(), result.getQueryName());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
+        assertEquals(String.class, result.getResponseType().getExpectedResponseType());
+        assertTrue(InstanceResponseType.class.isAssignableFrom(result.getUpdateResponseType().getClass()));
+        assertEquals(String.class, result.getUpdateResponseType().getExpectedResponseType());
+        assertEquals(MetaData.emptyInstance(), result.getMetaData());
+    }
+
+    @Test
+    void testSubscriptionQuerySpecifyingQueryName() {
+        String expectedQueryName = "myQueryName";
+
+        when(mockBus.subscriptionQuery(any(), any(), anyInt()))
+                .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
+
+        testSubject.subscriptionQuery(expectedQueryName, "subscription", String.class, String.class);
+
+        //noinspection unchecked
+        ArgumentCaptor<SubscriptionQueryMessage<String, String, String>> queryMessageCaptor =
+                ArgumentCaptor.forClass(SubscriptionQueryMessage.class);
+
+        verify(mockBus).subscriptionQuery(queryMessageCaptor.capture(), any(), anyInt());
+
+        SubscriptionQueryMessage<String, String, String> result = queryMessageCaptor.getValue();
+        assertEquals("subscription", result.getPayload());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(expectedQueryName, result.getQueryName());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getUpdateResponseType().getClass()));

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating behaviour of the {@link GenericQueryMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericQueryMessageTest {
+
+    @Test
+    void testQueryNameResemblesPayloadClassName() {
+        String testPayload = "payload";
+
+        String result = QueryMessage.queryName(testPayload);
+
+        assertEquals(String.class.getName(), result);
+    }
+
+    @Test
+    void testQueryNameResemblesMessagePayloadTypeClassName() {
+        String testPayload = "payload";
+        Message<?> testMessage = GenericMessage.asMessage(testPayload);
+
+        String result = QueryMessage.queryName(testMessage);
+
+        assertEquals(String.class.getName(), result);
+    }
+
+    @Test
+    void testQueryNameResemblesQueryMessageQueryName() {
+        String expectedQueryName = "myQueryName";
+        QueryMessage<String, String> testMessage =
+                new GenericQueryMessage<>("payload", expectedQueryName, ResponseTypes.instanceOf(String.class));
+
+        String result = QueryMessage.queryName(testMessage);
+
+        assertEquals(expectedQueryName, result);
+    }
+}


### PR DESCRIPTION
The `QueryGateway` recently received an adjustment which allowed the usage of `Message` instances for the `query` parameter. This was introduced to support addition of `MetaData` directly on the `QueryGateway`.

Due to this adjustment, some of the `default` `QueryGateway` methods now set the `queryName` parameter to the outcome of `Message.class.getName()`. As `Message` would (very likely) never be the desired `queryName`, this behaviour should be adjusted to verify whether the given `query` parameter is an instance of `Message`.

That's exactly what this pull request introduces. For this, a static method has been included in the `GenericMessage` class, which validates whether a given object is the payload or a message.

In case of the former, `payload.getClass().getName()` will be performed.
In case of the latter, `((Message) payload).getPayloadType().getName()` will be used as the message name.

Tests have been included in the `GenericMessageTest` and `DefaultQueryGatewayTest` classes.