### PR TITLE
Resolve Spring beans using Spring dependency resolution

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanDependencyResolverFactory.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringBeanDependencyResolverFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config.annotation;
+
+import org.axonframework.common.Priority;
+import org.axonframework.common.annotation.AnnotationUtils;
+import org.axonframework.eventhandling.AnnotationEventHandlerAdapter;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.modelling.command.EntityId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.DependencyDescriptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.NonNull;
+
+import java.lang.reflect.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+
+/**
+ * ParameterResolverFactory implementation that resolves parameters using Spring dependency resolution.
+ * Mark a parameter as {@link org.springframework.beans.factory.annotation.Autowired} to resolve said parameter
+ * using Spring dependency resolution.
+ *
+ * @author Joel Feinstein
+ * @since 4.5
+ * @see Autowired
+ */
+@Priority(Priority.HIGH)
+public class SpringBeanDependencyResolverFactory implements ParameterResolverFactory {
+
+    private final ApplicationContext applicationContext;
+
+    /**
+     * Default constructor requiring an application context, for use internally by Axon.
+     *
+     * @param applicationContext The Spring application context for the executing application
+     */
+    public SpringBeanDependencyResolverFactory(@NonNull ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public ParameterResolver<?> createInstance(Executable executable, Parameter[] parameters, int parameterIndex) {
+        final Optional<Boolean> ann = AnnotationUtils.findAnnotationAttribute(
+                parameters[parameterIndex], Autowired.class, "required");
+
+        if (!ann.isPresent()) {
+            return null;
+        }
+
+        final boolean required = ann.get();
+        final MethodParameter methodParameter;
+
+        if (executable instanceof Method) {
+            methodParameter = new MethodParameter((Method) executable, parameterIndex);
+        } else {
+            methodParameter = new MethodParameter((Constructor<?>) executable, parameterIndex);
+        }
+
+        final DependencyDescriptor dependencyDescriptor = new DependencyDescriptor(methodParameter, required);
+        return new SpringBeanDependencyResolver(applicationContext.getAutowireCapableBeanFactory(), dependencyDescriptor);
+    }
+
+    private static class SpringBeanDependencyResolver implements ParameterResolver<Object> {
+
+        private final AutowireCapableBeanFactory beanFactory;
+        private final DependencyDescriptor dependencyDescriptor;
+
+        public SpringBeanDependencyResolver(AutowireCapableBeanFactory beanFactory, DependencyDescriptor dependencyDescriptor) {
+            this.beanFactory = beanFactory;
+            this.dependencyDescriptor = dependencyDescriptor;
+        }
+
+        @Override
+        public Object resolveParameterValue(Message<?> message) {
+            return beanFactory.resolveDependency(dependencyDescriptor, null);
+        }
+
+        @Override
+        public boolean matches(Message<?> message) {
+            return true;
+        }
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringContextParameterResolverFactoryBuilder.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringContextParameterResolverFactoryBuilder.java
@@ -56,6 +56,8 @@ public final class SpringContextParameterResolverFactoryBuilder {
             final ManagedList<BeanDefinition> factories = new ManagedList<>();
             factories.add(BeanDefinitionBuilder.genericBeanDefinition(ClasspathParameterResolverFactoryBean.class)
                                                .getBeanDefinition());
+            factories.add(BeanDefinitionBuilder.genericBeanDefinition(SpringBeanDependencyResolverFactory.class)
+                                               .getBeanDefinition());
             factories.add(BeanDefinitionBuilder.genericBeanDefinition(SpringBeanParameterResolverFactory.class)
                                                .getBeanDefinition());
             AbstractBeanDefinition def =

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringParameterResolverFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringParameterResolverFactoryBean.java
@@ -35,6 +35,7 @@ import java.util.List;
  *
  * @author Allard Buijze
  * @see SpringBeanParameterResolverFactory
+ * @see SpringBeanDependencyResolverFactory
  * @see ClasspathParameterResolverFactory
  * @since 2.3.1
  */
@@ -63,9 +64,8 @@ public class SpringParameterResolverFactoryBean implements FactoryBean<Parameter
     @Override
     public void afterPropertiesSet() {
         factories.add(ClasspathParameterResolverFactory.forClassLoader(classLoader));
-        final SpringBeanParameterResolverFactory springBeanParameterResolverFactory = new SpringBeanParameterResolverFactory();
-        springBeanParameterResolverFactory.setApplicationContext(applicationContext);
-        factories.add(springBeanParameterResolverFactory);
+        factories.add(new SpringBeanDependencyResolverFactory(applicationContext));
+        factories.add(new SpringBeanParameterResolverFactory(applicationContext));
     }
 
     /**
@@ -75,6 +75,7 @@ public class SpringParameterResolverFactoryBean implements FactoryBean<Parameter
      *
      * @param additionalFactories The extra factories to register
      * @see SpringBeanParameterResolverFactory
+     * @see SpringBeanDependencyResolverFactory
      * @see ClasspathParameterResolverFactory
      */
     public void setAdditionalFactories(List<ParameterResolverFactory> additionalFactories) {

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBean.java
@@ -29,6 +29,7 @@ import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.MultiHandlerDefinition;
 import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.spring.config.annotation.SpringBeanDependencyResolverFactory;
 import org.axonframework.spring.config.annotation.SpringBeanParameterResolverFactory;
 import org.axonframework.spring.config.annotation.SpringHandlerDefinitionBean;
 import org.axonframework.spring.config.annotation.SpringHandlerEnhancerDefinitionBean;
@@ -85,6 +86,7 @@ public class SpringAggregateSnapshotterFactoryBean
         if (parameterResolverFactory == null) {
             parameterResolverFactory = MultiParameterResolverFactory
                     .ordered(ClasspathParameterResolverFactory.forClass(getObjectType()),
+                             new SpringBeanDependencyResolverFactory(applicationContext),
                              new SpringBeanParameterResolverFactory(applicationContext));
         }
 


### PR DESCRIPTION
This fixes #1620.  The Spring bean parameter resolver now uses Spring bean resolution.  This will behave exactly as if you were injecting a bean from anywhere within Spring.

### Discussion
Two tests are failing: `testMethodsAreProperlyInjected_ErrorOnMissingParameterType` and `testMethodsAreProperlyInjected_ErrorOnDuplicateParameterType`.  This is because Spring injection _does_ handle these cases, and the code will now behave accordingly (i.e. will trigger various forms of `BeansException` when there are problems).  It will also correctly inject `null` when dependencies are missing.