### PR TITLE
Segment split validation fix

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -1683,13 +1683,17 @@ class TrackingEventProcessorTest {
         int secondSegment = 1;
 
         CountDownLatch addedStatusLatch = new CountDownLatch(4);
+        CountDownLatch updatedStatusLatch = new CountDownLatch(1);
         CountDownLatch removedStatusLatch = new CountDownLatch(3);
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
+            assertEquals(1, updatedTrackerStatus.size());
             EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.values().iterator().next();
             if (eventTrackerStatus.trackerAdded()) {
                 addedStatusLatch.countDown();
             } else if (eventTrackerStatus.trackerRemoved()) {
                 removedStatusLatch.countDown();
+            } else {
+                updatedStatusLatch.countDown();
             }
         };
 
@@ -1715,6 +1719,7 @@ class TrackingEventProcessorTest {
         waitForSegmentStart(firstSegment);
 
         assertTrue(addedStatusLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(updatedStatusLatch.await(5, TimeUnit.SECONDS));
         assertTrue(removedStatusLatch.await(5, TimeUnit.SECONDS));
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -1683,17 +1683,13 @@ class TrackingEventProcessorTest {
         int secondSegment = 1;
 
         CountDownLatch addedStatusLatch = new CountDownLatch(4);
-        CountDownLatch updatedStatusLatch = new CountDownLatch(1);
         CountDownLatch removedStatusLatch = new CountDownLatch(3);
         EventTrackerStatusChangeListener statusChangeListener = updatedTrackerStatus -> {
-            assertEquals(1, updatedTrackerStatus.size());
             EventTrackerStatus eventTrackerStatus = updatedTrackerStatus.values().iterator().next();
             if (eventTrackerStatus.trackerAdded()) {
                 addedStatusLatch.countDown();
             } else if (eventTrackerStatus.trackerRemoved()) {
                 removedStatusLatch.countDown();
-            } else {
-                updatedStatusLatch.countDown();
             }
         };
 
@@ -1719,7 +1715,6 @@ class TrackingEventProcessorTest {
         waitForSegmentStart(firstSegment);
 
         assertTrue(addedStatusLatch.await(5, TimeUnit.SECONDS));
-        assertTrue(updatedStatusLatch.await(5, TimeUnit.SECONDS));
         assertTrue(removedStatusLatch.await(5, TimeUnit.SECONDS));
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/Segment.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/Segment.java
@@ -225,7 +225,7 @@ public class Segment implements Comparable<Segment> {
     public Segment[] split() {
 
         if ((mask << 1) < 0) {
-            throw new IllegalArgumentException("Unable to split the given segmentId, as the mask exceeds the max mask size.");
+            throw new IllegalStateException("Unable to split the given segmentId, as the mask exceeds the max mask size.");
         }
 
         Segment[] segments = new Segment[2];

--- a/messaging/src/test/java/org/axonframework/eventhandling/SegmentTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/SegmentTest.java
@@ -17,8 +17,7 @@
 package org.axonframework.eventhandling;
 
 import org.axonframework.messaging.MetaData;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -329,7 +328,7 @@ class SegmentTest {
     @Test
     void testSegmentSplitBeyondBoundary() {
         final Segment segment = new Segment(0, Integer.MAX_VALUE);
-        assertThrows(IllegalArgumentException.class, segment::split);
+        assertThrows(IllegalStateException.class, segment::split);
     }
 
     @Test


### PR DESCRIPTION
The split method used to throw an `IllegalArgumentException` although it is a zero-argument method. Changed to `IllegalStateException`.