### PR TITLE
Fixed infinite looping issue when tracking from a SequenceEventStorageEngine

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -56,6 +56,23 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
 
     private final NavigableMap<TrackingToken, TrackedEventMessage<?>> events = new ConcurrentSkipListMap<>();
     private final Map<String, List<DomainEventMessage<?>>> snapshots = new ConcurrentHashMap<>();
+    private final long offset;
+
+    /**
+     * Initializes an InMemoryEventStorageEngine. The engine will be empty, and there is no offset for the first token.
+     */
+    public InMemoryEventStorageEngine() {
+        this(0L);
+    }
+
+    /**
+     * Initializes an InMemoryEventStorageEngine using given {@code offset} to initialize the tokens with.
+     *
+     * @param offset The value to use for the token of the first event appended
+     */
+    public InMemoryEventStorageEngine(long offset) {
+        this.offset = offset;
+    }
 
     @Override
     public void appendEvents(List<? extends EventMessage<?>> events) {
@@ -145,8 +162,8 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
      * @return the tracking token for the next event
      */
     protected GlobalSequenceTrackingToken nextTrackingToken() {
-        return events.isEmpty() ? new GlobalSequenceTrackingToken(0) :
-                ((GlobalSequenceTrackingToken) events.lastKey()).next();
+        return events.isEmpty() ? new GlobalSequenceTrackingToken(offset) :
+               ((GlobalSequenceTrackingToken) events.lastKey()).next();
     }
 
     private static class MapEntrySpliterator extends Spliterators.AbstractSpliterator<TrackedEventMessage<?>> {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
@@ -271,8 +271,8 @@ class SequenceEventStorageEngineTest {
 
     @Test
     void testStreamFromPositionInActiveStorage() {
-        activeStorage = new InMemoryEventStorageEngine();
         historicStorage = new InMemoryEventStorageEngine();
+        activeStorage = new InMemoryEventStorageEngine(1);
 
         testSubject = new SequenceEventStorageEngine(historicStorage, activeStorage);
 
@@ -280,7 +280,8 @@ class SequenceEventStorageEngineTest {
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         DomainEventMessage<String> event3 = new GenericDomainEventMessage<>("type", "aggregate", 2, "test3");
         historicStorage.appendEvents(event1);
-        activeStorage.appendEvents(event1, event2, event3);
+
+        activeStorage.appendEvents(event2, event3);
 
         Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
         TrackedEventMessage<?> firstEvent = stream.findFirst().orElseThrow(IllegalStateException::new);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
@@ -19,11 +19,13 @@ package org.axonframework.eventsourcing.eventstore.inmemory;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngineTest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Rene de Waele
@@ -44,5 +46,14 @@ class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
         testSubject.appendEvents(GenericEventMessage.asEventMessage("test"));
 
         assertTrue(stream.findFirst().isPresent());
+    }
+
+    @Test
+    void testPublishedEventsEmittedToExistingStreams_WithOffset() {
+        testSubject = new InMemoryEventStorageEngine(1);
+        Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
+        testSubject.appendEvents(GenericEventMessage.asEventMessage("test"));
+
+        assertEquals(1, stream.findFirst().get().trackingToken().position().getAsLong());
     }
 }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -254,7 +254,7 @@ class TrackingEventProcessorTest {
     @Test
     void testSequenceEventStorageReceivesEachEventOnlyOnce() throws Exception {
         InMemoryEventStorageEngine historic = new InMemoryEventStorageEngine();
-        InMemoryEventStorageEngine active = new InMemoryEventStorageEngine();
+        InMemoryEventStorageEngine active = new InMemoryEventStorageEngine(2);
         SequenceEventStorageEngine sequenceEventStorageEngine = new SequenceEventStorageEngine(historic, active);
 
         EmbeddedEventStore sequenceEventBus = EmbeddedEventStore.builder().storageEngine(sequenceEventStorageEngine).build();
@@ -267,8 +267,7 @@ class TrackingEventProcessorTest {
                       });
 
         historic.appendEvents(createEvent(AGGREGATE, 1L, "message1"), createEvent(AGGREGATE, 2L, "message2"));
-        // to make sure tracking tokens match, we need to append the same number of events in the active store
-        active.appendEvents(createEvent(AGGREGATE, 1L, "message1"), createEvent(AGGREGATE, 2L, "message2"));
+        // to make sure tracking tokens match, we need to offset the InMemoryEventStorageEngine
         active.appendEvents(createEvent(AGGREGATE, 3L, "message3"), createEvent(AGGREGATE, 4L, "message4"),
                             createEvent(AGGREGATE, 5L, "message5"));
 


### PR DESCRIPTION
This PR resolves the issue that causes a Tracking Processor to possibly restream all events from the active storage when getting to the head of the stream.

Addresses #1491 