### PR TITLE
Client side Heartbeat Message enabling 

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -225,6 +225,12 @@ public class AxonServerConfiguration {
     private boolean forceReadFromLeader = false;
 
     /**
+     * Configuration specifics on sending heartbeat messages to ensure a fully operational end-to-end connection with
+     * Axon Server.
+     */
+    private HeartbeatConfiguration heartbeat = new HeartbeatConfiguration();
+
+    /**
      * Instantiate a {@link Builder} to create an {@link AxonServerConfiguration}.
      *
      * @return a {@link Builder} to be able to create an {@link AxonServerConfiguration}.
@@ -523,6 +529,14 @@ public class AxonServerConfiguration {
         return new FlowControlConfiguration(initialNrOfPermits, nrOfNewPermits, newPermitsThreshold);
     }
 
+    public HeartbeatConfiguration getHeartbeat() {
+        return heartbeat;
+    }
+
+    public void setHeartbeat(HeartbeatConfiguration heartbeat) {
+        this.heartbeat = heartbeat;
+    }
+
     /**
      * Configuration class for Flow Control of specific message types.
      *
@@ -598,6 +612,54 @@ public class AxonServerConfiguration {
 
         public void setNewPermitsThreshold(Integer newPermitsThreshold) {
             this.newPermitsThreshold = newPermitsThreshold;
+        }
+    }
+
+    public static class HeartbeatConfiguration {
+
+        private static final long DEFAULT_INTERVAL = 10_000;
+        private static final long DEFAULT_TIMEOUT = 7_500;
+
+        /**
+         * Enables heartbeat messages between a client and Axon Server. When enabled, the connection will be abandoned
+         * if a heartbeat message response <b>is not</b> returned in a timely manor. Defaults to {@code false}.
+         */
+        private boolean enabled = false;
+
+        /**
+         * Interval between consecutive heartbeat message sent in milliseconds. Defaults to {@code 10_000}
+         * milliseconds.
+         */
+        private long interval = DEFAULT_INTERVAL;
+
+        /**
+         * The time window within which a response is expected in milliseconds. The connection times out if no response
+         * is returned within this window. Defaults to {@code 7_500} milliseconds.
+         */
+        private long timeout = DEFAULT_TIMEOUT;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public long getInterval() {
+            return interval;
+        }
+
+        public void setInterval(long interval) {
+            this.interval = interval;
+        }
+
+        public long getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(long timeout) {
+            this.timeout = timeout;
         }
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -27,6 +27,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.TagsConfiguration;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.lifecycle.ShutdownHandler;
+import org.axonframework.lifecycle.StartHandler;
 
 import java.io.File;
 import java.util.List;
@@ -50,6 +51,9 @@ public class AxonServerConnectionManager {
     private final Map<String, AxonServerConnection> connections = new ConcurrentHashMap<>();
     private final AxonServerConnectionFactory connectionFactory;
     private final String defaultContext;
+    private final boolean heartbeatEnabled;
+    private final long heartbeatInterval;
+    private final long heartbeatTimeout;
 
     /**
      * Instantiate a {@link AxonServerConnectionManager} based on the fields contained in the {@link Builder}, using the
@@ -61,6 +65,11 @@ public class AxonServerConnectionManager {
     protected AxonServerConnectionManager(Builder builder, AxonServerConnectionFactory connectionFactory) {
         this.connectionFactory = connectionFactory;
         this.defaultContext = builder.axonServerConfiguration.getContext();
+        AxonServerConfiguration.HeartbeatConfiguration heartbeatConfig =
+                builder.axonServerConfiguration.getHeartbeat();
+        this.heartbeatEnabled = heartbeatConfig.isEnabled();
+        this.heartbeatInterval = heartbeatConfig.getInterval();
+        this.heartbeatTimeout = heartbeatConfig.getTimeout();
     }
 
     /**
@@ -75,10 +84,34 @@ public class AxonServerConnectionManager {
         return new Builder();
     }
 
+    /**
+     * Starts the {@link AxonServerConnectionManager}. Will enable heartbeat messages to be send to the connected Axon
+     * Server instance in the {@link Phase#INSTRUCTION_COMPONENTS} phase, if this has been enabled through the {@link
+     * AxonServerConfiguration.HeartbeatConfiguration#isEnabled()}.
+     */
+    @StartHandler(phase = Phase.INSTRUCTION_COMPONENTS)
+    public void start() {
+        if (heartbeatEnabled) {
+            getConnection().controlChannel()
+                           .enableHeartbeat(heartbeatInterval, heartbeatTimeout, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Retrieves the {@link AxonServerConnection} used for the default context of this application.
+     *
+     * @return the {@link AxonServerConnection} used for the default context of this application
+     */
     public AxonServerConnection getConnection() {
         return getConnection(getDefaultContext());
     }
 
+    /**
+     * Retrieves the {@link AxonServerConnection} used for the given {@code context} of this application.
+     *
+     * @param context the context for which to retrieve an {@link AxonServerConnection}
+     * @return the {@link AxonServerConnection} used for the given {@code context} of this application.
+     */
     public AxonServerConnection getConnection(String context) {
         return connections.computeIfAbsent(context, connectionFactory::connect);
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -135,7 +135,7 @@ class AxonServerConnectionManagerTest {
         assertNotNull(connectionManager.getConnection(config.getContext()));
 
         assertWithin(
-                25, TimeUnit.MILLISECONDS,
+                250, TimeUnit.MILLISECONDS,
                 // Retrieving the messages from the secondNode, as the stubServer forwards all messages to this instance
                 () -> assertFalse(secondNode.getPlatformService().getHeartbeatMessages().isEmpty())
         );

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/PlatformService.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/PlatformService.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2018. AxonIQ
+ * Copyright (c) 2010-2020. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +17,7 @@
 package org.axonframework.axonserver.connector;
 
 import io.axoniq.axonserver.grpc.control.ClientIdentification;
+import io.axoniq.axonserver.grpc.control.Heartbeat;
 import io.axoniq.axonserver.grpc.control.NodeInfo;
 import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
 import io.axoniq.axonserver.grpc.control.PlatformInfo;
@@ -28,16 +30,19 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Author: marc
+ * Stub platform service to tap into the {@link PlatformInboundInstruction} being sent.
+ *
+ * @author Marc Gathier
+ * @since 4.0
  */
 public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase {
 
     private final int port;
 
     private final List<ClientIdentification> clientIdentificationRequests = new CopyOnWriteArrayList<>();
+    private final List<Heartbeat> heartbeatMessages = new CopyOnWriteArrayList<>();
 
     public PlatformService(int port) {
-
         this.port = port;
     }
 
@@ -59,6 +64,10 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
         return Collections.unmodifiableList(clientIdentificationRequests);
     }
 
+    public List<Heartbeat> getHeartbeatMessages() {
+        return Collections.unmodifiableList(heartbeatMessages);
+    }
+
     @Override
     public StreamObserver<PlatformInboundInstruction> openStream(
             StreamObserver<PlatformOutboundInstruction> responseObserver) {
@@ -67,6 +76,8 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
             public void onNext(PlatformInboundInstruction platformInboundInstruction) {
                 if (platformInboundInstruction.hasRegister()) {
                     clientIdentificationRequests.add(platformInboundInstruction.getRegister());
+                } else if (platformInboundInstruction.hasHeartbeat()) {
+                    heartbeatMessages.add(platformInboundInstruction.getHeartbeat());
                 }
             }
 


### PR DESCRIPTION
This pull request introduces the means to have an Axon application enable heartbeats towards the Axon Server instance it is connected with. More specifically, it uses the `AxonServerConnection` of the default context this client is a part of.

Enabling is done through the `AxonServerConfiguration.HeartbeatConfiguration`, allowing the specification to simply enable heartbeats, the interval between heartbeats and the timeout of the connection of no response is received