### PR TITLE
[#1442] Use UPDATE query on storing a token

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 
 package org.axonframework.common;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Miscellaneous object utility methods
+ * Miscellaneous object utility methods.
+ *
+ * @author Allard Buijze
+ * @since 3.0
  */
 public abstract class ObjectUtils {
 
@@ -30,9 +34,9 @@ public abstract class ObjectUtils {
     /**
      * Returns the given instance, if not {@code null}, or otherwise the value provided by {@code defaultProvider}.
      *
-     * @param instance        The value to return, if not {@code null}
-     * @param defaultProvider To provide the value, when {@code instance} is {@code null}
-     * @param <T>             The type of value to return
+     * @param instance        the value to return, if not {@code null}
+     * @param defaultProvider to provide the value, when {@code instance} is {@code null}
+     * @param <T>             the type of value to return
      * @return {@code instance} if not {@code null}, otherwise the value provided by {@code defaultProvider}
      */
     public static <T> T getOrDefault(T instance, Supplier<T> defaultProvider) {
@@ -45,9 +49,9 @@ public abstract class ObjectUtils {
     /**
      * Returns the given instance, if not {@code null}, or otherwise the given {@code defaultValue}.
      *
-     * @param instance        The value to return, if not {@code null}
-     * @param defaultValue The value, when {@code instance} is {@code null}
-     * @param <T>             The type of value to return
+     * @param instance     the value to return, if not {@code null}
+     * @param defaultValue the value, when {@code instance} is {@code null}
+     * @param <T>          the type of value to return
      * @return {@code instance} if not {@code null}, otherwise {@code defaultValue}
      */
     public static <T> T getOrDefault(T instance, T defaultValue) {
@@ -56,12 +60,13 @@ public abstract class ObjectUtils {
         }
         return instance;
     }
+
     /**
      * Returns the given instance, if not {@code null} or of zero length, or otherwise the given {@code defaultValue}.
      *
-     * @param instance        The value to return, if not {@code null}
-     * @param defaultValue The value, when {@code instance} is {@code null}
-     * @param <T>             The type of value to return
+     * @param instance     the value to return, if not {@code null}
+     * @param defaultValue the value, when {@code instance} is {@code null}
+     * @param <T>          the type of value to return
      * @return {@code instance} if not {@code null}, otherwise {@code defaultValue}
      */
     public static <T extends CharSequence> T getNonEmptyOrDefault(T instance, T defaultValue) {
@@ -71,6 +76,31 @@ public abstract class ObjectUtils {
         return instance;
     }
 
+    /**
+     * Returns the result of the given {@code valueProvider} by ingesting the given {@code instance}, <em>if</em> the
+     * {@code instance} is not {@code null}. If it is, the {@code defaultValue} is returned.
+     *
+     * @param instance      the value to verify if it is not {@code null}. If it isn't, the given {@code valueProvider}
+     *                      will be invoked with this object
+     * @param valueProvider the function to return the result of by ingesting the {@code instance} if it is not null
+     * @param defaultValue  the value to return if the given {@code instance} is {@code null}
+     * @param <I>           the type of the {@code instance} to verify and use by the {@code valueProvider}
+     * @param <T>           the type of value to return
+     * @return the output of {@code valueProvider} by ingesting {@code instance} if it is not {@code null}, otherwise
+     * the {@code defaultValue}
+     */
+    public static <I, T> T getOrDefault(I instance, Function<I, T> valueProvider, T defaultValue) {
+        return instance != null ? valueProvider.apply(instance) : defaultValue;
+    }
+
+    /**
+     * Returns the type of the given {@code instance}, <em>if</em> it is not {@code null}. If it is {@code null}, {@link
+     * Void#getClass()} will be returned.
+     *
+     * @param instance the object to return the type for
+     * @param <T>      the generic type of the {@link Class} to return
+     * @return the type of the given {@code instance} if it is not {@code null}, otherwise {@link Void#getClass()}
+     */
     @SuppressWarnings("unchecked")
     public static <T> Class<T> nullSafeTypeOf(T instance) {
         if (instance == null) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/AbstractTokenEntry.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/AbstractTokenEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,20 @@ package org.axonframework.eventhandling.tokenstore;
 
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.eventhandling.TrackingToken;
-import org.axonframework.serialization.*;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.SimpleSerializedType;
 
-import javax.persistence.Basic;
-import javax.persistence.Column;
-import javax.persistence.Lob;
-import javax.persistence.MappedSuperclass;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.TemporalAmount;
 import java.util.Objects;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Lob;
+import javax.persistence.MappedSuperclass;
 
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 
@@ -118,14 +122,13 @@ public abstract class AbstractTokenEntry<T> {
     }
 
     /**
-     * Returns the {@link SerializedType} of the serialized token.
+     * Returns the {@link SerializedType} of the serialized token, or {@code null} if no token is stored by this entry.
      *
-     * @return the serialized type of the token
+     * @return the serialized type of the token, or {@code null} if no token is stored by this entry
      */
-    protected SerializedType getTokenType() {
-        return new SimpleSerializedType(tokenType, null);
+    public SerializedType getTokenType() {
+        return tokenType != null ? new SimpleSerializedType(tokenType, null) : null;
     }
-
 
     /**
      * Returns the storage timestamp of this token entry.

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -214,18 +214,16 @@ public class JdbcTokenStore implements TokenStore {
     public void storeToken(TrackingToken token, String processorName, int segment) throws UnableToClaimTokenException {
         Connection connection = getConnection();
         try {
-            int[] updatedTokens = executeUpdates(
+            int updatedToken = executeUpdate(
                     connection,
-                    e -> {
-                        throw new JdbcException(format(
-                                "Could not store token [%s] for processor [%s] and segment [%d]",
-                                token, processorName, segment
-                        ), e);
-                    },
-                    c -> storeUpdate(connection, token, processorName, segment)
+                    c -> storeUpdate(connection, token, processorName, segment),
+                    e -> new JdbcException(format(
+                            "Could not store token [%s] for processor [%s] and segment [%d]",
+                            token, processorName, segment
+                    ), e)
             );
 
-            if (updatedTokens[0] == 0) {
+            if (updatedToken == 0) {
                 logger.debug("Could not update token [{}] for processor [{}] and segment [{}]. "
                                      + "Trying load-then-save approach instead.",
                              token, processorName, segment);

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -226,7 +226,9 @@ public class JdbcTokenStore implements TokenStore {
             );
 
             if (updatedTokens[0] == 0) {
-                // Update couldn't succeed, trying to first load the token and than update it instead.
+                logger.debug("Could not update token [{}] for processor [{}] and segment [{}]. "
+                                     + "Trying load-then-save approach instead.",
+                             token, processorName, segment);
                 executeQuery(
                         connection,
                         c -> selectForUpdate(c, processorName, segment),

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -27,6 +27,8 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException;
 import org.axonframework.eventhandling.tokenstore.UnableToInitializeTokenException;
 import org.axonframework.eventhandling.tokenstore.UnableToRetrieveIdentifierException;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,10 +50,8 @@ import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
-import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
-import static org.axonframework.common.jdbc.JdbcUtils.executeQuery;
-import static org.axonframework.common.jdbc.JdbcUtils.executeUpdates;
-import static org.axonframework.common.jdbc.JdbcUtils.listResults;
+import static org.axonframework.common.ObjectUtils.getOrDefault;
+import static org.axonframework.common.jdbc.JdbcUtils.*;
 
 /**
  * Implementation of a token store that uses JDBC to save and load tokens. Before using this store make sure the
@@ -214,14 +214,32 @@ public class JdbcTokenStore implements TokenStore {
     public void storeToken(TrackingToken token, String processorName, int segment) throws UnableToClaimTokenException {
         Connection connection = getConnection();
         try {
-            executeQuery(connection,
-                         c -> selectForUpdate(c, processorName, segment),
-                         resultSet -> {
-                             updateToken(connection, resultSet, token, processorName, segment);
-                             return null;
-                         },
-                         e -> new JdbcException(format("Could not store token [%s] for processor [%s] and segment [%d]",
-                                                       token, processorName, segment), e));
+            int[] updatedTokens = executeUpdates(
+                    connection,
+                    e -> {
+                        throw new JdbcException(format(
+                                "Could not store token [%s] for processor [%s] and segment [%d]",
+                                token, processorName, segment
+                        ), e);
+                    },
+                    c -> storeUpdate(connection, token, processorName, segment)
+            );
+
+            if (updatedTokens[0] == 0) {
+                // Update couldn't succeed, trying to first load the token and than update it instead.
+                executeQuery(
+                        connection,
+                        c -> selectForUpdate(c, processorName, segment),
+                        resultSet -> {
+                            updateToken(connection, resultSet, token, processorName, segment);
+                            return null;
+                        },
+                        e -> new JdbcException(format(
+                                "Could not store token [%s] for processor [%s] and segment [%d]",
+                                token, processorName, segment
+                        ), e)
+                );
+            }
         } finally {
             closeQuietly(connection);
         }
@@ -312,6 +330,45 @@ public class JdbcTokenStore implements TokenStore {
         PreparedStatement preparedStatement =
                 connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
         preparedStatement.setString(1, processorName);
+        return preparedStatement;
+    }
+
+    /**
+     * Returns a {@link PreparedStatement} which updates the given {@code token} for the given {@code processorName} and
+     * {@code segment} combination.
+     *
+     * @param connection    the connection to the underlying database
+     * @param token         the new token to store
+     * @param processorName the name of the processor executing the update
+     * @param segment       the segment of the processor to executing the update
+     * @return a {@link PreparedStatement} that will update a token entry when executed
+     * @throws SQLException when an exception occurs while creating the prepared statement
+     */
+    protected PreparedStatement storeUpdate(Connection connection,
+                                            TrackingToken token,
+                                            String processorName,
+                                            int segment) throws SQLException {
+        AbstractTokenEntry<?> tokenToStore =
+                new GenericTokenEntry<>(token, serializer, contentType, processorName, segment);
+        Object tokenDataToStore = getOrDefault(tokenToStore.getSerializedToken(), SerializedObject::getData, null);
+        String tokenTypeToStore = getOrDefault(tokenToStore.getTokenType(), SerializedType::getName, null);
+
+        final String sql = "UPDATE " + schema.tokenTable() + " SET "
+                + schema.tokenColumn() + " = ?, "
+                + schema.tokenTypeColumn() + " = ?, "
+                + schema.timestampColumn() + " = ? "
+                + "WHERE " + schema.ownerColumn() + " = ? "
+                + "AND " + schema.processorNameColumn() + " = ? "
+                + "AND " + schema.segmentColumn() + " = ? ";
+        PreparedStatement preparedStatement = connection.prepareStatement(
+                sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY
+        );
+        preparedStatement.setObject(1, tokenDataToStore);
+        preparedStatement.setString(2, tokenTypeToStore);
+        preparedStatement.setString(3, tokenToStore.timestampAsString());
+        preparedStatement.setString(4, nodeId);
+        preparedStatement.setString(5, processorName);
+        preparedStatement.setInt(6, segment);
         return preparedStatement;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -139,7 +139,9 @@ public class JpaTokenStore implements TokenStore {
                                          .executeUpdate();
 
         if (updatedTokens == 0) {
-            // Update couldn't succeed, trying to first load the token and than update it instead.
+            logger.debug("Could not update token [{}] for processor [{}] and segment [{}]. "
+                                 + "Trying load-then-save approach instead.",
+                         token, processorName, segment);
             TokenEntry tokenEntry = loadToken(processorName, segment, entityManager);
             tokenEntry.updateToken(token, serializer);
         }

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.eventhandling.tokenstore.jpa;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.TrackingToken;
@@ -26,26 +24,28 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException;
 import org.axonframework.eventhandling.tokenstore.UnableToInitializeTokenException;
 import org.axonframework.eventhandling.tokenstore.UnableToRetrieveIdentifierException;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
+import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
  * Implementation of a token store that uses JPA to save and load tokens. This implementation uses {@link TokenEntry}
@@ -118,8 +118,31 @@ public class JpaTokenStore implements TokenStore {
     @Override
     public void storeToken(TrackingToken token, String processorName, int segment) {
         EntityManager entityManager = entityManagerProvider.getEntityManager();
-        TokenEntry tokenEntry = loadToken(processorName, segment, entityManager);
-        tokenEntry.updateToken(token, serializer);
+        TokenEntry tokenToStore = new TokenEntry(processorName, segment, token, serializer);
+        byte[] tokenDataToStore =
+                getOrDefault(tokenToStore.getSerializedToken(), SerializedObject::getData, new byte[0]);
+        String tokenTypeToStore = getOrDefault(tokenToStore.getTokenType(), SerializedType::getName, null);
+
+        int updatedTokens = entityManager.createQuery("UPDATE TokenEntry te SET "
+                                                              + "te.token = :token, "
+                                                              + "te.tokenType = :tokenType, "
+                                                              + "te.timestamp = :timestamp "
+                                                              + "WHERE te.owner = :owner "
+                                                              + "AND te.processorName = :processorName "
+                                                              + "AND te.segment = :segment")
+                                         .setParameter("token", tokenDataToStore)
+                                         .setParameter("tokenType", tokenTypeToStore)
+                                         .setParameter("timestamp", tokenToStore.timestampAsString())
+                                         .setParameter("owner", nodeId)
+                                         .setParameter("processorName", processorName)
+                                         .setParameter("segment", segment)
+                                         .executeUpdate();
+
+        if (updatedTokens == 0) {
+            // Update couldn't succeed, trying to first load the token and than update it instead.
+            TokenEntry tokenEntry = loadToken(processorName, segment, entityManager);
+            tokenEntry.updateToken(token, serializer);
+        }
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import org.junit.jupiter.api.*;
+
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link ObjectUtils}.
+ *
+ * @author Steven van Beelen
+ */
+class ObjectUtilsTest {
+
+    private static final String NULL_INSTANCE = null;
+    private static final String INSTANCE = "instance";
+    private static final String DEFAULT_VALUE = "default";
+
+    @Test
+    void testGetOrDefaultUsingValueProvider() {
+        Function<String, String> valueProvider = o -> o;
+        assertEquals(DEFAULT_VALUE, ObjectUtils.getOrDefault(NULL_INSTANCE, valueProvider, DEFAULT_VALUE));
+        assertEquals(INSTANCE, ObjectUtils.getOrDefault(INSTANCE, valueProvider, DEFAULT_VALUE));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -110,7 +110,7 @@ public class JpaTokenStoreTest {
                                                .getResultList();
         assertEquals(1, tokens.size());
         assertNotNull(tokens.get(0).getOwner());
-        assertNull(tokens.get(0).getToken(XStreamSerializer.builder().build()));
+        assertNull(tokens.get(0).getToken(TestSerializer.XSTREAM.getSerializer()));
     }
 
     @Transactional


### PR DESCRIPTION
This pull request adjusts the `TokenStore#storeToken(TrackingToken, String, int)` method for both the `JpaTokenStore` and the `JdbcTokenStore`. The current implementation first does a fetch, trying to achieve a token claim if necessary, and only after that the token entry is updated. 

Although this works, we can optimize this process by doing an `UPDATE` query instead, which is exactly what this PR provides. If the `UPDATE` query yielded zero updates, we move back to the old process of load-then-save.

This pull request resolves #1442.