### PR TITLE
[#1019] Tracking Processor Config configuration and Saga Token Defaults

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
@@ -18,7 +18,15 @@ package org.axonframework.config;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.ErrorHandler;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventHandlerInvoker;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
+import org.axonframework.eventhandling.LoggingErrorHandler;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventhandling.async.SequencingPolicy;
 import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
@@ -504,10 +512,23 @@ public interface EventProcessingConfigurer {
                                                          Function<Configuration, TransactionManager> transactionManagerBuilder);
 
     /**
+     * Register a {@link Function} that builds a {@link TrackingEventProcessorConfiguration} to be used by the {@link
+     * EventProcessor} corresponding to the given {@code name}.
+     *
+     * @param name                                       a {@link String} specifying the name of an {@link
+     *                                                   EventProcessor}
+     * @param trackingEventProcessorConfigurationBuilder a {@link Function} that builds a {@link TrackingEventProcessorConfiguration}
+     * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
+     */
+    EventProcessingConfigurer registerTrackingEventProcessorConfiguration(
+            String name,
+            Function<Configuration, TrackingEventProcessorConfiguration> trackingEventProcessorConfigurationBuilder
+    );
+
+    /**
      * Register a {@link Function} that builds a {@link TrackingEventProcessorConfiguration} to use as the default.
      *
-     * @param trackingEventProcessorConfigurationBuilder a {@link Function} that builds a
-     *                                                   {@link TrackingEventProcessorConfiguration}
+     * @param trackingEventProcessorConfigurationBuilder a {@link Function} that builds a {@link TrackingEventProcessorConfiguration}
      * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
      */
     EventProcessingConfigurer registerTrackingEventProcessorConfiguration(

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -289,6 +289,7 @@ public class EventProcessingModule
     private boolean noSagaProcessorCustomization(Class<?> type, String processingGroup, String processorName) {
         return DEFAULT_PROCESSING_GROUP_FUNCTION.apply(type).equals(processingGroup)
                 && processingGroup.equals(processorName)
+                && !eventProcessorBuilders.containsKey(processorName)
                 && !tepConfigs.containsKey(processorName);
     }
 
@@ -491,9 +492,11 @@ public class EventProcessingModule
     }
 
     @Override
-    public EventProcessingConfigurer registerTrackingEventProcessor(String name,
-                                                                    Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source) {
-        return registerTrackingEventProcessor(name, source, c -> defaultTrackingEventProcessorConfiguration.get());
+    public EventProcessingConfigurer registerTrackingEventProcessor(
+            String name,
+            Function<Configuration, StreamableMessageSource<TrackedEventMessage<?>>> source
+    ) {
+        return registerTrackingEventProcessor(name, source, c -> trackingEventProcessorConfig(name));
     }
 
     @Override
@@ -753,7 +756,7 @@ public class EventProcessingModule
      * Since class.getPackage() can be null e.g. for generated classes, the
      * package name is determined the old fashioned way based on the full
      * qualified class name.
-     * 
+     *
      * @param object
      *            {@link Object}
      * @return {@link String}


### PR DESCRIPTION
This pull request provides a combination of two solutions.

Firstly, a `EventProcessingConfigurer#registerTrackingEventProcessorConfiguration(String, Function<Configuration, TrackingEventProcessorConfiguration>)` method has been provided. This allows to define a `TrackingEventProcessorConfiguration` per processor out there. This enhance the current options which are the registration of a `TrackingEventProcessor` (through `registerTrackingEventProcessor(...)`) and the registration of a default `registerTrackingEventProcessorConfiguration`.
Adding this serves the purpose of higher flexibility when it comes to defining how to configure a `TrackingEventProcessor` without defining processor names or sources.

Secondly, a default `TrackingEventProcessorConfiguration` is specified for configured Saga instances (as was dictated by #1019). This default will _only_ be taken into account if the following statements are true:
1. The default Saga processing group name is used. Thus, `[simple-saga-class-name]Processor`.
2. The Saga processing group name and processor name are identical.
3. There is no custom `EventProcessorBuilder` corresponding the Saga's processor name.
3. There is no custom `TrackingEventProcessorConfiguration` configured for the Saga's processor name.

This is done as we assume that if _any_ custom processor configuration is in place for the given Saga, then the chances are high the user will define it's own `TrackingEventProcessorConfiguration` too.

This pull request resolves #1019 