### PR TITLE
Changed default values lockAttemptTimeout and maxLockAttempts

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -259,7 +259,7 @@ public class PessimisticLockFactory implements LockFactory {
 
         public boolean lock() {
             if (lock.getQueueLength() >= maximumQueued) {
-                throw new LockAcquisitionFailedException("Failed to acquire lock for aggregate identifier " + identifier + ": too many queued threads.");
+                throw new LockAcquisitionFailedException("Failed to acquire lock for identifier " + identifier + ": too many queued threads.");
             }
             try {
                 if (!lock.tryLock(0, TimeUnit.NANOSECONDS)) {
@@ -269,12 +269,13 @@ public class PessimisticLockFactory implements LockFactory {
                         checkForDeadlock();
                         if (attempts < 1) {
                             throw new LockAcquisitionFailedException(
-                                    "Failed to acquire lock for aggregate identifier(" + identifier + "), maximum attempts exceeded (" + acquireAttempts + ")"
+                                    "Failed to acquire lock for identifier(" + identifier + "), maximum attempts exceeded (" + acquireAttempts + ")"
                             );
                         }
                     } while (!lock.tryLock(lockAttemptTimeout, TimeUnit.MILLISECONDS));
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new LockAcquisitionFailedException("Thread was interrupted", e);
             }
             if (isClosed) {


### PR DESCRIPTION
When executing the test case repeatedly, it would fail after a few dozen attempts with a timeout.

A shorter lockAttemptTimeout greatly reduces the time needed to detect deadlocks, which in some cases would exceed the test timeout. Together they still represent a maximum of 60 seconds.

Also suppressed a ConcurrentModificationException, which may occur while iterating over LockFactories while the GC cleans unused entries.