### PR TITLE
Allow specific return types on creation policy always

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -34,6 +34,7 @@ import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.axonframework.modelling.command.inspection.CreationPolicyMember;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -400,8 +401,14 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
                 resultReference.set(handler.handle(command, newInstance));
                 return newInstance;
             });
-            Object commandHandlingResult = resultReference.get();
-            return commandHandlingResult != null ? commandHandlingResult : resolveReturnValue(command, aggregate);
+            return handlerHasVoidReturnType() ? resolveReturnValue(command, aggregate) : resultReference.get();
+        }
+
+        public boolean handlerHasVoidReturnType() {
+            return handler.unwrap(Method.class)
+                          .map(Method::getReturnType)
+                          .filter(void.class::equals)
+                          .isPresent();
         }
 
         @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
@@ -82,6 +82,15 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
+    void testAlwaysCreatePolicyWithResultReturnsNullCommandHandlingResult() {
+        fixture.givenNoPriorActivity()
+               .when(new AlwaysCreateWithResultCommand(AGGREGATE_ID, null))
+               .expectEvents(new AlwaysCreatedEvent(AGGREGATE_ID))
+               .expectResultMessagePayload(null)
+               .expectSuccessfulHandlerExecution();
+    }
+
+    @Test
     void testNeverCreatePolicy() {
         fixture.given(new CreatedEvent(AGGREGATE_ID))
                .when(new ExecuteOnExistingCommand(AGGREGATE_ID))


### PR DESCRIPTION
The `AggregateCreationPolicy#ALWAYS` on a command handler will currently ensure that the result of command handling will be the aggregate identifier. Thus similar to a command handling constructor. 

It however makes sense to place the annotation `@CreationPolicy(ALWAYS)` on a method with a specific return type, expecting the user specified returned result to be the command handling result.
This PR ensures that this is the behavior of a command handling function annotated with `@CreationPolicy(ALWAYS)`.

When a return value is given on such a method, it will be the result of command handling.
If none is provided, it will default to the aggregate identifier.