### PR TITLE
Routing Strategy Implementation Adjustments

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -111,9 +111,9 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                    .configuration(c.getComponent(AxonServerConfiguration.class))
                                    .localSegment(localSegment)
                                    .serializer(c.messageSerializer())
-                                   .routingStrategy(
-                                           c.getComponent(RoutingStrategy.class, AnnotationRoutingStrategy::new)
-                                   )
+                                   .routingStrategy(c.getComponent(
+                                           RoutingStrategy.class, AnnotationRoutingStrategy::defaultStrategy
+                                   ))
                                    .priorityCalculator(c.getComponent(
                                            CommandPriorityCalculator.class,
                                            CommandPriorityCalculator::defaultCommandPriorityCalculator

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AbstractRoutingStrategy.java
@@ -17,7 +17,6 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
-import org.axonframework.common.AxonConfigurationException;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -28,29 +27,29 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Allard Buijze
  * @since 2.0
  */
-public abstract class AbstractRoutingStrategy<B extends RoutingStrategy> implements RoutingStrategy {
+public abstract class AbstractRoutingStrategy implements RoutingStrategy {
 
     private final RoutingStrategy fallbackRoutingStrategy;
-
-    /**
-     * Instantiate a {@link AbstractRoutingStrategy} based on the fields contained in the given {@code builder}
-     *
-     * @param builder the {@link Builder} used to instantiate a {@link AbstractRoutingStrategy} instance
-     */
-    protected AbstractRoutingStrategy(Builder<B> builder) {
-        builder.validate();
-        this.fallbackRoutingStrategy = builder.fallbackRoutingStrategy;
-    }
 
     /**
      * Initializes the strategy using given {@link UnresolvedRoutingKeyPolicy} prescribing the fallback approach when
      * this implementation cannot resolve a routing key.
      *
      * @param fallbackRoutingStrategy the fallback routing to use whenever this {@link RoutingStrategy} doesn't succeed
-     * @deprecated in favor of the {@link #AbstractRoutingStrategy(Builder)}
+     * @deprecated in favor of {@link #AbstractRoutingStrategy(RoutingStrategy)}
      */
     @Deprecated
     public AbstractRoutingStrategy(UnresolvedRoutingKeyPolicy fallbackRoutingStrategy) {
+        this((RoutingStrategy) fallbackRoutingStrategy);
+    }
+
+    /**
+     * Initializes the strategy using given {@link RoutingStrategy} prescribing the fallback approach when this
+     * implementation cannot resolve a routing key.
+     *
+     * @param fallbackRoutingStrategy the fallback routing to use whenever this {@link RoutingStrategy} doesn't succeed
+     */
+    public AbstractRoutingStrategy(RoutingStrategy fallbackRoutingStrategy) {
         assertNonNull(fallbackRoutingStrategy, "Fallback RoutingStrategy may not be null");
         this.fallbackRoutingStrategy = fallbackRoutingStrategy;
     }
@@ -71,45 +70,4 @@ public abstract class AbstractRoutingStrategy<B extends RoutingStrategy> impleme
      * @return the String representing the Routing Key, or {@code null} if unresolved
      */
     protected abstract String doResolveRoutingKey(CommandMessage<?> command);
-
-    /**
-     * Builder class to instantiate a {@link AbstractRoutingStrategy}.
-     * <p>
-     * The fallback {@link RoutingStrategy} is defaulted to a {@link UnresolvedRoutingKeyPolicy#RANDOM_KEY}.
-     *
-     * @param <B> generic defining the type of {@link RoutingStrategy} this builder will create
-     */
-    protected static abstract class Builder<B extends RoutingStrategy> {
-
-        private RoutingStrategy fallbackRoutingStrategy = UnresolvedRoutingKeyPolicy.RANDOM_KEY;
-
-        /**
-         * Sets the fallback {@link RoutingStrategy} to use when the intended routing key resolution was unsuccessful.
-         * Defaults to a {@link UnresolvedRoutingKeyPolicy#RANDOM_KEY}
-         *
-         * @param fallbackRoutingStrategy a {@link RoutingStrategy} used as the fallback whenever the intended routing
-         *                                key resolution was unsuccessful
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<B> fallbackRoutingStrategy(RoutingStrategy fallbackRoutingStrategy) {
-            assertNonNull(fallbackRoutingStrategy, "Fallback RoutingStrategy may not be null");
-            this.fallbackRoutingStrategy = fallbackRoutingStrategy;
-            return this;
-        }
-
-        /**
-         * Initializes a {@link RoutingStrategy} implementation as specified through this Builder.
-         *
-         * @return a {@link RoutingStrategy} implementation as specified through this Builder
-         */
-        public abstract B build();
-
-        /**
-         * Validate whether the fields contained in this Builder as set accordingly.
-         *
-         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
-         *                                    specifications
-         */
-        protected abstract void validate();
-    }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -49,7 +49,7 @@ import static org.axonframework.common.ReflectionUtils.*;
  * @see DistributedCommandBus
  * @since 2.0
  */
-public class AnnotationRoutingStrategy extends AbstractRoutingStrategy<AnnotationRoutingStrategy> {
+public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
 
     private static final RoutingKeyResolver NO_RESOLVE = new RoutingKeyResolver((Method) null);
     private static final String NULL_DEFAULT = null;
@@ -87,7 +87,8 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy<Annotatio
      * @param builder the {@link Builder} used to instantiate a {@link AnnotationRoutingStrategy} instance
      */
     protected AnnotationRoutingStrategy(Builder builder) {
-        super(builder);
+        super(builder.fallbackRoutingStrategy);
+        builder.validate();
         this.annotationType = builder.annotationType;
     }
 
@@ -214,9 +215,24 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy<Annotatio
      * The {@code annotationType} is defaulted to {@link RoutingKey} and the {@code fallbackRoutingStrategy} to {@link
      * UnresolvedRoutingKeyPolicy#RANDOM_KEY}.
      */
-    public static class Builder extends AbstractRoutingStrategy.Builder<AnnotationRoutingStrategy> {
+    public static class Builder {
 
         private Class<? extends Annotation> annotationType = RoutingKey.class;
+        private RoutingStrategy fallbackRoutingStrategy = UnresolvedRoutingKeyPolicy.RANDOM_KEY;
+
+        /**
+         * Sets the fallback {@link RoutingStrategy} to use when the intended routing key resolution was unsuccessful.
+         * Defaults to a {@link UnresolvedRoutingKeyPolicy#RANDOM_KEY}
+         *
+         * @param fallbackRoutingStrategy a {@link RoutingStrategy} used as the fallback whenever the intended routing
+         *                                key resolution was unsuccessful
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder fallbackRoutingStrategy(RoutingStrategy fallbackRoutingStrategy) {
+            assertNonNull(fallbackRoutingStrategy, "Fallback RoutingStrategy may not be null");
+            this.fallbackRoutingStrategy = fallbackRoutingStrategy;
+            return this;
+        }
 
         /**
          * Sets the {@code annotationType} {@link Class} searched for by this routing strategy on a {@link
@@ -232,14 +248,23 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy<Annotatio
             return this;
         }
 
-        @Override
+        /**
+         * Initializes a {@link AnnotationRoutingStrategy} implementation as specified through this Builder.
+         *
+         * @return a {@link AnnotationRoutingStrategy} implementation as specified through this Builder
+         */
         public AnnotationRoutingStrategy build() {
             return new AnnotationRoutingStrategy(this);
         }
 
-        @Override
+        /**
+         * Validate whether the fields contained in this Builder as set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
         protected void validate() {
-            // Nothing to validate due to defaults
+            // Nothing to validate due to defaults; kept for overriding
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -30,25 +30,26 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ReflectionUtils.*;
 
 /**
- * RoutingStrategy that expects an {@link org.axonframework.commandhandling.RoutingKey} (meta-)annotation on the command
- * message's payload. Commands are routed based on an identifier annotated with the RoutingKey. This approach ensures
- * that commands with the same identifier, thus dealt with by the same target, are dispatched to the same node in
- * a {@link DistributedCommandBus}.
+ * RoutingStrategy that expects an {@link RoutingKey} (meta-)annotation on the command message's payload. Commands are
+ * routed based on an identifier annotated with the {@code RoutingKey}. This approach ensures that commands with the
+ * same identifier, thus dealt with by the same target, are dispatched to the same node in a distributed Command Bus
+ * (e.g. {@code AxonServerCommandBus} or {@link DistributedCommandBus}).
  * <p>
- * An example would be the TargetAggregateIdentifier annotation, which is meta-annotated with RoutingKey. See the
- * AnnotationCommandTargetResolver for more details on this approach.
- * <p/>
+ * An example would be the {@code TargetAggregateIdentifier} annotation, which is meta-annotated with {@code
+ * RoutingKey}. See the AnnotationCommandTargetResolver for more details on this approach.
+ * <p>
  * This class requires the returned routing keys to implement a proper {@link Object#toString()} method. An inconsistent
- * toString() method may result in different members using different routing keys for the same identifier.
+ * {@code toString()} method may result in different members using different routing keys for the same identifier.
  *
  * @author Allard Buijze
  * @see DistributedCommandBus
  * @since 2.0
  */
-public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
+public class AnnotationRoutingStrategy extends AbstractRoutingStrategy<AnnotationRoutingStrategy> {
 
     private static final RoutingKeyResolver NO_RESOLVE = new RoutingKeyResolver((Method) null);
     private static final String NULL_DEFAULT = null;
@@ -57,9 +58,46 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
     private final Map<Class<?>, RoutingKeyResolver> resolverMap = new ConcurrentHashMap<>();
 
     /**
-     * Initializes a Routing Strategy that fails when an incoming command does not define a field as the
-     * {@link RoutingKey} to base the routing on.
+     * Instantiate a Builder to be able to create a {@link AnnotationRoutingStrategy}.
+     * <p>
+     * The {@code annotationType} is defaulted to {@link RoutingKey} and the {@code fallbackRoutingStrategy} to {@link
+     * UnresolvedRoutingKeyPolicy#RANDOM_KEY}.
+     *
+     * @return a Builder to be able to create a {@link AnnotationRoutingStrategy}
      */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a default {@link AnnotationRoutingStrategy}.
+     * <p>
+     * The {@code annotationType} is defaulted to {@link RoutingKey} and the {@code fallbackRoutingStrategy} to {@link
+     * UnresolvedRoutingKeyPolicy#RANDOM_KEY}.
+     *
+     * @return a default {@link AnnotationRoutingStrategy}
+     */
+    public static AnnotationRoutingStrategy defaultStrategy() {
+        return builder().build();
+    }
+
+    /**
+     * Instantiate a {@link AnnotationRoutingStrategy} based on the fields contained in the given {@code builder}.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link AnnotationRoutingStrategy} instance
+     */
+    protected AnnotationRoutingStrategy(Builder builder) {
+        super(builder);
+        this.annotationType = builder.annotationType;
+    }
+
+    /**
+     * Initializes a Routing Strategy that fails when an incoming command does not define a field as the {@link
+     * RoutingKey} to base the routing on.
+     *
+     * @deprecated in favor of the {@link #builder()}
+     */
+    @Deprecated
     public AnnotationRoutingStrategy() {
         this(RoutingKey.class);
     }
@@ -69,18 +107,22 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
      *
      * @param annotationType the type of annotation marking the field or method providing the identifier of the targeted
      *                       model
+     * @deprecated in favor of the {@link #builder()}
      */
+    @Deprecated
     public AnnotationRoutingStrategy(Class<? extends Annotation> annotationType) {
         this(annotationType, UnresolvedRoutingKeyPolicy.ERROR);
     }
 
     /**
-     * Initializes a Routing Strategy that uses the given {@code unresolvedRoutingKeyPolicy} when an incoming
-     * command does not define a {@link RoutingKey} annotated field to base the routing on.
+     * Initializes a Routing Strategy that uses the given {@code unresolvedRoutingKeyPolicy} when an incoming command
+     * does not define a {@link RoutingKey} annotated field to base the routing on.
      *
      * @param unresolvedRoutingKeyPolicy a {@link UnresolvedRoutingKeyPolicy} indicating what should be done when a
      *                                   Command does not contain information about the routing key to use
+     * @deprecated in favor of the {@link #builder()}
      */
+    @Deprecated
     public AnnotationRoutingStrategy(UnresolvedRoutingKeyPolicy unresolvedRoutingKeyPolicy) {
         this(RoutingKey.class, unresolvedRoutingKeyPolicy);
     }
@@ -94,7 +136,9 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
      *                                   the targeted model
      * @param unresolvedRoutingKeyPolicy a {@link UnresolvedRoutingKeyPolicy} indicating what should be done when a
      *                                   Command does not contain information about the routing key to use
+     * @deprecated in favor of the {@link #builder()}
      */
+    @Deprecated
     public AnnotationRoutingStrategy(Class<? extends Annotation> annotationType,
                                      UnresolvedRoutingKeyPolicy unresolvedRoutingKeyPolicy) {
         super(unresolvedRoutingKeyPolicy);
@@ -119,7 +163,6 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
         return routingKey;
     }
 
-    @SuppressWarnings("unchecked")
     private String findIdentifier(CommandMessage<?> command) throws InvocationTargetException, IllegalAccessException {
         return resolverMap.computeIfAbsent(command.getPayloadType(), this::createResolver)
                           .identify(command.getPayload());
@@ -162,6 +205,41 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
                 return Objects.toString(ReflectionUtils.getFieldValue(field, command), NULL_DEFAULT);
             }
             return null;
+        }
+    }
+
+    /**
+     * Builder class to instantiate a {@link AnnotationRoutingStrategy}.
+     * <p>
+     * The {@code annotationType} is defaulted to {@link RoutingKey} and the {@code fallbackRoutingStrategy} to {@link
+     * UnresolvedRoutingKeyPolicy#RANDOM_KEY}.
+     */
+    public static class Builder extends AbstractRoutingStrategy.Builder<AnnotationRoutingStrategy> {
+
+        private Class<? extends Annotation> annotationType = RoutingKey.class;
+
+        /**
+         * Sets the {@code annotationType} {@link Class} searched for by this routing strategy on a {@link
+         * CommandMessage} to base the routing key on. Defaults to the {@link RoutingKey} annotation.
+         *
+         * @param annotationType an annotation {@link Class} to search for on a {@link CommandMessage} which contains
+         *                       the command's routing key
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder annotationType(Class<? extends Annotation> annotationType) {
+            assertNonNull(annotationType, "AnnotationType may not be null");
+            this.annotationType = annotationType;
+            return this;
+        }
+
+        @Override
+        public AnnotationRoutingStrategy build() {
+            return new AnnotationRoutingStrategy(this);
+        }
+
+        @Override
+        protected void validate() {
+            // Nothing to validate due to defaults
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategy.java
@@ -17,36 +17,69 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.common.AxonConfigurationException;
+
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 
 /**
- * RoutingStrategy implementation that uses the value in the MetaData of a CommandMessage assigned to a given key. The
- * value's {@code toString()} is used to convert the MetaData value to a String.
+ * RoutingStrategy implementation that uses the value in the {@link org.axonframework.messaging.MetaData} of a {@link
+ * CommandMessage} assigned to a given key. The value's {@code toString()} is used to convert the {@code MetaData} value
+ * to a String.
  *
  * @author Allard Buijze
  * @since 2.0
  */
-public class MetaDataRoutingStrategy extends AbstractRoutingStrategy {
+public class MetaDataRoutingStrategy extends AbstractRoutingStrategy<MetaDataRoutingStrategy> {
 
     private final String metaDataKey;
 
     /**
-     * Initializes the MetaDataRoutingStrategy where the given {@code metaDataKey} is used to get the Meta Data
-     * value. An error is raised when the MetaData key cannot be found.
+     * Instantiate a Builder to be able to create a {@link MetaDataRoutingStrategy}.
+     * <p>
+     * The {@code fallbackRoutingStrategy} to {@link UnresolvedRoutingKeyPolicy#RANDOM_KEY}. The {@code metaDataKey} is
+     * a <b>hard requirements</b> and as such should be provided.
      *
-     * @param metaDataKey The key on which the value is retrieved from the MetaData.
+     * @return a Builder to be able to create a {@link MetaDataRoutingStrategy}
      */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a {@link MetaDataRoutingStrategy} based on the fields contained in the give {@code builder}.
+     * <p>
+     * Will assert that the {@code metaDataKey} is not an empty {@link String} or {@code null} and will throw an {@link
+     * AxonConfigurationException} if this is the case.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link MetaDataRoutingStrategy} instance
+     */
+    protected MetaDataRoutingStrategy(Builder builder) {
+        super(builder);
+        this.metaDataKey = builder.metaDataKey;
+    }
+
+    /**
+     * Initializes the MetaDataRoutingStrategy where the given {@code metaDataKey} is used to get the Meta Data value.
+     * An error is raised when the MetaData key cannot be found.
+     *
+     * @param metaDataKey the key on which the value is retrieved from the MetaData
+     * @deprecated in favor of the {@link #builder()}
+     */
+    @Deprecated
     public MetaDataRoutingStrategy(String metaDataKey) {
         this(metaDataKey, UnresolvedRoutingKeyPolicy.ERROR);
     }
 
     /**
-     * Initializes the MetaDataRoutingStrategy where the given {@code metaDataKey} is used to get the Meta Data
-     * value. The given {@code unresolvedRoutingKeyPolicy} presecribes what to do when the Meta Data properties
-     * cannot be found.
+     * Initializes the MetaDataRoutingStrategy where the given {@code metaDataKey} is used to get the Meta Data value.
+     * The given {@code unresolvedRoutingKeyPolicy} prescribes what to do when the Meta Data properties cannot be
+     * found.
      *
-     * @param metaDataKey                The key on which the value is retrieved from the MetaData.
-     * @param unresolvedRoutingKeyPolicy The policy prescribing behavior when the routing key cannot be resolved
+     * @param metaDataKey                the key on which the value is retrieved from the MetaData
+     * @param unresolvedRoutingKeyPolicy the policy prescribing behavior when the routing key cannot be resolved
+     * @deprecated in favor of the {@link #builder()}
      */
+    @Deprecated
     public MetaDataRoutingStrategy(String metaDataKey, UnresolvedRoutingKeyPolicy unresolvedRoutingKeyPolicy) {
         super(unresolvedRoutingKeyPolicy);
         this.metaDataKey = metaDataKey;
@@ -56,5 +89,40 @@ public class MetaDataRoutingStrategy extends AbstractRoutingStrategy {
     protected String doResolveRoutingKey(CommandMessage<?> command) {
         Object value = command.getMetaData().get(metaDataKey);
         return value == null ? null : value.toString();
+    }
+
+    /**
+     * Builder class to instantiate a {@link AnnotationRoutingStrategy}.
+     * <p>
+     * The {@code fallbackRoutingStrategy} to {@link UnresolvedRoutingKeyPolicy#RANDOM_KEY}. The {@code metaDataKey} is
+     * a <b>hard requirements</b> and as such should be provided.
+     */
+    public static class Builder extends AbstractRoutingStrategy.Builder<MetaDataRoutingStrategy> {
+
+        private String metaDataKey;
+
+        /**
+         * Sets the {@code metaDataKey} searched for by this routing strategy on a {@link CommandMessage}'s {@link
+         * org.axonframework.messaging.MetaData} to base the routing key on.
+         *
+         * @param metaDataKey a {@link String} to search for in a {@link CommandMessage}'s {@link
+         *                    org.axonframework.messaging.MetaData} to base the routing key on
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder metaDataKey(String metaDataKey) {
+            assertNonEmpty(metaDataKey, "A metaDataKey may not be null or empty");
+            this.metaDataKey = metaDataKey;
+            return this;
+        }
+
+        @Override
+        public MetaDataRoutingStrategy build() {
+            return new MetaDataRoutingStrategy(this);
+        }
+
+        @Override
+        protected void validate() {
+            assertNonEmpty(metaDataKey, "The metaDataKey is a hard requirement and should be provided");
+        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
@@ -121,6 +121,14 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
+    void testBuildAnnotationRoutingStrategyFailsForNullFallbackRoutingStrategy() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> AnnotationRoutingStrategy.builder().fallbackRoutingStrategy(null)
+        );
+    }
+
+    @Test
     void testBuildAnnotationRoutingStrategyFailsForNullAnnotationType() {
         assertThrows(AxonConfigurationException.class, () -> AnnotationRoutingStrategy.builder().annotationType(null));
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
@@ -122,15 +122,14 @@ class AnnotationRoutingStrategyTest {
 
     @Test
     void testBuildAnnotationRoutingStrategyFailsForNullFallbackRoutingStrategy() {
-        assertThrows(
-                AxonConfigurationException.class,
-                () -> AnnotationRoutingStrategy.builder().fallbackRoutingStrategy(null)
-        );
+        AnnotationRoutingStrategy.Builder builderTestSubject = AnnotationRoutingStrategy.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.fallbackRoutingStrategy(null));
     }
 
     @Test
     void testBuildAnnotationRoutingStrategyFailsForNullAnnotationType() {
-        assertThrows(AxonConfigurationException.class, () -> AnnotationRoutingStrategy.builder().annotationType(null));
+        AnnotationRoutingStrategy.Builder builderTestSubject = AnnotationRoutingStrategy.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.annotationType(null));
     }
 
     public static class SomeFieldAnnotatedCommand {

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
@@ -56,22 +56,19 @@ class MetaDataRoutingStrategyTest {
 
     @Test
     void testBuildMetaDataRoutingStrategyFailsForNullFallbackRoutingStrategy() {
-        assertThrows(
-                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().fallbackRoutingStrategy(null)
-        );
+        MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.fallbackRoutingStrategy(null));
     }
 
     @Test
     void testBuildMetaDataRoutingStrategyFailsForNullMetaDataKey() {
-        assertThrows(
-                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().metaDataKey(null)
-        );
+        MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.metaDataKey(null));
     }
 
     @Test
     void testBuildMetaDataRoutingStrategyFailsForEmptyMetaDataKey() {
-        assertThrows(
-                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().metaDataKey("")
-        );
+        MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.metaDataKey(""));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
@@ -1,0 +1,55 @@
+package org.axonframework.commandhandling.distributed;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.messaging.MetaData;
+import org.junit.jupiter.api.*;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link MetaDataRoutingStrategy}.
+ *
+ * @author Steven van Beelen
+ */
+class MetaDataRoutingStrategyTest {
+
+    private static final String META_DATA_KEY = "some-metadata-key";
+
+    private MetaDataRoutingStrategy testSubject;
+
+    private final RoutingStrategy fallbackRoutingStrategy = mock(RoutingStrategy.class);
+
+    @BeforeEach
+    void setUp() {
+        testSubject = MetaDataRoutingStrategy.builder()
+                                             .metaDataKey(META_DATA_KEY)
+                                             .fallbackRoutingStrategy(fallbackRoutingStrategy)
+                                             .build();
+    }
+
+    @Test
+    void testResolvesRoutingKeyFromMetaData() {
+        String expectedRoutingKey = "some-routing-key";
+
+        MetaData testMetaData = MetaData.from(Collections.singletonMap(META_DATA_KEY, expectedRoutingKey));
+        CommandMessage<String> testCommand = new GenericCommandMessage<>("some-payload", testMetaData);
+
+        assertEquals(expectedRoutingKey, testSubject.getRoutingKey(testCommand));
+        verifyNoInteractions(fallbackRoutingStrategy);
+    }
+
+    @Test
+    void testResolvesRoutingKeyFromFallbackStrategy() {
+        String expectedRoutingKey = "some-routing-key";
+        when(fallbackRoutingStrategy.getRoutingKey(any())).thenReturn(expectedRoutingKey);
+
+        CommandMessage<String> testCommand = new GenericCommandMessage<>("some-payload", MetaData.emptyInstance());
+
+        assertEquals(expectedRoutingKey, testSubject.getRoutingKey(testCommand));
+        verify(fallbackRoutingStrategy).getRoutingKey(testCommand);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
@@ -2,6 +2,7 @@ package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
 
@@ -51,5 +52,26 @@ class MetaDataRoutingStrategyTest {
 
         assertEquals(expectedRoutingKey, testSubject.getRoutingKey(testCommand));
         verify(fallbackRoutingStrategy).getRoutingKey(testCommand);
+    }
+
+    @Test
+    void testBuildMetaDataRoutingStrategyFailsForNullFallbackRoutingStrategy() {
+        assertThrows(
+                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().fallbackRoutingStrategy(null)
+        );
+    }
+
+    @Test
+    void testBuildMetaDataRoutingStrategyFailsForNullMetaDataKey() {
+        assertThrows(
+                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().metaDataKey(null)
+        );
+    }
+
+    @Test
+    void testBuildMetaDataRoutingStrategyFailsForEmptyMetaDataKey() {
+        assertThrows(
+                AxonConfigurationException.class, () -> MetaDataRoutingStrategy.builder().metaDataKey("")
+        );
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicyTest.java
@@ -1,0 +1,36 @@
+package org.axonframework.commandhandling.distributed;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link UnresolvedRoutingKeyPolicy}.
+ *
+ * @author Steven van Beelen
+ */
+class UnresolvedRoutingKeyPolicyTest {
+
+    private final CommandMessage<String> testCommand = new GenericCommandMessage<>("some-payload");
+
+    @Test
+    void testErrorStrategy() {
+        assertThrows(CommandDispatchException.class, () -> UnresolvedRoutingKeyPolicy.ERROR.getRoutingKey(testCommand));
+    }
+
+    @Test
+    void testRandomStrategy() {
+        String firstResult = UnresolvedRoutingKeyPolicy.RANDOM_KEY.getRoutingKey(testCommand);
+        String secondResult = UnresolvedRoutingKeyPolicy.RANDOM_KEY.getRoutingKey(testCommand);
+        assertNotEquals(firstResult, secondResult);
+    }
+
+    @Test
+    void testStaticStrategy() {
+        String firstResult = UnresolvedRoutingKeyPolicy.STATIC_KEY.getRoutingKey(testCommand);
+        String secondResult = UnresolvedRoutingKeyPolicy.STATIC_KEY.getRoutingKey(testCommand);
+        assertEquals(firstResult, secondResult);
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -134,7 +134,7 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
     @Bean
     @ConditionalOnMissingBean
     public RoutingStrategy routingStrategy() {
-        return new AnnotationRoutingStrategy();
+        return AnnotationRoutingStrategy.defaultStrategy();
     }
 
     @Bean


### PR DESCRIPTION
This pull request makes a couple of arguably minor adjustments around the `RoutingStrategy` implementations provided:

- The `UnresolvedRoutingKeyPolicy` has been changed to a `RoutingStrategy`. As such, the `ERROR`, `RANDOM_KEY` and `STATIC_KEY` implementations from this enumeration are currently an actual `RoutingStrategy` implementation. This thus removes the switch-case logic present in the `AbstractRoutingStrategy`.
- The `unresolvedRoutingKeyPolicy` is adjusted towards a `fallbackRoutingStrategy`, as that's how it acted in the first place.
- The old default `fallbackRoutingStrategy` used to be `ERROR` but is adjusted towards `RANDOM_KEY`. `ERROR` made sense for applications using a single JVM `CommandBus` implementation. As the bias has switched to a distributed `CommandBus` (e.g. the `AxonServerCommandBus`), erroring isn't favourable when an aggregate-creation-command (which typically doesn't contain *any* routing key) is dispatched.
- On top of the above, the constructor creation of the `AbstractRoutingStrategy` has been deprecated in favour of a builder pattern (similarly as all other infrastructure components). To that end, adjustments have been made in the `AbstractRoutingStrategy`, and it's implementations the `AnnotationRoutingStrategy` and `MetaDataRoutingStrategy`.
- Test cases have been expanded an added.
- The JavaDoc has been adjusted accordingly with the above changes.
- When present, IDE warnings have been removed.