### PR TITLE
[#1682] Ensure provided first sequence number is used as fallback in absence of events in the historic event store

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
@@ -16,6 +16,11 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -26,11 +31,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import org.axonframework.eventhandling.DomainEventMessage;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingToken;
 
 /**
  * EventStorageEngine implementation that combines the streams of two event storage engines. The first event storage

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
@@ -93,8 +93,8 @@ public class SequenceEventStorageEngine implements EventStorageEngine {
     @Override
     public DomainEventStream readEvents(String aggregateIdentifier, long firstSequenceNumber) {
         DomainEventStream historic = historicStorage.readEvents(aggregateIdentifier, firstSequenceNumber);
-        return new ConcatenatingDomainEventStream(historic, aggregateIdentifier,
-                                                  (id, seq) -> activeStorage.readEvents(aggregateIdentifier, Math.max(seq, firstSequenceNumber)));
+        return new ConcatenatingDomainEventStream(historic, aggregateIdentifier, firstSequenceNumber,
+                                                  (id, seq) -> activeStorage.readEvents(aggregateIdentifier, seq));
     }
 
     @Override
@@ -173,14 +173,17 @@ public class SequenceEventStorageEngine implements EventStorageEngine {
 
         private final DomainEventStream historic;
         private final String aggregateIdentifier;
+        private final long firstSequenceNumber;
         private DomainEventStream actual;
         private final BiFunction<String, Long, DomainEventStream> domainEventStream;
 
         public ConcatenatingDomainEventStream(DomainEventStream historic,
                                               String aggregateIdentifier,
+                                              long firstSequenceNumber,
                                               BiFunction<String, Long, DomainEventStream> domainEventStream) {
             this.historic = historic;
             this.aggregateIdentifier = aggregateIdentifier;
+            this.firstSequenceNumber = firstSequenceNumber;
             this.domainEventStream = domainEventStream;
         }
 
@@ -201,7 +204,7 @@ public class SequenceEventStorageEngine implements EventStorageEngine {
 
         private long nextSequenceNumber() {
             Long lastSequenceNumber = historic.getLastSequenceNumber();
-            return lastSequenceNumber == null ? 0 : lastSequenceNumber + 1;
+            return lastSequenceNumber == null ? firstSequenceNumber : lastSequenceNumber + 1;
         }
 
         @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngine.java
@@ -16,11 +16,6 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
-import org.axonframework.eventhandling.DomainEventMessage;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingToken;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +26,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
 
 /**
  * EventStorageEngine implementation that combines the streams of two event storage engines. The first event storage
@@ -94,7 +94,7 @@ public class SequenceEventStorageEngine implements EventStorageEngine {
     public DomainEventStream readEvents(String aggregateIdentifier, long firstSequenceNumber) {
         DomainEventStream historic = historicStorage.readEvents(aggregateIdentifier, firstSequenceNumber);
         return new ConcatenatingDomainEventStream(historic, aggregateIdentifier,
-                                                  (id, seq) -> activeStorage.readEvents(aggregateIdentifier, seq));
+                                                  (id, seq) -> activeStorage.readEvents(aggregateIdentifier, Math.max(seq, firstSequenceNumber)));
     }
 
     @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
@@ -16,11 +16,19 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.longThat;
-import static org.mockito.Mockito.*;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -28,12 +36,27 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.axonframework.eventhandling.*;
-import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.longThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class SequenceEventStorageEngineTest {
     private EventStorageEngine activeStorage;
@@ -369,6 +392,4 @@ class SequenceEventStorageEngineTest {
         inOrder.verify(historicStorage).readEvents("aggregate", 2);
         inOrder.verify(activeStorage).readEvents("aggregate", 2);
     }
-
-    // TODO: Create test for batching issue as well?
 }


### PR DESCRIPTION
Mostly test cases that fails in the current 4.4.x branch, and a quick fix to the problem in #1682. 

`testAggregateEventsAreReadFromFirstSequenceNumberHistoricOnly` is for completeness, it also passes with the current implementation. 

The fix feels a bit of a hack, but I don't know the code well enough at this point. It could be that the `ConcatenatingDomainEventStream` should contain the first sequence number we tried to fetch as a member, and instead apply the fix in the private `nextSequenceNumber()`  method.

Something like:

````java
        private final long firstSequenceNumber;

         // ... 

        private long nextSequenceNumber() {
            Long lastSequenceNumber = historic.getLastSequenceNumber();
            return lastSequenceNumber == null ? firstSequenceNumber : lastSequenceNumber + 1;
        }
````

I can change the PR to include the above instead, just le me know.

-- 
Harald K