### PR TITLE
[#1453] Add TimestampWriter to facilitate writing timestamp as sql-timestamp

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/AbstractEventTableFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/AbstractEventTableFactory.java
@@ -42,7 +42,7 @@ public abstract class AbstractEventTableFactory implements EventTableFactory {
                 schema.payloadColumn() + " " + payloadType() + " NOT NULL,\n" +
                 schema.payloadRevisionColumn() + " VARCHAR(255),\n" +
                 schema.payloadTypeColumn() + " VARCHAR(255) NOT NULL,\n" +
-                schema.timestampColumn() + " VARCHAR(255) NOT NULL,\n" +
+                schema.timestampColumn() + " " + timestampType() + " ,\n" +
                 "PRIMARY KEY (" + schema.globalIndexColumn() + "),\n" +
                 "UNIQUE (" + schema.aggregateIdentifierColumn() + ", " +
                 schema.sequenceNumberColumn() + "),\n" +
@@ -63,7 +63,7 @@ public abstract class AbstractEventTableFactory implements EventTableFactory {
                 schema.payloadColumn() + " " + payloadType() + " NOT NULL,\n" +
                 schema.payloadRevisionColumn() + " VARCHAR(255),\n" +
                 schema.payloadTypeColumn() + " VARCHAR(255) NOT NULL,\n" +
-                schema.timestampColumn() + " VARCHAR(255) NOT NULL,\n" +
+                schema.timestampColumn() + " " + timestampType() + " ,\n" +
                 "PRIMARY KEY (" + schema.aggregateIdentifierColumn() + ", " +
                 schema.sequenceNumberColumn() + "),\n" +
                 "UNIQUE (" + schema.eventIdentifierColumn() + ")\n" +
@@ -84,4 +84,13 @@ public abstract class AbstractEventTableFactory implements EventTableFactory {
      * @return the sql for the payload column
      */
     protected abstract String payloadType();
+
+    /**
+     * Returns the sql to describe the type of timestamp column.
+     *
+     * @return the sql for the timestamp column
+     */
+    protected String timestampType() {
+        return " VARCHAR(255) NOT NULL ";
+    }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -33,20 +33,7 @@ import org.axonframework.eventhandling.TrackedEventData;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.AppendEventsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.AppendSnapshotStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.CleanGapsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateHeadTokenStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateTailTokenStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateTokenAtStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.DeleteSnapshotsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.FetchTrackedEventsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.JdbcEventStorageEngineStatements;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.LastSequenceNumberForStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataForAggregateStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataWithGapsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataWithoutGapsStatementBuilder;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadSnapshotDataStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.*;
 import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
@@ -221,7 +208,7 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      */
     protected PreparedStatement appendEvents(Connection connection, List<? extends EventMessage<?>> events,
                                              Serializer serializer) throws SQLException {
-        return appendEvents.build(connection, schema, dataType, events, serializer);
+        return appendEvents.build(connection, schema, dataType, events, serializer, this::writeTimestamp);
     }
 
     /**
@@ -270,7 +257,7 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
      */
     protected PreparedStatement appendSnapshot(Connection connection, DomainEventMessage<?> snapshot,
                                                Serializer serializer) throws SQLException {
-        return appendSnapshot.build(connection, schema, dataType, snapshot, serializer);
+        return appendSnapshot.build(connection, schema, dataType, snapshot, serializer, this::writeTimestamp);
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendEventsStatementBuilder.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendEventsStatementBuilder.java
@@ -44,6 +44,7 @@ public interface AppendEventsStatementBuilder {
      * @param dataType   The serialized type of the payload and metadata.
      * @param events     The events to be added.
      * @param serializer The serializer for the payload and metadata.
+     * @param timestampWriter Writer responsible for writing timestamp in the correct format for the given database.
      * @return the newly created {@link PreparedStatement}.
      * @throws SQLException when an exception occurs while creating the prepared statement.
      */

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendEventsStatementBuilder.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendEventsStatementBuilder.java
@@ -48,5 +48,5 @@ public interface AppendEventsStatementBuilder {
      * @throws SQLException when an exception occurs while creating the prepared statement.
      */
     PreparedStatement build(Connection connection, EventSchema schema, Class<?> dataType,
-                            List<? extends EventMessage<?>> events, Serializer serializer) throws SQLException;
+                            List<? extends EventMessage<?>> events, Serializer serializer, TimestampWriter timestampWriter) throws SQLException;
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendSnapshotStatementBuilder.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendSnapshotStatementBuilder.java
@@ -43,6 +43,7 @@ public interface AppendSnapshotStatementBuilder {
      * @param dataType   The serialized type of the payload and metadata.
      * @param snapshot   The snapshot to be appended.
      * @param serializer The serializer for the payload and metadata.
+     * @param timestampWriter Writer responsible for writing timestamp in the correct format for the given database.
      * @return The newly created {@link PreparedStatement}.
      * @throws SQLException when an exception occurs while creating the prepared statement.
      */

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendSnapshotStatementBuilder.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/AppendSnapshotStatementBuilder.java
@@ -47,5 +47,5 @@ public interface AppendSnapshotStatementBuilder {
      * @throws SQLException when an exception occurs while creating the prepared statement.
      */
     PreparedStatement build(Connection connection, EventSchema schema, Class<?> dataType,
-                            DomainEventMessage<?> snapshot, Serializer serializer) throws SQLException;
+                            DomainEventMessage<?> snapshot, Serializer serializer, TimestampWriter timestampWriter) throws SQLException;
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/TimestampWriter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/TimestampWriter.java
@@ -1,0 +1,10 @@
+package org.axonframework.eventsourcing.eventstore.jdbc.statements;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Instant;
+
+@FunctionalInterface
+public interface TimestampWriter {
+    void writeTimestamp(PreparedStatement preparedStatement, int position, Instant timestamp) throws SQLException;
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/TimestampWriter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/TimestampWriter.java
@@ -4,6 +4,17 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Instant;
 
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
+
+/**
+ * Writer interface for writing a formatted timestamp to a {@link PreparedStatement} during updates of the database.
+ * Used in {@link AppendEventsStatementBuilder} and {@link AppendSnapshotStatementBuilder}.
+ * Contract which defines how to build a PreparedStatement for use on {@link JdbcEventStorageEngine#cleanGaps(TrackingToken)}
+ *
+ * @author Trond Marius Øvstetun
+ * @since 4.4
+ */
 @FunctionalInterface
 public interface TimestampWriter {
     void writeTimestamp(PreparedStatement preparedStatement, int position, Instant timestamp) throws SQLException;


### PR DESCRIPTION
Used when writing timestamps to both event- and snapshot-tables.
Fixes #1453 .