### PR TITLE
[#1407] Handler(Enhancer)Definition beans not taken into account

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -860,7 +860,6 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         }
 
         void disconnect() {
-            running = false;
             commandExecutor.shutdown();
             try {
                 if (!commandExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
@@ -879,6 +878,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
             if (subscriberStreamObserver != null) {
                 subscriberStreamObserver.onCompleted();
             }
+            running = false;
         }
 
         /**

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot;
+
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class verifying a {@link HandlerEnhancerDefinition} configurations. For example, that a {@code
+ * HandlerEnhancerDefinition} bean will only wrap if there are message handling functions present.
+ *
+ * @author Steven van Beelen
+ */
+class HandlerEnhancerDefinitionConfigurationTest {
+
+    private static final AtomicBoolean VERIFY_ENHANCER = new AtomicBoolean(false);
+
+    @BeforeEach
+    void setUp() {
+        VERIFY_ENHANCER.compareAndSet(true, false);
+    }
+
+    @Test
+    void testHandlerEnhancerDefinitionWrapsEventHandler() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(ContextWithHandlers.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(CustomHandlerEnhancerDefinition.class);
+                    assertThat(context).hasSingleBean(MyEventHandlingComponent.class);
+
+                    assertTrue(VERIFY_ENHANCER.get());
+                });
+    }
+
+    @Test
+    void testHandlerEnhancerDefinitionDoesNotWrapInAbsenceOfMessageHandlers() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(ContextWithoutHandlers.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(CustomHandlerEnhancerDefinition.class);
+
+                    assertFalse(VERIFY_ENHANCER.get());
+                });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class ContextWithHandlers {
+
+        @Bean
+        public HandlerEnhancerDefinition customHandlerEnhancerDefinition() {
+            return new CustomHandlerEnhancerDefinition();
+        }
+
+        @Bean
+        public MyEventHandlingComponent myEventHandlingComponent() {
+            return new MyEventHandlingComponent();
+        }
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class ContextWithoutHandlers {
+
+        @Bean
+        public HandlerEnhancerDefinition customHandlerEnhancerDefinition() {
+            return new CustomHandlerEnhancerDefinition();
+        }
+    }
+
+    private static class CustomHandlerEnhancerDefinition implements HandlerEnhancerDefinition {
+
+        @Override
+        public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
+            VERIFY_ENHANCER.set(true);
+            return original;
+        }
+    }
+
+    @ProcessingGroup("customGroup")
+    private static class MyEventHandlingComponent {
+
+        @EventHandler
+        public void on(Object someEvent) {
+
+        }
+    }
+}


### PR DESCRIPTION
When creating the `SimpleEventHandlerInvoker`, the `EventProcessingModule` did not include the `HandlerDefinition` from the given `Configuration`. As such, the `AnnotationEventHandlerAdapter` created through the `SimpleEventHandlerInvoker.Builder` defaulted to the `ClasspathHandlerDefinition#forClass` output.

Due to this, `Handler(Enhancer)Definition` beans in a Spring (Boot) context would never be taken into account if a component would only contain `@EventHandler` annotated methods.

This PR resolves that by providing the `HandlerDefinition` from the `Configuration` (potentially) based on the `ClassLoader` of the first event handling component.

This pull request resolves #1407