### PR TITLE
Add forked-branch validation for GitHub Action steps

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Deploy to Sonatype
         # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if: github.github.head_ref == null && success() && matrix.deploy && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.github.head_ref == null && success() && matrix.deploy && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           ./mvnw -B -U deploy -DskipTests=true
         env:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Notify success to Slack
         # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if: success() && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if:  ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2
@@ -86,7 +86,7 @@ jobs:
 
       - name: Notify failure to Slack
         # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if: failure() && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -64,7 +64,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Sonatype
-        if: github.github.head_ref == null && success() && matrix.deploy
+        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
+        if: github.github.head_ref == null && success() && matrix.deploy && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           ./mvnw -B -U deploy -DskipTests=true
         env:
@@ -73,7 +74,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASS }}
 
       - name: Notify success to Slack
-        if: success()
+        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
+        if: success() && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2
@@ -83,7 +85,8 @@ jobs:
           color: good
 
       - name: Notify failure to Slack
-        if: failure()
+        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
+        if: failure() && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2


### PR DESCRIPTION
GitHub Actions rightfully does not open up the secrets in the repository towards forked pull requests.
However not having access to these complicates some of the current steps, like notifying Slack and pushing snapshots to sonatype.

GitHub did provide some enhancement towards this end to provide extra handles in exactly these scenarios, as is described in [this](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks) blog post. 

What is pointed out, is a dedicated [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event, which signals pull requests from forked branches.
Although usable, as it simply runs the GHA of the main project instead of the variant in the fork, it opens up the possibility for malicious access towards our secrets.
This fact is also clear from their own [documentation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target).

As a second gesture, the [workflow_run](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) event was introduced, which serves as a trigger whenever another workflow is "requested" or "completed".
This solution is more promising, but as it stands the only values provided on this event are "requested" and "completed" (as is also pointed out [here](https://github.community/t/workflow-run-success-type-reference/133194)).
Again this complicates our workflow tremendously, as we require the outcome of the previous run as well as the matrix values used during that run (required for the sonatype step, as it should only run on JDK8).

As neither of the proposed solutions from the blog really solves our issue, I went with the suggested solution in [this](https://github.community/t/is-there-a-way-to-tell-if-a-pr-is-from-a-forked-repository/134186) forum thread.
It essentially checks whether the repository name of the forked pull request is the same as the local repository name.
If it is, we access the steps using secrets. And if it isn't, it simply does not invoke those steps.

The result is that we do not have Slack notifications or snapshot builds on forked pull requests.
However, I deem those irrelevant enough, as both would occur anyhow as soon as the pull request is merged (as defined in the `push` event on `master` and the bug fix branches).
