### PR TITLE
Clear previous events when saga test fixture starts recording

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -101,6 +101,7 @@ public class EventValidator implements EventMessageHandler {
             eventBus.subscribe(eventMessages -> eventMessages.forEach(this::handle));
             recording = true;
         }
+        publishedEvents.clear();
     }
 
     @SuppressWarnings({"unchecked"})

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -95,6 +95,19 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
+    void testStartRecording_ClearsEventsAndCommands() {
+        testSubject = new FixtureExecutionResultImpl<>(sagaStore, eventScheduler, deadlineManager, eventBus,
+                                                       commandBus, StubSaga.class, AllFieldsFilter.instance());
+        testSubject.startRecording();
+        eventBus.publish(new GenericEventMessage<>(new TriggerSagaEndEvent(identifier)));
+        commandBus.dispatch(GenericCommandMessage.asCommandMessage("Command"));
+
+        testSubject.startRecording();
+        testSubject.expectPublishedEvents();
+        testSubject.expectNoDispatchedCommands();
+    }
+
+    @Test
     void testExpectPublishedEvents_WrongCount() {
         eventBus.publish(new GenericEventMessage<>(new TriggerSagaEndEvent(identifier)));
 


### PR DESCRIPTION
This makes the behavior of events consistent with the behavior of commands in the saga test fixture. The change here mirrors the implementation of `CommandValidator.startRecording()`.

Fixes #1436