### PR TITLE
Child Entities Duplicated in Aggregate Model

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -314,6 +315,23 @@ public class AnnotatedHandlerInspector<T> {
      */
     public Map<Class<?>, SortedSet<MessageHandlingMember<? super T>>> getAllInterceptors() {
         return Collections.unmodifiableMap(interceptors);
+    }
+
+    /**
+     * Returns a {@link Set} of all types which have been expected for handlers.
+     *
+     * @return a {@link Set} of all types which have been expected for handlers
+     */
+    public Set<Class<?>> getAllInspectedTypes() {
+        Set<Class<?>> inspectedTypes = new HashSet<>();
+        inspectedTypes.add(inspectedType);
+        subClassInspectors.stream()
+                          .map(AnnotatedHandlerInspector::getAllInspectedTypes)
+                          .forEach(inspectedTypes::addAll);
+        superClassInspectors.stream()
+                            .map(AnnotatedHandlerInspector::getAllInspectedTypes)
+                            .forEach(inspectedTypes::addAll);
+        return Collections.unmodifiableSet(inspectedTypes);
     }
 
     private static class ChainedMessageHandlerInterceptorMember<T> implements MessageHandlerInterceptorMemberChain<T> {

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
@@ -154,8 +154,10 @@ class AnnotatedHandlerInspectorTest {
     void testGetAllInspectedTypes() {
         Set<Class<?>> expectedInspectedTypes = Sets.newSet(pA.class, A.class, B.class, C.class, D.class);
 
-        inspector.getAllInspectedTypes()
-                 .forEach(inspectedType -> assertTrue(expectedInspectedTypes.contains(inspectedType)));
+        Set<Class<?>> resultInspectedTypes = inspector.getAllInspectedTypes();
+
+        resultInspectedTypes.forEach(resultType -> assertTrue(expectedInspectedTypes.contains(resultType)));
+        expectedInspectedTypes.forEach(expectedType -> assertTrue(resultInspectedTypes.contains(expectedType)));
     }
 
     @SuppressWarnings("unused")

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
@@ -24,11 +24,13 @@ import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.interceptors.MessageHandlerInterceptor;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
+import org.mockito.internal.util.collections.*;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -146,6 +148,14 @@ class AnnotatedHandlerInspectorTest {
         MessageHandlingMember<? super A> resultHandler = optionalHandler.get();
         chain.handle(testEvent, testTarget, resultHandler);
         assertThrows(MockException.class, () -> chain.handle(testEventTwo, testTarget, resultHandler));
+    }
+
+    @Test
+    void testGetAllInspectedTypes() {
+        Set<Class<?>> expectedInspectedTypes = Sets.newSet(pA.class, A.class, B.class, C.class, D.class);
+
+        inspector.getAllInspectedTypes()
+                 .forEach(inspectedType -> assertTrue(expectedInspectedTypes.contains(inspectedType)));
     }
 
     @SuppressWarnings("unused")

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -207,7 +207,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
         private static final String JAVAX_PERSISTENCE_ID = "javax.persistence.Id";
 
         private final Class<? extends T> inspectedType;
-        private final List<ChildEntity<T>> children;
+        private final Map<Class<?>, ChildEntity<T>> children;
         private final AnnotatedHandlerInspector<T> handlerInspector;
         private final Map<Class<?>, List<MessageHandlingMember<? super T>>> allCommandHandlerInterceptors;
         private final Map<Class<?>, List<MessageHandlingMember<? super T>>> allCommandHandlers;
@@ -229,7 +229,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
             this.allCommandHandlerInterceptors = new HashMap<>();
             this.allCommandHandlers = new HashMap<>();
             this.allEventHandlers = new HashMap<>();
-            this.children = new ArrayList<>();
+            this.children = new HashMap<>();
             this.handlerInspector = handlerInspector;
         }
 
@@ -377,7 +377,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
             childEntityDefinitions.forEach(
                     definition -> definition.createChildDefinition(entityMember, this)
                                             .ifPresent(child -> {
-                                                children.add(child);
+                                                children.put(child.childEntityClass(), child);
                                                 child.commandHandlers().forEach(
                                                         handler -> addHandler(allCommandHandlers, type, handler)
                                                 );
@@ -540,7 +540,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
                             format("Error handling event of type [%s] in aggregate", message.getPayloadType()), e);
                 }
             });
-            children.forEach(i -> i.publish(message, target));
+            children.values().forEach(childEntity -> childEntity.publish(message, target));
         }
 
         @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -335,10 +335,10 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
             List<Member> entityIdMembers = new ArrayList<>();
             List<Member> persistenceIdMembers = new ArrayList<>();
             List<Member> aggregateVersionMembers = new ArrayList<>();
-            for (Class<?> handlerType : handlerInspector.getAllHandlers().keySet()) {
+            for (Class<?> inspectedType : handlerInspector.getAllHandlers().keySet()) {
                 // Navigate fields for Axon related annotations
-                for (Field field : ReflectionUtils.fieldsOf(handlerType)) {
-                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, handlerType, field);
+                for (Field field : ReflectionUtils.fieldsOf(inspectedType)) {
+                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, inspectedType, field);
                     findAnnotationAttributes(field, EntityId.class).ifPresent(attributes -> entityIdMembers.add(field));
                     findAnnotationAttributes(field, JAVAX_PERSISTENCE_ID).ifPresent(
                             attributes -> persistenceIdMembers.add(field)
@@ -348,8 +348,8 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
                     );
                 }
                 // Navigate methods for Axon related annotations
-                for (Method method : ReflectionUtils.methodsOf(handlerType)) {
-                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, handlerType, method);
+                for (Method method : ReflectionUtils.methodsOf(inspectedType)) {
+                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, inspectedType, method);
                     findAnnotationAttributes(method, EntityId.class).ifPresent(attributes -> {
                         assertValidValueProvidingMethod(method, EntityId.class.getSimpleName());
                         entityIdMembers.add(method);

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -336,10 +336,10 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
             List<Member> entityIdMembers = new ArrayList<>();
             List<Member> persistenceIdMembers = new ArrayList<>();
             List<Member> aggregateVersionMembers = new ArrayList<>();
-            for (Class<?> inspectedType : handlerInspector.getAllInspectedTypes()) {
+            for (Class<?> handledType : handlerInspector.getAllInspectedTypes()) {
                 // Navigate fields for Axon related annotations
-                for (Field field : ReflectionUtils.fieldsOf(inspectedType, NOT_RECURSIVE)) {
-                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, inspectedType, field);
+                for (Field field : ReflectionUtils.fieldsOf(handledType, NOT_RECURSIVE)) {
+                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, handledType, field);
                     findAnnotationAttributes(field, EntityId.class).ifPresent(attributes -> entityIdMembers.add(field));
                     findAnnotationAttributes(field, JAVAX_PERSISTENCE_ID).ifPresent(
                             attributes -> persistenceIdMembers.add(field)
@@ -349,8 +349,8 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
                     );
                 }
                 // Navigate methods for Axon related annotations
-                for (Method method : ReflectionUtils.methodsOf(inspectedType, NOT_RECURSIVE)) {
-                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, inspectedType, method);
+                for (Method method : ReflectionUtils.methodsOf(handledType, NOT_RECURSIVE)) {
+                    createChildDefinitionsAndAddHandlers(childEntityDefinitions, handledType, method);
                     findAnnotationAttributes(method, EntityId.class).ifPresent(attributes -> {
                         assertValidValueProvidingMethod(method, EntityId.class.getSimpleName());
                         entityIdMembers.add(method);

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedChildEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedChildEntity.java
@@ -84,9 +84,4 @@ public class AnnotatedChildEntity<P, C> implements ChildEntity<P> {
     public List<MessageHandlingMember<? super P>> commandHandlers() {
         return commandHandlers;
     }
-
-    @Override
-    public Class<?> childEntityClass() {
-        return entityModel.entityClass();
-    }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedChildEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedChildEntity.java
@@ -82,4 +82,9 @@ public class AnnotatedChildEntity<P, C> implements ChildEntity<P> {
     public List<MessageHandlingMember<? super P>> commandHandlers() {
         return commandHandlers;
     }
+
+    @Override
+    public Class<?> childEntityClass() {
+        return entityModel.entityClass();
+    }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
@@ -44,11 +44,4 @@ public interface ChildEntity<T> {
      * @return a list of {@link MessageHandlingMember}s that are capable of processing command messages
      */
     List<MessageHandlingMember<? super T>> commandHandlers();
-
-    /**
-     * Returns the {@link Class} of this child entity.
-     *
-     * @return the {@link Class} of this child entity
-     */
-    Class<?> childEntityClass();
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
@@ -24,22 +24,24 @@ import java.util.List;
 /**
  * Interface describing en entity that is a child of another entity.
  *
- * @param <T>
+ * @param <T> defining the parent class this {@link ChildEntity} belongs to
+ * @author Allard Buijze
+ * @since 3.0
  */
 public interface ChildEntity<T> {
 
     /**
-     * Publish the given {@code msg} to the appropriate handlers on the given {@code declaringInstance}
+     * Publish the given {@code msg} to the appropriate handlers on the given {@code declaringInstance}.
      *
-     * @param msg               The message to publish
-     * @param declaringInstance The instance of this entity to invoke handlers on
+     * @param msg               the message to publish
+     * @param declaringInstance the instance of this entity to invoke handlers on
      */
     void publish(EventMessage<?> msg, T declaringInstance);
 
     /**
-     * Returns the command handlers declared in this entity
+     * Returns the command handlers declared in this entity.
      *
-     * @return a list of message handling members that are capable of processing command messages
+     * @return a list of {@link MessageHandlingMember}s that are capable of processing command messages
      */
     List<MessageHandlingMember<? super T>> commandHandlers();
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildEntity.java
@@ -42,4 +42,11 @@ public interface ChildEntity<T> {
      * @return a list of message handling members that are capable of processing command messages
      */
     List<MessageHandlingMember<? super T>> commandHandlers();
+
+    /**
+     * Returns the {@link Class} of this child entity.
+     *
+     * @return the {@link Class} of this child entity
+     */
+    Class<?> childEntityClass();
 }

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
@@ -15,37 +15,42 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test class validating an annotated aggregate model with {@link AggregateMember}s on the root level of a polymorphic
  * aggregate behaves as desired when a meta model is created with the {@link AnnotatedAggregateMetaModelFactory}.
+  *<p>
+ * The hierarchy of the Aggregate, is as follows:
+ * <p>
+ *          +--------------+
+ *          |Root Aggregate|
+ *          |   +------+   |
+ *          |   |Member|   |
+ *          |   +------+   |
+ *          +--------------+
+ *                 v
+ *          +------+-------+
+ *          |Node Aggregate|
+ *          +------+-------+
+ *          v              v
+ * +--------+-----+ +------+-------------+
+ * |Leaf Aggregate| |Other Leaf Aggregate|
+ * +--------------+ +--------------------+
+ * <p>
+ * On all levels an AggregateEvent handler is present. Only the Member has the MemberEvent handler. In such a set up
+ * we would assume the AggregateEvent handler to be invoked once in the root (which encompasses the root, node and
+ * leaf aggregate) and once in the member. Furthermore we would anticipate the MemberEvent handler to be invoked
+ * once too, since there only is a single occurrence of the member in the entire set up.
  *
  * @author Steven van Beelen
  */
 class AnnotatedRootMemberAggregateMetaModelFactoryTest {
 
-    private static final AtomicInteger aggregateEventCounter = new AtomicInteger(0);
-    private static final AtomicInteger memberEventCounter = new AtomicInteger(0);
+    private AtomicInteger aggregateEventCounter ;
+    private AtomicInteger memberEventCounter ;
 
-    /**
-     * The hierarchy of the Aggregate, is as follows:
-     * <p>
-     *          +--------------+
-     *          |Root Aggregate|
-     *          |   +------+   |
-     *          |   |Member|   |
-     *          |   +------+   |
-     *          +--------------+
-     *                 v
-     *          +------+-------+
-     *          |Node Aggregate|
-     *          +------+-------+
-     *          v              v
-     * +--------+-----+ +------+-------------+
-     * |Leaf Aggregate| |Other Leaf Aggregate|
-     * +--------------+ +--------------------+
-     * <p>
-     * On all levels an AggregateEvent handler is present. Only the Member has the MemberEvent handler. In such a set up
-     * we would assume the AggregateEvent handler to be invoked once in the root (which encompasses the root, node and
-     * leaf aggregate) and once in the member. Furthermore we would anticipate the MemberEvent handler to be invoked
-     * once too, since there only is a single occurrence of the member in the entire set up.
-     */
+    @BeforeEach
+    void setUp() {
+        aggregateEventCounter = new AtomicInteger(0);
+        memberEventCounter = new AtomicInteger(0);
+    }
+
     @Test
     void testCreateAggregateModelDoesNotDuplicateRootLevelAggregateMembers() {
         int expectedNumberOfAggregateEventHandlerInvocations = 2;
@@ -85,7 +90,7 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
     }
 
     @SuppressWarnings("unused")
-    private abstract static class RootAggregate {
+    private abstract class RootAggregate {
 
         @AggregateMember
         private final Member member = new Member();
@@ -96,7 +101,7 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
         }
     }
 
-    private abstract static class NodeAggregate extends RootAggregate {
+    private abstract class NodeAggregate extends RootAggregate {
 
         @EventHandler
         public void on(AggregateEvent event) {
@@ -104,7 +109,7 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
         }
     }
 
-    private static class LeafAggregate extends NodeAggregate {
+    private class LeafAggregate extends NodeAggregate {
 
         @EventHandler
         public void on(AggregateEvent event) {
@@ -112,7 +117,7 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
         }
     }
 
-    private static class OtherLeafAggregate extends NodeAggregate {
+    private class OtherLeafAggregate extends NodeAggregate {
 
         @EventHandler
         public void on(AggregateEvent event) {
@@ -121,7 +126,7 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
     }
 
     @SuppressWarnings("unused")
-    private static class Member {
+    private class Member {
 
         @EventHandler
         public void on(AggregateEvent event) {

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
@@ -6,7 +6,6 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.modelling.command.AggregateMember;
 import org.junit.jupiter.api.*;
 
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Steven van Beelen
  */
-class AnnotatedRootMembersAggregateMetaModelFactoryTest {
+class AnnotatedRootMemberAggregateMetaModelFactoryTest {
 
     private static final AtomicInteger aggregateEventCounter = new AtomicInteger(0);
     private static final AtomicInteger memberEventCounter = new AtomicInteger(0);
@@ -54,9 +53,8 @@ class AnnotatedRootMembersAggregateMetaModelFactoryTest {
         EventMessage<MemberEvent> testMemberEvent = GenericEventMessage.asEventMessage(new MemberEvent());
         LeafAggregate testModel = new LeafAggregate();
 
-        AggregateModel<RootAggregate> testSubject = AnnotatedAggregateMetaModelFactory.inspectAggregate(
-                RootAggregate.class, Collections.singleton(LeafAggregate.class)
-        );
+        AggregateModel<LeafAggregate> testSubject =
+                AnnotatedAggregateMetaModelFactory.inspectAggregate(LeafAggregate.class);
 
         testSubject.publish(testAggregateEvent, testModel);
         assertEquals(expectedNumberOfAggregateEventHandlerInvocations, aggregateEventCounter.get());

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMemberAggregateMetaModelFactoryTest.java
@@ -26,8 +26,20 @@ class AnnotatedRootMemberAggregateMetaModelFactoryTest {
     /**
      * The hierarchy of the Aggregate, is as follows:
      * <p>
-     * +--------------+ |Root Aggregate| |   +------+   | |   |Member|   | |   +------+   | +--------------+ v
-     * +------+-------+ |Node Aggregate| +------+-------+ v +------+-------+ |Leaf Aggregate| +--------------+
+     *          +--------------+
+     *          |Root Aggregate|
+     *          |   +------+   |
+     *          |   |Member|   |
+     *          |   +------+   |
+     *          +--------------+
+     *                 v
+     *          +------+-------+
+     *          |Node Aggregate|
+     *          +------+-------+
+     *          v              v
+     * +--------+-----+ +------+-------------+
+     * |Leaf Aggregate| |Other Leaf Aggregate|
+     * +--------------+ +--------------------+
      * <p>
      * On all levels an AggregateEvent handler is present. Only the Member has the MemberEvent handler. In such a set up
      * we would assume the AggregateEvent handler to be invoked once in the root (which encompasses the root, node and

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMembersAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMembersAggregateMetaModelFactoryTest.java
@@ -1,0 +1,116 @@
+package org.axonframework.modelling.command.inspection;
+
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.modelling.command.AggregateMember;
+import org.junit.jupiter.api.*;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating an annotated aggregate model with {@link AggregateMember}s on the root level of a polymorphic
+ * aggregate behaves as desired when a meta model is created with the {@link AnnotatedAggregateMetaModelFactory}.
+ *
+ * @author Steven van Beelen
+ */
+class AnnotatedRootMembersAggregateMetaModelFactoryTest {
+
+    private static final AtomicInteger aggregateEventCounter = new AtomicInteger(0);
+    private static final AtomicInteger memberEventCounter = new AtomicInteger(0);
+
+    /**
+     * The hierarchy of the Aggregate, is as follows:
+     * <p>
+     * +--------------+
+     * |Root Aggregate|
+     * |   +------+   |
+     * |   |Member|   |
+     * |   +------+   |
+     * +--------------+
+     *        v
+     * +------+-------+
+     * |Node Aggregate|
+     * +------+-------+
+     *        v
+     * +------+-------+
+     * |Leaf Aggregate|
+     * +--------------+
+     * <p>
+     * On all levels an AggregateEvent handler is present. Only the Member has the MemberEvent handler. In such a set up
+     * we would assume the AggregateEvent handler to be invoked once in the root (which encompasses the root, node and
+     * leaf aggregate) and once in the member. Furthermore we would anticipate the MemberEvent handler to be invoked
+     * once too, since there only is a single occurrence of the member in the entire set up.
+     */
+    @Test
+    void testCreateAggregateModelDoesNotDuplicateRootLevelAggregateMembers() {
+        int expectedNumberOfAggregateEventHandlerInvocations = 2;
+        int expectedNumberOfMemberEventHandlerInvocations = 1;
+
+        EventMessage<AggregateEvent> testAggregateEvent = GenericEventMessage.asEventMessage(new AggregateEvent());
+        EventMessage<MemberEvent> testMemberEvent = GenericEventMessage.asEventMessage(new MemberEvent());
+        LeafAggregate testModel = new LeafAggregate();
+
+        AggregateModel<RootAggregate> testSubject = AnnotatedAggregateMetaModelFactory.inspectAggregate(
+                RootAggregate.class, Collections.singleton(LeafAggregate.class)
+        );
+
+        testSubject.publish(testAggregateEvent, testModel);
+        assertEquals(expectedNumberOfAggregateEventHandlerInvocations, aggregateEventCounter.get());
+        testSubject.publish(testMemberEvent, testModel);
+        assertEquals(expectedNumberOfMemberEventHandlerInvocations, memberEventCounter.get());
+    }
+
+    @SuppressWarnings("unused")
+    private abstract static class RootAggregate {
+
+        @AggregateMember
+        private final Member member = new Member();
+
+        @EventHandler
+        public void on(AggregateEvent event) {
+            aggregateEventCounter.incrementAndGet();
+        }
+    }
+
+    private abstract static class NodeAggregate extends RootAggregate {
+
+        @EventHandler
+        public void on(AggregateEvent event) {
+            aggregateEventCounter.incrementAndGet();
+        }
+    }
+
+    private static class LeafAggregate extends NodeAggregate {
+
+        @EventHandler
+        public void on(AggregateEvent event) {
+            aggregateEventCounter.incrementAndGet();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class Member {
+
+        @EventHandler
+        public void on(AggregateEvent event) {
+            aggregateEventCounter.incrementAndGet();
+        }
+
+        @EventHandler
+        public void on(MemberEvent event) {
+            memberEventCounter.incrementAndGet();
+        }
+    }
+
+    private static class AggregateEvent {
+
+    }
+
+    private static class MemberEvent {
+
+    }
+}


### PR DESCRIPTION
Whenever an Aggregate class is provided which contained an hierarchy, there were possibilities that `@AggregateMember` annotated fields/methods would result in duplicate `ChildEntity` instances inside the `AggregateModel`. More specifically, this occurred if the root in the hierarchy contained the entities, whilst all other levels in the hierarchy only contained message handling functions.

The reason for this occurring turned out to be two fold:
1. The `AnnotatedAggregateModel#inspectFieldsAndMethods` methods loops over all classes found by the `AnnotatedHandlerInspector`. For the loop it however used the key set from the `AnnotatedHandlerInspector#getAllHandlers` method. Due to this it was possible that levels in the implementation hierarchy which *did not* contain any message handling functions were ignored entirely. This was however resolved by the subsequent for-loop which reflectively searches for all fields and methods. 
2. Although issue one was mitigated to some extent by the reflective search of all fields and methods, this also meant that *if* the `AnnotatedHandlerInspector#getAllHandlers` method responded with a class type on each level of the Aggregate hierarchy, that subsequent invocation of the reflective operation would have the fields/methods reoccur. Due to this, `ChildEntity` instances could be inserted into the model several times. Essentially for each level which contained a message handling function, which *is* the root implementation or a sub implementation of it.

To solve the above problem, both issues were tackled.
1. The `AnnotatedHandlerInspector` has a new method, called the `getAllInspectedTypes`. This returns the actual type, all super classes and all sub classes which have been validated by the inspector. It's this set which is used by the `AnnotatedAggregateModel` to visit every step in the hierarchy and check for annotated fields/methods.
2. The `AnnotatedAggregateModel` no longer uses a recursive version of the `ReflectionUtils` `fieldsOf`/`methodsOf` functions. This is replaced for a non-recursive variant instead, just checking for fields/methods on the exact class. This is now an option as the entire set of classes which is validated is correctly returned by the `AnnotatedHandlerInspector`.

There was a short side track in fixing this through the `ChildEntity` and `AnnotatedChildEntity` which was disregarded later. What's left of that side track in this PR is clean up of warnings and javadoc.