### PR TITLE
Allow message type validation on MessageHandlingMember

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -109,23 +109,8 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
     @Override
     public boolean canHandleType(Class<?> payloadType) {
         return inspector.getHandlers(listenerType)
-                        .filter(this::handlesEventMessage)
+                        .filter(messageHandlingMember -> messageHandlingMember.canHandleMessageType(EventMessage.class))
                         .anyMatch(handler -> handler.canHandleType(payloadType));
-    }
-
-    /**
-     * Validate whether the given {@code messageHandler} can handle a message of type {@link EventMessage} by checking
-     * the attributes on the {@link MessageHandler} annotation.
-     *
-     * @param messageHandler the {@link MessageHandlingMember} to validate if it handles messages of type {@link
-     *                       ResetContext}
-     * @return {@code true} if it handles messages of type {@link ResetContext}, {@code false} otherwise
-     */
-    private boolean handlesEventMessage(MessageHandlingMember<? super Object> messageHandler) {
-        return messageHandler.annotationAttributes(MessageHandler.class)
-                             .map(attributes -> attributes.get("messageType"))
-                             .map(messageType -> EventMessage.class.isAssignableFrom((Class<?>) messageType))
-                             .orElse(false);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -22,15 +22,11 @@ import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.HandlerDefinition;
-import org.axonframework.messaging.annotation.MessageHandler;
 import org.axonframework.messaging.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 
-import java.lang.reflect.Executable;
 import java.util.Optional;
-
-import static org.axonframework.common.annotation.AnnotationUtils.findAnnotationAttributes;
 
 /**
  * Adapter that turns any bean with {@link EventHandler} annotated methods into an {@link EventMessageHandler}.

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
@@ -34,6 +34,8 @@ import java.util.Optional;
  * Implementation of a {@link MessageHandlingMember} that is used to invoke message handler methods on the target type.
  *
  * @param <T> the target type
+ * @author Allard Buijze
+ * @since 3.0
  */
 public class AnnotatedMessageHandlingMember<T> implements MessageHandlingMember<T> {
 
@@ -95,6 +97,12 @@ public class AnnotatedMessageHandlingMember<T> implements MessageHandlingMember<
     @Override
     public boolean canHandleType(Class<?> payloadType) {
         return this.payloadType.isAssignableFrom(payloadType);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean canHandleMessageType(Class<? extends Message> messageType) {
+        return this.messageType.isAssignableFrom(messageType);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
@@ -74,6 +74,19 @@ public interface MessageHandlingMember<T> {
     }
 
     /**
+     * Checks if this handlers is capable of handling {@link Message} implementations of the given {@code messageType}.
+     * <p>
+     * It is recommended to suppress the raw type use validation of the {@code messageType} parameter when implementing
+     * this method, as usage of this method with a {@code Message} generic would required reflection or casting
+     * otherwise.
+     *
+     * @param messageType the {@link Message}'s type to check if it can be handled by this handler
+     * @return {@code true} if this handler can handle the given {@code messageType}, {@code false} otherwise
+     */
+    @SuppressWarnings("rawtypes")
+    boolean canHandleMessageType(Class<? extends Message> messageType);
+
+    /**
      * Handles the given {@code message} by invoking the appropriate method on given {@code target}. This may result in
      * an exception if the given target is not capable of handling the message or if an exception is thrown during
      * invocation of the method.
@@ -126,7 +139,6 @@ public interface MessageHandlingMember<T> {
      * Checks whether the method of the target entity contains the given {@code annotationType}.
      *
      * @param annotationType Annotation to check for on the target method
-     *
      * @return {@code true} if the annotation is present on the target method, {@code false} otherwise
      */
     boolean hasAnnotation(Class<? extends Annotation> annotationType);

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
@@ -66,6 +66,12 @@ public abstract class WrappedMessageHandlingMember<T> implements MessageHandling
         return delegate.canHandleType(payloadType);
     }
 
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean canHandleMessageType(Class<? extends Message> messageType) {
+        return delegate.canHandleMessageType(messageType);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <HT> Optional<HT> unwrap(Class<HT> handlerType) {

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
@@ -1,0 +1,43 @@
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link AnnotatedMessageHandlingMember}.
+ *
+ * @author Steven van Beelen
+ */
+class AnnotatedMessageHandlingMemberTest {
+
+    private AnnotatedMessageHandlingMember<AnnotatedHandler> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        testSubject = new AnnotatedMessageHandlingMember<>(
+                AnnotatedHandler.class.getMethods()[0],
+                EventMessage.class,
+                String.class,
+                ClasspathParameterResolverFactory.forClass(AnnotatedHandler.class)
+        );
+    }
+
+    @Test
+    void testCanHandleMessageType() {
+        assertTrue(testSubject.canHandleMessageType(EventMessage.class));
+        assertFalse(testSubject.canHandleMessageType(CommandMessage.class));
+    }
+
+    @SuppressWarnings("unused")
+    private static class AnnotatedHandler {
+
+        @EventHandler
+        public void handlingMethod(String event) {
+
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
@@ -100,6 +100,7 @@ class HandlerComparatorTest {
     }
 
     private static class StubMessageHandlingMember implements MessageHandlingMember<Object> {
+
         private final Class<?> payloadType;
         private final int priority;
 
@@ -122,6 +123,12 @@ class HandlerComparatorTest {
         @Override
         public boolean canHandle(Message<?> message) {
             throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public boolean canHandleMessageType(Class<? extends Message> messageType) {
+            throw new UnsupportedOperationException("Not implemented (yet)");
         }
 
         @Override

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMemberTest.java
@@ -1,0 +1,32 @@
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.queryhandling.QueryMessage;
+import org.junit.jupiter.api.*;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link WrappedMessageHandlingMember}.
+ *
+ * @author Steven van Beelen
+ */
+class WrappedMessageHandlingMemberTest {
+
+    private MessageHandlingMember<Object> mockedHandlingMember;
+    private WrappedMessageHandlingMember<Object> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        //noinspection unchecked
+        mockedHandlingMember = mock(MessageHandlingMember.class);
+
+        testSubject = new WrappedMessageHandlingMember<Object>(mockedHandlingMember) {
+        };
+    }
+
+    @Test
+    void testCanHandleMessageType() {
+        testSubject.canHandleMessageType(QueryMessage.class);
+        verify(mockedHandlingMember).canHandleMessageType(QueryMessage.class);
+    }
+}

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
@@ -18,12 +18,12 @@ package org.axonframework.modelling.command.inspection;
 
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandMessageHandlingMember;
-import org.axonframework.modelling.command.AggregateEntityNotFoundException;
 import org.axonframework.messaging.DefaultInterceptorChain;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.modelling.command.AggregateEntityNotFoundException;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -37,6 +37,8 @@ import java.util.stream.Collectors;
  *
  * @param <P> the parent entity type
  * @param <C> the child entity type
+ * @author Allard Buijze
+ * @since 3.0
  */
 public class ChildForwardingCommandMessageHandlingMember<P, C> implements CommandMessageHandlingMember<P> {
 
@@ -96,6 +98,12 @@ public class ChildForwardingCommandMessageHandlingMember<P, C> implements Comman
     @Override
     public boolean canHandle(Message<?> message) {
         return childHandler.canHandle(message);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean canHandleMessageType(Class<? extends Message> messageType) {
+        return childHandler.canHandleMessageType(messageType);
     }
 
     @SuppressWarnings("unchecked")

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMemberTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMemberTest.java
@@ -1,0 +1,41 @@
+package org.axonframework.modelling.command.inspection;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.junit.jupiter.api.*;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link ChildForwardingCommandMessageHandlingMember}.
+ *
+ * @author Steven van Beelen
+ */
+class ChildForwardingCommandMessageHandlingMemberTest {
+
+    private MessageHandlingMember<Object> childMember;
+
+    private ChildForwardingCommandMessageHandlingMember<Object, Object> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        //noinspection unchecked
+        childMember = mock(MessageHandlingMember.class);
+
+        testSubject = new ChildForwardingCommandMessageHandlingMember<>(
+                Collections.emptyList(), childMember, (msg, parent) -> parent
+        );
+    }
+
+    @Test
+    void testCanHandleMessageTypeIsDelegatedToChildHandler() {
+        when(childMember.canHandleMessageType(any())).thenReturn(true);
+
+        assertTrue(testSubject.canHandleMessageType(CommandMessage.class));
+
+        verify(childMember).canHandleMessageType(CommandMessage.class);
+    }
+}


### PR DESCRIPTION
There are several scenarios where it is beneficial to request a `MessageHandlingMember` which `Message` implementations it is capable to handle. Prior to this PR, this required either retrieval of annotations attributes or unwrapping of the `MessageHandlingMember` to validate further information. With this pull request, a `canHandleMessageType(Class<? extends Message>)` operation has been introduced which allows direct validation of the type of message it can handle.

This can be regarded as a follow up of #1593, which directly required such a validation.