### PR TITLE
[#1505] isCaughtUp() always returns true for pushing-"Event Streams"

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -72,7 +72,8 @@ class TrackingEventProcessorTest_MultiThreaded {
         eventBus = EmbeddedEventStore.builder().storageEngine(new InMemoryEventStorageEngine()).build();
 
         // A processor config, with a policy which guarantees segmenting by using the sequence number.
-        configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2));
+        configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
+                                                              .andEventAvailabilityTimeout(500, MILLISECONDS));
     }
 
     private void configureProcessor(TrackingEventProcessorConfiguration processorConfiguration) {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/utils/AssertUtils.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/utils/AssertUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2020. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,27 @@
 
 package org.axonframework.integrationtests.utils;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 /**
- * Utility class for special assertions
+ * Utility class providing additional forms of assertions, mainly involving time based checks.
+ *
+ * @author Sara Pellegrini
+ * @author Steven van Beelen
  */
-public class AssertUtils {
+public abstract class AssertUtils {
 
     private AssertUtils() {
-
+        // Utility class
     }
 
     /**
      * Assert that the given {@code assertion} succeeds with the given {@code time} and {@code unit}.
-     * @param time The time in which the assertion must pass
-     * @param unit The unit in which time is expressed
+     *
+     * @param time      The time in which the assertion must pass
+     * @param unit      The unit in which time is expressed
      * @param assertion the assertion to succeed within the deadline
      */
     public static void assertWithin(int time, TimeUnit unit, Runnable assertion) {
@@ -50,4 +56,55 @@ public class AssertUtils {
         } while (true);
     }
 
+    /**
+     * Assert that the given {@code assertion} succeeds for the entire {@code timeFrame}. The given {@code
+     * validationInterval} defines the interval between consecutive validations of the {@code assertion}.
+     *
+     * @param timeFrame          the {@link Duration} for which the given {@code assertion} should succeed
+     * @param validationInterval the {@link Duration} to wait between consecutive validation attempts of the given
+     *                           {@code assertion}
+     * @param assertion          a {@link Runnable} containing the assertion to succeed for the given {@code timeFrame}
+     */
+    public static void assertFor(Duration timeFrame, Duration validationInterval, Runnable assertion) {
+        long now = System.currentTimeMillis();
+        long deadline = timeFrame.plusMillis(now).toMillis();
+        while (now < deadline) {
+            assertion.run();
+            try {
+                Thread.sleep(validationInterval.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Testing thread has been interrupted. Unable to keep validating the given assertion."
+                );
+            }
+            now = System.currentTimeMillis();
+        }
+    }
+
+    /**
+     * Assert that the given {@code assertion} succeeds, up to and {@code until} the {@link BooleanSupplier} returns
+     * {@code false}. The given {@code validationInterval} defines the interval between consecutive validations of the
+     * {@code assertion}.
+     *
+     * @param until              a {@link BooleanSupplier} to return {@code false} if the given {@code assertion} should
+     *                           not be validated any more
+     * @param validationInterval the {@link Duration} to wait between consecutive validation attempts of the given
+     *                           {@code assertion}
+     * @param assertion          a {@link Runnable} containing the assertion to succeed up to and {@code until} the
+     *                           supplier returns {@code false}
+     */
+    public static void assertUntil(BooleanSupplier until, Duration validationInterval, Runnable assertion) {
+        while (until.getAsBoolean()) {
+            assertion.run();
+            try {
+                Thread.sleep(validationInterval.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Testing thread has been interrupted. Unable to keep validating the given assertion."
+                );
+            }
+        }
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -399,7 +399,6 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
     private void processBatch(Segment segment, BlockingStream<TrackedEventMessage<?>> eventStream) throws Exception {
         List<TrackedEventMessage<?>> batch = new ArrayList<>();
         try {
-            checkSegmentCaughtUp(segment, eventStream);
             TrackingToken lastToken;
             Collection<Segment> processingSegments;
             if (eventStream.hasNextAvailable(eventAvailabilityTimeout, MILLISECONDS)) {
@@ -467,6 +466,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
             updateActiveSegments(() -> activeSegments.computeIfPresent(
                     segment.getSegmentId(), (k, v) -> v.advancedTo(finalLastToken)
             ));
+            checkSegmentCaughtUp(segment, eventStream);
         } catch (InterruptedException e) {
             logger.error(String.format("Event processor [%s] was interrupted. Shutting down.", getName()), e);
             this.shutDown();

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -436,6 +436,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
                     return;
                 }
             } else {
+                checkSegmentCaughtUp(segment, eventStream);
                 // Refresh claim on token
                 transactionManager.executeInTransaction(
                         () -> tokenStore.extendClaim(getName(), segment.getSegmentId())
@@ -1200,19 +1201,16 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
          * Sets the {@link TransactionManager} used when processing {@link EventMessage}s.
          * <p/>
          * Note that setting this value influences the behavior for storing tokens either at the start or at the end of
-         * a batch.
-         * If a TransactionManager other than a {@link NoTransactionManager} is configured, the default behavior is to
-         * store the last token of the Batch to the Token Store before processing of events begins. If the
-         * {@link NoTransactionManager} is provided, the default is to extend the claim at the start of the unit of
-         * work, and update the token after processing Events.
-         * When tokens are stored at the start of a batch, a claim extension will be sent at the end of the batch if
-         * processing that batch took longer than the {@link
+         * a batch. If a TransactionManager other than a {@link NoTransactionManager} is configured, the default
+         * behavior is to store the last token of the Batch to the Token Store before processing of events begins. If
+         * the {@link NoTransactionManager} is provided, the default is to extend the claim at the start of the unit of
+         * work, and update the token after processing Events. When tokens are stored at the start of a batch, a claim
+         * extension will be sent at the end of the batch if processing that batch took longer than the {@link
          * TrackingEventProcessorConfiguration#andEventAvailabilityTimeout(long, TimeUnit) tokenClaimUpdateInterval}.
          * <p>
          * Use {@link #storingTokensAfterProcessing()} to force storage of tokens at the end of a batch.
          *
          * @param transactionManager the {@link TransactionManager} used when processing {@link EventMessage}s
-         *
          * @return the current Builder instance, for fluent interfacing
          * @see #storingTokensAfterProcessing()
          */
@@ -1252,10 +1250,10 @@ public class TrackingEventProcessor extends AbstractEventProcessor {
          * <p>
          * The default behavior is to store the last token of the Batch to the Token Store before processing of events
          * begins, if a TransactionManager is configured. If the {@link NoTransactionManager} is provided, the default
-         * is to extend the claim at the start of the unit of work, and update the token after processing Events.
-         * When tokens are stored at the start of a batch, a claim extension will be sent at the end of the batch if
-         * processing that batch took longer than the {@link
-         * TrackingEventProcessorConfiguration#andEventAvailabilityTimeout(long, TimeUnit) tokenClaimUpdateInterval}.
+         * is to extend the claim at the start of the unit of work, and update the token after processing Events. When
+         * tokens are stored at the start of a batch, a claim extension will be sent at the end of the batch if
+         * processing that batch took longer than the {@link TrackingEventProcessorConfiguration#andEventAvailabilityTimeout(long,
+         * TimeUnit) tokenClaimUpdateInterval}.
          *
          * @return the current Builder instance, for fluent interfacing
          */


### PR DESCRIPTION
This pull request introduce a minute change in the `TrackingEventProcessor#processBatch(Segment, BlockingStream<TrackedEventMessage<?>>)` method, namely moving the private `checkSegmentCaughtUp` method until after the first `eventAvailabilityTimeout` has been triggered.

Prior to this change, there was a window of opportunity within which an opened `BlockingStream` was referred to as empty whilst in actuality events were present. This can only occur of the underlying implementation of the  `BlockingStream` gets the events pushed (e.g. Axon Server), instead of pulling them itself (e.g. the `EmbeddedEventStore`). Further more, the `checkSegmentCaughtUp` validates whether the end of the `BlockingStream` has been reached and if this was true, the `caughtUp` flag was set to true. As an empty stream automatically means the end of the stream has been reached, `caughtUp` was set to true immediately.

Next to the aforementioned change, a test case has been added which uses some new `AssertUtils` methods.

This pull request resolves issue #1505.