### PR TITLE
Move the assignment of the defaults for the AbstractEventStorageEngine.Builder to the validate method.

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -248,10 +248,10 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
      */
     public abstract static class Builder {
 
-        private Supplier<Serializer> snapshotSerializer = XStreamSerializer::defaultSerializer;
+        private Supplier<Serializer> snapshotSerializer;
         protected EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
         private PersistenceExceptionResolver persistenceExceptionResolver;
-        private Supplier<Serializer> eventSerializer = XStreamSerializer::defaultSerializer;
+        private Supplier<Serializer> eventSerializer;
         private Predicate<? super DomainEventData<?>> snapshotFilter = i -> true;
 
         /**
@@ -328,7 +328,13 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
          *                                    specifications
          */
         protected void validate() throws AxonConfigurationException {
-            // Kept to be overridden
+            if (snapshotSerializer == null) {
+                snapshotSerializer = XStreamSerializer::defaultSerializer;
+            }
+
+            if (eventSerializer == null) {
+                eventSerializer = XStreamSerializer::defaultSerializer;
+            }
         }
     }
 }


### PR DESCRIPTION
When moving to Java 11, we noticed that XStream causes some warnings as it does some illegal reflection. [This is their issue on the topic](https://github.com/x-stream/xstream/issues/101), however it's unlikely to be fixed properly anytime soon. 
We would like to exclude XStream as a dependancy which is not possible at the moment as the `AbstractEventStorageEngine.Builder` uses the XStreamSerialiser as the default when it's constructed. Moving this to the `validate()` method means that we can use the Jackson serialiser without needing to keep XStream as a required dependency.
