### PR TITLE
[#1469] End Saga when Deadline expires

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
@@ -18,8 +18,8 @@ package org.axonframework.modelling.saga;
 
 import org.axonframework.common.Assert;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.modelling.saga.metamodel.SagaModel;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.modelling.saga.metamodel.SagaModel;
 
 import java.util.Set;
 import java.util.function.Consumer;
@@ -43,9 +43,9 @@ public class AnnotatedSaga<T> extends SagaLifecycle implements Saga<T> {
     private volatile boolean isActive = true;
 
     /**
-     * Creates an AnnotatedSaga instance to wrap the given {@code annotatedSaga}, identifier with the given
-     * {@code sagaId} and associated with the given {@code associationValues}. The {@code metaModel} provides the
-     * description of the structure of the Saga.
+     * Creates an AnnotatedSaga instance to wrap the given {@code annotatedSaga}, identifier with the given {@code
+     * sagaId} and associated with the given {@code associationValues}. The {@code metaModel} provides the description
+     * of the structure of the Saga.
      *
      * @param sagaId            The identifier of this Saga instance
      * @param associationValues The current associations of this Saga
@@ -118,7 +118,7 @@ public class AnnotatedSaga<T> extends SagaLifecycle implements Saga<T> {
 
     private Object handle(MessageHandlingMember<? super T> handler, EventMessage<?> event) {
         try {
-            return  executeWithResult(() -> handler.handle(event, sagaInstance));
+            return executeWithResult(() -> handler.handle(event, sagaInstance));
         } catch (RuntimeException | Error e) {
             throw e;
         } catch (Exception e) {
@@ -131,9 +131,7 @@ public class AnnotatedSaga<T> extends SagaLifecycle implements Saga<T> {
     }
 
     private Boolean isEndingHandler(MessageHandlingMember<? super T> handler) {
-        return handler.unwrap(SagaMethodMessageHandlingMember.class)
-                      .map(SagaMethodMessageHandlingMember::isEndingHandler)
-                      .orElse(false);
+        return handler.hasAnnotation(EndSaga.class);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
@@ -123,15 +123,7 @@ public class AnnotatedSaga<T> extends SagaLifecycle implements Saga<T> {
             throw e;
         } catch (Exception e) {
             throw new SagaExecutionException("Exception while handling an Event in a Saga", e);
-        } finally {
-            if (isEndingHandler(handler)) {
-                doEnd();
-            }
         }
-    }
-
-    private Boolean isEndingHandler(MessageHandlingMember<? super T> handler) {
-        return handler.hasAnnotation(EndSaga.class);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
@@ -1,0 +1,48 @@
+package org.axonframework.modelling.saga;
+
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
+
+/**
+ * A {@link HandlerEnhancerDefinition} inspecting the existence of the {@link EndSaga} annotation on {@link
+ * MessageHandlingMember}s. If present, the given {@code MessageHandlingMember} will be wrapped in a {@link
+ * EndSageMessageHandlingMember}.
+ *
+ * @author Steven van Beelen
+ * @since 4.5
+ */
+public class EndSagaMessageHandlerDefinition implements HandlerEnhancerDefinition {
+
+    @Override
+    public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
+        return original.hasAnnotation(EndSaga.class) ? new EndSageMessageHandlingMember<>(original) : original;
+    }
+
+    /**
+     * A {@link WrappedMessageHandlingMember} implementation dedicated towards {@link MessageHandlingMember}s annotated
+     * with {@link EndSaga}. After invocation of the {@link #handle(Message, Object)} method, the saga's is ended
+     * through the {@link SagaLifecycle#end()} method.
+     *
+     * @param <T> the entity type wrapped by this {@link MessageHandlingMember}
+     */
+    public static class EndSageMessageHandlingMember<T> extends WrappedMessageHandlingMember<T> {
+
+        /**
+         * Initializes the member using the given {@code delegate}.
+         *
+         * @param delegate the actual message handling member to delegate to
+         */
+        protected EndSageMessageHandlingMember(MessageHandlingMember<T> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public Object handle(Message<?> message, T target) throws Exception {
+            Object result = super.handle(message, target);
+            SagaLifecycle.end();
+            return result;
+        }
+    }
+}

--- a/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
@@ -40,9 +40,11 @@ public class EndSagaMessageHandlerDefinition implements HandlerEnhancerDefinitio
 
         @Override
         public Object handle(Message<?> message, T target) throws Exception {
-            Object result = super.handle(message, target);
-            SagaLifecycle.end();
-            return result;
+            try {
+                return super.handle(message, target);
+            } finally {
+                SagaLifecycle.end();
+            }
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
@@ -46,10 +46,16 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
      * @param associationPropertyName The association property name to look up in the message
      * @param associationResolver     The association resolver configured for this handler
      * @param endingHandler           Flag to indicate if an invocation of the given handler should end the saga
+     * @deprecated in favour of the constructor not providing the {@code endingHandler} parameter, since that parameter
+     * is no longer supported.
      */
-    public SagaMethodMessageHandlingMember(MessageHandlingMember<T> delegate, SagaCreationPolicy creationPolicy,
-                                           String associationKey, String associationPropertyName,
-                                           AssociationResolver associationResolver, boolean endingHandler) {
+    @Deprecated
+    public SagaMethodMessageHandlingMember(MessageHandlingMember<T> delegate,
+                                           SagaCreationPolicy creationPolicy,
+                                           String associationKey,
+                                           String associationPropertyName,
+                                           AssociationResolver associationResolver,
+                                           boolean endingHandler) {
         super(delegate);
         this.delegate = delegate;
         this.creationPolicy = creationPolicy;
@@ -60,8 +66,31 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
     }
 
     /**
-     * The AssociationValue to find the saga instance with, or {@code null} if no AssociationValue can be found on
-     * the given {@code eventMessage}.
+     * Creates a SagaMethodMessageHandler.
+     *
+     * @param creationPolicy          The creation policy for the handlerMethod
+     * @param delegate                The message handler for the event
+     * @param associationKey          The association key configured for this handler
+     * @param associationPropertyName The association property name to look up in the message
+     * @param associationResolver     The association resolver configured for this handler
+     */
+    public SagaMethodMessageHandlingMember(MessageHandlingMember<T> delegate,
+                                           SagaCreationPolicy creationPolicy,
+                                           String associationKey,
+                                           String associationPropertyName,
+                                           AssociationResolver associationResolver) {
+        super(delegate);
+        this.delegate = delegate;
+        this.creationPolicy = creationPolicy;
+        this.associationKey = associationKey;
+        this.associationPropertyName = associationPropertyName;
+        this.associationResolver = associationResolver;
+        this.endingHandler = false;
+    }
+
+    /**
+     * The AssociationValue to find the saga instance with, or {@code null} if no AssociationValue can be found on the
+     * given {@code eventMessage}.
      *
      * @param eventMessage The event message containing the value of the association
      * @return the AssociationValue to find the saga instance with, or {@code null} if none found
@@ -91,9 +120,11 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
     /**
      * Indicates whether this handler is one that ends the Saga lifecycle
      *
-     * @return {@code true} if the Saga lifecycle ends unconditionally after this call, otherwise
-     * {@code false}
+     * @return {@code true} if the Saga lifecycle ends unconditionally after this call, otherwise {@code false}
+     * @deprecated in favor of the dedicated {@link EndSagaMessageHandlerDefinition} and {@link
+     * EndSagaMessageHandlerDefinition.EndSageMessageHandlingMember}
      */
+    @Deprecated
     public boolean isEndingHandler() {
         return endingHandler;
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
@@ -86,16 +86,4 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
     public SagaCreationPolicy getCreationPolicy() {
         return creationPolicy;
     }
-
-    /**
-     * Indicates whether this handler is one that ends the Saga lifecycle
-     *
-     * @return {@code true} if the Saga lifecycle ends unconditionally after this call, otherwise {@code false}
-     * @deprecated in favor of the dedicated {@link EndSagaMessageHandlerDefinition} and {@link
-     * EndSagaMessageHandlerDefinition.EndSageMessageHandlingMember}
-     */
-    @Deprecated
-    public boolean isEndingHandler() {
-        return false;
-    }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
@@ -35,35 +35,6 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
     private final String associationKey;
     private final String associationPropertyName;
     private final AssociationResolver associationResolver;
-    private final boolean endingHandler;
-
-    /**
-     * Creates a SagaMethodMessageHandler.
-     *
-     * @param creationPolicy          The creation policy for the handlerMethod
-     * @param delegate                The message handler for the event
-     * @param associationKey          The association key configured for this handler
-     * @param associationPropertyName The association property name to look up in the message
-     * @param associationResolver     The association resolver configured for this handler
-     * @param endingHandler           Flag to indicate if an invocation of the given handler should end the saga
-     * @deprecated in favour of the constructor not providing the {@code endingHandler} parameter, since that parameter
-     * is no longer supported.
-     */
-    @Deprecated
-    public SagaMethodMessageHandlingMember(MessageHandlingMember<T> delegate,
-                                           SagaCreationPolicy creationPolicy,
-                                           String associationKey,
-                                           String associationPropertyName,
-                                           AssociationResolver associationResolver,
-                                           boolean endingHandler) {
-        super(delegate);
-        this.delegate = delegate;
-        this.creationPolicy = creationPolicy;
-        this.associationKey = associationKey;
-        this.associationPropertyName = associationPropertyName;
-        this.associationResolver = associationResolver;
-        this.endingHandler = endingHandler;
-    }
 
     /**
      * Creates a SagaMethodMessageHandler.
@@ -85,7 +56,6 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
         this.associationKey = associationKey;
         this.associationPropertyName = associationPropertyName;
         this.associationResolver = associationResolver;
-        this.endingHandler = false;
     }
 
     /**
@@ -126,6 +96,6 @@ public class SagaMethodMessageHandlingMember<T> extends WrappedMessageHandlingMe
      */
     @Deprecated
     public boolean isEndingHandler() {
-        return endingHandler;
+        return false;
     }
 }

--- a/modelling/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.HandlerEnhancerDefinition
+++ b/modelling/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.HandlerEnhancerDefinition
@@ -31,5 +31,6 @@
 #
 
 org.axonframework.modelling.saga.SagaMethodMessageHandlerDefinition
+org.axonframework.modelling.saga.EndSagaMessageHandlerDefinition
 org.axonframework.modelling.command.inspection.MethodCommandHandlerInterceptorDefinition
 org.axonframework.modelling.command.inspection.MethodCreationPolicyDefinition

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -57,6 +57,7 @@ import org.axonframework.modelling.command.VersionedAggregateIdentifier;
 import org.axonframework.modelling.command.inspection.MethodCommandHandlerInterceptorDefinition;
 import org.axonframework.modelling.command.inspection.MethodCreationPolicyDefinition;
 import org.axonframework.modelling.saga.AssociationValue;
+import org.axonframework.modelling.saga.EndSagaMessageHandlerDefinition;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.SagaMethodMessageHandlerDefinition;
 import org.axonframework.modelling.saga.StartSaga;
@@ -321,7 +322,8 @@ public class SpringAxonAutoConfigurerTest {
                         MethodCreationPolicyDefinition.class,
                         MethodCreationPolicyDefinition.class,
                         MyHandlerEnhancerDefinition.class,
-                        MessageHandlerInterceptorDefinition.class
+                        MessageHandlerInterceptorDefinition.class,
+                        EndSagaMessageHandlerDefinition.class
                 ),
                 enhancerClasses
         );

--- a/test/src/test/java/org/axonframework/test/saga/TriggerSagaStartEvent.java
+++ b/test/src/test/java/org/axonframework/test/saga/TriggerSagaStartEvent.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.test.saga;
 
+import java.util.Objects;
+
 /**
  * Event signaling the start of a saga.
  *
@@ -23,13 +25,49 @@ package org.axonframework.test.saga;
  */
 public class TriggerSagaStartEvent {
 
-    private String identifier;
+    private final String identifier;
+    private final String deadlineName;
 
     public TriggerSagaStartEvent(String identifier) {
+        this(identifier, "deadlineName");
+    }
+
+    public TriggerSagaStartEvent(String identifier, String deadlineName) {
         this.identifier = identifier;
+        this.deadlineName = deadlineName;
     }
 
     public String getIdentifier() {
         return identifier;
+    }
+
+    public String getDeadlineName() {
+        return deadlineName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TriggerSagaStartEvent that = (TriggerSagaStartEvent) o;
+        return Objects.equals(identifier, that.identifier)
+                && Objects.equals(deadlineName, that.deadlineName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, deadlineName);
+    }
+
+    @Override
+    public String toString() {
+        return "TriggerSagaStartEvent{" +
+                "identifier='" + identifier + '\'' +
+                ", deadlineName='" + deadlineName + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
This pull request changes when a message handling member in a Saga can end a saga.
It does so by adjusting the validation done in the `AnnotatedSaga`, to simply check whether a `MessageHandlingMember` contains the `@EndSaga` annotation.
As an `AnnotatedSaga` can only be invoked for message handling through `EventMessages` and `DeadlineMessages`, I deemed this adjusted easier than introduce a new Handler Enhancer Definition for this exact combination. Or, adjusting the `DeadlineMethodMessageHandlerDefinition` to include specifics about Sagas, which I feel don't belong there.

Tests have been included from the perspective of a `SagaTestFixture`, as well as the `DeadlineManager` test suite.
As such, this PR resolves #1469 