### PR TITLE
[#1402] Enhance MessageTimerMonitor customizability

### DIFF
--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 
@@ -28,9 +29,14 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Times allTimer messages, successful and failed messages
+ * A {@link MessageMonitor} which introduces a {@link Timer} for the overall timer of all {@link Message}s being
+ * ingested, as well as a success, failure and ignored {@code Timer}.
  *
  * @author Marijn van Zelst
  * @author Ivan Dugalic
@@ -40,31 +46,66 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
 
     private final String meterNamePrefix;
     private final MeterRegistry meterRegistry;
-    private final Function<Message<?>, Iterable<Tag>> tagsBuilder;
-
     private final Clock clock;
+    private final Function<Message<?>, Iterable<Tag>> tagsBuilder;
+    private final UnaryOperator<Timer.Builder> timerCustomization;
 
     /**
-     * Creates a message timer monitor
+     * Instantiate a Builder to be able to create a {@link MessageTimerMonitor}.
+     * <p>
+     * The {@link Clock} is defaulted to a {@link Clock#SYSTEM}, the {@code tagsBuilder} to a {@link Function} returning
+     * {@link Tags#empty()} and the {@code timerCustomization} to a no-op. The {@code meterNamePrefix} and {@link
+     * MeterRegistry} are <b>hard requirements</b> and as such should be provided.
      *
-     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
-     * @param meterRegistry   The meter registry used to create and register the meters
-     * @return The message timer monitor
+     * @return a Builder to be able to create a {@link MessageTimerMonitor}
      */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a {@link MessageTimerMonitor} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@code meterNamePrefix} and {@link MeterRegistry} are not {@code null} and will throw an
+     * {@link AxonConfigurationException} if this is the case.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link MessageTimerMonitor} instance
+     */
+    protected MessageTimerMonitor(Builder builder) {
+        builder.validate();
+        this.meterNamePrefix = builder.meterNamePrefix;
+        this.meterRegistry = builder.meterRegistry;
+        this.clock = builder.clock;
+        this.tagsBuilder = builder.tagsBuilder;
+        this.timerCustomization = builder.timerCustomization;
+    }
+
+    /**
+     * Creates a message timer monitor.
+     *
+     * @param meterNamePrefix the prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   the meter registry used to create and register the meters
+     * @return the message timer monitor
+     * @deprecated in favor of using the {@link #builder()}
+     */
+    @Deprecated
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry) {
         return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM);
     }
 
     /**
-     * Creates a message timer monitor
+     * Creates a message timer monitor.
      *
-     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
-     * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     * @param meterNamePrefix the prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   the meter registry used to create and register the meters
+     * @param tagsBuilder     the function used to construct the list of micrometer {@link Tag}, based on the ingested
      *                        message
-     * @return The message timer monitor
+     * @return the message timer monitor
+     * @deprecated in favor of using the {@link #builder()}
      */
-    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry,
+    @Deprecated
+    public static MessageTimerMonitor buildMonitor(String meterNamePrefix,
+                                                   MeterRegistry meterRegistry,
                                                    Function<Message<?>, Iterable<Tag>> tagsBuilder) {
         return buildMonitor(meterNamePrefix, meterRegistry, Clock.SYSTEM, tagsBuilder);
     }
@@ -72,65 +113,47 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
     /**
      * Creates a message timer monitor.
      *
-     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
-     * @param meterRegistry   The meter registry used to create and register the meters
-     * @param clock           The clock used to measure the process time per message
-     * @return The message timer monitor
+     * @param meterNamePrefix the prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   the meter registry used to create and register the meters
+     * @param clock           the clock used to measure the process time per message
+     * @return the message timer monitor
+     * @deprecated in favor of using the {@link #builder()}
      */
+    @Deprecated
     public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock) {
-        return new MessageTimerMonitor(meterNamePrefix, meterRegistry, clock);
+        return buildMonitor(meterNamePrefix, meterRegistry, clock, message -> Tags.empty());
     }
 
     /**
      * Creates a message timer monitor.
      *
-     * @param meterNamePrefix The prefix for the meter name that will be created in the given meterRegistry
-     * @param meterRegistry   The meter registry used to create and register the meters
-     * @param tagsBuilder     The function used to construct the list of micrometer {@link Tag}, based on the ingested
+     * @param meterNamePrefix the prefix for the meter name that will be created in the given meterRegistry
+     * @param meterRegistry   the meter registry used to create and register the meters
+     * @param tagsBuilder     the function used to construct the list of micrometer {@link Tag}, based on the ingested
      *                        message
-     * @param clock           The clock used to measure the process time per message
-     * @return The message timer monitor
+     * @param clock           the clock used to measure the process time per message
+     * @return the message timer monitor
+     * @deprecated in favor of using the {@link #builder()}
      */
-    public static MessageTimerMonitor buildMonitor(String meterNamePrefix, MeterRegistry meterRegistry, Clock clock,
+    @Deprecated
+    public static MessageTimerMonitor buildMonitor(String meterNamePrefix,
+                                                   MeterRegistry meterRegistry,
+                                                   Clock clock,
                                                    Function<Message<?>, Iterable<Tag>> tagsBuilder) {
-        return new MessageTimerMonitor(meterNamePrefix, meterRegistry, tagsBuilder, clock);
-    }
-
-    private static Timer buildTimer(String meterNamePrefix, String timerName, MeterRegistry meterRegistry,
-                                    Iterable<Tag> tags) {
-        return Timer.builder(meterNamePrefix + "." + timerName)
-                    .distributionStatisticExpiry(Duration.of(10, ChronoUnit.MINUTES))
-                    .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
-                    .tags(tags)
-                    .register(meterRegistry);
-    }
-
-    private MessageTimerMonitor(String meterNamePrefix,
-                                MeterRegistry meterRegistry,
-                                Function<Message<?>, Iterable<Tag>> tagsBuilder,
-                                Clock clock) {
-        this.meterNamePrefix = meterNamePrefix;
-        this.meterRegistry = meterRegistry;
-        this.tagsBuilder = tagsBuilder;
-        this.clock = clock;
-    }
-
-    private MessageTimerMonitor(String meterNamePrefix,
-                                MeterRegistry meterRegistry,
-                                Clock clock) {
-        this(meterNamePrefix,
-             meterRegistry,
-             message -> Tags.empty(),
-             clock);
+        return builder().meterNamePrefix(meterNamePrefix)
+                        .meterRegistry(meterRegistry)
+                        .clock(clock)
+                        .tagsBuilder(tagsBuilder)
+                        .build();
     }
 
     @Override
     public MonitorCallback onMessageIngested(Message<?> message) {
         Iterable<Tag> tags = tagsBuilder.apply(message);
-        Timer allTimer = buildTimer(meterNamePrefix, "allTimer", meterRegistry, tags);
-        Timer successTimer = buildTimer(meterNamePrefix, "successTimer", meterRegistry, tags);
-        Timer failureTimer = buildTimer(meterNamePrefix, "failureTimer", meterRegistry, tags);
-        Timer ignoredTimer = buildTimer(meterNamePrefix, "ignoredTimer", meterRegistry, tags);
+        Timer allTimer = buildTimer(meterNamePrefix, "allTimer", meterRegistry, tags, timerCustomization);
+        Timer successTimer = buildTimer(meterNamePrefix, "successTimer", meterRegistry, tags, timerCustomization);
+        Timer failureTimer = buildTimer(meterNamePrefix, "failureTimer", meterRegistry, tags, timerCustomization);
+        Timer ignoredTimer = buildTimer(meterNamePrefix, "ignoredTimer", meterRegistry, tags, timerCustomization);
 
         long startTime = clock.monotonicTime();
 
@@ -156,5 +179,125 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>> {
                 ignoredTimer.record(duration, TimeUnit.NANOSECONDS);
             }
         };
+    }
+
+    private static Timer buildTimer(String meterNamePrefix,
+                                    String timerName,
+                                    MeterRegistry meterRegistry,
+                                    Iterable<Tag> tags,
+                                    UnaryOperator<Timer.Builder> timerCustomization) {
+        Timer.Builder timerBuilder = Timer.builder(meterNamePrefix + "." + timerName)
+                                          .distributionStatisticExpiry(Duration.of(10, ChronoUnit.MINUTES))
+                                          .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999)
+                                          .tags(tags);
+        return timerCustomization.apply(timerBuilder).register(meterRegistry);
+    }
+
+    /**
+     * Builder class to instantiate a {@link MessageTimerMonitor}.
+     * <p>
+     * The {@link Clock} is defaulted to a {@link Clock#SYSTEM}, the {@code tagsBuilder} to a {@link Function} returning
+     * {@link Tags#empty()} and the {@code timerCustomization} to a no-op. The {@code meterNamePrefix} and {@link
+     * MeterRegistry} are <b>hard requirements</b> and as such should be provided.
+     */
+    public static class Builder {
+
+        private String meterNamePrefix;
+        private MeterRegistry meterRegistry;
+        private Clock clock = Clock.SYSTEM;
+        private Function<Message<?>, Iterable<Tag>> tagsBuilder = message -> Tags.empty();
+        private UnaryOperator<Timer.Builder> timerCustomization = timerBuilder -> timerBuilder;
+
+        /**
+         * Sets the name used to prefix the names of the {@link Timer} instances created by this {@link
+         * MessageMonitor}.
+         *
+         * @param meterNamePrefix a {@link String} used to prefix the names of the {@link Timer} instances created by
+         *                        this {@link MessageMonitor}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder meterNamePrefix(String meterNamePrefix) {
+            assertNonEmpty(meterNamePrefix, "The meter name prefix may not be null or empty");
+            this.meterNamePrefix = meterNamePrefix;
+            return this;
+        }
+
+        /**
+         * Specifies the {@link MeterRegistry} used to registered the {@link Timer} instances to.
+         *
+         * @param meterRegistry the {@link MeterRegistry} used to registered the {@link Timer} instances to
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder meterRegistry(MeterRegistry meterRegistry) {
+            assertNonNull(meterRegistry, "MeterRegistry may not be null");
+            this.meterRegistry = meterRegistry;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Clock} used to define the processing duration of a given message being pushed through this
+         * {@link MessageMonitor}. Defaults to the {@link Clock#SYSTEM}.
+         *
+         * @param clock the {@link Clock} used to define the processing duration of a given message
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder clock(Clock clock) {
+            assertNonNull(clock, "Clock may not be null");
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Configures the {@link Function} used to deduce what the {@link Tag}s should be for a message being monitored.
+         * Defaults to a {@link Function} returning {@link Tags#empty()}.
+         *
+         * @param tagsBuilder a {@link Function} used to deduce what the {@link Tag}s should be for a message being
+         *                    monitored
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder tagsBuilder(Function<Message<?>, Iterable<Tag>> tagsBuilder) {
+            assertNonNull(tagsBuilder, "TagsBuilder may not be null");
+            this.tagsBuilder = tagsBuilder;
+            return this;
+        }
+
+        /**
+         * Allows for specifying a customization which will be added during the creation of the {@link Timer}. Defaults
+         * to a no-op. This for example allows more fine grained control over the published percentiles used by the
+         * {@link Timer}.
+         * <p>
+         * Without any customization, a {@link Timer} define the {@link Timer.Builder#distributionStatisticExpiry(Duration)}
+         * with a {@link Duration} of 10 minutes and {@link Timer.Builder#publishPercentiles(double...)} with the
+         * percentiles {@code 0.5}, {@code 0.75}, {@code 0.95}, {@code 0.98}, {@code 0.99} and {@code 0.999}.
+         *
+         * @param timerCustomization a {@link UnaryOperator} taking in and returning a {@link Timer.Builder} forming a
+         *                           customization on the {@link Timer} being created
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder timerCustomization(UnaryOperator<Timer.Builder> timerCustomization) {
+            assertNonNull(timerCustomization, "TimerCustomization may not be null");
+            this.timerCustomization = timerCustomization;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link MessageTimerMonitor} as specified through this Builder.
+         *
+         * @return a {@link MessageTimerMonitor} as specified through this Builder
+         */
+        public MessageTimerMonitor build() {
+            return new MessageTimerMonitor(this);
+        }
+
+        /**
+         * Validate whether the fields contained in this Builder as set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        protected void validate() {
+            assertNonEmpty(meterNamePrefix, "The meter name prefix is a hard requirement and should be provided");
+            assertNonNull(meterRegistry, "The MeterRegistry is a hard requirement and should be provided");
+        }
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
@@ -37,33 +38,49 @@ import static java.util.Objects.requireNonNull;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
-
+/**
+ * Test class validating the {@link MessageTimerMonitor}.
+ *
+ * @author Marijn van Zelst
+ */
 class MessageTimerMonitorTest {
 
-    private static final String PROCESSOR_NAME = "processorName";
+    private static final String METER_NAME_PREFIX = "some-prefix";
+
+    private MockClock mockedClock;
+    private SimpleMeterRegistry meterRegistry;
+    private MessageTimerMonitor.Builder testSubjectBuilder;
+
+    @BeforeEach
+    void setUp() {
+        mockedClock = new MockClock();
+        meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, mockedClock);
+        testSubjectBuilder = MessageTimerMonitor.builder()
+                                                .meterNamePrefix(METER_NAME_PREFIX)
+                                                .meterRegistry(meterRegistry)
+                                                .clock(mockedClock);
+    }
 
     @Test
     void testMessagesWithoutTags() {
-        MockClock testClock = new MockClock();
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
+        MessageTimerMonitor testSubject = testSubjectBuilder.build();
+
         EventMessage<Object> foo = asEventMessage(1);
         EventMessage<Object> bar = asEventMessage("bar");
         EventMessage<Object> baz = asEventMessage("baz");
 
-        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME,
-                                                                           meterRegistry,
-                                                                           testClock);
-        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
-                .onMessagesIngested(Arrays.asList(foo, bar, baz));
-        testClock.addSeconds(1);
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks =
+                testSubject.onMessagesIngested(Arrays.asList(foo, bar, baz));
+
+        mockedClock.addSeconds(1);
         callbacks.get(foo).reportSuccess();
         callbacks.get(bar).reportFailure(null);
         callbacks.get(baz).reportIgnored();
 
-        Timer all = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".allTimer").timer());
-        Timer successTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".successTimer").timer());
-        Timer failureTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timer());
-        Timer ignoredTimer = requireNonNull(meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timer());
+        Timer all = requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".allTimer").timer());
+        Timer successTimer = requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".successTimer").timer());
+        Timer failureTimer = requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".failureTimer").timer());
+        Timer ignoredTimer = requireNonNull(meterRegistry.find(METER_NAME_PREFIX + ".ignoredTimer").timer());
 
         assertEquals(3, all.totalTime(TimeUnit.SECONDS), 0);
         assertEquals(1, successTimer.totalTime(TimeUnit.SECONDS), 0);
@@ -73,29 +90,26 @@ class MessageTimerMonitorTest {
 
     @Test
     void testMessagesWithPayloadTypeAsCustomTag() {
-        MockClock testClock = new MockClock();
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
+        MessageTimerMonitor testSubject = testSubjectBuilder.tagsBuilder(
+                message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName())
+        ).build();
+
         EventMessage<Object> foo = asEventMessage(1);
         EventMessage<Object> bar = asEventMessage("bar");
         EventMessage<Object> baz = asEventMessage("baz");
 
-        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME,
-                                                                           meterRegistry,
-                                                                           testClock,
-                                                                           message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG,
-                                                                                              message.getPayloadType()
-                                                                                                     .getSimpleName()));
-        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
-                .onMessagesIngested(Arrays.asList(foo, bar, baz));
-        testClock.addSeconds(1);
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks =
+                testSubject.onMessagesIngested(Arrays.asList(foo, bar, baz));
+
+        mockedClock.addSeconds(1);
         callbacks.get(foo).reportSuccess();
         callbacks.get(bar).reportFailure(null);
         callbacks.get(baz).reportIgnored();
 
-        Collection<Timer> all = meterRegistry.find(PROCESSOR_NAME + ".allTimer").timers();
-        Collection<Timer> successTimer = meterRegistry.find(PROCESSOR_NAME + ".successTimer").timers();
-        Collection<Timer> failureTimer = meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timers();
-        Collection<Timer> ignoredTimer = meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timers();
+        Collection<Timer> all = meterRegistry.find(METER_NAME_PREFIX + ".allTimer").timers();
+        Collection<Timer> successTimer = meterRegistry.find(METER_NAME_PREFIX + ".successTimer").timers();
+        Collection<Timer> failureTimer = meterRegistry.find(METER_NAME_PREFIX + ".failureTimer").timers();
+        Collection<Timer> ignoredTimer = meterRegistry.find(METER_NAME_PREFIX + ".ignoredTimer").timers();
 
         // Expecting two timers with the same meter name ([name=PROCESSOR_NAME.suffix ; payloadType=Integer] , [name=PROCESSOR_NAME.suffix ; payloadType=String])
         assertEquals(2, all.size(), 0);
@@ -129,8 +143,10 @@ class MessageTimerMonitorTest {
 
     @Test
     void testMessagesWithMetadataAsCustomTag() {
-        MockClock testClock = new MockClock();
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, testClock);
+        MessageTimerMonitor testSubject = testSubjectBuilder.tagsBuilder(
+                message -> Tags.of("myMetaData", message.getMetaData().get("myMetadataKey").toString())
+        ).build();
+
         EventMessage<Object> foo = asEventMessage("foo").withMetaData(Collections.singletonMap("myMetadataKey",
                                                                                                "myMetadataValue1"));
         EventMessage<Object> bar = asEventMessage("bar").withMetaData(Collections.singletonMap("myMetadataKey",
@@ -138,25 +154,18 @@ class MessageTimerMonitorTest {
         EventMessage<Object> baz = asEventMessage("baz").withMetaData(Collections.singletonMap("myMetadataKey",
                                                                                                "myMetadataValue2"));
 
-        MessageTimerMonitor testSubject = MessageTimerMonitor.buildMonitor(PROCESSOR_NAME,
-                                                                           meterRegistry,
-                                                                           testClock,
-                                                                           message -> Tags
-                                                                                   .of("myMetaData",
-                                                                                       message.getMetaData()
-                                                                                              .get("myMetadataKey")
-                                                                                              .toString()));
-        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks = testSubject
-                .onMessagesIngested(Arrays.asList(foo, bar, baz));
-        testClock.addSeconds(1);
+        Map<? super Message<?>, MessageMonitor.MonitorCallback> callbacks =
+                testSubject.onMessagesIngested(Arrays.asList(foo, bar, baz));
+
+        mockedClock.addSeconds(1);
         callbacks.get(foo).reportSuccess();
         callbacks.get(bar).reportFailure(null);
         callbacks.get(baz).reportIgnored();
 
-        Collection<Timer> all = meterRegistry.find(PROCESSOR_NAME + ".allTimer").timers();
-        Collection<Timer> successTimer = meterRegistry.find(PROCESSOR_NAME + ".successTimer").timers();
-        Collection<Timer> failureTimer = meterRegistry.find(PROCESSOR_NAME + ".failureTimer").timers();
-        Collection<Timer> ignoredTimer = meterRegistry.find(PROCESSOR_NAME + ".ignoredTimer").timers();
+        Collection<Timer> all = meterRegistry.find(METER_NAME_PREFIX + ".allTimer").timers();
+        Collection<Timer> successTimer = meterRegistry.find(METER_NAME_PREFIX + ".successTimer").timers();
+        Collection<Timer> failureTimer = meterRegistry.find(METER_NAME_PREFIX + ".failureTimer").timers();
+        Collection<Timer> ignoredTimer = meterRegistry.find(METER_NAME_PREFIX + ".ignoredTimer").timers();
 
         // Expecting two timers with the same meter name ([name=PROCESSOR_NAME.suffix ; payloadType=Integer] , [name=PROCESSOR_NAME.suffix ; payloadType=String])
         assertEquals(2, all.size(), 0);
@@ -186,5 +195,55 @@ class MessageTimerMonitorTest {
         assertTrue(failureTimer.stream()
                                .filter(timer -> Objects.equals(timer.getId().getTag("myMetaData"), "myMetadataValue2"))
                                .allMatch(timer -> timer.totalTime(TimeUnit.SECONDS) == 1));
+    }
+
+    @Test
+    void testBuildWithNullMeterNamePrefixThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(null));
+    }
+
+    @Test
+    void testBuildWithEmptyMeterNamePrefixThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(""));
+    }
+
+    @Test
+    void testBuildWithoutMeterNamePrefixThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder()
+                                                                     .meterRegistry(meterRegistry);
+        assertThrows(AxonConfigurationException.class, testSubject::build);
+    }
+
+    @Test
+    void testBuildWithNullMeterRegistryThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.meterRegistry(null));
+    }
+
+    @Test
+    void testBuildWithoutMeterRegistryThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder()
+                                                                     .meterNamePrefix(METER_NAME_PREFIX);
+        assertThrows(AxonConfigurationException.class, testSubject::build);
+    }
+
+    @Test
+    void testBuildWithNullClockThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.clock(null));
+    }
+
+    @Test
+    void testBuildWithNullTagsBuilderThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.tagsBuilder(null));
+    }
+
+    @Test
+    void testBuildWithNullTimerCustomizationThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.timerCustomization(null));
     }
 }

--- a/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
@@ -190,7 +190,7 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>>, MetricSe
          *                                    specifications
          */
         protected void validate() {
-            // Kept for overriding
+            // No assertions required, kept for overriding
         }
     }
 }

--- a/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * A {@link MessageMonitor which creates {@link Timer} instances for the overall, success, failure and ignored time an
+ * A {@link MessageMonitor} which creates {@link Timer} instances for the overall, success, failure and ignored time an
  * ingested {@link Message} takes.
  *
  * @author Marijn van Zelst

--- a/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
@@ -20,15 +20,21 @@ import com.codahale.metrics.Clock;
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Timer;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Times allTimer messages, successful and failed messages
+ * A {@link MessageMonitor which creates {@link Timer} instances for the overall, success, failure and ignored time an
+ * ingested {@link Message} takes.
  *
  * @author Marijn van Zelst
  * @since 3.0
@@ -41,8 +47,40 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>>, MetricSe
     private final Timer ignoredTimer;
 
     /**
-     * Creates a MessageTimerMonitor using a default clock
+     * Instantiate a Builder to be able to create a {@link MessageTimerMonitor}.
+     * <p>
+     * The {@link Clock} is defaulted to a {@link Clock#defaultClock()} and the {@code reservoirFactory} defaults to
+     * creating a {@link ExponentiallyDecayingReservoir}.
+     *
+     * @return a Builder to be able to create a {@link MessageTimerMonitor}
      */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a {@link MessageTimerMonitor} based on the fields contained in the {@link Builder}.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link MessageTimerMonitor} instance
+     */
+    protected MessageTimerMonitor(Builder builder) {
+        builder.validate();
+
+        Clock clock = builder.clock;
+        Supplier<Reservoir> reservoirFactory = builder.reservoirFactory;
+
+        allTimer = new Timer(reservoirFactory.get(), clock);
+        successTimer = new Timer(reservoirFactory.get(), clock);
+        failureTimer = new Timer(reservoirFactory.get(), clock);
+        ignoredTimer = new Timer(reservoirFactory.get(), clock);
+    }
+
+    /**
+     * Creates a MessageTimerMonitor using a default clock
+     *
+     * @deprecated in favor of the {@link #builder()}
+     */
+    @Deprecated
     public MessageTimerMonitor() {
         this(Clock.defaultClock());
     }
@@ -51,7 +89,9 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>>, MetricSe
      * Creates a MessageTimerMonitor using the provided clock
      *
      * @param clock the clock used to measure the process time of each message
+     * @deprecated in favor of the {@link #builder()}
      */
+    @Deprecated
     public MessageTimerMonitor(Clock clock) {
         allTimer = new Timer(new ExponentiallyDecayingReservoir(), clock);
         successTimer = new Timer(new ExponentiallyDecayingReservoir(), clock);
@@ -94,5 +134,63 @@ public class MessageTimerMonitor implements MessageMonitor<Message<?>>, MetricSe
         metrics.put("failureTimer", failureTimer);
         metrics.put("ignoredTimer", ignoredTimer);
         return metrics;
+    }
+
+    /**
+     * Builder class to instantiate a {@link MessageTimerMonitor}.
+     * <p>
+     * The {@link Clock} is defaulted to a {@link Clock#defaultClock()} and the {@code reservoirFactory} defaults to
+     * creating a {@link ExponentiallyDecayingReservoir}.
+     */
+    public static class Builder {
+
+        private Clock clock = Clock.defaultClock();
+        private Supplier<Reservoir> reservoirFactory = ExponentiallyDecayingReservoir::new;
+
+        /**
+         * Sets the {@link Clock} used to define the processing duration of a given message being pushed through this
+         * {@link MessageMonitor}. Defaults to the {@link Clock#defaultClock}.
+         *
+         * @param clock the {@link Clock} used to define the processing duration of a given message
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder clock(Clock clock) {
+            assertNonNull(clock, "Clock may not be null");
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Sets factory method creating a {@link Reservoir} to be used by the {@link Timer} instances created by this
+         * {@link MessageMonitor}. Defaults to a {@link Supplier} of {@link ExponentiallyDecayingReservoir}.
+         *
+         * @param reservoirFactory a factory method creating a {@link Reservoir} to be used by the {@link Timer}
+         *                         instances created by this {@link MessageMonitor}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder reservoirFactory(Supplier<Reservoir> reservoirFactory) {
+            assertNonNull(reservoirFactory, "ReservoirFactory may not be null");
+            this.reservoirFactory = reservoirFactory;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link MessageTimerMonitor} as specified through this Builder.
+         *
+         * @return a {@link MessageTimerMonitor} as specified through this Builder
+         */
+        public MessageTimerMonitor build() {
+            return new MessageTimerMonitor(this);
+        }
+
+        /**
+         * Validate whether the fields contained in this Builder as set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        protected void validate() {
+            // Kept for overriding
+        }
     }
 }

--- a/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
@@ -18,6 +18,7 @@ package org.axonframework.metrics;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -25,12 +26,26 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating the {@link MessageTimerMonitor}.
+ *
+ * @author Marijn van Zelst
+ */
 class MessageTimerMonitorTest {
 
+    private TestClock testClock;
+    private MessageTimerMonitor testSubject;
+
+    @BeforeEach
+    void setUp() {
+        testClock = new TestClock();
+        testSubject = MessageTimerMonitor.builder()
+                                         .clock(testClock)
+                                         .build();
+    }
+
     @Test
-    void testSuccessMessage(){
-        TestClock testClock = new TestClock();
-        MessageTimerMonitor testSubject = new MessageTimerMonitor(testClock);
+    void testSuccessMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportSuccess();
@@ -49,9 +64,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testFailureMessage(){
-        TestClock testClock = new TestClock();
-        MessageTimerMonitor testSubject = new MessageTimerMonitor(testClock);
+    void testFailureMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportFailure(null);
@@ -70,9 +83,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testIgnoredMessage(){
-        TestClock testClock = new TestClock();
-        MessageTimerMonitor testSubject = new MessageTimerMonitor(testClock);
+    void testIgnoredMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportIgnored();
@@ -90,4 +101,15 @@ class MessageTimerMonitorTest {
         assertArrayEquals(new long[]{}, failureTimer.getSnapshot().getValues());
     }
 
+    @Test
+    void testBuildWithNullClockThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.clock(null));
+    }
+
+    @Test
+    void testBuildWithNullReservoirFactoryThrowsAxonConfigurationException() {
+        MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
+        assertThrows(AxonConfigurationException.class, () -> testSubject.reservoirFactory(null));
+    }
 }

--- a/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
@@ -17,12 +17,14 @@
 package org.axonframework.metrics;
 
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.SlidingTimeWindowReservoir;
 import com.codahale.metrics.Timer;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -99,6 +101,35 @@ class MessageTimerMonitorTest {
         assertArrayEquals(new long[]{}, successTimer.getSnapshot().getValues());
         assertArrayEquals(new long[]{1000000}, ignoredTimer.getSnapshot().getValues());
         assertArrayEquals(new long[]{}, failureTimer.getSnapshot().getValues());
+    }
+
+    /**
+     * A different {@link com.codahale.metrics.Reservoir} is used, which simply means the storage approach of the metric
+     * histogram is adjusted. Within the test space, this still renders the same results, hence the similar assertion as
+     * in {@link #testSuccessMessage()}.
+     */
+    @Test
+    void testCustomReservoir() {
+        MessageTimerMonitor customReservoirTestSubject =
+                MessageTimerMonitor.builder()
+                                   .clock(testClock)
+                                   .reservoirFactory(() -> new SlidingTimeWindowReservoir(2000, TimeUnit.MILLISECONDS))
+                                   .build();
+
+        MessageMonitor.MonitorCallback result = customReservoirTestSubject.onMessageIngested(null);
+        testClock.increase(1000);
+        result.reportSuccess();
+
+        Map<String, Metric> metrics = customReservoirTestSubject.getMetrics();
+        Timer all = (Timer) metrics.get("allTimer");
+        Timer successTimer = (Timer) metrics.get("successTimer");
+        Timer failureTimer = (Timer) metrics.get("failureTimer");
+        Timer ignoredTimer = (Timer) metrics.get("ignoredTimer");
+
+        assertArrayEquals(new long[]{1000000}, all.getSnapshot().getValues());
+        assertArrayEquals(new long[]{1000000}, successTimer.getSnapshot().getValues());
+        assertArrayEquals(new long[]{}, failureTimer.getSnapshot().getValues());
+        assertArrayEquals(new long[]{}, ignoredTimer.getSnapshot().getValues());
     }
 
     @Test


### PR DESCRIPTION
This pull request makes it friendlier to adjust the `MessageTimerMonitor` for both DropWizard Metrics and Micrometer.
It does so by firstly introducing a `Builder` to both, allowing for the removal of the old constructor/builder overloading.

The DropWizard `MessageTimerMonitor` now through the builder allows a means to adjust the `Reservoir` (DropWizard) for the `Timer`. The Micrometer `MessageTimerMonitor` adds the option to configure a `UnaryOperator<Timer.Builder>` which is invoked during the creation of the `Timer`. Either solution allows for more fine-grained control over what's being monitored.

The `MessageTimerMonitor` is arguably the sole `MessageMonitor` implementation for both DropWizard Metrics and Micrometer which benefits from such an adjustment. As such this PR can be regarded to resolve #1402.