### PR TITLE
Fixed issue using load or create in combination with Caching repository

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
@@ -16,15 +16,13 @@
 
 package org.axonframework.eventsourcing;
 
-import org.axonframework.modelling.command.Aggregate;
-import org.axonframework.modelling.command.RepositoryProvider;
-import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.common.caching.Cache;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-
-import java.util.concurrent.Callable;
+import org.axonframework.modelling.command.Aggregate;
+import org.axonframework.modelling.command.RepositoryProvider;
+import org.axonframework.modelling.command.inspection.AggregateModel;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -80,14 +78,6 @@ public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T
     protected void validateOnLoad(Aggregate<T> aggregate, Long expectedVersion) {
         CurrentUnitOfWork.get().onRollback(u -> cache.remove(aggregate.identifierAsString()));
         super.validateOnLoad(aggregate, expectedVersion);
-    }
-
-    @Override
-    protected EventSourcedAggregate<T> doCreateNewForLock(Callable<T> factoryMethod) throws Exception {
-        EventSourcedAggregate<T> aggregate = super.doCreateNewForLock(factoryMethod);
-        CurrentUnitOfWork.get().onRollback(u -> cache.remove(aggregate.identifierAsString()));
-        cache.put(aggregate.identifierAsString(), new AggregateCacheEntry<>(aggregate));
-        return aggregate;
     }
 
     @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/utils/StubAggregate.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/utils/StubAggregate.java
@@ -22,8 +22,6 @@ import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.AggregateLifecycle;
 
-import java.util.UUID;
-
 /**
  * @author Allard Buijze
  */
@@ -33,7 +31,10 @@ public class StubAggregate {
     private String identifier;
 
     public StubAggregate() {
-        identifier = UUID.randomUUID().toString();
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
     }
 
     public StubAggregate(Object identifier) {


### PR DESCRIPTION
In a load-or-create situation, the created aggregate may not have its identifier set, yet. The CachingEventSourcingRepository would fail when attempting to add a created aggregate to the cache, if null keys are not allowed.

This commit removes the addition of entries to the cache when creating an aggregate. Instead, it relies on the entry being added when the aggregate is saved (i.e. when the unit of work is preparing for commit).