### PR TITLE
Axon Micrometer with Tags/Dimensions

### DIFF
--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -114,19 +114,6 @@ import static java.util.stream.Collectors.toList;
  *
  * @author Allard Buijze
  * @since 3.0
- *
- * commandBus.counter.success=10
- * createOrder.commandBus.counter.success=1
- * updateOrder.commandBus.counter.success=9
- *
- *
- * commandBus.counter.success{payloadType=createOrder, ...}
- *
- * mojaSaga.counter.success=10
- * tvojaSaga.counter.success=14
- *
- *
- * eventProcessor.counter.success {paylodType=nesto, processorName=nesto}=24
  */
 public class DefaultConfigurer implements Configurer {
 

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -114,6 +114,19 @@ import static java.util.stream.Collectors.toList;
  *
  * @author Allard Buijze
  * @since 3.0
+ *
+ * commandBus.counter.success=10
+ * createOrder.commandBus.counter.success=1
+ * updateOrder.commandBus.counter.success=9
+ *
+ *
+ * commandBus.counter.success{payloadType=createOrder, ...}
+ *
+ * mojaSaga.counter.success=10
+ * tvojaSaga.counter.success=14
+ *
+ *
+ * eventProcessor.counter.success {paylodType=nesto, processorName=nesto}=24
  */
 public class DefaultConfigurer implements Configurer {
 

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -59,7 +59,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the created capacity monitor
+     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, 10, TimeUnit.MINUTES);
@@ -85,7 +85,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param meterRegistry   The meter registry used to create and register the meters
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
-     * @return the created capacity monitor (with the default tag `payloadType`)
+     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit) {
@@ -116,7 +116,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
      * @param clock           The clock used to measure the process time per message
-     * @return the created capacity monitor (with the default tag `payloadType`)
+     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit, Clock clock) {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -18,11 +18,16 @@ package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import org.axonframework.messaging.Message;
 import org.axonframework.micrometer.reservoir.SlidingTimeWindowReservoir;
 import org.axonframework.monitoring.MessageMonitor;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Calculates capacity by tracking, within the configured time window, the average message processing time
@@ -40,10 +45,14 @@ import java.util.concurrent.TimeUnit;
  */
 public class CapacityMonitor implements MessageMonitor<Message<?>> {
 
-    private final SlidingTimeWindowReservoir timeWindowedDurationMeasurements;
+    private final Map<String, SlidingTimeWindowReservoir> timeWindowedDurationMeasurementsMap;
     private final TimeUnit timeUnit;
     private final Clock clock;
     private final long window;
+    private final String meterNamePrefix;
+    private final MeterRegistry meterRegistry;
+    private final Function<Message<?>, Iterable<Tag>> tagsBuilder;
+
 
     /**
      * Creates a capacity monitor with the default time window 10 minutes
@@ -61,13 +70,41 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @return the created capacity monitor
+     */
+    public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
+                                               Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return buildMonitor(meterNamePrefix, meterRegistry, 10, TimeUnit.MINUTES, tagsBuilder);
+    }
+
+    /**
+     * Creates a capacity monitor with the default system clock
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
-     * @return the created capacity monitor
+     * @return the created capacity monitor (with the default tag `payloadType`)
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit) {
         return buildMonitor(meterNamePrefix, meterRegistry, window, timeUnit, Clock.SYSTEM);
+    }
+
+    /**
+     * Creates a capacity monitor with the default system clock
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
+     * @param window          The length of the window to measure the capacity over
+     * @param timeUnit        The temporal unit of the time window
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @return the created capacity monitor
+     */
+    public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
+                                               TimeUnit timeUnit, Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return buildMonitor(meterNamePrefix, meterRegistry, window, timeUnit, Clock.SYSTEM, tagsBuilder);
     }
 
     /**
@@ -79,26 +116,87 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
      * @param clock           The clock used to measure the process time per message
-     * @return the created capacity monitor
+     * @return the created capacity monitor (with the default tag `payloadType`)
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit, Clock clock) {
-        CapacityMonitor capacityMonitor = new CapacityMonitor(window, timeUnit, clock);
-        meterRegistry.gauge(meterNamePrefix + ".capacity", capacityMonitor, CapacityMonitor::calculateCapacity);
-        return capacityMonitor;
+
+        return new CapacityMonitor(window, timeUnit, clock, meterNamePrefix, meterRegistry);
+    }
+
+    /**
+     * Creates a capacity monitor with the given time window. Uses the provided clock
+     * to measure process time per message.
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
+     * @param window          The length of the window to measure the capacity over
+     * @param timeUnit        The temporal unit of the time window
+     * @param clock           The clock used to measure the process time per message
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @return the created capacity monitor
+     */
+    public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
+                                               TimeUnit timeUnit, Clock clock,
+                                               Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+
+        return new CapacityMonitor(window, timeUnit, clock, meterNamePrefix, meterRegistry, tagsBuilder);
     }
 
 
-    private CapacityMonitor(long window, TimeUnit timeUnit, Clock clock) {
-        this.timeWindowedDurationMeasurements = new SlidingTimeWindowReservoir(window, timeUnit, clock);
+    private CapacityMonitor(long window, TimeUnit timeUnit, Clock clock, String meterNamePrefix,
+                            MeterRegistry meterRegistry) {
+        this(window,
+             timeUnit,
+             clock,
+             meterNamePrefix,
+             meterRegistry,
+             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+    }
+
+    private CapacityMonitor(long window, TimeUnit timeUnit, Clock clock, String meterNamePrefix,
+                            MeterRegistry meterRegistry,
+                            Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        this.timeWindowedDurationMeasurementsMap = new ConcurrentHashMap<>();
         this.timeUnit = timeUnit;
         this.clock = clock;
         this.window = window;
+        this.meterNamePrefix = meterNamePrefix;
+        this.meterRegistry = meterRegistry;
+        this.tagsBuilder = tagsBuilder;
+    }
+
+    private SlidingTimeWindowReservoir createIfAbsent(String meterNamePrefix, Tags tags, long window, TimeUnit timeUnit,
+                                                      Clock clock) {
+        String key = meterNamePrefix + tags.stream()
+                                           .map(tag -> tag.getKey() + tag.getValue())
+                                           .reduce(String::concat)
+                                           .orElse("");
+        SlidingTimeWindowReservoir value;
+        if ((value = timeWindowedDurationMeasurementsMap.get(key)) == null) {
+            SlidingTimeWindowReservoir newValue = new SlidingTimeWindowReservoir(window, timeUnit, clock);
+            timeWindowedDurationMeasurementsMap.put(key, newValue);
+            return newValue;
+        }
+
+        return value;
     }
 
     @Override
     public MonitorCallback onMessageIngested(Message<?> message) {
+        final Iterable<Tag> tags = tagsBuilder.apply(message);
+        final SlidingTimeWindowReservoir timeWindowedDurationMeasurements = createIfAbsent(meterNamePrefix,
+                                                                                           Tags.of(tags),
+                                                                                           this.window,
+                                                                                           this.timeUnit,
+                                                                                           this.clock);
+        meterRegistry.gauge(meterNamePrefix + ".capacity",
+                            tags,
+                            this,
+                            value -> calculateCapacity(timeWindowedDurationMeasurements));
+
         final long start = clock.monotonicTime();
+
         return new MonitorCallback() {
             @Override
             public void reportSuccess() {
@@ -117,7 +215,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
         };
     }
 
-    private double calculateCapacity() {
+    private double calculateCapacity(SlidingTimeWindowReservoir timeWindowedDurationMeasurements) {
         long totalProcessTime = timeWindowedDurationMeasurements.getMeasurements().stream().reduce(0L, Long::sum);
         return (double) totalProcessTime / timeUnit.toNanos(window);
     }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
  * that messages will have to wait to be processed.
  *
  * @author Marijn van Zelst
+ * @author Ivan Dugalic
  * @since 4.1
  */
 public class CapacityMonitor implements MessageMonitor<Message<?>> {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -79,7 +79,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
     }
 
     /**
-     * Creates a capacity monitor with the default system clock
+     * Creates a capacity monitor with the default system clock.
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -172,14 +172,8 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
                                            .map(tag -> tag.getKey() + tag.getValue())
                                            .reduce(String::concat)
                                            .orElse("");
-        SlidingTimeWindowReservoir value;
-        if ((value = timeWindowedDurationMeasurementsMap.get(key)) == null) {
-            SlidingTimeWindowReservoir newValue = new SlidingTimeWindowReservoir(window, timeUnit, clock);
-            timeWindowedDurationMeasurementsMap.put(key, newValue);
-            return newValue;
-        }
-
-        return value;
+        timeWindowedDurationMeasurementsMap.putIfAbsent(key, new SlidingTimeWindowReservoir(window, timeUnit, clock));
+        return timeWindowedDurationMeasurementsMap.get(key);
     }
 
     @Override

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -93,7 +93,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
     }
 
     /**
-     * Creates a capacity monitor with the default system clock
+     * Creates a capacity monitor with the default system clock.
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -59,7 +59,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, 10, TimeUnit.MINUTES);
@@ -70,8 +70,9 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the created capacity monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
                                                Function<Message<?>, Iterable<Tag>> tagsBuilder) {
@@ -85,7 +86,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param meterRegistry   The meter registry used to create and register the meters
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
-     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit) {
@@ -99,8 +100,9 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param meterRegistry   The meter registry used to create and register the meters
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the created capacity monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit, Function<Message<?>, Iterable<Tag>> tagsBuilder) {
@@ -116,7 +118,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
      * @param clock           The clock used to measure the process time per message
-     * @return the created capacity monitor (with the default {@link Tag} `payloadType`)
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit, Clock clock) {
@@ -133,8 +135,9 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
      * @param window          The length of the window to measure the capacity over
      * @param timeUnit        The temporal unit of the time window
      * @param clock           The clock used to measure the process time per message
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the created capacity monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The created capacity monitor
      */
     public static CapacityMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, long window,
                                                TimeUnit timeUnit, Clock clock,
@@ -151,7 +154,7 @@ public class CapacityMonitor implements MessageMonitor<Message<?>> {
              clock,
              meterNamePrefix,
              meterRegistry,
-             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+             message -> Tags.empty());
     }
 
     private CapacityMonitor(long window, TimeUnit timeUnit, Clock clock, String meterNamePrefix,

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
  * Measures the difference in message timestamps between the last ingested and the last processed message.
  *
  * @author Marijn van Zelst
+ * @author Ivan Dugalic
  * @since 4.1
  */
 public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage<?>> {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -69,7 +69,7 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
     }
 
     /**
-     * Creates an event processor latency monitor
+     * Creates an event processor latency monitor.
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -46,7 +46,7 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
     private EventProcessorLatencyMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         this(meterNamePrefix,
              meterRegistry,
-             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+             message -> Tags.empty());
     }
 
     private EventProcessorLatencyMonitor(String meterNamePrefix,
@@ -62,7 +62,7 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the created event processor latency monitor (with the default {@link Tag} `payloadType`)
+     * @return The created event processor latency monitor
      */
     public static EventProcessorLatencyMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return new EventProcessorLatencyMonitor(meterNamePrefix, meterRegistry);
@@ -73,8 +73,9 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the created event processor latency monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The created event processor latency monitor
      */
     public static EventProcessorLatencyMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
                                                             Function<Message<?>, Iterable<Tag>> tagsBuilder) {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -18,11 +18,15 @@ package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitorCallback;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
 /**
  * Measures the difference in message timestamps between the last ingested and the last processed message.
@@ -32,10 +36,25 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage<?>> {
 
+
+    private final String meterNamePrefix;
+    private final MeterRegistry meterRegistry;
+    private final Function<Message<?>, Iterable<Tag>> tagsBuilder;
     private final AtomicLong lastReceivedTime = new AtomicLong(-1);
     private final AtomicLong lastProcessedTime = new AtomicLong(-1);
 
-    private EventProcessorLatencyMonitor() {
+    private EventProcessorLatencyMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
+        this(meterNamePrefix,
+             meterRegistry,
+             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+    }
+
+    private EventProcessorLatencyMonitor(String meterNamePrefix,
+                                         MeterRegistry meterRegistry,
+                                         Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        this.meterNamePrefix = meterNamePrefix;
+        this.meterRegistry = meterRegistry;
+        this.tagsBuilder = tagsBuilder;
     }
 
     /**
@@ -46,11 +65,20 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
      * @return the created event processor latency monitor
      */
     public static EventProcessorLatencyMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
-        EventProcessorLatencyMonitor eventProcessorLatencyMonitor = new EventProcessorLatencyMonitor();
-        Gauge.builder(meterNamePrefix + ".latency",
-                      eventProcessorLatencyMonitor,
-                      EventProcessorLatencyMonitor::calculateLatency).register(meterRegistry);
-        return eventProcessorLatencyMonitor;
+        return new EventProcessorLatencyMonitor(meterNamePrefix, meterRegistry);
+    }
+
+    /**
+     * Creates an event processor latency monitor
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @return the created event processor latency monitor
+     */
+    public static EventProcessorLatencyMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
+                                                            Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return new EventProcessorLatencyMonitor(meterNamePrefix, meterRegistry, tagsBuilder);
     }
 
     @Override
@@ -58,7 +86,15 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
         if (message == null) {
             return NoOpMessageMonitorCallback.INSTANCE;
         }
+        final Iterable<Tag> tags = tagsBuilder.apply(message);
+        Gauge.builder(meterNamePrefix + ".latency",
+                      this,
+                      EventProcessorLatencyMonitor::calculateLatency)
+             .tags(tags)
+             .register(meterRegistry);
+
         updateIfMaxValue(lastReceivedTime, message.getTimestamp().toEpochMilli());
+
         return new MonitorCallback() {
             @Override
             public void reportSuccess() {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -62,7 +62,7 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the created event processor latency monitor
+     * @return the created event processor latency monitor (with the default {@link Tag} `payloadType`)
      */
     public static EventProcessorLatencyMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return new EventProcessorLatencyMonitor(meterNamePrefix, meterRegistry);

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -153,19 +153,13 @@ public class GlobalMetricRegistry {
                                                              componentName));
         }
         if (CommandBus.class.isAssignableFrom(componentType)) {
-            return registerCommandBus(componentName,
-                                      message -> Tags
-                                              .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+            return registerCommandBus(componentName, TagsUtil.PAYLOAD_TYPE_TAGGER_FUNCTION);
         }
         if (EventBus.class.isAssignableFrom(componentType)) {
-            return registerEventBus(componentName,
-                                    message -> Tags
-                                            .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+            return registerEventBus(componentName, TagsUtil.PAYLOAD_TYPE_TAGGER_FUNCTION);
         }
         if (QueryBus.class.isAssignableFrom(componentType)) {
-            return registerQueryBus(componentName,
-                                    message -> Tags
-                                            .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+            return registerQueryBus(componentName, TagsUtil.PAYLOAD_TYPE_TAGGER_FUNCTION);
         }
         logger.warn("Cannot provide MessageMonitor for component [{}] of type [{}]. Returning No-Op instance.",
                     componentName, componentType.getSimpleName());

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -196,9 +196,9 @@ public class GlobalMetricRegistry {
     }
 
     /**
-     * Registers new metrics to the registry to monitor an {@link EventProcessor}. The monitor will be registered with
-     * the registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
-     * on the event processor to initiate the monitoring.
+     * Registers new metrics to the registry to monitor an {@link EventProcessor} using {@link Tag}s through the given
+     * {@code tagsBuilder}. The monitor will be registered with the registry under the given {@code name}.
+     * The returned {@link MessageMonitor} can be installed on the event processor to initiate the monitoring.
      *
      * @param name        The name under which the EventProcessor should be registered to the registry
      * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
@@ -240,9 +240,9 @@ public class GlobalMetricRegistry {
     }
 
     /**
-     * Registers new metrics to the registry to monitor an {@link EventBus} using {@link Tag}s through the given {@code tagsBuilder}. The monitor will be registered with the
-     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
-     * on the event bus to initiate the monitoring.
+     * Registers new metrics to the registry to monitor an {@link EventBus} using {@link Tag}s through the given {@code
+     * tagsBuilder}. The monitor will be registered with the registry under the given {@code name}.
+     * The returned {@link MessageMonitor} can be installed on the event bus to initiate the monitoring.
      *
      * @param name        The name under which the eventBus should be registered to the registry
      * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
@@ -270,9 +270,9 @@ public class GlobalMetricRegistry {
     }
 
     /**
-     * Registers new metrics to the registry to monitor a {@link CommandBus}. The monitor will be registered with the
-     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
-     * on the command bus to initiate the monitoring.
+     * Registers new metrics to the registry to monitor a {@link CommandBus} using {@link Tag}s through the given {@code
+     * tagsBuilder}. The monitor will be registered with the registry under the given {@code name}.
+     * The returned {@link MessageMonitor} can be installed on the command bus to initiate the monitoring.
      *
      * @param name        The name under which the commandBus should be registered to the registry
      * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
@@ -297,9 +297,9 @@ public class GlobalMetricRegistry {
     }
 
     /**
-     * Registers new metrics to the registry to monitor a {@link QueryBus}. The monitor will be registered with the
-     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
-     * on the command bus to initiate the monitoring.
+     * Registers new metrics to the registry to monitor a {@link QueryBus} using {@link Tag}s through the given {@code
+     * tagsBuilder}. The monitor will be registered with the registry under the given {@code name}.
+     * The returned {@link MessageMonitor} can be installed on the command bus to initiate the monitoring.
      *
      * @param name        The name under which the commandBus should be registered to the registry
      * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -97,8 +97,6 @@ public class GlobalMetricRegistry {
      */
     public MessageMonitor<? extends Message<?>> registerComponent(Class<?> componentType, String componentName) {
         if (EventProcessor.class.isAssignableFrom(componentType)) {
-            // TODO This will introduce a breaking change on the metrics API level, as it will change the name of the metrics.
-            // The name of the metrics is fixed to "eventProcessor" now, and the processor name is not part/prefix of the metrics name any more. It is a meter tag/dimension now.
             return registerEventProcessor(EVENT_PROCESSOR_METRICS_NAME,
                                           message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG,
                                                              message.getPayloadType().getSimpleName(),
@@ -158,7 +156,8 @@ public class GlobalMetricRegistry {
                                                                           Function<Message<?>, Iterable<Tag>> tagsBuilder) {
         MessageTimerMonitor messageTimerMonitor = MessageTimerMonitor.buildMonitor(name, registry, tagsBuilder);
         EventProcessorLatencyMonitor eventProcessorLatencyMonitor = EventProcessorLatencyMonitor.buildMonitor(name,
-                                                                                                              registry);
+                                                                                                              registry,
+                                                                                                              tagsBuilder);
         CapacityMonitor capacityMonitor = CapacityMonitor.buildMonitor(name, registry, tagsBuilder);
         MessageCountingMonitor messageCountingMonitor = MessageCountingMonitor.buildMonitor(name,
                                                                                             registry,

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -240,7 +240,7 @@ public class GlobalMetricRegistry {
     }
 
     /**
-     * Registers new metrics to the registry to monitor an {@link EventBus}. The monitor will be registered with the
+     * Registers new metrics to the registry to monitor an {@link EventBus} using {@link Tag}s through the given {@code tagsBuilder}. The monitor will be registered with the
      * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
      * on the event bus to initiate the monitoring.
      *

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -126,6 +126,8 @@ public class GlobalMetricRegistry {
      *
      * @param name the name under which the EventProcessor should be registered to the registry
      * @return MessageMonitor to monitor the behavior of an EventProcessor
+     *
+     * @deprecated As of release 4.4, replaced by {@link #registerEventProcessor(String, Function)}
      */
     @Deprecated
     public MessageMonitor<? super EventMessage<?>> registerEventProcessor(String name) {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/GlobalMetricRegistry.java
@@ -63,7 +63,7 @@ public class GlobalMetricRegistry {
     /**
      * Initializes a {@link GlobalMetricRegistry} delegating to the given {@code meterRegistry}.
      *
-     * @param meterRegistry the metric registry which will record the metrics
+     * @param meterRegistry The metric registry which will record the metrics
      */
     public GlobalMetricRegistry(MeterRegistry meterRegistry) {
         this.registry = meterRegistry;
@@ -74,8 +74,8 @@ public class GlobalMetricRegistry {
      * {@link Configurer#configureMessageMonitor(Function)}.
      * Components registered by the configurer will be added by invocation of {@link #registerComponent(Class, String)}.
      *
-     * @param configurer the application's configurer
-     * @return configurer with the new registration applied
+     * @param configurer The application's configurer
+     * @return Configurer with the new registration applied
      */
     @SuppressWarnings("unchecked")
     public Configurer registerWithConfigurer(Configurer configurer) {
@@ -85,23 +85,35 @@ public class GlobalMetricRegistry {
     }
 
     /**
+     * Registers the metric registry with the given {@code configurer} via
+     * {@link Configurer#configureMessageMonitor(Function)}.
+     * Components registered by the configurer will be added by invocation of {@link
+     * #registerComponentWithDefaultTags(Class, String)}.
+     *
+     * @param configurer The application's configurer
+     * @return Configurer with the new registration applied (with the default set of Micrometer {@link Tag}s/dimensions)
+     */
+    @SuppressWarnings("unchecked")
+    public Configurer registerWithConfigurerWithDefaultTags(Configurer configurer) {
+        return configurer.configureMessageMonitor(
+                configuration -> (componentType, componentName) -> (MessageMonitor<Message<?>>) registerComponentWithDefaultTags(
+                        componentType, componentName));
+    }
+
+    /**
      * Registers new metrics to the registry to monitor a component of given {@code type}. The monitor will be
      * registered with the registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
      * on the component to initiate the monitoring.
      *
-     * @param componentType the type of component to register
-     * @param componentName the name under which the component should be registered to the registry
+     * @param componentType The type of component to register
+     * @param componentName The name under which the component should be registered to the registry
      * @return MessageMonitor to monitor the behavior of a given type
      *
      * @throws IllegalArgumentException if the component type is not recognized
      */
     public MessageMonitor<? extends Message<?>> registerComponent(Class<?> componentType, String componentName) {
         if (EventProcessor.class.isAssignableFrom(componentType)) {
-            return registerEventProcessor(EVENT_PROCESSOR_METRICS_NAME,
-                                          message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG,
-                                                             message.getPayloadType().getSimpleName(),
-                                                             TagsUtil.PROCESSOR_NAME_TAG,
-                                                             componentName));
+            return registerEventProcessor(componentName);
         }
         if (CommandBus.class.isAssignableFrom(componentType)) {
             return registerCommandBus(componentName);
@@ -118,16 +130,56 @@ public class GlobalMetricRegistry {
     }
 
     /**
+     * Registers new metrics to the registry to monitor a component of given {@code type}. The monitor will be
+     * registered with the registry under the given {@code name} and the default set of Micrometer {@link Tag}s.
+     * The default set of Micrometer {@link Tag}s includes the 'message payload type' and additionally the 'processor
+     * name'
+     * for the event processors.
+     * The returned {@link MessageMonitor} can be installed on the component to initiate the monitoring.
+     *
+     * @param componentType The type of component to register
+     * @param componentName The name under which the component should be registered to the registry
+     * @return MessageMonitor (with Micrometer {@link Tag}s/dimensions enabled) to monitor the behavior of a given type
+     *
+     * @throws IllegalArgumentException if the component type is not recognized
+     */
+    public MessageMonitor<? extends Message<?>> registerComponentWithDefaultTags(Class<?> componentType,
+                                                                                 String componentName) {
+        if (EventProcessor.class.isAssignableFrom(componentType)) {
+            return registerEventProcessor(EVENT_PROCESSOR_METRICS_NAME,
+                                          message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG,
+                                                             message.getPayloadType().getSimpleName(),
+                                                             TagsUtil.PROCESSOR_NAME_TAG,
+                                                             componentName));
+        }
+        if (CommandBus.class.isAssignableFrom(componentType)) {
+            return registerCommandBus(componentName,
+                                      message -> Tags
+                                              .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+        }
+        if (EventBus.class.isAssignableFrom(componentType)) {
+            return registerEventBus(componentName,
+                                    message -> Tags
+                                            .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+        }
+        if (QueryBus.class.isAssignableFrom(componentType)) {
+            return registerQueryBus(componentName,
+                                    message -> Tags
+                                            .of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+        }
+        logger.warn("Cannot provide MessageMonitor for component [{}] of type [{}]. Returning No-Op instance.",
+                    componentName, componentType.getSimpleName());
+        return NoOpMessageMonitor.instance();
+    }
+
+    /**
      * Registers new metrics to the registry to monitor an {@link EventProcessor}. The monitor will be registered with
      * the registry under the given {@code eventProcessorName}. The returned {@link MessageMonitor} can be installed
      * on the event processor to initiate the monitoring.
      *
-     * @param name the name under which the EventProcessor should be registered to the registry
+     * @param name The name under which the EventProcessor should be registered to the registry
      * @return MessageMonitor to monitor the behavior of an EventProcessor
-     *
-     * @deprecated As of release 4.4, replaced by {@link #registerEventProcessor(String, Function)}
      */
-    @Deprecated
     public MessageMonitor<? super EventMessage<?>> registerEventProcessor(String name) {
         MessageTimerMonitor messageTimerMonitor = MessageTimerMonitor.buildMonitor(name, registry);
         EventProcessorLatencyMonitor eventProcessorLatencyMonitor = EventProcessorLatencyMonitor.buildMonitor(name,
@@ -149,7 +201,8 @@ public class GlobalMetricRegistry {
      * on the event processor to initiate the monitoring.
      *
      * @param name        The name under which the EventProcessor should be registered to the registry
-     * @param tagsBuilder The function used to construct the list of micrometer tags, based on the ingested message
+     * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                    message
      * @return The messageMonitor to monitor the behavior of an EventProcessor
      */
     public MessageMonitor<? super EventMessage<?>> registerEventProcessor(String name,
@@ -176,7 +229,7 @@ public class GlobalMetricRegistry {
      * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
      * on the event bus to initiate the monitoring.
      *
-     * @param name the name under which the eventBus should be registered to the registry
+     * @param name The name under which the eventBus should be registered to the registry
      * @return MessageMonitor to monitor the behavior of an EventBus
      */
     public MessageMonitor<? super EventMessage<?>> registerEventBus(String name) {
@@ -187,14 +240,59 @@ public class GlobalMetricRegistry {
     }
 
     /**
+     * Registers new metrics to the registry to monitor an {@link EventBus}. The monitor will be registered with the
+     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
+     * on the event bus to initiate the monitoring.
+     *
+     * @param name        The name under which the eventBus should be registered to the registry
+     * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                    message
+     * @return MessageMonitor to monitor the behavior of an EventBus
+     */
+    public MessageMonitor<? super EventMessage<?>> registerEventBus(String name,
+                                                                    Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        MessageCountingMonitor messageCountingMonitor = MessageCountingMonitor.buildMonitor(name, registry);
+        MessageTimerMonitor messageTimerMonitor = MessageTimerMonitor.buildMonitor(name, registry, tagsBuilder);
+
+        return new MultiMessageMonitor<>(Arrays.asList(messageCountingMonitor, messageTimerMonitor));
+    }
+
+    /**
      * Registers new metrics to the registry to monitor a {@link CommandBus}. The monitor will be registered with the
      * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
      * on the command bus to initiate the monitoring.
      *
-     * @param name the name under which the commandBus should be registered to the registry
+     * @param name The name under which the commandBus should be registered to the registry
      * @return MessageMonitor to monitor the behavior of a CommandBus
      */
     public MessageMonitor<? super CommandMessage<?>> registerCommandBus(String name) {
+        return registerDefaultHandlerMessageMonitor(name);
+    }
+
+    /**
+     * Registers new metrics to the registry to monitor a {@link CommandBus}. The monitor will be registered with the
+     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
+     * on the command bus to initiate the monitoring.
+     *
+     * @param name        The name under which the commandBus should be registered to the registry
+     * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                    message
+     * @return MessageMonitor to monitor the behavior of a CommandBus
+     */
+    public MessageMonitor<? super CommandMessage<?>> registerCommandBus(String name,
+                                                                        Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return registerDefaultHandlerMessageMonitor(name, tagsBuilder);
+    }
+
+    /**
+     * Registers new metrics to the registry to monitor a {@link QueryBus}. The monitor will be registered with the
+     * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
+     * on the command bus to initiate the monitoring.
+     *
+     * @param name The name under which the commandBus should be registered to the registry
+     * @return MessageMonitor to monitor the behavior of a QueryBus
+     */
+    public MessageMonitor<? super QueryMessage<?, ?>> registerQueryBus(String name) {
         return registerDefaultHandlerMessageMonitor(name);
     }
 
@@ -203,17 +301,31 @@ public class GlobalMetricRegistry {
      * registry under the given {@code name}. The returned {@link MessageMonitor} can be installed
      * on the command bus to initiate the monitoring.
      *
-     * @param name the name under which the commandBus should be registered to the registry
+     * @param name        The name under which the commandBus should be registered to the registry
+     * @param tagsBuilder The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                    message
      * @return MessageMonitor to monitor the behavior of a QueryBus
      */
-    public MessageMonitor<? super QueryMessage<?, ?>> registerQueryBus(String name) {
-        return registerDefaultHandlerMessageMonitor(name);
+    public MessageMonitor<? super QueryMessage<?, ?>> registerQueryBus(String name,
+                                                                       Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return registerDefaultHandlerMessageMonitor(name, tagsBuilder);
     }
 
     private MessageMonitor<Message<?>> registerDefaultHandlerMessageMonitor(String name) {
         MessageTimerMonitor messageTimerMonitor = MessageTimerMonitor.buildMonitor(name, registry);
         CapacityMonitor capacityMonitor = CapacityMonitor.buildMonitor(name, registry);
         MessageCountingMonitor messageCountingMonitor = MessageCountingMonitor.buildMonitor(name, registry);
+
+        return new MultiMessageMonitor<>(messageTimerMonitor, capacityMonitor, messageCountingMonitor);
+    }
+
+    private MessageMonitor<Message<?>> registerDefaultHandlerMessageMonitor(String name,
+                                                                            Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        MessageTimerMonitor messageTimerMonitor = MessageTimerMonitor.buildMonitor(name, registry, tagsBuilder);
+        CapacityMonitor capacityMonitor = CapacityMonitor.buildMonitor(name, registry, tagsBuilder);
+        MessageCountingMonitor messageCountingMonitor = MessageCountingMonitor.buildMonitor(name,
+                                                                                            registry,
+                                                                                            tagsBuilder);
 
         return new MultiMessageMonitor<>(messageTimerMonitor, capacityMonitor, messageCountingMonitor);
     }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
@@ -63,7 +63,7 @@ public class MessageCountingMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the message counting monitor (with the default tag `payloadType`)
+     * @return the message counting monitor (with the default {@link Tag} `payloadType`)
      */
     public static MessageCountingMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
 

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
  * Counts the number of ingested, successful, failed and processed messages
  *
  * @author Marijn van Zelst
+ * @author Ivan Dugalic
  * @since 4.1
  */
 public class MessageCountingMonitor implements MessageMonitor<Message<?>> {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
@@ -33,11 +33,11 @@ import java.util.function.Function;
  */
 public class MessageCountingMonitor implements MessageMonitor<Message<?>> {
 
-    public static final String INGESTED_COUNTER = ".ingestedCounter";
-    public static final String SUCCESS_COUNTER = ".successCounter";
-    public static final String FAILURE_COUNTER = ".failureCounter";
-    public static final String PROCESSED_COUNTER = ".processedCounter";
-    public static final String IGNORED_COUNTER = ".ignoredCounter";
+    private static final String INGESTED_COUNTER = ".ingestedCounter";
+    private static final String SUCCESS_COUNTER = ".successCounter";
+    private static final String FAILURE_COUNTER = ".failureCounter";
+    private static final String PROCESSED_COUNTER = ".processedCounter";
+    private static final String IGNORED_COUNTER = ".ignoredCounter";
 
     private final String meterNamePrefix;
     private final MeterRegistry meterRegistry;

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
@@ -47,7 +47,7 @@ public class MessageCountingMonitor implements MessageMonitor<Message<?>> {
 
         this(meterNamePrefix,
              meterRegistry,
-             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()));
+             message -> Tags.empty());
     }
 
 
@@ -63,7 +63,7 @@ public class MessageCountingMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the message counting monitor (with the default {@link Tag} `payloadType`)
+     * @return The message counting monitor
      */
     public static MessageCountingMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
 
@@ -75,8 +75,9 @@ public class MessageCountingMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the message counting monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The message counting monitor
      */
     public static MessageCountingMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
                                                       Function<Message<?>, Iterable<Tag>> tagsBuilder) {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -80,7 +80,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
     }
 
     /**
-     * Creates a message timer monitor
+     * Creates a message timer monitor.
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -68,7 +68,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
     }
 
     /**
-     * Creates a message timer monitor
+     * Creates a message timer monitor.
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -48,7 +48,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the message timer monitor (with the default tag `payloadType`)
+     * @return the message timer monitor (with the default {@link Tag} `payloadType`)
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM);

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
  * Times allTimer messages, successful and failed messages
  *
  * @author Marijn van Zelst
+ * @author Ivan Dugalic
  * @since 4.1
  */
 public class MessageTimerMonitor implements MessageMonitor<Message<?>> {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -48,7 +48,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the message timer monitor (with the default {@link Tag} `payloadType`)
+     * @return The message timer monitor
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM);
@@ -59,8 +59,9 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
-     * @return the message timer monitor
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
+     * @return The message timer monitor
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
                                                    Function<Message<?>, Iterable<Tag>> tagsBuilder) {
@@ -73,7 +74,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
      * @param clock           The clock used to measure the process time per message
-     * @return the message timer monitor (with the default {@link Tag} `payloadType`)
+     * @return The message timer monitor
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock) {
         return new MessageTimerMonitor(meterNamePrefix, meterRegistry, clock);
@@ -84,9 +85,10 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     *                        message
      * @param clock           The clock used to measure the process time per message
-     * @return the message timer monitor
+     * @return The message timer monitor
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock,
                                                    Function<Message<?>, Iterable<Tag>> tagsBuilder) {
@@ -117,7 +119,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
                                 Clock clock) {
         this(meterNamePrefix,
              meterRegistry,
-             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()),
+             message -> Tags.empty(),
              clock);
     }
 

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -73,7 +73,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
      * @param clock           The clock used to measure the process time per message
-     * @return the message timer monitor (with the default tag `payloadType`)
+     * @return the message timer monitor (with the default {@link Tag} `payloadType`)
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock) {
         return new MessageTimerMonitor(meterNamePrefix, meterRegistry, clock);

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -18,6 +18,8 @@ package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
@@ -25,6 +27,7 @@ import org.axonframework.monitoring.MessageMonitor;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Times allTimer messages, successful and failed messages
@@ -34,10 +37,10 @@ import java.util.concurrent.TimeUnit;
  */
 public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
 
-    private final Timer allTimer;
-    private final Timer successTimer;
-    private final Timer failureTimer;
-    private final Timer ignoredTimer;
+    private final String meterNamePrefix;
+    private final MeterRegistry meterRegistry;
+    private final Function<Message<?>, Iterable<Tag>> tagsBuilder;
+
     private final Clock clock;
 
     /**
@@ -45,7 +48,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
-     * @return the message timer monitor
+     * @return the message timer monitor (with the default tag `payloadType`)
      */
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM);
@@ -56,36 +59,78 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
      *
      * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
      * @param meterRegistry   The meter registry used to create and register the meters
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
+     * @return the message timer monitor
+     */
+    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
+                                                   Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM, tagsBuilder);
+    }
+
+    /**
+     * Creates a message timer monitor
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
+     * @param clock           The clock used to measure the process time per message
+     * @return the message timer monitor (with the default tag `payloadType`)
+     */
+    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock) {
+        return new MessageTimerMonitor(meterNamePrefix, meterRegistry, clock);
+    }
+
+    /**
+     * Creates a message timer monitor
+     *
+     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   The meter registry used to create and register the meters
+     * @param tagsBuilder     The function used to construct the list of micrometer tags, based on the ingested message
      * @param clock           The clock used to measure the process time per message
      * @return the message timer monitor
      */
-    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock) {
-        Timer allTimer = buildTimer(meterNamePrefix, "allTimer", meterRegistry);
-        Timer successTimer = buildTimer(meterNamePrefix, "successTimer", meterRegistry);
-        Timer failureTimer = buildTimer(meterNamePrefix, "failureTimer", meterRegistry);
-        Timer ignoredTimer = buildTimer(meterNamePrefix, "ignoredTimer", meterRegistry);
-        return new MessageTimerMonitor(allTimer, successTimer, failureTimer, ignoredTimer, clock);
+    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock,
+                                                   Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+        return new MessageTimerMonitor(meterNamePrefix, meterRegistry, tagsBuilder, clock);
     }
 
-    private static Timer buildTimer(String meterNamePrefix, String timerName, MeterRegistry meterRegistry) {
+    private static Timer buildTimer(String meterNamePrefix, String timerName, MeterRegistry meterRegistry,
+                                    Iterable<Tag> tags) {
         return Timer.builder(meterNamePrefix + "." + timerName)
                     .distributionStatisticExpiry(Duration.of(10, ChronoUnit.MINUTES))
                     .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
+                    .tags(tags)
                     .register(meterRegistry);
     }
 
-    private MessageTimerMonitor(Timer allTimer, Timer successTimer, Timer failureTimer, Timer ignoredTimer,
+    private MessageTimerMonitor(String meterNamePrefix,
+                                MeterRegistry meterRegistry,
+                                Function<Message<?>, Iterable<Tag>> tagsBuilder,
                                 Clock clock) {
-        this.allTimer = allTimer;
-        this.successTimer = successTimer;
-        this.failureTimer = failureTimer;
-        this.ignoredTimer = ignoredTimer;
+        this.meterNamePrefix = meterNamePrefix;
+        this.meterRegistry = meterRegistry;
+        this.tagsBuilder = tagsBuilder;
         this.clock = clock;
+    }
+
+    private MessageTimerMonitor(String meterNamePrefix,
+                                MeterRegistry meterRegistry,
+                                Clock clock) {
+        this(meterNamePrefix,
+             meterRegistry,
+             message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()),
+             clock);
     }
 
     @Override
     public MonitorCallback onMessageIngested(Message<?> message) {
+        Iterable<Tag> tags = tagsBuilder.apply(message);
+        Timer allTimer = buildTimer(meterNamePrefix, "allTimer", meterRegistry, tags);
+        Timer successTimer = buildTimer(meterNamePrefix, "successTimer", meterRegistry, tags);
+        Timer failureTimer = buildTimer(meterNamePrefix, "failureTimer", meterRegistry, tags);
+        Timer ignoredTimer = buildTimer(meterNamePrefix, "ignoredTimer", meterRegistry, tags);
+
         long startTime = clock.monotonicTime();
+
         return new MonitorCallback() {
             @Override
             public void reportSuccess() {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
@@ -44,6 +44,10 @@ public class MetricsConfigurerModule implements ConfigurerModule {
 
     @Override
     public void configureModule(Configurer configurer) {
-        globalMetricRegistry.registerWithConfigurer(configurer);
+        if (useDimensions) {
+            globalMetricRegistry.registerWithConfigurerWithDefaultTags(configurer);
+        } else {
+            globalMetricRegistry.registerWithConfigurer(configurer);
+        }
     }
 }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
@@ -26,6 +26,7 @@ import org.axonframework.config.ConfigurerModule;
  *
  * @author Steven van Beelen
  * @author Marijn van Zelst
+ * @author Ivan Dugalic
  * @since 4.1
  */
 public class MetricsConfigurerModule implements ConfigurerModule {

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
@@ -31,9 +31,15 @@ import org.axonframework.config.ConfigurerModule;
 public class MetricsConfigurerModule implements ConfigurerModule {
 
     private final GlobalMetricRegistry globalMetricRegistry;
+    private final boolean useDimensions;
 
     public MetricsConfigurerModule(GlobalMetricRegistry globalMetricRegistry) {
+        this(globalMetricRegistry, false);
+    }
+
+    public MetricsConfigurerModule(GlobalMetricRegistry globalMetricRegistry, boolean useDimensions) {
         this.globalMetricRegistry = globalMetricRegistry;
+        this.useDimensions = useDimensions;
     }
 
     @Override

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
@@ -36,7 +36,8 @@ import java.util.function.Function;
  * @author Marijn van Zelst
  * @since 4.1
  * @deprecated As of release 4.4, replaced by specific monitors {@link MessageCountingMonitor}, {@link CapacityMonitor},
- * {@link EventProcessorLatencyMonitor}, {@link MessageCountingMonitor}
+ * {@link EventProcessorLatencyMonitor}, {@link MessageCountingMonitor} that can be used to register meters on Axon
+ * components directly.
  */
 @Deprecated
 public class PayloadTypeMessageMonitorWrapper<T extends MessageMonitor<Message<?>>>

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
@@ -35,6 +35,8 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @author Marijn van Zelst
  * @since 4.1
+ * @deprecated As of release 4.4, replaced by specific monitors {@link MessageCountingMonitor}, {@link CapacityMonitor},
+ * {@link EventProcessorLatencyMonitor}, {@link MessageCountingMonitor}
  */
 @Deprecated
 public class PayloadTypeMessageMonitorWrapper<T extends MessageMonitor<Message<?>>>

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
@@ -32,11 +32,11 @@ import java.util.function.Function;
  * MessageMonitor}.
  *
  * @param <T> The type of the MessageMonitor created for every payload type.Must implement both {@link MessageMonitor}
- *
  * @author Steven van Beelen
  * @author Marijn van Zelst
  * @since 4.1
  */
+@Deprecated
 public class PayloadTypeMessageMonitorWrapper<T extends MessageMonitor<Message<?>>>
         implements MessageMonitor<Message<?>> {
 

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapper.java
@@ -35,9 +35,8 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @author Marijn van Zelst
  * @since 4.1
- * @deprecated As of release 4.4, replaced by specific monitors {@link MessageCountingMonitor}, {@link CapacityMonitor},
- * {@link EventProcessorLatencyMonitor}, {@link MessageCountingMonitor} that can be used to register meters on Axon
- * components directly.
+ * @deprecated As of release 4.4, replaced by using {@link Tag}s on the monitor implementations.
+ * Use {@link org.axonframework.micrometer.GlobalMetricRegistry#registerWithConfigurerWithDefaultTags(Configurer) to achieve the same behavior as this implementation.
  */
 @Deprecated
 public class PayloadTypeMessageMonitorWrapper<T extends MessageMonitor<Message<?>>>

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -8,6 +8,9 @@ package org.axonframework.micrometer;
  */
 public class TagsUtil {
 
+    private TagsUtil() {
+    }
+
     public static final String PAYLOAD_TYPE_TAG = "payloadType";
     public static final String PROCESSOR_NAME_TAG = "processorName";
 }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -1,0 +1,7 @@
+package org.axonframework.micrometer;
+
+public class TagsUtil {
+
+    public static final String PAYLOAD_TYPE_TAG = "payloadType";
+    public static final String PROCESSOR_NAME_TAG = "processorName";
+}

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -1,12 +1,17 @@
 package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.axonframework.messaging.Message;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for micrometer tag management.
  * <p>
  * Contains 'static final' fields which represent the micrometer tag KEY that should be consistent across different
- * metrics.
+ * metrics, and functions responsible for creating the Micrometer {@link Tag}s based on the message that is ingested.
  *
  * @author Ivan Dugalic
  * @since 4.4
@@ -24,4 +29,17 @@ public class TagsUtil {
      * The micrometer {@link Tag} key that represents the Axon event processor name
      */
     public static final String PROCESSOR_NAME_TAG = "processorName";
+    /**
+     * The function for creating the Micrometer {@link Tag}s based on the message payload type.
+     */
+    public static final Function<Message<?>, Iterable<Tag>> PAYLOAD_TYPE_TAGGER_FUNCTION = message -> Tags.of(
+            PAYLOAD_TYPE_TAG,
+            message.getPayloadType().getSimpleName());
+
+    /**
+     * The function for creating the Micrometer {@link Tag}s based on the message metadata.
+     */
+    public static final Function<Message<?>, Iterable<Tag>> META_DATA_TAGGER_FUNCTION = message -> message
+            .getMetaData().entrySet().stream().map(it -> Tag.of(it.getKey(), it.getValue().toString()))
+            .collect(Collectors.toList());
 }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -7,6 +7,9 @@ import io.micrometer.core.instrument.Tag;
  * <p>
  * Contains 'static final' fields which represent the micrometer tag KEY that should be consistent across different
  * metrics.
+ *
+ * @author Ivan Dugalic
+ * @since 4.4
  */
 public class TagsUtil {
 

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -1,5 +1,7 @@
 package org.axonframework.micrometer;
 
+import io.micrometer.core.instrument.Tag;
+
 /**
  * Utility class for micrometer tag management.
  * <p>
@@ -11,6 +13,12 @@ public class TagsUtil {
     private TagsUtil() {
     }
 
+    /**
+     * The micrometer {@link Tag} key that represents the Axon message payload type
+     */
     public static final String PAYLOAD_TYPE_TAG = "payloadType";
+    /**
+     * The micrometer {@link Tag} key that represents the Axon event processor name
+     */
     public static final String PROCESSOR_NAME_TAG = "processorName";
 }

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/TagsUtil.java
@@ -1,5 +1,11 @@
 package org.axonframework.micrometer;
 
+/**
+ * Utility class for micrometer tag management.
+ * <p>
+ * Contains 'static final' fields which represent the micrometer tag KEY that should be consistent across different
+ * metrics.
+ */
 public class TagsUtil {
 
     public static final String PAYLOAD_TYPE_TAG = "payloadType";

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
@@ -18,8 +18,7 @@ package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MockClock;
-import io.micrometer.core.instrument.simple.CountingMode;
-import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
@@ -27,7 +26,10 @@ import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
@@ -36,38 +38,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class CapacityMonitorTest {
 
     @Test
-    void testSingleThreadedCapacity() {
-        MockClock testClock = new MockClock();
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(new SimpleConfig() {
-            @Override
-            public String get(String key) {
-                return null;
-            }
-
-            @Override
-            public CountingMode mode() {
-                return CountingMode.STEP;
-            }
-        }, testClock);
-        CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1", meterRegistry, 1, TimeUnit.SECONDS, testClock);
-
-        MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
-
-        testClock.addSeconds(1);
-
-        monitorCallback.reportSuccess();
-
-        Gauge capacityGauge = meterRegistry.get("1.capacity").gauge();
-        assertEquals(1, capacityGauge.value(), 0);
-    }
-
-    @Test
-    void testMultithreadedCapacity() {
+    void testCapacity() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1", meterRegistry, 1, TimeUnit.SECONDS, testClock);
 
-        EventMessage<Object> foo = asEventMessage("foo");
+        EventMessage<Object> foo = asEventMessage(1);
         EventMessage<Object> bar = asEventMessage("bar");
         Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
                 .onMessagesIngested(Arrays.asList(foo, bar));
@@ -77,16 +53,54 @@ class CapacityMonitorTest {
         callbacks.get(foo).reportSuccess();
         callbacks.get(bar).reportFailure(null);
 
-        Gauge capacityGauge = meterRegistry.get("1.capacity").gauge();
-        assertEquals(2, capacityGauge.value(), 0);
+        Collection<Gauge> capacityGauges = meterRegistry.find("1.capacity").gauges();
+        assertEquals(2, capacityGauges.size(), 0);
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects.equals(gauge.getId().getTag("payloadType"), "Integer")));
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects.equals(gauge.getId().getTag("payloadType"), "String")));
     }
 
     @Test
-    void testEmptyCapacity() {
+    void testCapacityWithCustomTags() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        CapacityMonitor.buildMonitor("1", meterRegistry, 1, TimeUnit.SECONDS, testClock);
-        Gauge capacityGauge = meterRegistry.get("1.capacity").gauge();
-        assertEquals(0, capacityGauge.value(), 0);
+        CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1",
+                                                                   meterRegistry,
+                                                                   1,
+                                                                   TimeUnit.SECONDS,
+                                                                   testClock,
+                                                                   message -> Tags.of("myPayloadType",
+                                                                                      message.getPayloadType()
+                                                                                             .getSimpleName(),
+                                                                                      "myMetaData",
+                                                                                      message.getMetaData()
+                                                                                             .get("myMetadataKey")
+                                                                                             .toString()));
+
+        EventMessage<Object> foo = asEventMessage(1).withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                           "myMetadataValue1"));
+        EventMessage<Object> bar = asEventMessage("bar").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue2"));
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
+                .onMessagesIngested(Arrays.asList(foo, bar));
+
+        testClock.addSeconds(1);
+
+        callbacks.get(foo).reportSuccess();
+        callbacks.get(bar).reportFailure(null);
+
+        Collection<Gauge> capacityGauges = meterRegistry.find("1.capacity").gauges();
+        assertEquals(2, capacityGauges.size(), 0);
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects.equals(gauge.getId().getTag("myPayloadType"), "Integer")));
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects.equals(gauge.getId().getTag("myPayloadType"), "String")));
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects
+                                         .equals(gauge.getId().getTag("myMetaData"), "myMetadataValue1")));
+        assertTrue(capacityGauges.stream()
+                                 .anyMatch(gauge -> Objects
+                                         .equals(gauge.getId().getTag("myMetaData"), "myMetadataValue2")));
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
@@ -46,11 +46,14 @@ class EventProcessorLatencyMonitorTest {
     void testMessages() {
         EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
                                                                                              meterRegistry);
-        EventMessage<?> firstEventMessage = mock(EventMessage.class);
-        when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
 
-        EventMessage<?> secondEventMessage = mock(EventMessage.class);
+        EventMessage<String> firstEventMessage = mock(EventMessage.class);
+        when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
+        when(firstEventMessage.getPayloadType()).thenReturn(String.class);
+
+        EventMessage<Integer> secondEventMessage = mock(EventMessage.class);
         when(secondEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(1000));
+        when(secondEventMessage.getPayloadType()).thenReturn(Integer.class);
 
         Map<? super EventMessage<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
                 .onMessagesIngested(Arrays.asList(firstEventMessage, secondEventMessage));
@@ -64,11 +67,13 @@ class EventProcessorLatencyMonitorTest {
     void testFailureMessage() {
         EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
                                                                                              meterRegistry);
-        EventMessage<?> firstEventMessage = mock(EventMessage.class);
+        EventMessage<String> firstEventMessage = mock(EventMessage.class);
         when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
+        when(firstEventMessage.getPayloadType()).thenReturn(String.class);
 
-        EventMessage<?> secondEventMessage = mock(EventMessage.class);
+        EventMessage<Integer> secondEventMessage = mock(EventMessage.class);
         when(secondEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(1000));
+        when(secondEventMessage.getPayloadType()).thenReturn(Integer.class);
 
         Map<? super EventMessage<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
                 .onMessagesIngested(Arrays.asList(firstEventMessage, secondEventMessage));
@@ -76,16 +81,5 @@ class EventProcessorLatencyMonitorTest {
 
         Gauge latencyGauge = Objects.requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".latency").gauge());
         assertEquals(1000, latencyGauge.value(), 0);
-    }
-
-    @Test
-    void testNullMessage() {
-        EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
-                                                                                             meterRegistry);
-        MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
-        monitorCallback.reportSuccess();
-
-        Gauge latencyGauge = Objects.requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".latency").gauge());
-        assertEquals(0, latencyGauge.value(), 0);
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
@@ -18,6 +18,7 @@ package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.monitoring.MessageMonitor;
@@ -43,7 +44,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testMessages() {
+    void testMessagesWithoutTags() {
         EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
                                                                                              meterRegistry);
 
@@ -64,9 +65,38 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testFailureMessage() {
+    void testMessagesWithPayloadAsCustomTag() {
         EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
-                                                                                             meterRegistry);
+                                                                                             meterRegistry,
+                                                                                             message -> Tags
+                                                                                                     .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                                                                                                         message.getPayloadType()
+                                                                                                                .getSimpleName()));
+
+        EventMessage<String> firstEventMessage = mock(EventMessage.class);
+        when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
+        when(firstEventMessage.getPayloadType()).thenReturn(String.class);
+
+        EventMessage<Integer> secondEventMessage = mock(EventMessage.class);
+        when(secondEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(1000));
+        when(secondEventMessage.getPayloadType()).thenReturn(Integer.class);
+
+        Map<? super EventMessage<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
+                .onMessagesIngested(Arrays.asList(firstEventMessage, secondEventMessage));
+        callbacks.get(firstEventMessage).reportSuccess();
+
+        Gauge latencyGauge = Objects.requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".latency").gauge());
+        assertEquals(1000, latencyGauge.value(), 0);
+    }
+
+    @Test
+    void testFailureMessageWithPayloadAsCustomTag() {
+        EventProcessorLatencyMonitor testSubject = EventProcessorLatencyMonitor.buildMonitor(METER_NAME_PREFIX,
+                                                                                             meterRegistry,
+                                                                                             message -> Tags
+                                                                                                     .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                                                                                                         message.getPayloadType()
+                                                                                                                .getSimpleName()));
         EventMessage<String> firstEventMessage = mock(EventMessage.class);
         when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
         when(firstEventMessage.getPayloadType()).thenReturn(String.class);

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
@@ -19,6 +19,7 @@ package org.axonframework.micrometer;
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
@@ -85,8 +86,47 @@ class GlobalMetricRegistryTest {
     }
 
     @Test
+    void createEventProcessorMonitorWithTags() {
+        MessageMonitor<? super EventMessage<?>> monitor1 = subject.registerEventProcessor("test1", message -> Tags
+                .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                    message.getPayloadType()
+                           .getSimpleName()));
+        MessageMonitor<? super EventMessage<?>> monitor2 = subject.registerEventProcessor("test2", message -> Tags
+                .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                    message.getPayloadType()
+                           .getSimpleName()));
+
+        monitor1.onMessageIngested(asEventMessage("test")).reportSuccess();
+        monitor2.onMessageIngested(asEventMessage("test")).reportSuccess();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ConsoleReporter.forRegistry(dropWizardRegistry).outputTo(new PrintStream(out)).build().report();
+        String output = new String(out.toByteArray());
+
+        assertTrue(output.contains("test1"));
+        assertTrue(output.contains("test2"));
+    }
+
+    @Test
     void createEventBusMonitor() {
         MessageMonitor<? super EventMessage<?>> monitor = subject.registerEventBus("eventBus");
+
+        monitor.onMessageIngested(asEventMessage("test")).reportSuccess();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConsoleReporter.forRegistry(dropWizardRegistry).outputTo(new PrintStream(out)).build().report();
+        String output = new String(out.toByteArray());
+
+        assertTrue(output.contains("eventBus"));
+    }
+
+    @Test
+    void createEventBusMonitorWithTags() {
+        MessageMonitor<? super EventMessage<?>> monitor = subject.registerEventBus("eventBus", message -> Tags
+                .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                    message.getPayloadType()
+                           .getSimpleName()));
 
         monitor.onMessageIngested(asEventMessage("test")).reportSuccess();
 
@@ -111,8 +151,31 @@ class GlobalMetricRegistryTest {
     }
 
     @Test
+    void createCommandBusMonitorWithTags() {
+        MessageMonitor<? super CommandMessage<?>> monitor = subject.registerCommandBus("commandBus", message -> Tags
+                .of(TagsUtil.PAYLOAD_TYPE_TAG,
+                    message.getPayloadType()
+                           .getSimpleName()));
+
+        monitor.onMessageIngested(new GenericCommandMessage<>("test")).reportSuccess();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ConsoleReporter.forRegistry(dropWizardRegistry).outputTo(new PrintStream(out)).build().report();
+        String output = new String(out.toByteArray());
+
+        assertTrue(output.contains("commandBus"));
+    }
+
+    @Test
     void createMonitorForUnknownComponent() {
         MessageMonitor<? extends Message<?>> actual = subject.registerComponent(String.class, "test");
+
+        assertSame(NoOpMessageMonitor.instance(), actual);
+    }
+
+    @Test
+    void createMonitorForUnknownComponentWithTags() {
+        MessageMonitor<? extends Message<?>> actual = subject.registerComponentWithDefaultTags(String.class, "test");
 
         assertSame(NoOpMessageMonitor.instance(), actual);
     }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
@@ -24,9 +25,11 @@ import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
-import static java.util.Objects.requireNonNull;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,7 +41,7 @@ class MessageCountingMonitorTest {
     void testMessages() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         MessageCountingMonitor testSubject = MessageCountingMonitor.buildMonitor(PROCESSOR_NAME, meterRegistry);
-        EventMessage<Object> foo = asEventMessage("foo");
+        EventMessage<Object> foo = asEventMessage(1);
         EventMessage<Object> bar = asEventMessage("bar");
         EventMessage<Object> baz = asEventMessage("baz");
         Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
@@ -47,16 +50,143 @@ class MessageCountingMonitorTest {
         callbacks.get(bar).reportFailure(null);
         callbacks.get(baz).reportIgnored();
 
-        Counter ingestedCounter = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ingestedCounter").counter());
-        Counter processedCounter = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".processedCounter").counter());
-        Counter successCounter = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".successCounter").counter());
-        Counter failureCounter = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".failureCounter").counter());
-        Counter ignoredCounter = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ignoredCounter").counter());
+        Collection<Counter> ingestedCounters = meterRegistry.find(PROCESSOR_NAME + ".ingestedCounter").counters();
+        Collection<Counter> processedCounters = meterRegistry.find(PROCESSOR_NAME + ".processedCounter").counters();
+        Collection<Counter> successCounters = meterRegistry.find(PROCESSOR_NAME + ".successCounter").counters();
+        Collection<Counter> failureCounters = meterRegistry.find(PROCESSOR_NAME + ".failureCounter").counters();
+        Collection<Counter> ignoredCounters = meterRegistry.find(PROCESSOR_NAME + ".ignoredCounter").counters();
 
-        assertEquals(3, ingestedCounter.count(), 0);
-        assertEquals(2, processedCounter.count(), 0);
-        assertEquals(1, successCounter.count(), 0);
-        assertEquals(1, failureCounter.count(), 0);
-        assertEquals(1, ignoredCounter.count(), 0);
+        assertEquals(2, ingestedCounters.size(), 0);
+        assertEquals(2, processedCounters.size(), 0);
+        assertEquals(2, successCounters.size(), 0);
+        assertEquals(2, failureCounters.size(), 0);
+        assertEquals(2, ignoredCounters.size(), 0);
+
+
+        assertTrue(ingestedCounters.stream()
+                                   .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "Integer"))
+                                   .allMatch(counter -> counter.count() == 1));
+        assertTrue(ingestedCounters.stream()
+                                   .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "String"))
+                                   .allMatch(counter -> counter.count() == 2));
+
+
+        assertTrue(processedCounters.stream()
+                                    .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "Integer"))
+                                    .allMatch(counter -> counter.count() == 1));
+        assertTrue(processedCounters.stream()
+                                    .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "String"))
+                                    .allMatch(counter -> counter.count() == 1));
+
+
+        assertTrue(successCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "Integer"))
+                                  .allMatch(counter -> counter.count() == 1));
+        assertTrue(successCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "String"))
+                                  .allMatch(counter -> counter.count() == 0));
+
+
+        assertTrue(failureCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "Integer"))
+                                  .allMatch(counter -> counter.count() == 0));
+        assertTrue(failureCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "String"))
+                                  .allMatch(counter -> counter.count() == 1));
+
+
+        assertTrue(ignoredCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "Integer"))
+                                  .allMatch(counter -> counter.count() == 0));
+        assertTrue(ignoredCounters.stream()
+                                  .filter(counter -> Objects.equals(counter.getId().getTag("payloadType"), "String"))
+                                  .allMatch(counter -> counter.count() == 1));
+    }
+
+    @Test
+    void testMessagesWithCustomTags() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MessageCountingMonitor testSubject = MessageCountingMonitor.buildMonitor(PROCESSOR_NAME,
+                                                                                 meterRegistry,
+                                                                                 message -> Tags
+                                                                                         .of("myMetaData",
+                                                                                             message.getMetaData()
+                                                                                                    .get("myMetadataKey")
+                                                                                                    .toString()));
+        EventMessage<Object> foo = asEventMessage(1).withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                           "myMetadataValue1"));
+        EventMessage<Object> bar = asEventMessage("bar").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue2"));
+        ;
+        EventMessage<Object> baz = asEventMessage("baz").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue2"));
+        ;
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
+                .onMessagesIngested(Arrays.asList(foo, bar, baz));
+        callbacks.get(foo).reportSuccess();
+        callbacks.get(bar).reportFailure(null);
+        callbacks.get(baz).reportIgnored();
+
+        Collection<Counter> ingestedCounters = meterRegistry.find(PROCESSOR_NAME + ".ingestedCounter").counters();
+        Collection<Counter> processedCounters = meterRegistry.find(PROCESSOR_NAME + ".processedCounter").counters();
+        Collection<Counter> successCounters = meterRegistry.find(PROCESSOR_NAME + ".successCounter").counters();
+        Collection<Counter> failureCounters = meterRegistry.find(PROCESSOR_NAME + ".failureCounter").counters();
+        Collection<Counter> ignoredCounters = meterRegistry.find(PROCESSOR_NAME + ".ignoredCounter").counters();
+
+        assertEquals(2, ingestedCounters.size(), 0);
+        assertEquals(2, processedCounters.size(), 0);
+        assertEquals(2, successCounters.size(), 0);
+        assertEquals(2, failureCounters.size(), 0);
+        assertEquals(2, ignoredCounters.size(), 0);
+
+
+        assertTrue(ingestedCounters.stream()
+                                   .filter(counter -> Objects
+                                           .equals(counter.getId().getTag("myMetaData"), "myMetadataValue1"))
+                                   .allMatch(counter -> counter.count() == 1));
+        assertTrue(ingestedCounters.stream()
+                                   .filter(counter -> Objects
+                                           .equals(counter.getId().getTag("myMetaData"), "myMetadataValue2"))
+                                   .allMatch(counter -> counter.count() == 2));
+
+
+        assertTrue(processedCounters.stream()
+                                    .filter(counter -> Objects
+                                            .equals(counter.getId().getTag("myMetaData"), "myMetadataValue1"))
+                                    .allMatch(counter -> counter.count() == 1));
+        assertTrue(processedCounters.stream()
+                                    .filter(counter -> Objects
+                                            .equals(counter.getId().getTag("payloadType"), "myMetadataValue2"))
+                                    .allMatch(counter -> counter.count() == 1));
+
+
+        assertTrue(successCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue1"))
+                                  .allMatch(counter -> counter.count() == 1));
+        assertTrue(successCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue2"))
+                                  .allMatch(counter -> counter.count() == 0));
+
+
+        assertTrue(failureCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue1"))
+                                  .allMatch(counter -> counter.count() == 0));
+        assertTrue(failureCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue2"))
+                                  .allMatch(counter -> counter.count() == 1));
+
+
+        assertTrue(ignoredCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue1"))
+                                  .allMatch(counter -> counter.count() == 0));
+        assertTrue(ignoredCounters.stream()
+                                  .filter(counter -> Objects
+                                          .equals(counter.getId().getTag("payloadType"), "myMetadataValue2"))
+                                  .allMatch(counter -> counter.count() == 1));
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
@@ -17,15 +17,23 @@
 package org.axonframework.micrometer;
 
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Objects.requireNonNull;
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MessageTimerMonitorTest {
@@ -33,62 +41,114 @@ class MessageTimerMonitorTest {
     private static final String PROCESSOR_NAME = "processorName";
 
     @Test
-    void testSuccessMessage() {
+    void testMessages() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
+        EventMessage<Object> foo = asEventMessage(1);
+        EventMessage<Object> bar = asEventMessage("bar");
+        EventMessage<Object> baz = asEventMessage("baz");
+
         MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME, meterRegistry, testClock);
-        MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
+                .onMessagesIngested(Arrays.asList(foo, bar, baz));
         testClock.addSeconds(1);
-        monitorCallback.reportSuccess();
+        callbacks.get(foo).reportSuccess();
+        callbacks.get(bar).reportFailure(null);
+        callbacks.get(baz).reportIgnored();
 
-        Timer all = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".allTimer").timer());
-        Timer successTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".successTimer").timer());
-        Timer failureTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timer());
-        Timer ignoredTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timer());
+        Collection<Timer> all = meterRegistry.find(PROCESSOR_NAME + ".allTimer").timers();
+        Collection<Timer> successTimer = meterRegistry.find(PROCESSOR_NAME + ".successTimer").timers();
+        Collection<Timer> failureTimer = meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timers();
+        Collection<Timer> ignoredTimer = meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timers();
 
-        assertEquals(1, all.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(1, successTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, failureTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, ignoredTimer.totalTime(TimeUnit.SECONDS), 0);
+        // Expecting two timers with the same meter name ([name=PROCESSOR_NAME.suffix ; payloadType=Integer] , [name=PROCESSOR_NAME.suffix ; payloadType=String])
+        assertEquals(2, all.size(), 0);
+        assertEquals(2, successTimer.size(), 0);
+        assertEquals(2, failureTimer.size(), 0);
+        assertEquals(2, ignoredTimer.size(), 0);
+
+        assertTrue(all.stream()
+                      .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "Integer"))
+                      .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
+        assertTrue(all.stream()
+                      .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "String"))
+                      .allMatch(timer -> (timer.totalTime(TimeUnit.SECONDS) == 2 && timer.max(TimeUnit.SECONDS) == 1)));
+
+        assertTrue(successTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "Integer"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
+
+        assertTrue(successTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "String"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 0));
+
+        assertTrue(failureTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "Integer"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 0));
+
+        assertTrue(failureTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("payloadType"), "String"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
     }
 
     @Test
-    void testFailureMessage() {
+    void testMessagesWithCustomTags() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
-        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME, meterRegistry, testClock);
-        MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
+        EventMessage<Object> foo = asEventMessage("foo").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue1"));
+        EventMessage<Object> bar = asEventMessage("bar").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue2"));
+        EventMessage<Object> baz = asEventMessage("baz").withMetaData(Collections.singletonMap("myMetadataKey",
+                                                                                               "myMetadataValue2"));
+
+        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME,
+                                                                           meterRegistry,
+                                                                           testClock,
+                                                                           message -> Tags
+                                                                                   .of("myMetaData",
+                                                                                       message.getMetaData()
+                                                                                              .get("myMetadataKey")
+                                                                                              .toString()));
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
+                .onMessagesIngested(Arrays.asList(foo, bar, baz));
         testClock.addSeconds(1);
-        monitorCallback.reportFailure(null);
+        callbacks.get(foo).reportSuccess();
+        callbacks.get(bar).reportFailure(null);
+        callbacks.get(baz).reportIgnored();
 
-        Timer all = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".allTimer").timer());
-        Timer successTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".successTimer").timer());
-        Timer failureTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timer());
-        Timer ignoredTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timer());
+        Collection<Timer> all = meterRegistry.find(PROCESSOR_NAME + ".allTimer").timers();
+        Collection<Timer> successTimer = meterRegistry.find(PROCESSOR_NAME + ".successTimer").timers();
+        Collection<Timer> failureTimer = meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timers();
+        Collection<Timer> ignoredTimer = meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timers();
 
-        assertEquals(1, all.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, successTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(1, failureTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, ignoredTimer.totalTime(TimeUnit.SECONDS), 0);
-    }
+        // Expecting two timers with the same meter name ([name=PROCESSOR_NAME.suffix ; payloadType=Integer] , [name=PROCESSOR_NAME.suffix ; payloadType=String])
+        assertEquals(2, all.size(), 0);
+        assertEquals(2, successTimer.size(), 0);
+        assertEquals(2, failureTimer.size(), 0);
+        assertEquals(2, ignoredTimer.size(), 0);
 
-    @Test
-    void testIgnoredMessage() {
-        MockClock testClock = new MockClock();
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
-        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME, meterRegistry, testClock);
-        MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
-        testClock.addSeconds(1);
-        monitorCallback.reportIgnored();
+        assertTrue(all.stream()
+                      .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue1"))
+                      .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
+        assertTrue(all.stream()
+                      .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue2"))
+                      .allMatch(timer -> (timer.totalTime(TimeUnit.SECONDS) == 2 && timer.max(TimeUnit.SECONDS) == 1)));
 
-        Timer all = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".allTimer").timer());
-        Timer successTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".successTimer").timer());
-        Timer failureTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timer());
-        Timer ignoredTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timer());
+        assertTrue(successTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue1"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
 
-        assertEquals(1, all.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, successTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(0, failureTimer.totalTime(TimeUnit.SECONDS), 0);
-        assertEquals(1, ignoredTimer.totalTime(TimeUnit.SECONDS), 0);
+        assertTrue(successTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue2"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 0));
+
+        assertTrue(failureTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue1"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 0));
+
+        assertTrue(failureTimer.stream()
+                               .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue2"))
+                               .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/MetricsProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/MetricsProperties.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class MetricsProperties {
 
     private AutoConfiguration autoConfiguration = new AutoConfiguration();
+    private Micrometer micrometer = new Micrometer();
 
     /**
      * Retrieves the AutoConfiguration settings for Metrics
@@ -45,6 +46,24 @@ public class MetricsProperties {
      */
     public void setAutoConfiguration(AutoConfiguration autoConfiguration) {
         this.autoConfiguration = autoConfiguration;
+    }
+
+    /**
+     * Retrieves the Micrometer specific settings for Metrics
+     *
+     * @return the Micrometer settings for Metrics
+     */
+    public Micrometer getMicrometer() {
+        return micrometer;
+    }
+
+    /**
+     * Defines the Micrometer settings for Metrics.
+     *
+     * @param micrometer the Micrometer settings for Metrics.
+     */
+    public void setMicrometer(Micrometer micrometer) {
+        this.micrometer = micrometer;
     }
 
     /**
@@ -74,6 +93,32 @@ public class MetricsProperties {
          */
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    public static class Micrometer {
+
+        /**
+         * Enables Micrometer tags for this application.
+         */
+        private boolean dimensional = false;
+
+        /**
+         * Indicates whether the Micrometer Tags/Dimensions will be used
+         *
+         * @return true if the Micrometer Tags/Dimensions will be used, false if otherwise
+         */
+        public boolean isDimensional() {
+            return dimensional;
+        }
+
+        /**
+         * Disables (if {@code false}, default) or enables (if {@code true}) the usage of Micrometer Tags/Dimensions
+         *
+         * @param dimensional whether the Micrometer Tags/Dimensions will be used
+         */
+        public void setDimensional(boolean dimensional) {
+            this.dimensional = dimensional;
         }
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/MicrometerMetricsAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/MicrometerMetricsAutoConfiguration.java
@@ -68,9 +68,9 @@ public class MicrometerMetricsAutoConfiguration {
     @ConditionalOnMissingBean(MetricsConfigurerModule.class)
     @ConditionalOnBean(GlobalMetricRegistry.class)
     @ConditionalOnProperty(value = "axon.metrics.auto-configuration.enabled", matchIfMissing = true)
-    public static MetricsConfigurerModule metricsConfigurerModule(GlobalMetricRegistry globalMetricRegistry) {
-        return new MetricsConfigurerModule(globalMetricRegistry);
+    public static MetricsConfigurerModule metricsConfigurerModule(GlobalMetricRegistry globalMetricRegistry,
+                                                                  MetricsProperties metricsProperties) {
+        return new MetricsConfigurerModule(globalMetricRegistry, metricsProperties.getMicrometer().isDimensional());
     }
-
 }
 


### PR DESCRIPTION
All Axon monitors have been changed to use tags that enable `dimensionality`.
By default, the message `palyoadType` is a tag for every metric. One can add/configure metrics with custom Tags/Dimensions (for example, from message metadata) as well.

Before this change, the axon-micrometer was `hierarchical`, which means it only supported a flat metric name.