### PR TITLE
Remove QuartzEventScheduler hard dependency on XStream #1685

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -47,6 +47,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.*;
@@ -79,9 +80,8 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     /**
      * Instantiate a {@link QuartzEventScheduler} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link Scheduler}, {@link EventBus} and {@link TransactionManager} are not {@code null},
+     * Will assert that the {@link Scheduler} and {@link EventBus} are not {@code null},
      * and will throw an {@link AxonConfigurationException} if any of them is {@code null}.
-     * If the {@link EventJobDataBinder is {@code null} it is defaulted to a {@link DirectEventJobDataBinder }
      * The EventBus, TransactionManager and EventJobDataBinder will be tied to the Scheduler's context. If this
      * initialization step fails, this will too result in an AxonConfigurationException.
      *
@@ -91,7 +91,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         builder.validate();
         scheduler = builder.scheduler;
         eventBus = builder.eventBus;
-        jobDataBinder = builder.jobDataBinder != null ? builder.jobDataBinder : new DirectEventJobDataBinder();
+        jobDataBinder = builder.jobDataBinderSupplier.get();
         transactionManager = builder.transactionManager;
 
         try {
@@ -340,14 +340,15 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     /**
      * Builder class to instantiate a {@link QuartzEventScheduler}.
      * <p>
-     * The {@link TransactionManager} defaults to a {@link NoTransactionManager}.
+     * The {@link EventJobDataBinder} is defaulted to an {@link DirectEventJobDataBinder}, and the
+     * {@link TransactionManager} defaults to a {@link NoTransactionManager}.
      * The {@link Scheduler} and {@link EventBus} are a <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
         private Scheduler scheduler;
         private EventBus eventBus;
-        private EventJobDataBinder jobDataBinder;
+        private Supplier<EventJobDataBinder> jobDataBinderSupplier = DirectEventJobDataBinder::new;
         private TransactionManager transactionManager = NoTransactionManager.INSTANCE;
 
         /**
@@ -384,7 +385,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
          */
         public Builder jobDataBinder(EventJobDataBinder jobDataBinder) {
             assertNonNull(jobDataBinder, "EventJobDataBinder may not be null");
-            this.jobDataBinder = jobDataBinder;
+            this.jobDataBinderSupplier = () -> jobDataBinder;
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -79,9 +79,9 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     /**
      * Instantiate a {@link QuartzEventScheduler} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link Scheduler}, {@link EventBus}, {@link EventJobDataBinder} and
-     * {@link TransactionManager} are not {@code null}, and will throw an {@link AxonConfigurationException} if any of
-     * them is {@code null}.
+     * Will assert that the {@link Scheduler}, {@link EventBus} and {@link TransactionManager} are not {@code null},
+     * and will throw an {@link AxonConfigurationException} if any of them is {@code null}.
+     * If the {@link EventJobDataBinder is {@code null} it is defaulted to a {@link DirectEventJobDataBinder }
      * The EventBus, TransactionManager and EventJobDataBinder will be tied to the Scheduler's context. If this
      * initialization step fails, this will too result in an AxonConfigurationException.
      *
@@ -91,7 +91,7 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         builder.validate();
         scheduler = builder.scheduler;
         eventBus = builder.eventBus;
-        jobDataBinder = builder.jobDataBinder;
+        jobDataBinder = builder.jobDataBinder != null ? builder.jobDataBinder : new DirectEventJobDataBinder();
         transactionManager = builder.transactionManager;
 
         try {
@@ -340,15 +340,14 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
     /**
      * Builder class to instantiate a {@link QuartzEventScheduler}.
      * <p>
-     * The {@link EventJobDataBinder} is defaulted to an {@link DirectEventJobDataBinder}, and the
-     * {@link TransactionManager} defaults to a {@link NoTransactionManager}.
+     * The {@link TransactionManager} defaults to a {@link NoTransactionManager}.
      * The {@link Scheduler} and {@link EventBus} are a <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
         private Scheduler scheduler;
         private EventBus eventBus;
-        private EventJobDataBinder jobDataBinder = new DirectEventJobDataBinder();
+        private EventJobDataBinder jobDataBinder;
         private TransactionManager transactionManager = NoTransactionManager.INSTANCE;
 
         /**


### PR DESCRIPTION
Provide the ability to construct an instance of the `QuartzEventScheduler` using the `QuartzEventScheduler.Builder` without the immediate construction of the `EventJobDataBinder` on initialisation of the builder.

Delay the defaulting of the EventJobDataBinder to the construction of the `QuartzEventScheduler` in the single constructor `protected QuartzEventScheduler(Builder builder)`. Delaying the default allows a user to specify an alternative `EventJobDataBinder` using the builder. If an alternative is set, the default is no longer applied.

The default `DirectEventJobDataBinder()` references XStream. By specifying an alternative `EventJobDataBinder`, a user can bypass the XStream hard dependency.
