### PR TITLE
[#1338] EventTrackerStatusChangeListener for Tracking Event Processors

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/grpc/FakeEventTrackerStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,8 +24,9 @@ import org.axonframework.eventhandling.TrackingToken;
 import java.util.OptionalLong;
 
 /**
- * Created by Sara Pellegrini on 01/08/2018.
- * sara.pellegrini@gmail.com
+ * Implementation of the {@link EventTrackerStatus} for testing purposes.
+ *
+ * @author Sara Pellegrini
  */
 public class FakeEventTrackerStatus implements EventTrackerStatus {
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -50,11 +50,8 @@ import org.axonframework.serialization.SerializationException;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -19,7 +19,6 @@ package org.axonframework.integrationtests.eventhandling;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.eventhandling.AddedTrackerStatus;
 import org.axonframework.eventhandling.EventHandlerInvoker;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
@@ -30,7 +29,6 @@ import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.MultiEventHandlerInvoker;
 import org.axonframework.eventhandling.PropagatingErrorHandler;
-import org.axonframework.eventhandling.RemovedTrackerStatus;
 import org.axonframework.eventhandling.ReplayToken;
 import org.axonframework.eventhandling.SimpleEventHandlerInvoker;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -86,6 +84,9 @@ import static org.axonframework.integrationtests.utils.EventTestUtils.createEven
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+;
+;
 
 /**
  * Test class validating the {@link TrackingEventProcessor}. This test class is part of the {@code integrationtests}
@@ -1548,9 +1549,9 @@ class TrackingEventProcessorTest {
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
             assertEquals(1, updatedTrackerStatus.size());
             EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
-            if (eventTrackerStatus instanceof AddedTrackerStatus) {
+            if (eventTrackerStatus.addedTracker()) {
                 addedStatusCounter.getAndIncrement();
-            } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+            } else if (eventTrackerStatus.removedTracker()) {
                 removedStatusCounter.getAndIncrement();
             } else {
                 updatedStatusCounter.getAndIncrement();
@@ -1605,9 +1606,9 @@ class TrackingEventProcessorTest {
             public void onEventTrackerStatusChange(Map<Integer, EventTrackerStatus> updatedTrackerStatus) {
                 assertEquals(1, updatedTrackerStatus.size());
                 EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
-                if (eventTrackerStatus instanceof AddedTrackerStatus) {
+                if (eventTrackerStatus.addedTracker()) {
                     addedStatusCounter.getAndIncrement();
-                } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+                } else if (eventTrackerStatus.removedTracker()) {
                     removedStatusCounter.getAndIncrement();
                 } else {
                     updatedStatusCounter.getAndIncrement();
@@ -1644,15 +1645,15 @@ class TrackingEventProcessorTest {
         int firstSegment = 0;
         int secondSegment = 1;
 
-        CountDownLatch addedStatusLatch = new CountDownLatch(3);
-        CountDownLatch updatedStatusLatch = new CountDownLatch(3);
-        CountDownLatch removedStatusLatch = new CountDownLatch(2);
+        CountDownLatch addedStatusLatch = new CountDownLatch(4);
+        CountDownLatch updatedStatusLatch = new CountDownLatch(1);
+        CountDownLatch removedStatusLatch = new CountDownLatch(3);
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
             assertEquals(1, updatedTrackerStatus.size());
-            EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
-            if (eventTrackerStatus instanceof AddedTrackerStatus) {
+            EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.values().iterator().next();
+            if (eventTrackerStatus.addedTracker()) {
                 addedStatusLatch.countDown();
-            } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+            } else if (eventTrackerStatus.removedTracker()) {
                 removedStatusLatch.countDown();
             } else {
                 updatedStatusLatch.countDown();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -19,15 +19,18 @@ package org.axonframework.integrationtests.eventhandling;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.AddedTrackerStatus;
 import org.axonframework.eventhandling.EventHandlerInvoker;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.EventTrackerStatus;
+import org.axonframework.eventhandling.EventTrackerStatusChangeListener;
 import org.axonframework.eventhandling.GapAwareTrackingToken;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.MultiEventHandlerInvoker;
 import org.axonframework.eventhandling.PropagatingErrorHandler;
+import org.axonframework.eventhandling.RemovedTrackerStatus;
 import org.axonframework.eventhandling.ReplayToken;
 import org.axonframework.eventhandling.SimpleEventHandlerInvoker;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -47,8 +50,11 @@ import org.axonframework.serialization.SerializationException;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.annotation.DirtiesContext;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -85,7 +91,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Test class validating the {@link TrackingEventProcessor}.
+ * Test class validating the {@link TrackingEventProcessor}. This test class is part of the {@code integrationtests}
+ * module as it relies on both the {@code messaging} (where the {@code TrackingEventProcessor} resides) and {@code
+ * eventsourcing} modules.
  *
  * @author Rene de Waele
  */
@@ -1512,6 +1520,172 @@ class TrackingEventProcessorTest {
         verify(tokenStore, times(1)).retrieveStorageIdentifier();
 
         assertEquals(id, id2);
+    }
+
+    /**
+     * This test can spot three invocations of the {@link EventTrackerStatusChangeListener}, but asserts two:
+     * <ol>
+     *     <li> First call is when the single active {@link org.axonframework.eventhandling.Segment} is added.</li>
+     *     <li> Second call is when the status transitions to {@link EventTrackerStatus#isCaughtUp()}.</li>
+     *     <li>
+     *         The last not asserted call is when the {@link TrackingEventProcessor} is shutting down, which removes the
+     *         status. This isn't taking into account as it is part of the {@link #tearDown()}.
+     *     </li>
+     * </ol>
+     * <p>
+     * More changes occur on the {@link EventTrackerStatus}, but by default only complete additions, removals and {@code
+     * boolean} field updates are included as changes.
+     */
+    @Test
+    void testPublishedEventsUpdateStatusAndHitChangeListener() throws Exception {
+        CountDownLatch eventHandlingLatch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            eventHandlingLatch.countDown();
+            return null;
+        }).when(mockHandler).handle(any());
+
+        CountDownLatch statusChangeLatch = new CountDownLatch(2);
+        AtomicInteger addedStatusCounter = new AtomicInteger(0);
+        AtomicInteger updatedStatusCounter = new AtomicInteger(0);
+        AtomicInteger removedStatusCounter = new AtomicInteger(0);
+        EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
+            assertEquals(1, updatedTrackerStatus.size());
+            EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
+            if (eventTrackerStatus instanceof AddedTrackerStatus) {
+                addedStatusCounter.getAndIncrement();
+            } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+                removedStatusCounter.getAndIncrement();
+            } else {
+                updatedStatusCounter.getAndIncrement();
+            }
+            statusChangeLatch.countDown();
+        };
+
+        TrackingEventProcessorConfiguration tepConfiguration =
+                TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
+                                                   .andEventTrackerStatusChangeListener(statusChangeListener);
+        initProcessor(tepConfiguration);
+
+        testSubject.start();
+        // Give it a bit of time to start
+        Thread.sleep(200);
+        publishEvents(2);
+
+        assertTrue(eventHandlingLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(statusChangeLatch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, addedStatusCounter.get());
+        assertEquals(1, updatedStatusCounter.get());
+        assertEquals(0, removedStatusCounter.get());
+    }
+
+    /**
+     * This test can spot five invocations of the {@link EventTrackerStatusChangeListener}, but asserts four:
+     * <ol>
+     *     <li> First call is when the single active {@link org.axonframework.eventhandling.Segment} is added.</li>
+     *     <li> Second call is when the status transitions to {@link EventTrackerStatus#isCaughtUp()}.</li>
+     *     <li> Third call is when the {@link EventTrackerStatus#getCurrentPosition()} moves to 0.</li>
+     *     <li> Fourth call is when the {@link EventTrackerStatus#getCurrentPosition()} moves to 1.</li>
+     *     <li>
+     *         The last not asserted call is when the {@link TrackingEventProcessor} is shutting down, which removes the
+     *         status. This isn't taking into account as it is part of the {@link #tearDown()}.
+     *     </li>
+     * </ol>
+     */
+    @Test
+    void testPublishedEventsUpdateStatusAndHitChangeListenerIncludingPositions() throws Exception {
+        CountDownLatch eventHandlingLatch = new CountDownLatch(2);
+        doAnswer(invocation -> {
+            eventHandlingLatch.countDown();
+            return null;
+        }).when(mockHandler).handle(any());
+
+        CountDownLatch statusChangeLatch = new CountDownLatch(4);
+        AtomicInteger addedStatusCounter = new AtomicInteger(0);
+        AtomicInteger updatedStatusCounter = new AtomicInteger(0);
+        AtomicInteger removedStatusCounter = new AtomicInteger(0);
+        EventTrackerStatusChangeListener statusChangeListener = new EventTrackerStatusChangeListener() {
+            @Override
+            public void onEventTrackerStatusChange(Map<Integer, EventTrackerStatus> updatedTrackerStatus) {
+                assertEquals(1, updatedTrackerStatus.size());
+                EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
+                if (eventTrackerStatus instanceof AddedTrackerStatus) {
+                    addedStatusCounter.getAndIncrement();
+                } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+                    removedStatusCounter.getAndIncrement();
+                } else {
+                    updatedStatusCounter.getAndIncrement();
+                }
+                statusChangeLatch.countDown();
+            }
+
+            @Override
+            public boolean validatePositions() {
+                return true;
+            }
+        };
+
+        TrackingEventProcessorConfiguration tepConfiguration =
+                TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
+                                                   .andEventTrackerStatusChangeListener(statusChangeListener);
+        initProcessor(tepConfiguration);
+
+        testSubject.start();
+        // Give it a bit of time to start
+        Thread.sleep(200);
+        publishEvents(2);
+
+        assertTrue(eventHandlingLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(statusChangeLatch.await(5, TimeUnit.SECONDS));
+        assertEquals(1, addedStatusCounter.get());
+        assertEquals(3, updatedStatusCounter.get());
+        assertEquals(0, removedStatusCounter.get());
+    }
+
+    @Test
+    @Timeout(value = 10)
+    void testSplitAndMergeInfluenceOnChangeListenerInvocations() throws InterruptedException {
+        int firstSegment = 0;
+        int secondSegment = 1;
+
+        CountDownLatch addedStatusLatch = new CountDownLatch(3);
+        CountDownLatch updatedStatusLatch = new CountDownLatch(3);
+        CountDownLatch removedStatusLatch = new CountDownLatch(2);
+        EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
+            assertEquals(1, updatedTrackerStatus.size());
+            EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
+            if (eventTrackerStatus instanceof AddedTrackerStatus) {
+                addedStatusLatch.countDown();
+            } else if (eventTrackerStatus instanceof RemovedTrackerStatus) {
+                removedStatusLatch.countDown();
+            } else {
+                updatedStatusLatch.countDown();
+            }
+        };
+
+        TrackingEventProcessorConfiguration tepConfiguration =
+                TrackingEventProcessorConfiguration.forParallelProcessing(2)
+                                                   .andEventTrackerStatusChangeListener(statusChangeListener);
+        initProcessor(tepConfiguration);
+        tokenStore.initializeTokenSegments(testSubject.getName(), 1);
+
+        publishEvents(2);
+        testSubject.start();
+        waitForSegmentStart(firstSegment);
+
+        assertTrue(testSubject.splitSegment(firstSegment).join(), "Expected split to succeed");
+        assertArrayEquals(new int[]{firstSegment, secondSegment}, tokenStore.fetchSegments(testSubject.getName()));
+        waitForSegmentStart(secondSegment);
+
+        assertWithin(
+                50, TimeUnit.MILLISECONDS,
+                () -> assertTrue(testSubject.mergeSegment(firstSegment).join(), "Expected merge to succeed")
+        );
+        assertArrayEquals(new int[]{firstSegment}, tokenStore.fetchSegments(testSubject.getName()));
+        waitForSegmentStart(firstSegment);
+
+        assertTrue(addedStatusLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(updatedStatusLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(removedStatusLatch.await(5, TimeUnit.SECONDS));
     }
 
     private void waitForStatus(String description,

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -85,9 +85,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-;
-;
-
 /**
  * Test class validating the {@link TrackingEventProcessor}. This test class is part of the {@code integrationtests}
  * module as it relies on both the {@code messaging} (where the {@code TrackingEventProcessor} resides) and {@code
@@ -1549,9 +1546,9 @@ class TrackingEventProcessorTest {
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
             assertEquals(1, updatedTrackerStatus.size());
             EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
-            if (eventTrackerStatus.addedTracker()) {
+            if (eventTrackerStatus.trackerAdded()) {
                 addedStatusCounter.getAndIncrement();
-            } else if (eventTrackerStatus.removedTracker()) {
+            } else if (eventTrackerStatus.trackerRemoved()) {
                 removedStatusCounter.getAndIncrement();
             } else {
                 updatedStatusCounter.getAndIncrement();
@@ -1606,9 +1603,9 @@ class TrackingEventProcessorTest {
             public void onEventTrackerStatusChange(Map<Integer, EventTrackerStatus> updatedTrackerStatus) {
                 assertEquals(1, updatedTrackerStatus.size());
                 EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.get(0);
-                if (eventTrackerStatus.addedTracker()) {
+                if (eventTrackerStatus.trackerAdded()) {
                     addedStatusCounter.getAndIncrement();
-                } else if (eventTrackerStatus.removedTracker()) {
+                } else if (eventTrackerStatus.trackerRemoved()) {
                     removedStatusCounter.getAndIncrement();
                 } else {
                     updatedStatusCounter.getAndIncrement();
@@ -1651,9 +1648,9 @@ class TrackingEventProcessorTest {
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
             assertEquals(1, updatedTrackerStatus.size());
             EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.values().iterator().next();
-            if (eventTrackerStatus.addedTracker()) {
+            if (eventTrackerStatus.trackerAdded()) {
                 addedStatusLatch.countDown();
-            } else if (eventTrackerStatus.removedTracker()) {
+            } else if (eventTrackerStatus.trackerRemoved()) {
                 removedStatusLatch.countDown();
             } else {
                 updatedStatusLatch.countDown();

--- a/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
@@ -35,6 +35,11 @@ public class AddedTrackerStatus extends WrappedTrackerStatus {
     }
 
     @Override
+    public boolean addedTracker() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "AddedTrackerStatus{" +
                 "segment=" + getSegment() +

--- a/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+/**
+ * References a new {@link EventTrackerStatus} which work just has started on. Can be used as a marker to react on in
+ * the {@link EventTrackerStatusChangeListener}.
+ *
+ * @author Steven van Beelen
+ * @since 4.4
+ */
+public class AddedTrackerStatus extends WrappedTrackerStatus {
+
+    /**
+     * Initializes the {@link AddedTrackerStatus} using the given {@code addedTrackerStatus}.
+     *
+     * @param addedTrackerStatus the added {@link EventTrackerStatus} this implementation references
+     */
+    public AddedTrackerStatus(EventTrackerStatus addedTrackerStatus) {
+        super(addedTrackerStatus);
+    }
+
+    @Override
+    public String toString() {
+        return "AddedTrackerStatus{" +
+                "segment=" + getSegment() +
+                ", caughtUp=" + isCaughtUp() +
+                ", replaying=" + isReplaying() +
+                ", merging=" + isMerging() +
+                ", errorState=" + isErrorState() +
+                ", error=" + getError() +
+                ", trackingToken=" + getTrackingToken() +
+                ", currentPosition=" + getCurrentPosition() +
+                ", resetPosition=" + getResetPosition() +
+                ", mergeCompletedPosition=" + mergeCompletedPosition()
+                + "}";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AddedTrackerStatus.java
@@ -35,7 +35,7 @@ public class AddedTrackerStatus extends WrappedTrackerStatus {
     }
 
     @Override
-    public boolean addedTracker() {
+    public boolean trackerAdded() {
         return true;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -124,7 +124,7 @@ public interface EventTrackerStatus {
      *
      * @return {@code true} if this {@link EventTrackerStatus} just started, {@code false} otherwise
      */
-    default boolean addedTracker() {
+    default boolean trackerAdded() {
         return false;
     }
 
@@ -134,7 +134,7 @@ public interface EventTrackerStatus {
      *
      * @return {@code true} if this {@link EventTrackerStatus} was just removed, {@code false} otherwise
      */
-    default boolean removedTracker() {
+    default boolean trackerRemoved() {
         return false;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -28,6 +28,7 @@ import java.util.OptionalLong;
  * @since 3.2
  */
 public interface EventTrackerStatus {
+
     /**
      * The segment for which this status is valid.
      *
@@ -47,25 +48,27 @@ public interface EventTrackerStatus {
     /**
      * Indicates whether this Segment is still replaying previously processed Events.
      * <p>
-     * Note that this method will only recognize a replay if the tokens have been reset using
-     * {@link TrackingEventProcessor#resetTokens()}. Removing tokens directly from the underlying {@link TokenStore} will not be
-     * recognized as a replay.
+     * Note that this method will only recognize a replay if the tokens have been reset using {@link
+     * TrackingEventProcessor#resetTokens()}. Removing tokens directly from the underlying {@link TokenStore} will not
+     * be recognized as a replay.
      *
-     * @return {@code true} if this segment is replaying historic events after a {@link TrackingEventProcessor#resetTokens() reset}, otherwise {@code false}
+     * @return {@code true} if this segment is replaying historic events after a {@link
+     * TrackingEventProcessor#resetTokens() reset}, otherwise {@code false}
      */
     boolean isReplaying();
 
     /**
-     * Indicates whether this Segment is still merging two (or more) Segments. The merging process will be done once all Segments have reached the same position.
+     * Indicates whether this Segment is still merging two (or more) Segments. The merging process will be done once all
+     * Segments have reached the same position.
      *
      * @return {@code true} if this segment is merging Segments, otherwise {@code false}
      */
     boolean isMerging();
 
     /**
-     * Return the estimated relative token position this Segment will have after a merge operation is complete.
-     * Will return a non-empty result as long as {@link EventTrackerStatus#isMerging()} } returns true.
-     * In case no estimation can be given or no merge in progress, an {@code OptionalLong.empty()} will be returned.
+     * Return the estimated relative token position this Segment will have after a merge operation is complete. Will
+     * return a non-empty result as long as {@link EventTrackerStatus#isMerging()} } returns true. In case no estimation
+     * can be given or no merge in progress, an {@code OptionalLong.empty()} will be returned.
      *
      * @return return the estimated relative position this Segment will reach after a merge operation is complete.
      */
@@ -98,22 +101,32 @@ public interface EventTrackerStatus {
     Throwable getError();
 
     /**
-     * Return the estimated relative current token position this Segment represents.
-     * In case of replay is active, return the estimated relative position reached by merge operation.
-     * In case of merge is active, return the estimated relative position reached by merge operation.
-     * In case no estimation can be given, or no replay or merge in progress, an {@code OptionalLong.empty()} will be returned.
+     * Return the estimated relative current token position this Segment represents. In case of replay is active, return
+     * the estimated relative position reached by merge operation. In case of merge is active, return the estimated
+     * relative position reached by merge operation. In case no estimation can be given, or no replay or merge in
+     * progress, an {@code OptionalLong.empty()} will be returned.
      *
      * @return return the estimated relative current token position this Segment represents
      */
     OptionalLong getCurrentPosition();
 
     /**
-     * Return the relative position at which a reset was triggered for this Segment.
-     * In case a replay finished or no replay is active, an {@code OptionalLong.empty()} will be returned.
+     * Return the relative position at which a reset was triggered for this Segment. In case a replay finished or no
+     * replay is active, an {@code OptionalLong.empty()} will be returned.
      *
      * @return the relative position at which a reset was triggered for this Segment
      */
     OptionalLong getResetPosition();
+
+    /**
+     * Check whether {@code this} {@link EventTrackerStatus} is different from {@code that}.
+     *
+     * @param that the other {@link EventTrackerStatus} to validate the difference with
+     * @return {@code true} if both {@link EventTrackerStatus}'s are different, {@code false} otherwise
+     */
+    default boolean isDifferent(EventTrackerStatus that) {
+        return isDifferent(that, true);
+    }
 
     /**
      * Check whether {@code this} {@link EventTrackerStatus} is different from {@code that}.

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatus.java
@@ -119,6 +119,26 @@ public interface EventTrackerStatus {
     OptionalLong getResetPosition();
 
     /**
+     * Returns a {@code boolean} describing whether this {@link EventTrackerStatus} is starting it's progress for the
+     * first time. Particularly useful if the {@link EventTrackerStatusChangeListener} should react to added status'.
+     *
+     * @return {@code true} if this {@link EventTrackerStatus} just started, {@code false} otherwise
+     */
+    default boolean addedTracker() {
+        return false;
+    }
+
+    /**
+     * Returns a {@code boolean} describing whether this {@link EventTrackerStatus} has just stopped it's progress.
+     * Particularly useful if the {@link EventTrackerStatusChangeListener} should react to removed status'.
+     *
+     * @return {@code true} if this {@link EventTrackerStatus} was just removed, {@code false} otherwise
+     */
+    default boolean removedTracker() {
+        return false;
+    }
+
+    /**
      * Check whether {@code this} {@link EventTrackerStatus} is different from {@code that}.
      *
      * @param that the other {@link EventTrackerStatus} to validate the difference with

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatusChangeListener.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventTrackerStatusChangeListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import java.util.Map;
+
+/**
+ * Represent a listener that is notified whenever the {@link Map} of {@link EventTrackerStatus}' in the {@link
+ * TrackingEventProcessor} this component is registered to has changed.
+ *
+ * @author Steven van Beelen
+ * @since 4.4
+ */
+public interface EventTrackerStatusChangeListener {
+
+    /**
+     * Notification that an {@link EventTrackerStatus} has changed. Implementations should take into account that this
+     * listener may be called concurrently, and that multiple invocations do not necessarily reflect the order in which
+     * changes have occurred. If this order is important to the implementation, it should verify the {@link Segment} and
+     * the status' positions of the given {@code updatedTrackerStatus} through the {@link
+     * EventTrackerStatus#getSegment()} and {@link EventTrackerStatus#getCurrentPosition()} methods respectively.
+     *
+     * @param updatedTrackerStatus the updated {@link EventTrackerStatus} to react on
+     */
+    void onEventTrackerStatusChange(Map<Integer, EventTrackerStatus> updatedTrackerStatus);
+
+    /**
+     * Flag dictating whether an {@link EventTrackerStatus}'s positions (e.g. {@link
+     * EventTrackerStatus#getCurrentPosition()}) should be taken into account as a change to listen for. Defaults to
+     * {@code false}, as positions typically change a lot in a running system.
+     *
+     * @return {@code true} if positions should be validated, {@code false} otherwise.
+     */
+    default boolean validatePositions() {
+        return false;
+    }
+
+    /**
+     * Returns a no-op implementation of the {@link EventTrackerStatusChangeListener}.
+     *
+     * @return a no-op implementation of the {@link EventTrackerStatusChangeListener}
+     */
+    static EventTrackerStatusChangeListener noOp() {
+        return ignored -> {
+        };
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+/**
+ * References an {@link EventTrackerStatus} which no active work is occurring on. Can be used as a marker to react on in
+ * the {@link EventTrackerStatusChangeListener}.
+ *
+ * @author Steven van Beelen
+ * @since 4.4
+ */
+public class RemovedTrackerStatus extends WrappedTrackerStatus {
+
+    /**
+     * Initializes the {@link RemovedTrackerStatus} using the given {@code removedTrackerStatus}.
+     *
+     * @param removedTrackerStatus the removed {@link EventTrackerStatus} this implementation references
+     */
+    public RemovedTrackerStatus(EventTrackerStatus removedTrackerStatus) {
+        super(removedTrackerStatus);
+    }
+
+    @Override
+    public String toString() {
+        return "RemovedTrackerStatus{" +
+                "segment=" + getSegment() +
+                ", caughtUp=" + isCaughtUp() +
+                ", replaying=" + isReplaying() +
+                ", merging=" + isMerging() +
+                ", errorState=" + isErrorState() +
+                ", error=" + getError() +
+                ", trackingToken=" + getTrackingToken() +
+                ", currentPosition=" + getCurrentPosition() +
+                ", resetPosition=" + getResetPosition() +
+                ", mergeCompletedPosition=" + mergeCompletedPosition()
+                + "}";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
@@ -35,6 +35,11 @@ public class RemovedTrackerStatus extends WrappedTrackerStatus {
     }
 
     @Override
+    public boolean removedTracker() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "RemovedTrackerStatus{" +
                 "segment=" + getSegment() +

--- a/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/RemovedTrackerStatus.java
@@ -35,7 +35,7 @@ public class RemovedTrackerStatus extends WrappedTrackerStatus {
     }
 
     @Override
-    public boolean removedTracker() {
+    public boolean trackerRemoved() {
         return true;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -870,7 +870,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
                                                              Map<Integer, EventTrackerStatus> newSegments) {
         Set<Integer> newSegmentIds = new HashSet<>(newSegments.keySet());
         newSegmentIds.removeAll(oldSegments.keySet());
-        if (newSegmentIds.size() != 0) {
+        if (!newSegmentIds.isEmpty()) {
             return newSegmentIds.stream()
                                 .collect(Collectors.toMap(
                                         segmentId -> segmentId,
@@ -880,7 +880,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
 
         Set<Integer> oldSegmentIds = new HashSet<>(oldSegments.keySet());
         oldSegmentIds.removeAll(newSegments.keySet());
-        if (oldSegmentIds.size() != 0) {
+        if (!oldSegmentIds.isEmpty()) {
             return oldSegmentIds.stream()
                                 .collect(Collectors.toMap(
                                         segmentId -> segmentId,

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 
 /**
@@ -49,6 +50,7 @@ public class TrackingEventProcessorConfiguration {
     private Function<String, ThreadFactory> threadFactory;
     private long tokenClaimInterval;
     private int eventAvailabilityTimeout = 1000;
+    private EventTrackerStatusChangeListener eventTrackerStatusChangeListener = EventTrackerStatusChangeListener.noOp();
 
     /**
      * Initialize a configuration with single threaded processing.
@@ -165,6 +167,21 @@ public class TrackingEventProcessorConfiguration {
     }
 
     /**
+     * Sets the {@link EventTrackerStatusChangeListener} which will be called on {@link EventTrackerStatus} changes.
+     * Defaults to {@link EventTrackerStatusChangeListener#noOp()}.
+     *
+     * @param eventTrackerStatusChangeListener the {@link EventTrackerStatusChangeListener} to use
+     * @return {@code this} for method chaining
+     */
+    public TrackingEventProcessorConfiguration andEventTrackerStatusChangeListener(
+            EventTrackerStatusChangeListener eventTrackerStatusChangeListener
+    ) {
+        assertNonNull(eventTrackerStatusChangeListener, "EventTrackerStatusChangeListener may not be null");
+        this.eventTrackerStatusChangeListener = eventTrackerStatusChangeListener;
+        return this;
+    }
+
+    /**
      * @return the maximum number of events to process in a single batch.
      */
     public int getBatchSize() {
@@ -219,5 +236,15 @@ public class TrackingEventProcessorConfiguration {
      */
     public long getTokenClaimInterval() {
         return tokenClaimInterval;
+    }
+
+    /**
+     * Returns the {@link EventTrackerStatusChangeListener} defined in this configuration, to be called whenever an
+     * {@link EventTrackerStatus} change occurs.
+     *
+     * @return the {@link EventTrackerStatusChangeListener} defined in this configuration
+     */
+    public EventTrackerStatusChangeListener getEventTrackerStatusChangeListener() {
+        return eventTrackerStatusChangeListener;
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * Wrapper around an {@link EventTrackerStatus}, delegating all calls to a {@code delegate}. Extend this class to
+ * provide additional functionality to the delegate.
+ *
+ * @author Steven van Beelen
+ * @since 4.4
+ */
+public abstract class WrappedTrackerStatus implements EventTrackerStatus {
+
+    private final EventTrackerStatus delegate;
+
+    /**
+     * Initializes the {@link EventTrackerStatus} using the given {@code delegate}.
+     *
+     * @param delegate the actual {@link EventTrackerStatus} to delegate to
+     */
+    public WrappedTrackerStatus(EventTrackerStatus delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Segment getSegment() {
+        return delegate.getSegment();
+    }
+
+    @Override
+    public boolean isCaughtUp() {
+        return delegate.isCaughtUp();
+    }
+
+    @Override
+    public boolean isReplaying() {
+        return delegate.isReplaying();
+    }
+
+    @Override
+    public boolean isMerging() {
+        return delegate.isMerging();
+    }
+
+    @Override
+    public OptionalLong mergeCompletedPosition() {
+        return delegate.mergeCompletedPosition();
+    }
+
+    @Override
+    public TrackingToken getTrackingToken() {
+        return delegate.getTrackingToken();
+    }
+
+    @Override
+    public boolean isErrorState() {
+        return delegate.isErrorState();
+    }
+
+    @Override
+    public Throwable getError() {
+        return delegate.getError();
+    }
+
+    @Override
+    public OptionalLong getCurrentPosition() {
+        return delegate.getCurrentPosition();
+    }
+
+    @Override
+    public OptionalLong getResetPosition() {
+        return delegate.getResetPosition();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WrappedTrackerStatus that = (WrappedTrackerStatus) o;
+        return Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
@@ -90,13 +90,13 @@ public abstract class WrappedTrackerStatus implements EventTrackerStatus {
     }
 
     @Override
-    public boolean addedTracker() {
-        return delegate.addedTracker();
+    public boolean trackerAdded() {
+        return delegate.trackerAdded();
     }
 
     @Override
-    public boolean removedTracker() {
-        return delegate.removedTracker();
+    public boolean trackerRemoved() {
+        return delegate.trackerRemoved();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/WrappedTrackerStatus.java
@@ -90,6 +90,16 @@ public abstract class WrappedTrackerStatus implements EventTrackerStatus {
     }
 
     @Override
+    public boolean addedTracker() {
+        return delegate.addedTracker();
+    }
+
+    @Override
+    public boolean removedTracker() {
+        return delegate.removedTracker();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
@@ -151,16 +151,16 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testAddedTracker() {
+    void testTrackerAdded() {
         AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
 
-        assertTrue(testSubject.addedTracker());
+        assertTrue(testSubject.trackerAdded());
     }
 
     @Test
-    void testRemovedTracker() {
+    void testTrackerRemoved() {
         AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
 
-        assertFalse(testSubject.removedTracker());
+        assertFalse(testSubject.trackerRemoved());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
@@ -79,7 +79,7 @@ class AddedTrackerStatusTest {
 
     @Test
     void testGetTrackingToken() {
-        TrackingToken expectedTrackingToken =  new GlobalSequenceTrackingToken(0);
+        TrackingToken expectedTrackingToken = new GlobalSequenceTrackingToken(0);
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getTrackingToken()).thenReturn(expectedTrackingToken);
 
@@ -148,5 +148,19 @@ class AddedTrackerStatusTest {
         OptionalLong result = testSubject.mergeCompletedPosition();
         assertTrue(result.isPresent());
         assertEquals(expectedMergeCompletedPosition, result.getAsLong());
+    }
+
+    @Test
+    void testAddedTracker() {
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
+
+        assertTrue(testSubject.addedTracker());
+    }
+
+    @Test
+    void testRemovedTracker() {
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
+
+        assertFalse(testSubject.removedTracker());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.junit.jupiter.api.*;
+
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link AddedTrackerStatus}.
+ *
+ * @author Steven van Beelen
+ */
+class AddedTrackerStatusTest {
+
+    @Test
+    void testGetSegment() {
+        Segment expectedSegment = Segment.ROOT_SEGMENT;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getSegment()).thenReturn(expectedSegment);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedSegment, testSubject.getSegment());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsCaughtUp() {
+        boolean expectedIsCaughtUp = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isCaughtUp()).thenReturn(expectedIsCaughtUp);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedIsCaughtUp, testSubject.isCaughtUp());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsReplaying() {
+        boolean expectedIsReplaying = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isReplaying()).thenReturn(expectedIsReplaying);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedIsReplaying, testSubject.isReplaying());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsMerging() {
+        boolean expectedIsMerging = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isMerging()).thenReturn(expectedIsMerging);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedIsMerging, testSubject.isMerging());
+    }
+
+    @Test
+    void testGetTrackingToken() {
+        TrackingToken expectedTrackingToken =  new GlobalSequenceTrackingToken(0);
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getTrackingToken()).thenReturn(expectedTrackingToken);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedTrackingToken, testSubject.getTrackingToken());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsErrorState() {
+        boolean expectedIsErrorState = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isErrorState()).thenReturn(expectedIsErrorState);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedIsErrorState, testSubject.isErrorState());
+    }
+
+    @Test
+    void testGetError() {
+        Exception expectedException = new IllegalArgumentException("some-exception");
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getError()).thenReturn(expectedException);
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        assertEquals(expectedException, testSubject.getError());
+    }
+
+    @Test
+    void testGetCurrentPosition() {
+        long expectedCurrentPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getCurrentPosition()).thenReturn(OptionalLong.of(expectedCurrentPosition));
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.getCurrentPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedCurrentPosition, result.getAsLong());
+    }
+
+    @Test
+    void testGetResetPosition() {
+        long expectedResetPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getResetPosition()).thenReturn(OptionalLong.of(expectedResetPosition));
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.getResetPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedResetPosition, result.getAsLong());
+    }
+
+    @Test
+    void testMergeCompletedPosition() {
+        long expectedMergeCompletedPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.mergeCompletedPosition()).thenReturn(OptionalLong.of(expectedMergeCompletedPosition));
+
+        AddedTrackerStatus testSubject = new AddedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.mergeCompletedPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedMergeCompletedPosition, result.getAsLong());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusChangeListenerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusChangeListenerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Test class validating the default methods of the {@link EventTrackerStatusChangeListener}.
+ *
+ * @author Steven van Beelen
+ */
+class EventTrackerStatusChangeListenerTest {
+
+    @Test
+    void testValidatePositionReturnsFalse() {
+        assertFalse(EventTrackerStatusChangeListener.noOp().validatePositions());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@code default} methods on the {@link EventTrackerStatus}.
+ *
+ * @author Steven van Beelen
+ */
+class EventTrackerStatusTest {
+
+    private static final boolean DO_NOT_VALIDATE_POSITIONS = false;
+    private static final boolean VALIDATE_POSITIONS = true;
+
+    private FakeEventTrackerStatus thisStatus;
+    private FakeEventTrackerStatus thatStatus;
+
+    @BeforeEach
+    void setUp() {
+        thisStatus = new FakeEventTrackerStatus();
+        thatStatus = new FakeEventTrackerStatus();
+    }
+
+    @Test
+    void testIsDifferentReturnsFalseForIdenticalObjects() {
+        assertFalse(thisStatus.isDifferent(thisStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertFalse(thisStatus.isDifferent(thisStatus, VALIDATE_POSITIONS));
+    }
+
+    @Test
+    void testIsDifferentReturnsTrueForDifferentEventTrackerStatusImplementations() {
+        AddedTrackerStatus otherStatus = new AddedTrackerStatus(thatStatus);
+        assertTrue(thisStatus.isDifferent(otherStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertTrue(thisStatus.isDifferent(otherStatus, VALIDATE_POSITIONS));
+    }
+
+    @Test
+    void testIsDifferentReturnsFalseForSimilarStatusObjects() {
+        assertFalse(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertFalse(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
+    }
+
+    @Test
+    void testIsDifferentReturnsFalseForSimilarStatusObjectsWhenDisregardingPositions() {
+        assertFalse(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertFalse(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
+
+        thisStatus.setMerging(true);
+        thatStatus.setMerging(false);
+        assertTrue(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertTrue(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
+
+        thisStatus.setMerging(false);
+        thisStatus.setCurrentPosition(10L);
+        thatStatus.setCurrentPosition(42L);
+        assertFalse(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
+        assertTrue(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
+    }
+
+    @Test
+    void testMatchStates() {
+        assertTrue(thisStatus.matchStates(thatStatus));
+
+        thisStatus.setSegment(Segment.ROOT_SEGMENT);
+        thisStatus.setTrackingToken(new GlobalSequenceTrackingToken(0L));
+        thisStatus.setCaughtUp(true);
+        thisStatus.setReplaying(true);
+        thisStatus.setMerging(true);
+        thisStatus.setErrorState(true);
+        thisStatus.setError(new IllegalArgumentException("some-exception"));
+        assertFalse(thisStatus.matchStates(thatStatus));
+
+        thatStatus.setSegment(Segment.ROOT_SEGMENT);
+        thatStatus.setTrackingToken(new GlobalSequenceTrackingToken(0L));
+        thatStatus.setCaughtUp(true);
+        thatStatus.setReplaying(true);
+        thatStatus.setMerging(true);
+        thatStatus.setErrorState(true);
+        thatStatus.setError(new IllegalArgumentException("some-exception"));
+        assertTrue(thisStatus.matchStates(thatStatus));
+    }
+
+    @Test
+    void testMatchPositions() {
+        assertTrue(thisStatus.matchPositions(thatStatus));
+
+        thisStatus.setCurrentPosition(10L);
+        thisStatus.setResetPosition(42L);
+        thisStatus.setMergeCompletedPosition(1337L);
+        assertFalse(thisStatus.matchPositions(thatStatus));
+
+        thatStatus.setCurrentPosition(10L);
+        thatStatus.setResetPosition(42L);
+        thatStatus.setMergeCompletedPosition(1337L);
+        assertTrue(thisStatus.matchPositions(thatStatus));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
@@ -19,7 +19,6 @@ package org.axonframework.eventhandling;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@code default} methods on the {@link EventTrackerStatus}.
@@ -112,5 +111,15 @@ class EventTrackerStatusTest {
         thatStatus.setResetPosition(42L);
         thatStatus.setMergeCompletedPosition(1337L);
         assertTrue(thisStatus.matchPositions(thatStatus));
+    }
+
+    @Test
+    void testAddedTracker() {
+        assertFalse(thisStatus.addedTracker());
+    }
+
+    @Test
+    void testRemovedTracker() {
+        assertFalse(thisStatus.removedTracker());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
@@ -43,14 +43,14 @@ class EventTrackerStatusTest {
     @Test
     void testIsDifferentReturnsFalseForIdenticalObjects() {
         assertFalse(thisStatus.isDifferent(thisStatus, DO_NOT_VALIDATE_POSITIONS));
-        assertFalse(thisStatus.isDifferent(thisStatus, VALIDATE_POSITIONS));
+        assertFalse(thisStatus.isDifferent(thisStatus));
     }
 
     @Test
     void testIsDifferentReturnsTrueForDifferentEventTrackerStatusImplementations() {
         AddedTrackerStatus otherStatus = new AddedTrackerStatus(thatStatus);
         assertTrue(thisStatus.isDifferent(otherStatus, DO_NOT_VALIDATE_POSITIONS));
-        assertTrue(thisStatus.isDifferent(otherStatus, VALIDATE_POSITIONS));
+        assertTrue(thisStatus.isDifferent(otherStatus));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
@@ -114,12 +114,12 @@ class EventTrackerStatusTest {
     }
 
     @Test
-    void testAddedTracker() {
-        assertFalse(thisStatus.addedTracker());
+    void testTrackerAdded() {
+        assertFalse(thisStatus.trackerAdded());
     }
 
     @Test
-    void testRemovedTracker() {
-        assertFalse(thisStatus.removedTracker());
+    void testTrackerRemoved() {
+        assertFalse(thisStatus.trackerRemoved());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/FakeEventTrackerStatus.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/FakeEventTrackerStatus.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * Implementation of the {@link EventTrackerStatus} for testing purposes.
+ *
+ * @author Sara Pellegrini
+ * @author Steven van Beelen
+ */
+public class FakeEventTrackerStatus implements EventTrackerStatus {
+
+    private Segment segment;
+    private TrackingToken trackingToken;
+    private boolean caughtUp;
+    private boolean replaying;
+    private boolean merging;
+    private boolean isError;
+    private Throwable error;
+    private Long currentPosition;
+    private Long resetPosition;
+    private Long mergeCompletedPosition;
+
+    @Override
+    public Segment getSegment() {
+        return segment;
+    }
+
+    public void setSegment(Segment segment) {
+        this.segment = segment;
+    }
+
+    @Override
+    public TrackingToken getTrackingToken() {
+        return trackingToken;
+    }
+
+    public void setTrackingToken(TrackingToken trackingToken) {
+        this.trackingToken = trackingToken;
+    }
+
+    @Override
+    public boolean isCaughtUp() {
+        return caughtUp;
+    }
+
+    public void setCaughtUp(boolean caughtUp) {
+        this.caughtUp = caughtUp;
+    }
+
+    @Override
+    public boolean isReplaying() {
+        return replaying;
+    }
+
+    public void setReplaying(boolean replaying) {
+        this.replaying = replaying;
+    }
+
+    @Override
+    public boolean isMerging() {
+        return merging;
+    }
+
+    public void setMerging(boolean merging) {
+        this.merging = merging;
+    }
+
+    @Override
+    public boolean isErrorState() {
+        return isError;
+    }
+
+    public void setErrorState(boolean error) {
+        isError = error;
+    }
+
+    @Override
+    public Throwable getError() {
+        return error;
+    }
+
+    public void setError(Throwable error) {
+        this.error = error;
+    }
+
+    @Override
+    public OptionalLong getCurrentPosition() {
+        return Objects.nonNull(currentPosition) ? OptionalLong.of(currentPosition) : OptionalLong.empty();
+    }
+
+    public void setCurrentPosition(Long currentPosition) {
+        this.currentPosition = currentPosition;
+    }
+
+    @Override
+    public OptionalLong getResetPosition() {
+        return Objects.nonNull(resetPosition) ? OptionalLong.of(resetPosition) : OptionalLong.empty();
+    }
+
+    public void setResetPosition(Long resetPosition) {
+        this.resetPosition = resetPosition;
+    }
+
+    @Override
+    public OptionalLong mergeCompletedPosition() {
+        return Objects.nonNull(mergeCompletedPosition) ? OptionalLong.of(mergeCompletedPosition) : OptionalLong.empty();
+    }
+
+    public void setMergeCompletedPosition(Long mergeCompletedPosition) {
+        this.mergeCompletedPosition = mergeCompletedPosition;
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
@@ -151,16 +151,16 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testAddedTracker() {
+    void testTrackerAdded() {
         RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
 
-        assertFalse(testSubject.addedTracker());
+        assertFalse(testSubject.trackerAdded());
     }
 
     @Test
-    void testRemovedTracker() {
+    void testTrackerRemoved() {
         RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
 
-        assertTrue(testSubject.removedTracker());
+        assertTrue(testSubject.trackerRemoved());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
@@ -149,4 +149,18 @@ class RemovedTrackerStatusTest {
         assertTrue(result.isPresent());
         assertEquals(expectedMergeCompletedPosition, result.getAsLong());
     }
+
+    @Test
+    void testAddedTracker() {
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
+
+        assertFalse(testSubject.addedTracker());
+    }
+
+    @Test
+    void testRemovedTracker() {
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
+
+        assertTrue(testSubject.removedTracker());
+    }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.junit.jupiter.api.*;
+
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link RemovedTrackerStatus}.
+ *
+ * @author Steven van Beelen
+ */
+class RemovedTrackerStatusTest {
+
+    @Test
+    void testGetSegment() {
+        Segment expectedSegment = Segment.ROOT_SEGMENT;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getSegment()).thenReturn(expectedSegment);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedSegment, testSubject.getSegment());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsCaughtUp() {
+        boolean expectedIsCaughtUp = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isCaughtUp()).thenReturn(expectedIsCaughtUp);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedIsCaughtUp, testSubject.isCaughtUp());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsReplaying() {
+        boolean expectedIsReplaying = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isReplaying()).thenReturn(expectedIsReplaying);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedIsReplaying, testSubject.isReplaying());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsMerging() {
+        boolean expectedIsMerging = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isMerging()).thenReturn(expectedIsMerging);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedIsMerging, testSubject.isMerging());
+    }
+
+    @Test
+    void testGetTrackingToken() {
+        TrackingToken expectedTrackingToken = new GlobalSequenceTrackingToken(0);
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getTrackingToken()).thenReturn(expectedTrackingToken);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedTrackingToken, testSubject.getTrackingToken());
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testIsErrorState() {
+        boolean expectedIsErrorState = true;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.isErrorState()).thenReturn(expectedIsErrorState);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedIsErrorState, testSubject.isErrorState());
+    }
+
+    @Test
+    void testGetError() {
+        Exception expectedException = new IllegalArgumentException("some-exception");
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getError()).thenReturn(expectedException);
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        assertEquals(expectedException, testSubject.getError());
+    }
+
+    @Test
+    void testGetCurrentPosition() {
+        long expectedCurrentPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getCurrentPosition()).thenReturn(OptionalLong.of(expectedCurrentPosition));
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.getCurrentPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedCurrentPosition, result.getAsLong());
+    }
+
+    @Test
+    void testGetResetPosition() {
+        long expectedResetPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.getResetPosition()).thenReturn(OptionalLong.of(expectedResetPosition));
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.getResetPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedResetPosition, result.getAsLong());
+    }
+
+    @Test
+    void testMergeCompletedPosition() {
+        long expectedMergeCompletedPosition = 0L;
+        EventTrackerStatus delegate = mock(EventTrackerStatus.class);
+        when(delegate.mergeCompletedPosition()).thenReturn(OptionalLong.of(expectedMergeCompletedPosition));
+
+        RemovedTrackerStatus testSubject = new RemovedTrackerStatus(delegate);
+
+        OptionalLong result = testSubject.mergeCompletedPosition();
+        assertTrue(result.isPresent());
+        assertEquals(expectedMergeCompletedPosition, result.getAsLong());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/TrackingEventProcessorConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/TrackingEventProcessorConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.junit.jupiter.api.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link TrackingEventProcessorConfiguration}
+ *
+ * @author Steven van Beelen
+ */
+class TrackingEventProcessorConfigurationTest {
+
+    @Test
+    void testConfiguredEventTrackerStatusChangeListener() {
+        Map<Integer, EventTrackerStatus> expectedTrackerStatus = Collections.emptyMap();
+        EventTrackerStatusChangeListener expectedChangeListener =
+                updatedTrackerStatus -> assertEquals(expectedTrackerStatus, updatedTrackerStatus);
+        TrackingEventProcessorConfiguration testSubject =
+                TrackingEventProcessorConfiguration.forSingleThreadedProcessing();
+
+        testSubject.andEventTrackerStatusChangeListener(expectedChangeListener);
+
+        EventTrackerStatusChangeListener resultChangeListener = testSubject.getEventTrackerStatusChangeListener();
+        assertEquals(expectedChangeListener, resultChangeListener);
+        resultChangeListener.onEventTrackerStatusChange(expectedTrackerStatus);
+    }
+}


### PR DESCRIPTION
This pull request introduces the `EventTrackerStatusChangeListener`, which is a configurable option for the `TrackingEventProcessor`.
The `EventTrackerStatusChangeListener` will react to updates of the `EventTrackerStatus` objects (used by a `TrackingEventProcessor` to portray it's status to the outside world).

Users of the `EventTrackerStatusChangeListener` functional interface can choose to react only to ` boolean` status changes like when `isReplaying`/`isMerging` turns true/false, or if they want to include the positions of the status fields as well. The latter is turned off by default, as positions will likely shift _very often_. Lastly, special cases like the removal or addition of a status object are reflected by a `RemovedTrackerStatus` and `AddedTrackerStatus` object, allowing users to react to those special scenarios.

This pull request resolves #1338.