### PR TITLE
Change Optional#orElse to Optional#orElseGet invocation

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractAggregateFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractAggregateFactory.java
@@ -70,7 +70,7 @@ public abstract class AbstractAggregateFactory<T> implements AggregateFactory<T>
 
     @Override
     public final T createAggregateRoot(String aggregateIdentifier, DomainEventMessage<?> firstEvent) {
-        return postProcessInstance(fromSnapshot(firstEvent).orElse(doCreateAggregate(aggregateIdentifier, firstEvent)));
+        return postProcessInstance(fromSnapshot(firstEvent).orElseGet(() -> doCreateAggregate(aggregateIdentifier, firstEvent)));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Change Optional#orElse(...) into Optional#orElseGet(...), because it is called wether or not the optional contains a value, possibly causing problems, because it is an abstract method that we do not know the implementation of.