### PR TITLE
[#1486] Use force read from leader property

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -493,12 +493,14 @@ public class AxonServerEventStore extends AbstractEventStore {
                     ? -1
                     : ((GlobalSequenceTrackingToken) trackingToken).getGlobalIndex();
 
-            EventStream stream =
-                    connectionManager.getConnection(context)
-                                     .eventChannel()
-                                     .openStream(nextToken,
-                                                 configuration.getEventFlowControl().getInitialNrOfPermits(),
-                                                 configuration.getEventFlowControl().getNrOfNewPermits());
+            EventStream stream = connectionManager.getConnection(context)
+                                                  .eventChannel()
+                                                  .openStream(
+                                                          nextToken,
+                                                          configuration.getEventFlowControl().getInitialNrOfPermits(),
+                                                          configuration.getEventFlowControl().getNrOfNewPermits(),
+                                                          configuration.isForceReadFromLeader()
+                                                  );
 
             return new EventBuffer(stream, upcasterChain, eventSerializer, configuration.isDisableEventBlacklisting());
         }


### PR DESCRIPTION
The new connector implementation missed the use of the `AxonServerConfiguration#isForceReadFromLeader` when opening up the event stream. This PR resolve that, and as such resolves #1486 