### PR TITLE
[#1593] Filter ResetHandlers from canHandleType

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -121,7 +121,7 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
      *                       ResetContext}
      * @return {@code true} if it handles messages of type {@link ResetContext}, {@code false} otherwise
      */
-    private Boolean handlesEventMessage(MessageHandlingMember<? super Object> messageHandler) {
+    private boolean handlesEventMessage(MessageHandlingMember<? super Object> messageHandler) {
         return messageHandler.annotationAttributes(MessageHandler.class)
                              .map(attributes -> attributes.get("messageType"))
                              .map(messageType -> EventMessage.class.isAssignableFrom((Class<?>) messageType))

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -16,16 +16,19 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.eventhandling.replay.GenericResetContext;
 import org.axonframework.eventhandling.replay.ResetContext;
 import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.MessageHandler;
 import org.axonframework.messaging.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
+import java.lang.reflect.Executable;
 import java.util.Optional;
 
 /**
@@ -105,8 +108,25 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
     @Override
     public boolean canHandleType(Class<?> payloadType) {
         return inspector.getHandlers(listenerType)
-                        .filter(messageHandler -> !messageHandler.hasAnnotation(ResetHandler.class))
+                        .filter(messageHandler -> !handlesResetContext(messageHandler))
                         .anyMatch(handler -> handler.canHandleType(payloadType));
+    }
+
+    /**
+     * Validate whether the given {@code messageHandler} can handle the {@link ResetContext} by checking the attributes
+     * on the {@link MessageHandler} annotation.
+     *
+     * @param messageHandler the {@link MessageHandlingMember} to validate if it handles messages of type {@link
+     *                       ResetContext}
+     * @return {@code true} if it handles messages of type {@link ResetContext}, {@code false} otherwise
+     */
+    private Boolean handlesResetContext(MessageHandlingMember<? super Object> messageHandler) {
+        return messageHandler.unwrap(Executable.class)
+                             .map(handler -> AnnotationUtils.findAnnotationAttributes(handler, MessageHandler.class))
+                             .map(Optional::get)
+                             .map(attributes -> attributes.get("messageType"))
+                             .map(messageType -> messageType.equals(ResetContext.class))
+                             .orElse(false);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -124,7 +124,7 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
     private Boolean handlesEventMessage(MessageHandlingMember<? super Object> messageHandler) {
         return messageHandler.annotationAttributes(MessageHandler.class)
                              .map(attributes -> attributes.get("messageType"))
-                             .map(messageType -> messageType.equals(EventMessage.class))
+                             .map(messageType -> EventMessage.class.isAssignableFrom((Class<?>) messageType))
                              .orElse(false);
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -122,8 +122,7 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
      * @return {@code true} if it handles messages of type {@link ResetContext}, {@code false} otherwise
      */
     private Boolean handlesEventMessage(MessageHandlingMember<? super Object> messageHandler) {
-        return messageHandler.unwrap(Executable.class)
-                             .flatMap(handler -> findAnnotationAttributes(handler, MessageHandler.class))
+        return messageHandler.annotationAttributes(MessageHandler.class)
                              .map(attributes -> attributes.get("messageType"))
                              .map(messageType -> messageType.equals(EventMessage.class))
                              .orElse(false);

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -105,6 +105,7 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
     @Override
     public boolean canHandleType(Class<?> payloadType) {
         return inspector.getHandlers(listenerType)
+                        .filter(messageHandler -> !messageHandler.hasAnnotation(ResetHandler.class))
                         .anyMatch(handler -> handler.canHandleType(payloadType));
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
@@ -156,7 +156,7 @@ class AnnotationEventHandlerAdapterTest {
 
         @EventHandler
         public void handleNormally(Long value) {
-            // noop
+            // No-op
         }
 
         @ExceptionHandler(resultType = IllegalArgumentException.class)
@@ -175,7 +175,7 @@ class AnnotationEventHandlerAdapterTest {
 
         @EventHandler
         public void handleNormally(Long value) {
-            // noop
+            // No-op
         }
 
         @ExceptionHandler
@@ -209,17 +209,17 @@ class AnnotationEventHandlerAdapterTest {
 
         @EventHandler
         public void handle(Long event) {
-
+            // No-op
         }
 
         @ResetHandler
         public void reset() {
-
+            // No-op
         }
 
         @ResetHandler
         public void resetWithContext(String resetContext, SomeResource someResource) {
-
+            // No-op
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
@@ -115,6 +115,16 @@ class AnnotationEventHandlerAdapterTest {
         }
     }
 
+    @Test
+    void testCanHandleTypeDoesNotReturnResetHandlers() {
+        SomeResetHandlerWithContext annotatedEventListener = new SomeResetHandlerWithContext();
+        testSubject = new AnnotationEventHandlerAdapter(annotatedEventListener, parameterResolverFactory);
+
+        assertTrue(testSubject.canHandleType(Long.class));
+        assertFalse(testSubject.canHandleType(String.class));
+        assertFalse(testSubject.canHandleType(Integer.class));
+    }
+
     @SuppressWarnings("unused")
     private static class SomeHandler {
 
@@ -191,6 +201,25 @@ class AnnotationEventHandlerAdapterTest {
         @MessageHandlerInterceptor
         public void intercept(Object any) {
             invocations.add(any.toString());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class SomeResetHandlerWithContext {
+
+        @EventHandler
+        public void handle(Long event) {
+
+        }
+
+        @ResetHandler
+        public void reset() {
+
+        }
+
+        @ResetHandler
+        public void resetWithContext(String resetContext, SomeResource someResource) {
+
         }
     }
 


### PR DESCRIPTION
The `AnnotationEventHandlerAdapter#canHandleType` should *not* take `@ResetHandler` annotated methods into account when being invoked, because the reset handling members will only be invoked through a `EventHandlerInvoker` directly instead of as a result of general message handling.

The fact this filter was not in place was the main reason of issue #1593, which noted that events were not filtered out of the entire stream when a plain `@ResetHandler` (thus without a "reset context" as the message) was present. This occurred, since a `@ResetHandler` without any specific reset context was capable of handling _any_ type of message. Due to this no events where ever filtered out of the stream, since the framework assumed everything could be handled.

Introducing the simple filter solves the problem, and as such resolves #1593 