### PR TITLE
Introduce ScopeDescriptor ParameterResolver

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/NoScopeDescriptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/NoScopeDescriptor.java
@@ -1,0 +1,23 @@
+package org.axonframework.messaging;
+
+/**
+ * A {@link ScopeDescriptor} describing no active scope.
+ *
+ * @author Steven van Beelen
+ * @since 4.5
+ */
+public class NoScopeDescriptor implements ScopeDescriptor {
+
+    /**
+     * A statically available instance of the {@link NoScopeDescriptor}.
+     */
+    public static final NoScopeDescriptor INSTANCE = new NoScopeDescriptor();
+
+    private NoScopeDescriptor() {
+    }
+
+    @Override
+    public String scopeDescription() {
+        return "NoActiveScope";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactory.java
@@ -1,0 +1,46 @@
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.Scope;
+import org.axonframework.messaging.ScopeDescriptor;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Parameter;
+
+import static org.axonframework.messaging.NoScopeDescriptor.INSTANCE;
+
+/**
+ * Factory for a {@link ScopeDescriptor} {@link ParameterResolver}. Will return the result of {@link
+ * Scope#describeCurrentScope()}. If no current scope is active, {@link org.axonframework.messaging.NoScopeDescriptor#INSTANCE}
+ * will be returned.
+ *
+ * @author Steven van Beelen
+ * @since 4.5
+ */
+public class ScopeDescriptorParameterResolverFactory implements ParameterResolverFactory {
+
+    @Override
+    public ParameterResolver<ScopeDescriptor> createInstance(Executable executable,
+                                                             Parameter[] parameters,
+                                                             int parameterIndex) {
+        return ScopeDescriptor.class.isAssignableFrom(parameters[parameterIndex].getType())
+                ? new ScopeDescriptorParameterResolver() : null;
+    }
+
+    private static class ScopeDescriptorParameterResolver implements ParameterResolver<ScopeDescriptor> {
+
+        @Override
+        public ScopeDescriptor resolveParameterValue(Message<?> message) {
+            try {
+                return Scope.describeCurrentScope();
+            } catch (IllegalStateException e) {
+                return INSTANCE;
+            }
+        }
+
+        @Override
+        public boolean matches(Message<?> message) {
+            return true;
+        }
+    }
+}

--- a/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
+++ b/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
@@ -25,3 +25,4 @@ org.axonframework.messaging.annotation.DefaultParameterResolverFactory
 org.axonframework.messaging.annotation.MessageIdentifierParameterResolverFactory
 org.axonframework.messaging.annotation.SourceIdParameterResolverFactory
 org.axonframework.messaging.annotation.ResultParameterResolverFactory
+org.axonframework.messaging.annotation.ScopeDescriptorParameterResolverFactory

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactoryTest.java
@@ -1,0 +1,56 @@
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.NoScopeDescriptor;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link ScopeDescriptorParameterResolverFactory}.
+ *
+ * @author Steven van Beelen
+ */
+class ScopeDescriptorParameterResolverFactoryTest {
+
+    private final ScopeDescriptorParameterResolverFactory testSubject = new ScopeDescriptorParameterResolverFactory();
+
+    private Method scopeDescriptorLessMethod;
+    private Method scopeDescriptorUsingMethod;
+    private Message<?> testMessage;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        scopeDescriptorUsingMethod = getClass().getMethod("someScopeDescriptorUsingMethod", ScopeDescriptor.class);
+        scopeDescriptorLessMethod = getClass().getMethod("someScopeDescriptorLessMethod", String.class);
+        testMessage = mock(Message.class);
+    }
+
+    @Test
+    void testParameterResolverIsNullForScopeDescriptorLessMethod() {
+        assertNull(testSubject.createInstance(scopeDescriptorLessMethod, scopeDescriptorLessMethod.getParameters(), 0));
+    }
+
+    @Test
+    void testResolvesNoScopeDescriptor() {
+        ParameterResolver<ScopeDescriptor> resolver =
+                testSubject.createInstance(scopeDescriptorUsingMethod, scopeDescriptorUsingMethod.getParameters(), 0);
+
+        assertTrue(resolver.matches(testMessage));
+        assertEquals(NoScopeDescriptor.INSTANCE, resolver.resolveParameterValue(testMessage));
+    }
+
+    @SuppressWarnings("unused")
+    public void someScopeDescriptorLessMethod(String s) {
+        // Used for testing
+    }
+
+    @SuppressWarnings("unused")
+    public void someScopeDescriptorUsingMethod(ScopeDescriptor scopeDescriptor) {
+        // Used for testing
+    }
+}

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ScopeDescriptor.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ScopeDescriptor.java
@@ -1,0 +1,72 @@
+package org.axonframework.test.aggregate;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateScopeDescriptor;
+import org.junit.jupiter.api.*;
+
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+import static org.axonframework.test.matchers.Matchers.*;
+
+/**
+ * Test class validating a {@link org.axonframework.messaging.ScopeDescriptor}, specifically an {@link
+ * org.axonframework.modelling.command.AggregateScopeDescriptor}, can be resolved on Aggregate's message handling
+ * functions.
+ *
+ * @author Steven van Beelen
+ */
+class FixtureTest_ScopeDescriptor {
+
+    private FixtureConfiguration<TestAggregate> fixture;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new AggregateTestFixture<>(TestAggregate.class);
+    }
+
+    @Test
+    void testResolvesScopeDescriptor() {
+        fixture.givenNoPriorActivity()
+               .when("some-identifier")
+               .expectEventsMatching(payloadsMatching(sequenceOf(matches(
+                       event -> ScopeDescriptorEvent.class.isAssignableFrom(event.getClass()) &&
+                               AggregateScopeDescriptor.class.isAssignableFrom(
+                                       ((ScopeDescriptorEvent) event).scopeDescriptor.getClass()
+                               )
+               ))));
+    }
+
+    private static class ScopeDescriptorEvent {
+
+        private final String identifier;
+        private final ScopeDescriptor scopeDescriptor;
+
+        private ScopeDescriptorEvent(String identifier, ScopeDescriptor scopeDescriptor) {
+            this.identifier = identifier;
+            this.scopeDescriptor = scopeDescriptor;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class TestAggregate {
+
+        @SuppressWarnings("FieldCanBeLocal")
+        @AggregateIdentifier
+        private String identifier;
+
+        @CommandHandler
+        public TestAggregate(String identifier, ScopeDescriptor scopeDescriptor) {
+            apply(new ScopeDescriptorEvent(identifier, scopeDescriptor));
+        }
+
+        @EventSourcingHandler
+        public void on(ScopeDescriptorEvent event) {
+            identifier = event.identifier;
+        }
+
+        public TestAggregate() {
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScopeDescriptor.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScopeDescriptor.java
@@ -1,0 +1,72 @@
+package org.axonframework.test.saga;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.axonframework.modelling.saga.SagaEventHandler;
+import org.axonframework.modelling.saga.SagaScopeDescriptor;
+import org.axonframework.modelling.saga.StartSaga;
+import org.junit.jupiter.api.*;
+
+import static org.axonframework.test.matchers.Matchers.*;
+
+/**
+ * Test class validating a {@link org.axonframework.messaging.ScopeDescriptor}, specifically an {@link
+ * org.axonframework.modelling.command.AggregateScopeDescriptor}, can be resolved on Aggregate's message handling
+ * functions.
+ *
+ * @author Steven van Beelen
+ */
+class FixtureTest_ScopeDescriptor {
+
+    private FixtureConfiguration fixture;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new SagaTestFixture<>(TestSaga.class);
+    }
+
+    @Test
+    void testResolvesScopeDescriptor() {
+        fixture.givenNoPriorActivity()
+               .whenPublishingA(new SagaStartEvent("some-identifier"))
+               .expectDispatchedCommandsMatching(payloadsMatching(sequenceOf(matches(
+                       command -> ScopeDescriptorCommand.class.isAssignableFrom(command.getClass()) &&
+                               SagaScopeDescriptor.class.isAssignableFrom(
+                                       ((ScopeDescriptorCommand) command).scopeDescriptor.getClass()
+                               )
+               ))));
+    }
+
+    private static class SagaStartEvent {
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final String identifier;
+
+        private SagaStartEvent(String identifier) {
+            this.identifier = identifier;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+    }
+
+    private static class ScopeDescriptorCommand {
+
+        private final ScopeDescriptor scopeDescriptor;
+
+        private ScopeDescriptorCommand(ScopeDescriptor scopeDescriptor) {
+            this.scopeDescriptor = scopeDescriptor;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class TestSaga {
+
+        @StartSaga
+        @SagaEventHandler(associationProperty = "identifier")
+        public void on(SagaStartEvent event, ScopeDescriptor scopeDescriptor, CommandGateway commandGateway) {
+            commandGateway.send(new ScopeDescriptorCommand(scopeDescriptor));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the `ScopeDescriptorParameterResolverFactory`, which will resolve the `ScopeDescriptor` of the current `Scope` into message handling functions. This would allow for automatically resolving the `AggregateScopeDescriptor` and `SagaScopeDescriptor` (for which tests are added) since those are the only current `ScopeDescriptor` implementations.
In absence of a current `Scope`, a `NoScopeDescriptor` will be returned, as otherwise an `IllegalStateException` would be thrown from within the parameter resolver. Added, this signals users there is no scope active at that moment in time.