### PR TITLE
[#1604] Create head token if tokenAt has no result

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -153,7 +153,8 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
                      .map(TrackedEventMessage::trackingToken)
                      .map(tt -> (GlobalSequenceTrackingToken) tt)
                      .map(tt -> new GlobalSequenceTrackingToken(tt.getGlobalIndex() - 1))
-                     .orElse(null);
+                     .map(tt -> (TrackingToken) tt)
+                     .orElse(createHeadToken());
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -154,7 +154,7 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
                      .map(tt -> (GlobalSequenceTrackingToken) tt)
                      .map(tt -> new GlobalSequenceTrackingToken(tt.getGlobalIndex() - 1))
                      .map(tt -> (TrackingToken) tt)
-                     .orElse(createHeadToken());
+                     .orElseGet(this::createHeadToken);
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -436,7 +436,7 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
 
     @Override
     public TrackingToken createHeadToken() {
-        return createToken(mostRecentToken());
+        return createToken(mostRecentIndex());
     }
 
     @Override
@@ -447,10 +447,10 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
                 resultSet -> nextAndExtract(resultSet, 1, Long.class),
                 e -> new EventStoreException(format("Failed to get token at [%s]", dateTime), e)
         ));
-        return index != null ? createToken(index) : createToken(mostRecentToken());
+        return index != null ? createToken(index) : createToken(mostRecentIndex());
     }
 
-    private Long mostRecentToken() {
+    private Long mostRecentIndex() {
         return transactionManager.fetchInTransaction(() -> executeQuery(
                 getConnection(),
                 this::createHeadToken,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -31,11 +31,24 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackedDomainEventData;
 import org.axonframework.eventhandling.TrackedEventData;
 import org.axonframework.eventhandling.TrackingToken;
-import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
-import org.axonframework.eventsourcing.eventstore.jdbc.statements.*;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.AppendEventsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.AppendSnapshotStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.CleanGapsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateHeadTokenStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateTailTokenStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.CreateTokenAtStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.DeleteSnapshotsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.FetchTrackedEventsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.JdbcEventStorageEngineStatements;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.LastSequenceNumberForStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataForAggregateStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataWithGapsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadEventDataWithoutGapsStatementBuilder;
+import org.axonframework.eventsourcing.eventstore.jdbc.statements.ReadSnapshotDataStatementBuilder;
 import org.axonframework.eventsourcing.eventstore.jdbc.statements.TimestampWriter;
+import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
@@ -418,35 +431,38 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
                 resultSet -> nextAndExtract(resultSet, 1, Long.class),
                 e -> new EventStoreException("Failed to get tail token", e)
         ));
-        return Optional.ofNullable(index)
-                       .map(seq -> GapAwareTrackingToken.newInstance(seq, Collections.emptySet()))
-                       .orElse(null);
+        return createToken(index);
     }
 
     @Override
     public TrackingToken createHeadToken() {
+        return createToken(mostRecentToken());
+    }
+
+    @Override
+    public TrackingToken createTokenAt(Instant dateTime) {
         Long index = transactionManager.fetchInTransaction(() -> executeQuery(
+                getConnection(),
+                connection -> createTokenAt(connection, dateTime),
+                resultSet -> nextAndExtract(resultSet, 1, Long.class),
+                e -> new EventStoreException(format("Failed to get token at [%s]", dateTime), e)
+        ));
+        return index != null ? createToken(index) : createToken(mostRecentToken());
+    }
+
+    private Long mostRecentToken() {
+        return transactionManager.fetchInTransaction(() -> executeQuery(
                 getConnection(),
                 this::createHeadToken,
                 resultSet -> nextAndExtract(resultSet, 1, Long.class),
                 e -> new EventStoreException("Failed to get head token", e)
         ));
+    }
+
+    private TrackingToken createToken(Long index) {
         return Optional.ofNullable(index)
                        .map(seq -> GapAwareTrackingToken.newInstance(seq, Collections.emptySet()))
                        .orElse(null);
-    }
-
-    @Override
-    public TrackingToken createTokenAt(Instant dateTime) {
-        Long index = transactionManager.fetchInTransaction(
-                () -> executeQuery(getConnection(),
-                                   connection -> createTokenAt(connection, dateTime),
-                                   resultSet -> nextAndExtract(resultSet, 1, Long.class),
-                                   e -> new EventStoreException(format("Failed to get token at [%s]", dateTime), e)));
-        if (index == null) {
-            return null;
-        }
-        return GapAwareTrackingToken.newInstance(index, Collections.emptySet());
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -355,7 +355,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     private boolean noTokenFound(List<Long> tokens) {
-        return tokens.size() == 0 || tokens.get(0) == null;
+        return tokens.isEmpty() || tokens.get(0) == null;
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -325,7 +325,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
     @Override
     public TrackingToken createHeadToken() {
-        return createToken(mostRecentToken());
+        return createToken(mostRecentIndex());
     }
 
     @Override
@@ -338,10 +338,10 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
                 .setParameter("dateTime", formatInstant(dateTime))
                 .getResultList();
 
-        return noTokenFound(results) ? createToken(mostRecentToken()) : createToken(results);
+        return noTokenFound(results) ? createToken(mostRecentIndex()) : createToken(results);
     }
 
-    private List<Long> mostRecentToken() {
+    private List<Long> mostRecentIndex() {
         return entityManager()
                 .createQuery("SELECT MAX(e.globalIndex) FROM " + domainEventEntryEntityName() + " e", Long.class)
                 .getResultList();

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -325,27 +325,37 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
     @Override
     public TrackingToken createHeadToken() {
-        List<Long> results = entityManager().createQuery(
-                "SELECT MAX(e.globalIndex) FROM " + domainEventEntryEntityName() + " e", Long.class
-        ).getResultList();
-        return createToken(results);
+        return createToken(mostRecentToken());
     }
 
     @Override
     public TrackingToken createTokenAt(Instant dateTime) {
-        List<Long> results = entityManager().createQuery(
-                "SELECT MIN(e.globalIndex) - 1 FROM " + domainEventEntryEntityName()
-                        + " e WHERE e.timeStamp >= :dateTime", Long.class
-        ).setParameter("dateTime", formatInstant(dateTime))
-                                            .getResultList();
-        return createToken(results);
+        List<Long> results = entityManager()
+                .createQuery(
+                        "SELECT MIN(e.globalIndex) - 1 FROM " + domainEventEntryEntityName() + " e "
+                                + "WHERE e.timeStamp >= :dateTime", Long.class
+                )
+                .setParameter("dateTime", formatInstant(dateTime))
+                .getResultList();
+
+        return noTokenFound(results) ? createToken(mostRecentToken()) : createToken(results);
     }
 
-    private TrackingToken createToken(List<Long> results) {
-        if (results.size() == 0 || results.get(0) == null) {
+    private List<Long> mostRecentToken() {
+        return entityManager()
+                .createQuery("SELECT MAX(e.globalIndex) FROM " + domainEventEntryEntityName() + " e", Long.class)
+                .getResultList();
+    }
+
+    private TrackingToken createToken(List<Long> tokens) {
+        if (noTokenFound(tokens)) {
             return null;
         }
-        return GapAwareTrackingToken.newInstance(results.get(0), Collections.emptySet());
+        return GapAwareTrackingToken.newInstance(tokens.get(0), Collections.emptySet());
+    }
+
+    private boolean noTokenFound(List<Long> tokens) {
+        return tokens.size() == 0 || tokens.get(0) == null;
     }
 
     /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
@@ -72,8 +72,8 @@ class MultiStreamableMessageSourceTest {
 
         eventStoreA.publish(publishedEvent);
 
-        BlockingStream<TrackedEventMessage<?>> singleEventStream = testSubject.openStream(testSubject
-                                                                                                  .createTailToken());
+        BlockingStream<TrackedEventMessage<?>> singleEventStream =
+                testSubject.openStream(testSubject.createTailToken());
 
         assertTrue(singleEventStream.hasNextAvailable());
         assertEquals(publishedEvent.getPayload(), singleEventStream.nextAvailable().getPayload());
@@ -107,8 +107,8 @@ class MultiStreamableMessageSourceTest {
         EventMessage<?> publishedEvent = new GenericDomainEventMessage<>("Aggregate", "id", 0, "Event1");
 
         eventStoreA.publish(publishedEvent);
-        BlockingStream<TrackedEventMessage<?>> singleEventStream = testSubject.openStream(testSubject
-                                                                                                  .createTailToken());
+        BlockingStream<TrackedEventMessage<?>> singleEventStream =
+                testSubject.openStream(testSubject.createTailToken());
 
         assertTrue(singleEventStream.hasNextAvailable());
         TrackedEventMessage<?> actual = singleEventStream.nextAvailable();
@@ -151,8 +151,8 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void longPoll() throws InterruptedException {
-        BlockingStream<TrackedEventMessage<?>> singleEventStream = testSubject.openStream(testSubject
-                                                                                                  .createTokenAt(Instant.now()));
+        BlockingStream<TrackedEventMessage<?>> singleEventStream =
+                testSubject.openStream(testSubject.createTokenAt(Instant.now()));
 
         long beforePollTime = System.currentTimeMillis();
         assertFalse(singleEventStream.hasNextAvailable(100, TimeUnit.MILLISECONDS));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/MultiStreamableMessageSourceTest.java
@@ -352,8 +352,7 @@ class MultiStreamableMessageSourceTest {
     void configuredDifferentComparator() throws InterruptedException {
         Comparator<Map.Entry<String, TrackedEventMessage<?>>> eventStoreAPriority =
                 Comparator.comparing((Map.Entry<String, TrackedEventMessage<?>> e) -> !e.getKey().equals("eventStoreA"))
-                          .
-                                  thenComparing(e -> e.getValue().getTimestamp());
+                          .thenComparing(e -> e.getValue().getTimestamp());
 
         EmbeddedEventStore eventStoreC = EmbeddedEventStore.builder().storageEngine(new InMemoryEventStorageEngine())
                                                            .build();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -231,6 +231,22 @@ public abstract class EventStorageEngineTest {
         assertEventStreamsById(Arrays.asList(event3, event4, event5), readEvents);
     }
 
+    @Test
+    void testCreateTokenAtTimeAfterLastEvent() {
+        DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
+        DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
+        DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
+
+        testSubject.appendEvents(event1, event2, event3);
+
+        TrackingToken tokenAt = testSubject.createTokenAt(Instant.parse("2008-12-03T10:15:30.00Z"));
+
+        List<EventMessage<?>> readEvents = testSubject.readEvents(tokenAt, false)
+                                                      .collect(toList());
+
+        assertTrue(readEvents.isEmpty());
+    }
+
     protected void setTestSubject(EventStorageEngine testSubject) {
         this.testSubject = testSubject;
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -231,20 +231,42 @@ public abstract class EventStorageEngineTest {
         assertEventStreamsById(Arrays.asList(event3, event4, event5), readEvents);
     }
 
+    /**
+     * If the dateTime is after the last event in the store, the token should default to the position of the last event.
+     */
     @Test
     void testCreateTokenAtTimeAfterLastEvent() {
+        Instant dateTimeAfterLastEvent = Instant.parse("2008-12-03T10:15:30.00Z");
+
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
-
         testSubject.appendEvents(event1, event2, event3);
 
-        TrackingToken tokenAt = testSubject.createTokenAt(Instant.parse("2008-12-03T10:15:30.00Z"));
+        TrackingToken result = testSubject.createTokenAt(dateTimeAfterLastEvent);
 
-        List<EventMessage<?>> readEvents = testSubject.readEvents(tokenAt, false)
-                                                      .collect(toList());
+        List<EventMessage<?>> readEvents = testSubject.readEvents(result, false).collect(toList());
 
         assertTrue(readEvents.isEmpty());
+    }
+
+    /**
+     * If the dateTime is before the first event in the store, the token should default to the position of the first event.
+     */
+    @Test
+    void testCreateTokenAtTimeBeforeFirstEvent() {
+        Instant dateTimeBeforeFirstEvent = Instant.parse("2006-12-03T10:15:30.00Z");
+
+        DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
+        DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
+        DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
+        testSubject.appendEvents(event1, event2, event3);
+
+        TrackingToken result = testSubject.createTokenAt(dateTimeBeforeFirstEvent);
+
+        List<EventMessage<?>> readEvents = testSubject.readEvents(result, false).collect(toList());
+
+        assertEventStreamsById(Arrays.asList(event1, event2, event3), readEvents);
     }
 
     protected void setTestSubject(EventStorageEngine testSubject) {


### PR DESCRIPTION
The documentation of the `StreamableMessageSource#createTokenAt(Instant)` states the following:

```
/**
 * Creates a token that tracks all events after given {@code dateTime}. If there is an event exactly at the given
 * {@code dateTime}, it will be tracked too.
 *
 * @param dateTime The date and time for determining criteria how the tracking token should be created. A tracking
 *                 token should point at very first event before this date and time.
 * @return a tracking token at the given {@code dateTime}, if there aren't events matching this criteria {@code
 * null} is returned
 * @throws UnsupportedOperationException if the implementation does not support the creation of time-based tokens
 */
```

As noted on the `@param dateTime` line, a create tracking token should point at the very first event _before_ this date and time.
If the provided `dateTime` is a timestamp _after_ the last event in the event store however, the JPA, JDBC and InMemory implementations of the `EventStorageEngine` defaulted to a `null`. Thus, a tail token. 

This discrepancy between the implementation and the documentation is resolved in this PR, as such resolving #1604
As a side note, warnings have been removed from the `MultiStreamableMessageSourceTest`.