### PR TITLE
[#1418] Allow activation of default type information on the JacksonSerializer

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.axonframework.common.AxonConfigurationException;
@@ -267,6 +268,7 @@ public class JacksonSerializer implements Serializer {
         private Converter converter = new ChainingConverter();
         private ObjectMapper objectMapper = new ObjectMapper();
         private boolean lenientDeserialization = false;
+        private PolymorphicTypeValidator polymorphicTypeValidator;
 
         /**
          * Sets the {@link RevisionResolver} used to resolve the revision from an object to be serialized. Defaults to
@@ -317,7 +319,6 @@ public class JacksonSerializer implements Serializer {
          *
          * @param classLoader the {@link ClassLoader} used to load classes with when deserializing
          * @return the current Builder instance, for fluent interfacing
-         *
          * @see #objectMapper(ObjectMapper)
          * @see com.fasterxml.jackson.databind.type.TypeFactory#withClassLoader(ClassLoader)
          * @deprecated Ensure the ObjectMapper is configured with the correct class loader instead
@@ -329,14 +330,37 @@ public class JacksonSerializer implements Serializer {
 
         /**
          * Configures the underlying ObjectMapper to be lenient when deserializing JSON into Java objects. Specifically,
-         * enables the {@link DeserializationFeature#ACCEPT_SINGLE_VALUE_AS_ARRAY} and
-         * {@link DeserializationFeature#UNWRAP_SINGLE_VALUE_ARRAYS}, and disables
-         * {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES}.
+         * enables the {@link DeserializationFeature#ACCEPT_SINGLE_VALUE_AS_ARRAY} and {@link
+         * DeserializationFeature#UNWRAP_SINGLE_VALUE_ARRAYS}, and disables {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES}.
          *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder lenientDeserialization() {
             lenientDeserialization = true;
+            return this;
+        }
+
+        /**
+         * Configures the underlying {@link ObjectMapper} to include type information when serializing Java objects into
+         * JSON. Specifically, it calls {@link ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator,
+         * ObjectMapper.DefaultTyping)} with the given {@code polymorphicTypeValidator} and {@link
+         * ObjectMapper.DefaultTyping#NON_CONCRETE_AND_ARRAYS}. This can be toggled on to allow {@link
+         * java.util.Collection}s of objects, for example query {@link java.util.List} responses, to automatically
+         * include the types without require the use of {@link com.fasterxml.jackson.annotation.JsonTypeInfo} on the
+         * objects themselves.
+         * <p>
+         * Note: Jackson documentation is very <b>specific</b> on the {@link PolymorphicTypeValidator} used for security
+         * reasons. Allowing all subtypes to be included (with the {@link com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator}
+         * implementation for example) can be risky for untrusted content.
+         *
+         * @param polymorphicTypeValidator the {@link PolymorphicTypeValidator} used to call {@link
+         *                                 ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator,
+         *                                 ObjectMapper.DefaultTyping)}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder activateDefaultTyping(PolymorphicTypeValidator polymorphicTypeValidator) {
+            assertNonNull(polymorphicTypeValidator, "PolymorphicTypeValidator may not be null");
+            this.polymorphicTypeValidator = polymorphicTypeValidator;
             return this;
         }
 
@@ -350,6 +374,11 @@ public class JacksonSerializer implements Serializer {
                 objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
                 objectMapper.enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS);
                 objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            }
+            if (polymorphicTypeValidator != null) {
+                objectMapper.activateDefaultTyping(
+                        polymorphicTypeValidator, ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS
+                );
             }
             return new JacksonSerializer(this);
         }

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -97,11 +95,7 @@ class JacksonSerializerTest {
 
     @Test
     void testSerializeAndDeserializeList() {
-        objectMapper.activateDefaultTyping(
-                objectMapper.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE
-        );
-
+        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
         SimpleSerializableType toSerialize = new SimpleSerializableType("first", time,
                                                                         new SimpleSerializableType("nested"));
 
@@ -239,13 +233,7 @@ class JacksonSerializerTest {
     @Test
     void testSerializeMetaDataWithComplexObjects() {
         // Typing must be enabled for this (which we expect end-users to do)
-        PolymorphicTypeValidator polymorphicTypeValidator =
-                BasicPolymorphicTypeValidator.builder()
-                                             .allowIfSubType(ComplexObject.class)
-                                             .build();
-        JacksonSerializer testSubject = JacksonSerializer.builder()
-                                                         .activateDefaultTyping(polymorphicTypeValidator)
-                                                         .build();
+        JacksonSerializer testSubject = JacksonSerializer.builder().defaultTyping().build();
 
         MetaData metaData = MetaData.with("myKey", new ComplexObject("String1", "String2", 3));
         SerializedObject<byte[]> serialized = testSubject.serialize(metaData, byte[].class);
@@ -258,20 +246,13 @@ class JacksonSerializerTest {
      * Test case corresponding with a {@link org.axonframework.queryhandling.QueryHandler} annotated method which
      * returns a {@link List} of {@link ComplexObject}. Upon deserialization, the type info is required by the {@link
      * ObjectMapper} to <b>not</b> defer to an {@link ArrayList} of {@link java.util.LinkedHashMap}s. This can be
-     * enabled through {@link JacksonSerializer.Builder#activateDefaultTyping(PolymorphicTypeValidator)} or by providing
-     * an {@link ObjectMapper} which is configured with {@link ObjectMapper#activateDefaultTyping(PolymorphicTypeValidator,
-     * ObjectMapper.DefaultTyping)}.
+     * enabled through {@link JacksonSerializer.Builder#defaultTyping()} or by providing an {@link ObjectMapper} which
+     * is configured with {@link ObjectMapper#enableDefaultTyping(ObjectMapper.DefaultTyping)}.
      */
     @Test
     void testSerializeCollectionOfObjects() {
         // Typing must be enabled for this (which we expect end-users to do)
-        PolymorphicTypeValidator polymorphicTypeValidator =
-                BasicPolymorphicTypeValidator.builder()
-                                             .allowIfSubType(ComplexObject.class)
-                                             .build();
-        JacksonSerializer testSubject = JacksonSerializer.builder()
-                                                         .activateDefaultTyping(polymorphicTypeValidator)
-                                                         .build();
+        JacksonSerializer testSubject = JacksonSerializer.builder().defaultTyping().build();
 
         List<ComplexObject> objectToSerialize = new ArrayList<>();
         objectToSerialize.add(new ComplexObject("String1", "String2", 3));

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <projectreactor.version>3.2.6.RELEASE</projectreactor.version>
         <micrometer.version>1.3.0</micrometer.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.10.3</jackson.version>
         <!--
             Please note that there are dependencies between the gRPC and Netty TcNative versions.
             gRPC is quite specific about the version of Netty TcNative, so check the dependencies on

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <projectreactor.version>3.2.6.RELEASE</projectreactor.version>
         <micrometer.version>1.3.0</micrometer.version>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
-        <jackson.version>2.10.3</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <!--
             Please note that there are dependencies between the gRPC and Netty TcNative versions.
             gRPC is quite specific about the version of Netty TcNative, so check the dependencies on


### PR DESCRIPTION
As pointed out in issue #1418 (and several others), returning a `List` of complex objects as a result of a `@QueryHandler` annotated method will result in receiving a `ArrayList` containing `LinkedHashMap` instances instead of the expected Query Response.

This follows from the fact that the `ObjectMapper` can not deduce the type required within the collection, which can be resolved by adding type information upon serialization.

Although configurable on the `ObjectMapper` somebody would use for the `JacksonSerializer`, I think it's beneficial to allow configuration of default type information directly on the `JacksonSerializer` instead. This is inline with the already present `JacksonSerializer.Builder#lenientSerialization` method.

This pull request introduce just such a functionality, specifying the requirement to provide a thorough `PolymorphicTypeValidator` for security reasons, as is stated in Jackson's documentation.

This PR resolves #1418. 