### PR TITLE
[#1520] Make CommandMessageFilter implementations Jackson serializable

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/CommandMessageFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/CommandMessageFilter.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.commandhandling.distributed;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.commandfilter.AndCommandMessageFilter;
 import org.axonframework.commandhandling.distributed.commandfilter.NegateCommandMessageFilter;
@@ -24,18 +25,20 @@ import org.axonframework.commandhandling.distributed.commandfilter.OrCommandMess
 import java.io.Serializable;
 
 /**
- * Interface describing a filter that can be applied to commands to describe the type of commands supported by a node
- * in a cluster.
+ * Interface describing a filter that can be applied to commands to describe the type of commands supported by a node in
+ * a cluster.
  *
  * @author Allard Buijze
  * @since 4.0
  */
+@FunctionalInterface
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "className")
 public interface CommandMessageFilter extends Serializable {
 
     /**
      * Indicates whether the given {@code commandMessage} matches this filter.
      *
-     * @param commandMessage The message to match
+     * @param commandMessage the message to match
      * @return {@code true} if the command matches, otherwise {@code false}
      */
     boolean matches(CommandMessage<?> commandMessage);
@@ -43,7 +46,7 @@ public interface CommandMessageFilter extends Serializable {
     /**
      * Returns a filter that matches when both this instance and the given {@code other} match.
      *
-     * @param other The other filter to match against
+     * @param other the other filter to match against
      * @return a filter that matches when both this instance and the other match
      */
     default CommandMessageFilter and(CommandMessageFilter other) {
@@ -68,5 +71,4 @@ public interface CommandMessageFilter extends Serializable {
     default CommandMessageFilter or(CommandMessageFilter other) {
         return new OrCommandMessageFilter(this, other);
     }
-
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAll.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAll.java
@@ -20,14 +20,15 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
 /**
- * A command filter that accepts all CommandMessages
+ * A command filter that accepts all {@link CommandMessage}s.
  *
  * @author Koen Lavooij
+ * @since 3.0
  */
 public enum AcceptAll implements CommandMessageFilter {
 
     /**
-     * Singleton instance of the {@link AcceptAll} filter
+     * Singleton instance of the {@link AcceptAll} filter.
      */
     INSTANCE;
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilter.java
@@ -16,11 +16,17 @@
 
 package org.axonframework.commandhandling.distributed.commandfilter;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
+import java.beans.ConstructorProperties;
+import java.util.Objects;
+
 /**
- * Filter that matches whenever both supplied filters match
+ * A {@link CommandMessageFilter} implementation that matches whenever both supplied {@link CommandMessageFilter}
+ * instances match.
  *
  * @author Allard Buijze
  * @since 4.0
@@ -33,10 +39,12 @@ public class AndCommandMessageFilter implements CommandMessageFilter {
     /**
      * Initialize the filter to match when both the {@code first} and the {@code second} filter match.
      *
-     * @param first  The first filter to match
-     * @param second The second filter to match
+     * @param first  the first filter to match
+     * @param second the second filter to match
      */
-    public AndCommandMessageFilter(CommandMessageFilter first, CommandMessageFilter second) {
+    @ConstructorProperties({"first", "second"})
+    public AndCommandMessageFilter(@JsonProperty("first") CommandMessageFilter first,
+                                   @JsonProperty("second") CommandMessageFilter second) {
         this.first = first;
         this.second = second;
     }
@@ -44,5 +52,41 @@ public class AndCommandMessageFilter implements CommandMessageFilter {
     @Override
     public boolean matches(CommandMessage<?> commandMessage) {
         return first.matches(commandMessage) && second.matches(commandMessage);
+    }
+
+    @JsonGetter
+    private CommandMessageFilter getFirst() {
+        return first;
+    }
+
+    @JsonGetter
+    private CommandMessageFilter getSecond() {
+        return second;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AndCommandMessageFilter that = (AndCommandMessageFilter) o;
+        return Objects.equals(first, that.first) &&
+                Objects.equals(second, that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second);
+    }
+
+    @Override
+    public String toString() {
+        return "AndCommandMessageFilter{" +
+                "first=" + first +
+                ", second=" + second +
+                '}';
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilter.java
@@ -16,9 +16,12 @@
 
 package org.axonframework.commandhandling.distributed.commandfilter;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
+import java.beans.ConstructorProperties;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -27,10 +30,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A filter for CommandMessages which filters CommandMessages by a Command Name. It can be combined with other
- * CommandNameFilters in an efficient manner.
+ * A {@link CommandMessageFilter} implementation which filters {@link CommandMessage}s by the {@link
+ * CommandMessage#getCommandName()}. It can be combined with other {@link CommandMessageFilter} instances in an
+ * efficient manner.
  *
  * @author Koen Lavooij
+ * @since 3.0
  */
 public class CommandNameFilter implements CommandMessageFilter {
 
@@ -41,7 +46,8 @@ public class CommandNameFilter implements CommandMessageFilter {
      *
      * @param commandNames commands that can be handled
      */
-    public CommandNameFilter(Set<String> commandNames) {
+    @ConstructorProperties("commandNames")
+    public CommandNameFilter(@JsonProperty("commandNames") Set<String> commandNames) {
         this.commandNames = new HashSet<>(commandNames);
     }
 
@@ -88,10 +94,19 @@ public class CommandNameFilter implements CommandMessageFilter {
         }
     }
 
+    @JsonGetter
+    private Set<String> getCommandNames() {
+        return commandNames;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         CommandNameFilter that = (CommandNameFilter) o;
         return Objects.equals(commandNames, that.commandNames);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAll.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAll.java
@@ -20,7 +20,7 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
 /**
- * A command filter that denies all {@link CommandMessage}s.
+ * A {@link CommandMessageFilter} that denies all {@link CommandMessage}s.
  *
  * @author Koen Lavooij
  * @since 3.0

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAll.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAll.java
@@ -20,14 +20,15 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
 /**
- * A Command Message predicate that denies all CommandMessages
+ * A command filter that denies all {@link CommandMessage}s.
  *
  * @author Koen Lavooij
+ * @since 3.0
  */
 public enum DenyAll implements CommandMessageFilter {
 
     /**
-     * Singleton instance of the {@link DenyAll} filter
+     * Singleton instance of the {@link DenyAll} filter.
      */
     INSTANCE;
 
@@ -56,5 +57,4 @@ public enum DenyAll implements CommandMessageFilter {
     public String toString() {
         return "DenyAll{}";
     }
-
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilter.java
@@ -16,9 +16,12 @@
 
 package org.axonframework.commandhandling.distributed.commandfilter;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
+import java.beans.ConstructorProperties;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -27,14 +30,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A Predicate for CommandMessage's that can deny commands based on their name. It can be combined with other
- * DenyCommandNameFilters in an efficient manner.
+ * A {@link CommandMessageFilter} implementation which denies {@link CommandMessage}s based on their {@link
+ * CommandMessage#getCommandName()}. It can be combined with other {@link CommandMessageFilter} instances in an
+ * efficient manner.
  *
  * @author Koen Lavooij
  * @author Allard Buijze
- * @since 4.0
+ * @since 3.0
  */
 public class DenyCommandNameFilter implements CommandMessageFilter {
+
     private final Set<String> commandNames;
 
     /**
@@ -43,13 +48,14 @@ public class DenyCommandNameFilter implements CommandMessageFilter {
      *
      * @param commandNames the names of commands blocked by this filter
      */
-    public DenyCommandNameFilter(Set<String> commandNames) {
+    @ConstructorProperties("commandNames")
+    public DenyCommandNameFilter(@JsonProperty("commandNames") Set<String> commandNames) {
         this.commandNames = new HashSet<>(commandNames);
     }
 
     /**
-     * Initializes a {@link DenyCommandNameFilter} for a single {@code commandName}. Commands with a name equal
-     * to the given commandName will be blocked by this filter.
+     * Initializes a {@link DenyCommandNameFilter} for a single {@code commandName}. Commands with a name equal to the
+     * given commandName will be blocked by this filter.
      *
      * @param commandName the name of the command blocked by this filter
      */
@@ -58,7 +64,7 @@ public class DenyCommandNameFilter implements CommandMessageFilter {
     }
 
     @Override
-    public boolean matches(CommandMessage commandMessage) {
+    public boolean matches(CommandMessage<?> commandMessage) {
         return !commandNames.contains(commandMessage.getCommandName());
     }
 
@@ -82,6 +88,11 @@ public class DenyCommandNameFilter implements CommandMessageFilter {
         } else {
             return new OrCommandMessageFilter(this, other);
         }
+    }
+
+    @JsonGetter
+    private Set<String> getCommandNames() {
+        return commandNames;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilter.java
@@ -16,11 +16,17 @@
 
 package org.axonframework.commandhandling.distributed.commandfilter;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
+import java.beans.ConstructorProperties;
+import java.util.Objects;
+
 /**
- * Filter that negates the result of another matcher
+ * A {@link CommandMessageFilter} implementation that negates the result of another {@link CommandMessageFilter}
+ * instance.
  *
  * @author Allard Buijze
  * @since 4.0
@@ -30,16 +36,46 @@ public class NegateCommandMessageFilter implements CommandMessageFilter {
     private final CommandMessageFilter filter;
 
     /**
-     * Initialize a filter that negates results of the the given {@code filter}.
+     * Initialize a {@link CommandMessageFilter} that negates results of the the given {@code filter}.
      *
-     * @param filter The filter to negate
+     * @param filter the filter to negate
      */
-    public NegateCommandMessageFilter(CommandMessageFilter filter) {
+    @ConstructorProperties("filter")
+    public NegateCommandMessageFilter(@JsonProperty("filter") CommandMessageFilter filter) {
         this.filter = filter;
     }
 
     @Override
     public boolean matches(CommandMessage<?> commandMessage) {
         return !filter.matches(commandMessage);
+    }
+
+    @JsonGetter
+    private CommandMessageFilter getFilter() {
+        return filter;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NegateCommandMessageFilter that = (NegateCommandMessageFilter) o;
+        return Objects.equals(filter, that.filter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filter);
+    }
+
+    @Override
+    public String toString() {
+        return "NegateCommandMessageFilter{" +
+                "filter=" + filter +
+                '}';
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilter.java
@@ -16,26 +16,35 @@
 
 package org.axonframework.commandhandling.distributed.commandfilter;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.CommandMessageFilter;
 
+import java.beans.ConstructorProperties;
+import java.util.Objects;
+
 /**
- * Filter that matches whenever one of the two supplied filters matches
+ * A {@link CommandMessageFilter} implementation that matches whenever either of the supplied {@link
+ * CommandMessageFilter} instances match.
  *
  * @author Allard Buijze
  * @since 4.0
  */
 public class OrCommandMessageFilter implements CommandMessageFilter {
+
     private final CommandMessageFilter first;
     private final CommandMessageFilter second;
 
     /**
      * Initialize the filter to match when either the {@code first} or the {@code second} filter matches.
      *
-     * @param first  The first filter to match
-     * @param second The second filter to match
+     * @param first  the first filter to match
+     * @param second the second filter to match
      */
-    public OrCommandMessageFilter(CommandMessageFilter first, CommandMessageFilter second) {
+    @ConstructorProperties({"first", "second"})
+    public OrCommandMessageFilter(@JsonProperty("first") CommandMessageFilter first,
+                                  @JsonProperty("second") CommandMessageFilter second) {
         this.first = first;
         this.second = second;
     }
@@ -43,5 +52,41 @@ public class OrCommandMessageFilter implements CommandMessageFilter {
     @Override
     public boolean matches(CommandMessage<?> commandMessage) {
         return first.matches(commandMessage) || second.matches(commandMessage);
+    }
+
+    @JsonGetter
+    private CommandMessageFilter getFirst() {
+        return first;
+    }
+
+    @JsonGetter
+    private CommandMessageFilter getSecond() {
+        return second;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrCommandMessageFilter that = (OrCommandMessageFilter) o;
+        return Objects.equals(first, that.first) &&
+                Objects.equals(second, that.second);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second);
+    }
+
+    @Override
+    public String toString() {
+        return "OrCommandMessageFilter{" +
+                "first=" + first +
+                ", second=" + second +
+                '}';
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAllSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAllSerializationTest.java
@@ -1,0 +1,30 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link AcceptAll} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class AcceptAllSerializationTest {
+
+    private final AcceptAll testSubject = AcceptAll.INSTANCE;
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testAcceptAllShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilterSerializationTest.java
@@ -1,0 +1,31 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link AndCommandMessageFilter} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class AndCommandMessageFilterSerializationTest {
+
+    private final AndCommandMessageFilter testSubject =
+            new AndCommandMessageFilter(new CommandNameFilter("firstName"), new CommandNameFilter("secondName"));
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testAndCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandFilterTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandFilterTest.java
@@ -19,12 +19,18 @@ package org.axonframework.commandhandling.distributed.commandfilter;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.GenericMessage;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating the filtering process of the {@link AcceptAll}, {@link DenyAll}, {@link CommandNameFilter} and
+ * {@link DenyCommandNameFilter}.
+ *
+ * @author Koen Lavooij
+ */
 class CommandFilterTest {
+
     @Test
     void testAcceptAll() {
         CommandMessage<Object> testCommand = new GenericCommandMessage<>(new Object());
@@ -47,7 +53,8 @@ class CommandFilterTest {
 
     @Test
     void testCommandNameFilter() {
-        CommandMessage<Object> testCommand = new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
+        CommandMessage<Object> testCommand =
+                new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
 
         CommandNameFilter filterAcceptable = new CommandNameFilter("acceptable");
         CommandNameFilter filterOther = new CommandNameFilter("other");
@@ -76,7 +83,8 @@ class CommandFilterTest {
 
     @Test
     void testDenyCommandNameFilter() {
-        CommandMessage<Object> testCommand = new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
+        CommandMessage<Object> testCommand =
+                new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
 
         DenyCommandNameFilter filterAcceptable = new DenyCommandNameFilter("acceptable");
         DenyCommandNameFilter filterOther = new DenyCommandNameFilter("other");
@@ -102,5 +110,4 @@ class CommandFilterTest {
         assertFalse(filterAcceptable.and(DenyAll.INSTANCE).matches(testCommand));
         assertFalse(filterAcceptable.and(AcceptAll.INSTANCE).matches(testCommand));
     }
-
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilterSerializationTest.java
@@ -1,0 +1,31 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.internal.util.collections.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link CommandNameFilter} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class CommandNameFilterSerializationTest {
+
+    private final CommandNameFilter testSubject = new CommandNameFilter(Sets.newSet("firstName", "secondName"));
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testCommandNameFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAllSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAllSerializationTest.java
@@ -1,0 +1,30 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link DenyAll} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class DenyAllSerializationTest {
+
+    private final DenyAll testSubject = DenyAll.INSTANCE;
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testDenyAllFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilterSerializationTest.java
@@ -1,0 +1,31 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.internal.util.collections.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link DenyCommandNameFilter} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class DenyCommandNameFilterSerializationTest {
+
+    private final DenyCommandNameFilter testSubject = new DenyCommandNameFilter(Sets.newSet("firstName", "secondName"));
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testDenyCommandNameFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilterSerializationTest.java
@@ -1,0 +1,30 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link NegateCommandMessageFilter} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class NegateCommandMessageFilterSerializationTest {
+
+    private final NegateCommandMessageFilter testSubject = new NegateCommandMessageFilter(AcceptAll.INSTANCE);
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testNegateCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilterSerializationTest.java
@@ -1,0 +1,31 @@
+package org.axonframework.commandhandling.distributed.commandfilter;
+
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link OrCommandMessageFilter} can be serialized through Axon's {@link
+ * org.axonframework.serialization.Serializer} implementations.
+ *
+ * @author Steven van Beelen
+ */
+class OrCommandMessageFilterSerializationTest {
+
+    private final OrCommandMessageFilter testSubject =
+            new OrCommandMessageFilter(new CommandNameFilter("firstName"), new CommandNameFilter("secondName"));
+
+    private static Collection<TestSerializer> testSerializers() {
+        return TestSerializer.all();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSerializers")
+    void testOrCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+        assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
+    }
+}


### PR DESCRIPTION
This PR adjusts the `CommandMessageFilter` implementations such that they can be de-/serialized through the `JacksonSerializer`. This wasn't in place just yet, since the filters were only ever serialized through the `XStreamSerializer` instance in for example the [`SpringCloudCommandRouter`](https://github.com/AxonFramework/extension-springcloud/blob/master/springcloud/src/main/java/org/axonframework/extensions/springcloud/commandhandling/SpringCloudCommandRouter.java). Pull request [#25](https://github.com/AxonFramework/extension-springcloud/pull/25) on the Spring Cloud Extension however opened up the configuration of the `Serializer`, essentially allowing for an unusable configuration of the `JacksonSerializer`.

To allow jackson serialization, both the `@ConstructorProperties` and `@JsonProperty` annotations have been included, among others. Furthermore, serialization specific test cases have been added to validate all `CommandMessageFilter` implementations can actually be de-/serialized by all Axon's `Serializer` instances.

Any touched files have seen slight clean up on indenting and JavaDoc.
This pull request resolves #1520