### PR TITLE
Fix loading issue when updating token with null token in JpaTokenStore

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -30,6 +30,8 @@ import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
@@ -38,8 +40,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -120,7 +120,7 @@ public class JpaTokenStore implements TokenStore {
         EntityManager entityManager = entityManagerProvider.getEntityManager();
         TokenEntry tokenToStore = new TokenEntry(processorName, segment, token, serializer);
         byte[] tokenDataToStore =
-                getOrDefault(tokenToStore.getSerializedToken(), SerializedObject::getData, new byte[0]);
+                getOrDefault(tokenToStore.getSerializedToken(), SerializedObject::getData, null);
         String tokenTypeToStore = getOrDefault(tokenToStore.getTokenType(), SerializedType::getName, null);
 
         int updatedTokens = entityManager.createQuery("UPDATE TokenEntry te SET "

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
@@ -113,6 +113,17 @@ public class JdbcTokenStoreTest {
         transactionManager.executeInTransaction(() -> assertEquals(token, tokenStore.fetchToken("test", 0)));
     }
 
+    @Transactional
+    @Test
+    void testUpdateAndLoadNullToken() {
+        tokenStore.initializeTokenSegments("test", 1);
+        tokenStore.fetchToken("test", 0);
+
+        tokenStore.storeToken(null, "test", 0);
+
+        TrackingToken token = tokenStore.fetchToken("test", 0);
+        assertNull(token);
+    }
 
     @Transactional
     @Test


### PR DESCRIPTION
The storeToken did an attempt to use an update query to update the token contents. An empty token was stored as an empty byte array. However, upon retrieval, there is a check for null tokens, whereas an empty byte array is seen as a regular token type.

Resolves #1495