### PR TITLE
Suppress exceptions thrown by UnitOfWork Lifecycle handlers

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/MessageProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/MessageProcessingContext.java
@@ -68,7 +68,15 @@ public class MessageProcessingContext<T extends Message<?>> {
         }
         Deque<Consumer<UnitOfWork<T>>> l = handlers.getOrDefault(phase, EMPTY);
         while (!l.isEmpty()) {
-            l.remove().accept(unitOfWork);
+            try {
+                l.remove().accept(unitOfWork);
+            } catch (Exception e) {
+                if (phase.isSuppressHandlerErrors()) {
+                    LOGGER.info("An error occurred while executing a lifecycle phase handler for phase {}", phase, e);
+                } else {
+                    throw e;
+                }
+            }
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
@@ -382,13 +382,13 @@ public interface UnitOfWork<T extends Message<?>> {
          * Indicates that the unit of work has been created but has not been registered with the {@link
          * CurrentUnitOfWork} yet.
          */
-        NOT_STARTED(false, false),
+        NOT_STARTED(false, false, false),
 
         /**
          * Indicates that the Unit of Work has been registered with the {@link CurrentUnitOfWork} but has not been
          * committed, because its Message has not been processed yet.
          */
-        STARTED(true, false),
+        STARTED(true, false, false),
 
         /**
          * Indicates that the Unit of Work is preparing its commit. This means that {@link #commit()} has been invoked
@@ -399,42 +399,44 @@ public interface UnitOfWork<T extends Message<?>> {
          * exception is raised by any of the handlers the Unit of Work will go into the {@link #COMMIT} phase, otherwise
          * it will be rolled back.
          */
-        PREPARE_COMMIT(true, false),
+        PREPARE_COMMIT(true, false, false),
 
         /**
          * Indicates that the Unit of Work has been committed and is passed the {@link #PREPARE_COMMIT} phase.
          */
-        COMMIT(true, true),
+        COMMIT(true, true, false),
 
         /**
          * Indicates that the Unit of Work is being rolled back. Generally this is because an exception was raised while
          * processing the {@link #getMessage() message} or while the Unit of Work was being committed.
          */
-        ROLLBACK(true, true),
+        ROLLBACK(true, true, true),
 
         /**
          * Indicates that the Unit of Work is after a successful commit. In this phase the Unit of Work cannot be rolled
          * back anymore.
          */
-        AFTER_COMMIT(true, true),
+        AFTER_COMMIT(true, true, true),
 
         /**
          * Indicates that the Unit of Work is after a successful commit or after a rollback. Any resources tied to this
          * Unit of Work should be released.
          */
-        CLEANUP(false, true),
+        CLEANUP(false, true, true),
 
         /**
          * Indicates that the Unit of Work is at the end of its life cycle. This phase is final.
          */
-        CLOSED(false, true);
+        CLOSED(false, true, true);
 
         private final boolean started;
         private final boolean reverseCallbackOrder;
+        private final boolean suppressHandlerErrors;
 
-        Phase(boolean started, boolean reverseCallbackOrder) {
+        Phase(boolean started, boolean reverseCallbackOrder, boolean suppressHandlerErrors) {
             this.started = started;
             this.reverseCallbackOrder = reverseCallbackOrder;
+            this.suppressHandlerErrors = suppressHandlerErrors;
         }
 
         /**
@@ -460,9 +462,21 @@ public interface UnitOfWork<T extends Message<?>> {
         }
 
         /**
+         * Indicates whether the handlers triggered for this phase should have their exceptions suppressed. This is the
+         * case for phases where cleanup or post-error processing is done. Exceptions in those phases should not trigger
+         * exceptions, but to a best-effort attempt to clean up.
+         *
+         * @return {@code true} when errors should be suppressed, otherise {@code false}
+         */
+        public boolean isSuppressHandlerErrors() {
+            return suppressHandlerErrors;
+        }
+
+        /**
          * Check if this Phase comes before given other {@code phase}.
          *
          * @param phase The other Phase
+         *
          * @return {@code true} if this comes before the given {@code phase}, {@code false} otherwise.
          */
         public boolean isBefore(Phase phase) {


### PR DESCRIPTION
For some phases, exceptions thrown by Lifecycle handler should be suppressed. These are the phases where there is no more option to trigger a rollback. Suppressing these exceptions ensures that all lifecycle handlers are invoked.