### PR TITLE
Added root cause exception to stacktrace on error reading events

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
@@ -74,6 +74,21 @@ public class AxonServerException extends AxonException {
         this.details = details;
     }
 
+    /**
+     * /**
+     * Initializes the exception using the given {@code message}, {@code code}, and {@code cause}.
+     *
+     * @param message The message describing the exception
+     * @param code    The code of the error received from the Axon Server
+     * @param cause   The underlying cause of the exception
+     */
+    public AxonServerException(String code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+        this.details = Collections.emptyList();
+        this.source = null;
+    }
+
     public String code() {
         return code;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerException.java
@@ -57,7 +57,7 @@ public class AxonServerException extends AxonException {
     }
 
     /**
-     * Initializes the exception using the given {@code message}, {@code code}, {@code source} and {@code details} .
+     * Initializes the exception using the given {@code message}, {@code code}, {@code source} and {@code details}.
      *
      * @param message The message describing the exception
      * @param code    The code of the error received from the Axon Server
@@ -75,7 +75,6 @@ public class AxonServerException extends AxonException {
     }
 
     /**
-     * /**
      * Initializes the exception using the given {@code message}, {@code code}, and {@code cause}.
      *
      * @param message The message describing the exception

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
@@ -178,7 +178,8 @@ public class EventBuffer implements TrackingEventStream {
         // If the peeked event still is null, the EventStream might've been closed.
         if (peekEvent == null && delegate.isClosed()) {
             throw new AxonServerException(ErrorCode.OTHER.errorCode(),
-                                          "The Event Stream has been closed, so no further events can be retrieved");
+                                          "The Event Stream has been closed, so no further events can be retrieved",
+                                          delegate.getError().orElse(null));
         }
         return peekEvent;
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
@@ -30,16 +30,24 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.jupiter.api.*;
-import org.mockito.stubbing.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.stubbing.Answer;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class to verify the implementation of the {@link EventBuffer} class.
@@ -115,9 +123,11 @@ class EventBufferTest {
 
     @Test
     void testHasNextAvailableThrowsAxonServerExceptionWhenStreamFailed() {
-        eventStream.onError(new TestException());
+        TestException testException = new TestException();
+        eventStream.onError(testException);
 
-        assertThrows(AxonServerException.class, () -> testSubject.hasNextAvailable(0, TimeUnit.SECONDS));
+        AxonServerException actual = assertThrows(AxonServerException.class, () -> testSubject.hasNextAvailable(0, TimeUnit.SECONDS));
+        assertEquals(testException, actual.getCause());
 
         // a second attempt should still throw the exception
         assertThrows(AxonServerException.class, () -> testSubject.hasNextAvailable(0, TimeUnit.SECONDS));


### PR DESCRIPTION
The EventBuffer would throw an exception when unable to read events from the underlying stream, but it didn't report the original exception if the stream was closed due to an error. This made debugging very hard.
This commit adds the root cause of the closed connection to the exception thrown.