### PR TITLE
Allow easier retrieval of the AggregateFactory

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.config;
 
+import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.modelling.command.Repository;
 
 /**
@@ -23,20 +24,29 @@ import org.axonframework.modelling.command.Repository;
  * components to retrieve the Repository used to load Aggregates of the type defined in this Configuration.
  *
  * @param <A> The type of Aggregate defined in this Configuration
+ * @author Allard Buijze
+ * @since 3.0
  */
 public interface AggregateConfiguration<A> extends ModuleConfiguration {
 
     /**
-     * Returns the repository defined to load instances of the Aggregate type defined in this configuration
+     * Returns the repository defined to load instances of the Aggregate type defined in this configuration.
      *
      * @return the repository to load aggregates
      */
     Repository<A> repository();
 
     /**
-     * Returns the type of Aggregate defined in this Configuration.
+     * Returns the type of Aggregate defined in this configuration.
      *
-     * @return the type of Aggregate defined in this Configuration
+     * @return the type of Aggregate defined in this configuration
      */
     Class<A> aggregateType();
+
+    /**
+     * Returns the {@link AggregateFactory} defined in this configuration.
+     *
+     * @return the {@link AggregateFactory} defined in this configuration.
+     */
+    AggregateFactory<A> aggregateFactory();
 }

--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -394,6 +394,11 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
         return aggregate;
     }
 
+    @Override
+    public AggregateFactory<A> aggregateFactory() {
+        return aggregateFactory.get();
+    }
+
     /**
      * Registers subtypes of this aggregate to support aggregate polymorphism. Command Handlers defined on this
      * subtypes will be considered part of this aggregate's handlers.

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -22,6 +22,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.HandlerDefinition;
@@ -191,13 +192,45 @@ public interface Configuration {
     }
 
     /**
-     * Returns the Repository configured for the given {@code aggregateType}.
+     * Returns the {@link AggregateConfiguration} for the given {@code aggregateType}.
      *
-     * @param aggregateType The aggregate type to find the repository for
-     * @param <T>           The aggregate type
-     * @return the repository from which aggregates of the given type can be loaded
+     * @param aggregateType the aggregate type to find the {@link AggregateConfiguration} for
+     * @param <A>           the aggregate type
+     * @return the {@link AggregateConfiguration} for the given {@code aggregateType}
      */
-    <T> Repository<T> repository(Class<T> aggregateType);
+    default <A> AggregateConfiguration<A> aggregateConfiguration(Class<A> aggregateType) {
+        //noinspection unchecked
+        return findModules(AggregateConfiguration.class)
+                .stream()
+                .filter(aggregateConfig -> aggregateConfig.aggregateType().isAssignableFrom(aggregateType))
+                .findFirst()
+                .map(moduleConfig -> (AggregateConfiguration<A>) moduleConfig)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Aggregate " + aggregateType.getSimpleName() + " has not been configured"
+                ));
+    }
+
+    /**
+     * Returns the {@link Repository} configured for the given {@code aggregateType}.
+     *
+     * @param aggregateType the aggregate type to find the {@link Repository} for
+     * @param <A>           the aggregate type
+     * @return the {@link Repository} from which aggregates of the given {@code aggregateType} can be loaded
+     */
+    default <A> Repository<A> repository(Class<A> aggregateType) {
+        return aggregateConfiguration(aggregateType).repository();
+    }
+
+    /**
+     * Returns the {@link AggregateFactory} configured for the given {@code aggregateType}.
+     *
+     * @param aggregateType the aggregate type to find the {@link AggregateFactory} for
+     * @param <A>           the aggregate type
+     * @return the {@link AggregateFactory} which constructs aggregate of the given {@code aggregateType}
+     */
+    default <A> AggregateFactory<A> aggregateFactory(Class<A> aggregateType) {
+        return aggregateConfiguration(aggregateType).aggregateFactory();
+    }
 
     /**
      * Returns the Component declared under the given {@code componentType}, typically the interface the component

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -51,7 +51,6 @@ import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.MessageOriginProvider;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
-import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
@@ -726,21 +725,6 @@ public class DefaultConfigurer implements Configurer {
     }
 
     private class ConfigurationImpl implements Configuration {
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public <T> Repository<T> repository(Class<T> aggregateType) {
-            return DefaultConfigurer.this.modules
-                    .stream()
-                    .filter(AggregateConfiguration.class::isInstance)
-                    .map(moduleConfig -> (AggregateConfiguration<T>) moduleConfig)
-                    .filter(aggregateConfig -> aggregateConfig.aggregateType().isAssignableFrom(aggregateType))
-                    .findFirst()
-                    .map(AggregateConfiguration::repository)
-                    .orElseThrow(() -> new IllegalArgumentException(
-                            "Aggregate " + aggregateType.getSimpleName() + " has not been configured"
-                    ));
-        }
 
         @Override
         public <T> T getComponent(Class<T> componentType, Supplier<T> defaultImpl) {

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -20,6 +20,7 @@ import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.distributed.DistributedCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
+import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.GenericAggregateFactory;
 import org.axonframework.eventsourcing.NoSnapshotTriggerDefinition;
@@ -139,6 +140,15 @@ public class AggregateConfigurerTest {
         configuration.shutdown();
     }
 
+    @Test
+    void testAggregateFactoryConfiguration() {
+        AggregateFactory<TestAggregate> expectedAggregateFactory = new GenericAggregateFactory<>(TestAggregate.class);
+
+        testSubject.configureAggregateFactory(configuration -> expectedAggregateFactory);
+
+        assertEquals(expectedAggregateFactory, testSubject.aggregateFactory());
+    }
+
     private static class TestAggregate {
 
         TestAggregate() {
@@ -147,6 +157,7 @@ public class AggregateConfigurerTest {
     }
 
     private static class CreateACommand {
+
         private final String id;
 
         private CreateACommand(String id) {
@@ -159,6 +170,7 @@ public class AggregateConfigurerTest {
     }
 
     private static class ACreatedEvent {
+
         private final String id;
 
         private ACreatedEvent(String id) {
@@ -171,6 +183,7 @@ public class AggregateConfigurerTest {
     }
 
     private static class CreateBCommand {
+
         private final String id;
 
         private CreateBCommand(String id) {
@@ -183,6 +196,7 @@ public class AggregateConfigurerTest {
     }
 
     private static class DoSomethingCommand {
+
         @TargetAggregateIdentifier
         private final String id;
 
@@ -196,6 +210,7 @@ public class AggregateConfigurerTest {
     }
 
     private static class BSpecificCommand {
+
         @TargetAggregateIdentifier
         private final String id;
 


### PR DESCRIPTION
This pull request allows easier retrieval of the `AggregateFactory` by opening it up on the `AggregateConfiguration` class. This is for example use full if a user needs to create a `Snapshotter` instance, for which the `AggregateFactory` should be provided.