### PR TITLE
[#1588] Automatic @Revision-based SnapshotFilter

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
@@ -1,0 +1,32 @@
+package org.axonframework.eventsourcing.snapshotting;
+
+import org.axonframework.eventhandling.DomainEventData;
+
+import java.util.Objects;
+
+/**
+ * A {@link SnapshotFilter} implementation which based on a configurable allowed revision will only {@link
+ * #allow(DomainEventData)} {@link DomainEventData} containing that revision.
+ *
+ * @author Steven van Beelen
+ * @since 4.5
+ */
+public class RevisionSnapshotFilter implements SnapshotFilter {
+
+    private final String allowedRevision;
+
+    /**
+     * Construct a {@link RevisionSnapshotFilter} which returns {@code true} on {@link #allow(DomainEventData)}
+     * invocations where the {@link DomainEventData} contains the given {@code allowedRevision}.
+     *
+     * @param allowedRevision the revision which is allowed by this {@link SnapshotFilter}
+     */
+    public RevisionSnapshotFilter(String allowedRevision) {
+        this.allowedRevision = allowedRevision;
+    }
+
+    @Override
+    public boolean test(DomainEventData<?> domainEventData) {
+        return Objects.equals(domainEventData.getPayload().getType().getRevision(), allowedRevision);
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
@@ -1,0 +1,73 @@
+package org.axonframework.eventsourcing.snapshotting;
+
+import org.axonframework.eventhandling.DomainEventData;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventsourcing.eventstore.jpa.SnapshotEventEntry;
+import org.axonframework.eventsourcing.utils.TestSerializer;
+import org.axonframework.serialization.Revision;
+import org.axonframework.serialization.Serializer;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link RevisionSnapshotFilter}.
+ *
+ * @author Steven van Beelen
+ */
+class RevisionSnapshotFilterTest {
+
+    private static final String ALLOWED_REVISION = "LET ME IN";
+
+    private final Serializer serializer = TestSerializer.secureXStreamSerializer();
+    private final RevisionSnapshotFilter testSubject = new RevisionSnapshotFilter(ALLOWED_REVISION);
+
+    @Test
+    void testAllowsDomainEventDataContainingTheAllowedRevision() {
+        DomainEventMessage<RightAggregateVersion> snapshotEvent = new GenericDomainEventMessage<>(
+                RightAggregateVersion.class.getName(), "some-aggregate-id", 0, new RightAggregateVersion("some-state")
+        );
+        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
+
+        assertTrue(testSubject.allow(testDomainEventData));
+    }
+
+    @Test
+    void testDisallowsDomainEventDataContainingTheAllowedRevision() {
+        DomainEventMessage<WrongAggregateVersion> snapshotEvent = new GenericDomainEventMessage<>(
+                WrongAggregateVersion.class.getName(), "some-aggregate-id", 0, new WrongAggregateVersion("some-state")
+        );
+        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
+
+        assertFalse(testSubject.allow(testDomainEventData));
+    }
+
+    @Revision(ALLOWED_REVISION)
+    private static class RightAggregateVersion {
+
+        private final String state;
+
+        private RightAggregateVersion(String state) {
+            this.state = state;
+        }
+
+        public String getState() {
+            return state;
+        }
+    }
+
+    @Revision("some-other-revision")
+    private static class WrongAggregateVersion {
+
+        private final String state;
+
+        private WrongAggregateVersion(String state) {
+            this.state = state;
+        }
+
+        public String getState() {
+            return state;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new implementation of the `SnapshotFilter`: the `RevisionSnapshotFilter`.
This filter upon construction takes in an "allowed revision".
This `String` is validated against the revision on the type of the payload present in the `DomainEventData` when `test` is invoked.

Furthermore, the `AggregateConfigurer` checks for the existence of the `@Revision` annotation on the aggregate `Class`. If it's present, the attribute` revision` is used to create a `RevisionSnapshotFilter`, which is then set as the snapshot filter for this aggregate.

This pull request resolves #1588 