### PR TITLE
Snapshotter optimization

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
@@ -76,7 +76,7 @@ public class EventCountSnapshotTriggerDefinition implements SnapshotTriggerDefin
 
         @Override
         public void eventHandled(EventMessage<?> msg) {
-            if (++counter >= threshold && msg instanceof DomainEventMessage) {
+            if (msg instanceof DomainEventMessage && ++counter >= threshold) {
                 if (CurrentUnitOfWork.isStarted()) {
                     CurrentUnitOfWork.get().onPrepareCommit(
                             u -> scheduleSnapshot((DomainEventMessage) msg));

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
@@ -24,7 +24,18 @@ import java.io.Serializable;
 
 /**
  * Snapshotter trigger mechanism that counts the number of events to decide when to create a snapshot. A snapshot is
- * triggered when the number of events applied on an aggregate exceeds the given threshold.
+ * triggered when the number of events applied on an aggregate exceeds the given {@code threshold}.
+ * <p>
+ * This number can exceed in two distinct scenarios:
+ * <ol>
+ *     <li> When initializing / event sourcing the aggregate in question.</li>
+ *     <li> When new events are being applied by the aggregate.</li>
+ * </ol>
+ * <p>
+ * If the definable {@code threshold} is met in situation one, the snapshot will be triggered regardless of the outcome
+ * of command handling. Thus also if command handling returns exceptionally. If the {@code threshold} is only reached
+ * once the aggregate has been fully initialized, than the snapshot will only be triggered if handling resolves
+ * successfully.
  *
  * @author Allard Buijze
  * @since 3.0
@@ -35,8 +46,8 @@ public class EventCountSnapshotTriggerDefinition implements SnapshotTriggerDefin
     private final int threshold;
 
     /**
-     * Initialized the SnapshotTriggerDefinition to threshold snapshots using the given {@code snapshotter}
-     * when {@code threshold} events have been applied to an Aggregate instance
+     * Initialized the SnapshotTriggerDefinition to threshold snapshots using the given {@code snapshotter} when {@code
+     * threshold} events have been applied to an Aggregate instance
      *
      * @param snapshotter the snapshotter to notify when a snapshot needs to be taken
      * @param threshold   the number of events that will threshold the creation of a snapshot event

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinitionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@
 
 package org.axonframework.eventsourcing;
 
-import org.axonframework.eventsourcing.utils.StubAggregate;
-import org.axonframework.modelling.command.Aggregate;
-import org.axonframework.modelling.command.inspection.AnnotatedAggregate;
-import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventsourcing.utils.StubAggregate;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
-import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.modelling.command.Aggregate;
+import org.axonframework.modelling.command.inspection.AnnotatedAggregate;
+import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.junit.jupiter.api.*;
 
 import java.io.ByteArrayInputStream;
@@ -37,6 +36,8 @@ import java.io.ObjectOutputStream;
 import static org.mockito.Mockito.*;
 
 /**
+ * Test class validating the {@link EventCountSnapshotTriggerDefinition}.
+ *
  * @author Allard Buijze
  */
 class EventCountSnapshotTriggerDefinitionTest {
@@ -46,8 +47,6 @@ class EventCountSnapshotTriggerDefinitionTest {
     private String aggregateIdentifier;
     private Aggregate<?> aggregate;
 
-    private UnitOfWork<?> unitOfWork;
-
     @BeforeEach
     void setUp() {
         while (CurrentUnitOfWork.isStarted()) {
@@ -56,10 +55,12 @@ class EventCountSnapshotTriggerDefinitionTest {
         mockSnapshotter = mock(Snapshotter.class);
         testSubject = new EventCountSnapshotTriggerDefinition(mockSnapshotter, 3);
         aggregateIdentifier = "aggregateIdentifier";
-        unitOfWork = DefaultUnitOfWork.startAndGet(new GenericMessage<>("test"));
-        aggregate = AnnotatedAggregate.initialize(new StubAggregate(aggregateIdentifier),
-                                                  AnnotatedAggregateMetaModelFactory.inspectAggregate(StubAggregate.class), null);
-
+        DefaultUnitOfWork.startAndGet(new GenericMessage<>("test"));
+        aggregate = AnnotatedAggregate.initialize(
+                new StubAggregate(aggregateIdentifier),
+                AnnotatedAggregateMetaModelFactory.inspectAggregate(StubAggregate.class),
+                null
+        );
     }
 
     @AfterEach
@@ -72,8 +73,9 @@ class EventCountSnapshotTriggerDefinitionTest {
     @Test
     void testSnapshotterTriggeredOnUnitOfWorkCleanup() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>("type", aggregateIdentifier, 0,
-                                                                                "Mock contents", MetaData.emptyInstance());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
@@ -90,8 +92,9 @@ class EventCountSnapshotTriggerDefinitionTest {
     @Test
     void testSnapshotterTriggeredOnUnitOfWorkCommit() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>("type", aggregateIdentifier, 0,
-                                                                                "Mock contents", MetaData.emptyInstance());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
         trigger.initializationFinished();
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
@@ -104,10 +107,11 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkRollback() {
+    void testSnapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>("type", aggregateIdentifier, 0,
-                                                                                "Mock contents", MetaData.emptyInstance());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
         trigger.initializationFinished();
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
@@ -120,10 +124,28 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
+    void testSnapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
+        SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
+        trigger.eventHandled(msg);
+        trigger.eventHandled(msg);
+        trigger.eventHandled(msg);
+        trigger.eventHandled(msg);
+        trigger.initializationFinished();
+
+        verify(mockSnapshotter, never()).scheduleSnapshot(aggregate.rootType(), aggregateIdentifier);
+        CurrentUnitOfWork.get().rollback();
+        verify(mockSnapshotter).scheduleSnapshot(aggregate.rootType(), aggregateIdentifier);
+    }
+
+    @Test
     void testSnapshotterNotTriggered() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>("type", aggregateIdentifier, 0,
-                                                                                "Mock contents", MetaData.emptyInstance());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
@@ -136,8 +158,9 @@ class EventCountSnapshotTriggerDefinitionTest {
     @Test
     void testCounterDoesNotResetWhenSerialized() throws IOException, ClassNotFoundException {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>("type", aggregateIdentifier, 0,
-                                                                                "Mock contents", MetaData.emptyInstance());
+        GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
+                "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
+        );
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);
         trigger.eventHandled(msg);

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
@@ -198,6 +198,10 @@ public abstract class AbstractEventBus implements EventBus {
 
     private void addStagedMessages(UnitOfWork<?> unitOfWork, List<EventMessage<?>> messages) {
         unitOfWork.parent().ifPresent(parent -> addStagedMessages(parent, messages));
+        if (unitOfWork.isRolledBack()) {
+            // staged messages are irrelevant if the UoW has been rolled back
+            return;
+        }
         List<EventMessage<?>> stagedEvents = unitOfWork.getOrDefaultResource(eventsKey, Collections.emptyList());
         for (EventMessage<?> stagedEvent : stagedEvents) {
             if (!messages.contains(stagedEvent)) {


### PR DESCRIPTION
In a single UOW we should schedule at most one snapshot to be created. 
Since all Axon components use UOW to process a message and since Axon holds a lock on the aggregate we assume that scheduling a snapshot outside of UOW or from several distinct UOWs is less probable so we don't have a guard against those situations.