### PR TITLE
[#1382] Support Spring Boot DevTools

### DIFF
--- a/spring/src/main/resources/META-INF/spring-devtools.properties
+++ b/spring/src/main/resources/META-INF/spring-devtools.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2018. Axon Framework
+# Copyright (c) 2010-2020. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-restart.include.axon-messaging=axon-messaging-${project.version}.jar
-restart.include.axon-modelling=axon-modelling-${project.version}.jar
+restart.include.axon-config=axon-configuration-${project.version}.jar
+restart.include.axon-disruptor=axon-disruptor-${project.version}.jar
 restart.include.axon-eventsourcing=axon-eventsourcing-${project.version}.jar
+restart.include.axon-messaging=axon-messaging-${project.version}.jar
+restart.include.axon-metrics=axon-metrics-${project.version}.jar
+restart.include.axon-micrometer=axon-micrometer-${project.version}.jar
+restart.include.axon-modelling=axon-modelling-${project.version}.jar
+restart.include.axon-server-connector=axon-server-connector-${project.version}.jar
 restart.include.axon-spring=axon-spring-${project.version}.jar
-restart.include.axon-amqp=axon-amqp-${project.version}.jar
 restart.include.axon-spring-boot-autoconfigure=axon-spring-boot-autoconfigure-${project.version}.jar
-restart.include.axon-distributed-commandbus-jgroups=axon-distributed-commandbus-jgroups-${project.version}.jar
-restart.include.axon-distributed-commandbus-springcloud=axon-distributed-commandbus-springcloud-${project.version}.jar
-restart.include.axon-mongo=axon-mongo-${project.version}.jar


### PR DESCRIPTION
This pull request fine tunes the `spring-devtools.properties` file, by adjusting the included modules for restart. After local testing (at this stage uncertain how to provide test cases for this) it showed that [Spring Boot Devtools](https://docs.spring.io/spring-boot/docs/1.5.16.RELEASE/reference/html/using-boot-devtools.html) threw exceptions if any of the added jars was not included for restart.
With the adjustments in place, all worked as desired.

This pull request resolves #1382