### PR TITLE
[#1611] MetaData deserilization and Ignoring Snapshots on readEvents for seqNo = 0

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -475,7 +475,7 @@ public class AxonServerEventStore extends AbstractEventStore {
             EventChannel eventChannel = connectionManager.getConnection(context).eventChannel();
 
             AggregateEventStream aggregateStream;
-            if (firstSequenceNumber > 0) {
+            if (firstSequenceNumber >= 0) {
                 aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier, firstSequenceNumber);
             } else if (firstSequenceNumber == ALLOW_SNAPSHOTS_MAGIC_VALUE && !snapshotFilterSet) {
                 aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier, true);

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -342,6 +342,7 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private static final int ALLOW_SNAPSHOTS_MAGIC_VALUE = -42;
         private final String APPEND_EVENT_TRANSACTION = this + "/APPEND_EVENT_TRANSACTION";
+        private static final boolean WITHOUT_SNAPSHOTS = false;
 
         private final AxonServerConfiguration configuration;
         private final AxonServerConnectionManager connectionManager;
@@ -478,9 +479,9 @@ public class AxonServerEventStore extends AbstractEventStore {
             if (firstSequenceNumber >= 0) {
                 aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier, firstSequenceNumber);
             } else if (firstSequenceNumber == ALLOW_SNAPSHOTS_MAGIC_VALUE && !snapshotFilterSet) {
-                aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier, true);
-            } else {
                 aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier);
+            } else {
+                aggregateStream = eventChannel.openAggregateStream(aggregateIdentifier, WITHOUT_SNAPSHOTS);
             }
 
             return aggregateStream.asStream().map(GrpcBackedDomainEventData::new);

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -371,8 +371,8 @@ public class AxonServerEventStore extends AbstractEventStore {
             this.builder = builder;
             this.context = context;
 
-            this.snapshotSerializer = new GrpcMetaDataAwareSerializer(getSnapshotSerializer());
-            this.eventSerializer = new GrpcMetaDataAwareSerializer(getEventSerializer());
+            this.snapshotSerializer = new GrpcMetaDataAwareSerializer(super.getSnapshotSerializer());
+            this.eventSerializer = new GrpcMetaDataAwareSerializer(super.getEventSerializer());
         }
 
         /**
@@ -653,6 +653,16 @@ public class AxonServerEventStore extends AbstractEventStore {
                     return true;
                 }
             }, false);
+        }
+
+        @Override
+        public Serializer getSnapshotSerializer() {
+            return this.snapshotSerializer;
+        }
+
+        @Override
+        public Serializer getEventSerializer() {
+            return this.eventSerializer;
         }
 
         private static class Builder extends AbstractEventStorageEngine.Builder {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
@@ -92,11 +92,12 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
 
     @Override
     public void listAggregateEvents(GetAggregateEventsRequest request, StreamObserver<Event> responseObserver) {
-        Event snapshot = snapshots.get(request.getAggregateId());
+        Event snapshot = request.getAllowSnapshots() ? snapshots.get(request.getAggregateId()) : null;
         if (snapshot != null) {
             responseObserver.onNext(snapshot);
         }
-        events.stream().filter(e -> e.getAggregateIdentifier().equals(request.getAggregateId()))
+        events.stream()
+              .filter(e -> e.getAggregateIdentifier().equals(request.getAggregateId()))
               .filter(e -> snapshot == null || snapshot.getAggregateSequenceNumber() < e.getAggregateSequenceNumber())
               .forEach(responseObserver::onNext);
         responseObserver.onCompleted();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -23,47 +23,47 @@ import org.axonframework.axonserver.connector.event.EventStoreImpl;
 import org.axonframework.axonserver.connector.event.StubServer;
 import org.axonframework.axonserver.connector.util.TcpUtil;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
+import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+/**
+ * Test class validating the {@link AxonServerEventStore}
+ *
+ * @author Marc Gathier
+ */
 class AxonServerEventStoreTest {
 
+    private EventStoreImpl eventStore;
     private StubServer server;
-    private AxonServerEventStore testSubject;
     private EventUpcaster upcasterChain;
     private AxonServerConnectionManager axonServerConnectionManager;
-    private EventStoreImpl eventStore;
+
+    private AxonServerEventStore testSubject;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -80,14 +80,15 @@ class AxonServerEventStoreTest {
                                                                 .flowControl(2, 1, 1)
                                                                 .build();
         axonServerConnectionManager = AxonServerConnectionManager.builder()
-                                   .axonServerConfiguration(config)
-                                   .build();
+                                                                 .axonServerConfiguration(config)
+                                                                 .build();
         testSubject = AxonServerEventStore.builder()
                                           .configuration(config)
                                           .platformConnectionManager(axonServerConnectionManager)
                                           .upcasterChain(upcasterChain)
                                           .eventSerializer(JacksonSerializer.defaultSerializer())
                                           .snapshotSerializer(TestSerializer.secureXStreamSerializer())
+                                          .snapshotFilter(SnapshotFilter.allowAll())
                                           .build();
     }
 
@@ -139,7 +140,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testLoadSnapshotAndEventsWithMultiUpcaster() throws InterruptedException {
+    void testLoadSnapshotAndEventsWithMultiUpcaster() {
         reset(upcasterChain);
         when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
             Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
@@ -159,7 +160,6 @@ class AxonServerEventStoreTest {
 
         DomainEventStream actual = testSubject.readEvents("aggregateId");
         assertTrue(actual.hasNext());
-        assertEquals("Snapshot1", actual.next().getPayload());
         assertEquals("Snapshot1", actual.next().getPayload());
         assertEquals("Test3", actual.next().getPayload());
         assertEquals("Test3", actual.next().getPayload());
@@ -193,4 +193,39 @@ class AxonServerEventStoreTest {
                      () -> assertEquals(1, eventStore.getQueryEventsRequests().size()));
         assertFalse(eventStore.getQueryEventsRequests().get(0).getForceReadFromLeader());
     }
+
+    @Test
+    void testReadEventsReturnsSnapshotsAndEventsWithMetaData() {
+        Map<String, String> testMetaData = Collections.singletonMap("key", "value");
+        testSubject.storeSnapshot(
+                new GenericDomainEventMessage<>("aggregateType", "aggregateId", 1, "Snapshot1", testMetaData)
+        );
+        testSubject.publish(new GenericDomainEventMessage<>("aggregateType", "aggregateId", 0, "Test1", testMetaData),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 1, "Test2", testMetaData),
+                            new GenericDomainEventMessage<>("aggregateType", "aggregateId", 2, "Test3", testMetaData));
+
+        // Snapshot storage is async, so we need to make sure the first event is the snapshot
+        assertWithin(2, TimeUnit.SECONDS, () -> {
+            DomainEventStream snapshotValidationStream = testSubject.readEvents("aggregateId");
+            assertTrue(snapshotValidationStream.hasNext());
+            assertEquals("Snapshot1", snapshotValidationStream.next().getPayload());
+        });
+
+        DomainEventStream resultStream = testSubject.readEvents("aggregateId");
+
+        assertTrue(resultStream.hasNext());
+        DomainEventMessage<?> resultSnapshot = resultStream.next();
+        assertEquals("Snapshot1", resultSnapshot.getPayload());
+        assertTrue(resultSnapshot.getMetaData().containsKey("key"));
+        assertTrue(resultSnapshot.getMetaData().containsValue("value"));
+
+        assertTrue(resultStream.hasNext());
+        DomainEventMessage<?> resultEvent = resultStream.next();
+        assertEquals("Test3", resultEvent.getPayload());
+        assertTrue(resultEvent.getMetaData().containsKey("key"));
+        assertTrue(resultEvent.getMetaData().containsValue("value"));
+
+        assertFalse(resultStream.hasNext());
+    }
 }
+

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -74,13 +74,13 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
     @Override
     public Stream<? extends TrackedEventMessage<?>> readEvents(TrackingToken trackingToken, boolean mayBlock) {
         Stream<? extends TrackedEventData<?>> input = readEventData(trackingToken, mayBlock);
-        return upcastAndDeserializeTrackedEvents(input, eventSerializer, upcasterChain);
+        return upcastAndDeserializeTrackedEvents(input, getEventSerializer(), upcasterChain);
     }
 
     @Override
     public DomainEventStream readEvents(String aggregateIdentifier, long firstSequenceNumber) {
         Stream<? extends DomainEventData<?>> input = readEventData(aggregateIdentifier, firstSequenceNumber);
-        return upcastAndDeserializeDomainEvents(input, eventSerializer, upcasterChain);
+        return upcastAndDeserializeDomainEvents(input, getEventSerializer(), upcasterChain);
     }
 
     @Override
@@ -88,7 +88,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
         return readSnapshotData(aggregateIdentifier)
                 .filter(snapshotFilter::allow)
                 .map(snapshot -> upcastAndDeserializeDomainEvents(Stream.of(snapshot),
-                                                                  snapshotSerializer,
+                                                                  getSnapshotSerializer(),
                                                                   upcasterChain
                 ))
                 .flatMap(DomainEventStream::asStream)
@@ -98,12 +98,12 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
 
     @Override
     public void appendEvents(List<? extends EventMessage<?>> events) {
-        appendEvents(events, eventSerializer);
+        appendEvents(events, getEventSerializer());
     }
 
     @Override
     public void storeSnapshot(DomainEventMessage<?> snapshot) {
-        storeSnapshot(snapshot, snapshotSerializer);
+        storeSnapshot(snapshot, getSnapshotSerializer());
     }
 
     /**


### PR DESCRIPTION
This pull request is a resolution for two issues discovered in the `AxonServerEventStore`:

1. `MetaData` could no be serialized, because the used `Serializer` wasn't of type `GrpcMetaDataAwareSerializer`.
2. Snapshots are provided when invoking `AxonServerEventStore#readEvents` with a sequence number of 0.

---

<h4>Issue 1</h4>

Issue one has been trailed back to the invocation of `AxonIQEventStorageEngine#readEventData(String, long)`, since this operation does no ensure the event/snapshot `Serializer` which has been wrapped in a `GrpcMetaDataAwareSerializer` has been used. Due to this, the original Jackson/XStream/Custom `Serializer` would be invoked directly, which does not assume the event data to come in the form of a gRPC event.

The problem occurred because of the introduction of the `SnapshotFilter`. Pre Axon 4.4.x, this component wasn't used, similarly snapshot filtering in general, which enforced the optimization of retrieving both the snapshots and events in a single operation. Thus, `AxonIQEventStorageEngine#readEventData(String, long)` was *never* invoked directly by the `AbstractEventStorageEngine`, but only through the `AxonServerEventStore` itself and in doing so ensuring the `GrpcMetaDataAwareSerializer` was wrapped around the serializer.

Issue 1 was resolved by overriding the `getEventSerializer()` and `getSnapshotSerializer()` methods in the `AxonIQEventStorageEngine` and consistently using these methods in the `AbstractEventStorageEngine`.

---

<h4>Issue 2</h4>

Issue two boiled down to a wrong if-check in the `AxonIQEventStorageEngine#readEvents(String, long)`, which expected a sequence number higher than zero. This PR fixes this, and as such resolves #1611.
