### PR TITLE
Dedicated Snapshotter Configuration

### DIFF
--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -23,6 +23,7 @@ import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventsourcing.AggregateFactory;
+import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.HandlerDefinition;
@@ -334,6 +335,15 @@ public interface Configuration {
      */
     default DeadlineManager deadlineManager() {
         return getComponent(DeadlineManager.class);
+    }
+
+    /**
+     * Returns the {@link Snapshotter} defined in this Configuration.
+     *
+     * @return the {@link Snapshotter} defined in this Configuration
+     */
+    default Snapshotter snapshotter() {
+        return getComponent(Snapshotter.class);
     }
 
     /**

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -20,6 +20,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
@@ -445,6 +446,17 @@ public interface Configurer {
      * @return the current instance of the Configurer, for chaining purposes
      */
     Configurer registerHandlerDefinition(BiFunction<Configuration, Class, HandlerDefinition> handlerDefinitionClass);
+
+    /**
+     * Registers a {@link Snapshotter} instance with this {@link Configurer}. Defaults to a {@link
+     * org.axonframework.eventsourcing.AggregateSnapshotter} implementation.
+     *
+     * @param snapshotterBuilder the builder function for the {@link Snapshotter}
+     * @return the current instance of the Configurer, for chaining purposes
+     */
+    default Configurer configureSnapshotter(Function<Configuration, Snapshotter> snapshotterBuilder) {
+        return registerComponent(Snapshotter.class, snapshotterBuilder);
+    }
 
     /**
      * Retrieve the {@link EventProcessingConfigurer} registered as a module with this Configurer. If there aren't

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -37,6 +37,9 @@ import org.axonframework.eventhandling.gateway.DefaultEventGateway;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.jpa.JpaTokenStore;
+import org.axonframework.eventsourcing.AggregateFactory;
+import org.axonframework.eventsourcing.AggregateSnapshotter;
+import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
@@ -265,6 +268,7 @@ public class DefaultConfigurer implements Configurer {
         components.put(EventUpcaster.class, upcasterChain);
         components.put(EventGateway.class, new Component<>(config, "eventGateway", this::defaultEventGateway));
         components.put(TagsConfiguration.class, new Component<>(config, "tags", c -> new TagsConfiguration()));
+        components.put(Snapshotter.class, new Component<>(config, "snapshotter", this::defaultSnapshotter));
     }
 
     /**
@@ -424,6 +428,43 @@ public class DefaultConfigurer implements Configurer {
                                 .revisionResolver(config.getComponent(RevisionResolver.class,
                                                                       AnnotationRevisionResolver::new))
                                 .build();
+    }
+
+    /**
+     * Provides the default {@link Snapshotter} implementation, defaulting to a {@link AggregateSnapshotter}. Subclasses
+     * may override this method to provide their own default.
+     *
+     * @param config the configuration based on which the {@link Snapshotter} will be initialized
+     * @return the default {@link Snapshotter}
+     */
+    protected Snapshotter defaultSnapshotter(Configuration config) {
+        //noinspection rawtypes
+        List<AggregateConfiguration> aggregateConfigurations = config.findModules(AggregateConfiguration.class);
+        List<AggregateFactory<?>> aggregateFactories = new ArrayList<>();
+        for (AggregateConfiguration<?> aggregateConfiguration : aggregateConfigurations) {
+            aggregateFactories.add(aggregateConfiguration.aggregateFactory());
+        }
+        return AggregateSnapshotter.builder()
+                                   .eventStore(config.eventStore())
+                                   .transactionManager(config.getComponent(TransactionManager.class))
+                                   .aggregateFactories(aggregateFactories)
+                                   .repositoryProvider(config::repository)
+                                   .parameterResolverFactory(config.parameterResolverFactory())
+                                   .handlerDefinition(retrieveHandlerDefinition(config, aggregateConfigurations))
+                                   .build();
+    }
+
+    /**
+     * The class is required to be provided in case the {@code ClasspathHandlerDefinition is used to retrieve the {@link
+     * HandlerDefinition}. Ideally, a {@code HandlerDefinition} would be retrieved per aggregate class, as potentially
+     * users would be able to define different {@link ClassLoader} instances per aggregate. For now we have deduced the
+     * latter to be to much of an edge case. Hence we assume users will use the same ClassLoader for differing
+     * aggregates within a single configuration.
+     */
+    @SuppressWarnings("rawtypes")
+    private HandlerDefinition retrieveHandlerDefinition(Configuration configuration,
+                                                        List<AggregateConfiguration> aggregateConfigurations) {
+        return configuration.handlerDefinition(aggregateConfigurations.get(0).aggregateType());
     }
 
     @Override

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -96,6 +96,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -438,8 +439,11 @@ public class DefaultConfigurer implements Configurer {
      * @return the default {@link Snapshotter}
      */
     protected Snapshotter defaultSnapshotter(Configuration config) {
-        //noinspection rawtypes
-        List<AggregateConfiguration> aggregateConfigurations = config.findModules(AggregateConfiguration.class);
+        List<AggregateConfiguration<?>> aggregateConfigurations =
+                config.findModules(AggregateConfiguration.class)
+                      .stream()
+                      .map(aggregateConfiguration -> (AggregateConfiguration<?>) aggregateConfiguration)
+                      .collect(Collectors.toList());
         List<AggregateFactory<?>> aggregateFactories = new ArrayList<>();
         for (AggregateConfiguration<?> aggregateConfiguration : aggregateConfigurations) {
             aggregateFactories.add(aggregateConfiguration.aggregateFactory());
@@ -461,9 +465,8 @@ public class DefaultConfigurer implements Configurer {
      * latter to be to much of an edge case. Hence we assume users will use the same ClassLoader for differing
      * aggregates within a single configuration.
      */
-    @SuppressWarnings("rawtypes")
     private HandlerDefinition retrieveHandlerDefinition(Configuration configuration,
-                                                        List<AggregateConfiguration> aggregateConfigurations) {
+                                                        List<AggregateConfiguration<?>> aggregateConfigurations) {
         return configuration.handlerDefinition(aggregateConfigurations.get(0).aggregateType());
     }
 

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -31,9 +31,12 @@ import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventhandling.async.FullConcurrencyPolicy;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.eventsourcing.AggregateSnapshotter;
 import org.axonframework.eventsourcing.CachingEventSourcingRepository;
+import org.axonframework.eventsourcing.EventCountSnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.EventSourcingRepository;
+import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
@@ -335,7 +338,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    public void defaultConfigurationWithCache() throws Exception {
+    void defaultConfigurationWithCache() throws Exception {
         Configuration config = DefaultConfigurer.defaultConfiguration()
             .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
             .configureCommandBus(c -> AsynchronousCommandBus.builder().build())
@@ -350,6 +353,37 @@ class DefaultConfigurerTest {
         assertEquals("test", callback.get().getPayload());
         assertNotNull(config.repository(StubAggregate.class));
         assertEquals(CachingEventSourcingRepository.class, config.repository(StubAggregate.class).getClass());
+    }
+
+    @Test
+    void testConfiguredSnapshotterDefaultsToAggregateSnapshotter() {
+        Snapshotter defaultSnapshotter = DefaultConfigurer.jpaConfiguration(() -> em)
+                                                          .configureAggregate(StubAggregate.class)
+                                                          .buildConfiguration().snapshotter();
+
+        assertTrue(defaultSnapshotter instanceof AggregateSnapshotter);
+    }
+
+    @Test
+    void testConfigureSnapshotterSetsCustomSnapshotter() {
+        Snapshotter expectedSnapshotter = mock(Snapshotter.class);
+
+        AggregateConfigurer<StubAggregate> aggregateConfigurer = defaultConfiguration(StubAggregate.class)
+                .configureSnapshotTrigger(configuration -> {
+                    Snapshotter resultSnapshotter = configuration.snapshotter();
+                    assertEquals(expectedSnapshotter, resultSnapshotter);
+                    return new EventCountSnapshotTriggerDefinition(resultSnapshotter, 42);
+                });
+
+        Configuration result = DefaultConfigurer.defaultConfiguration()
+                                                .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                                                .configureSnapshotter(configuration -> expectedSnapshotter)
+                                                .configureAggregate(aggregateConfigurer)
+                                                .buildConfiguration();
+        result.start();
+
+        assertEquals(expectedSnapshotter, result.snapshotter());
+        assertEquals(expectedSnapshotter, result.getComponent(Snapshotter.class));
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Currently, only the Spring auto configuration provides a `Snapshotter` instance (the `SpringAggregateSnapshotter`) out of the box. The main Configuration API doesn't provide anything of the sort.
This is resolved in this pull request, by expanding the `Configurer` with a `configureSnapshotter (Function<Configuration, Snapshotter>)` method. The `Configuration` in turn has received a `snapshotter` method, returning the `Component` containing a `Snapshotter` implementation.
The `DefautlConfigurer` will default to an `AggregateSnapshotter` instance.