### PR TITLE
Improved termination heuristic when response is < batchsize/2 and the…

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngine.java
@@ -225,6 +225,8 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
 
         private final Function<T, List<? extends T>> fetchFunction;
         private final int batchSize;
+        private final int smallResultTreshold;
+        private boolean contiguousSmallResultSeen = false;
         private final boolean fetchUntilEmpty;
 
         private Iterator<? extends T> iterator;
@@ -237,6 +239,7 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
             super(Long.MAX_VALUE, NONNULL | ORDERED | DISTINCT | CONCURRENT);
             this.fetchFunction = fetchFunction;
             this.batchSize = batchSize;
+            this.smallResultTreshold = this.batchSize/2;
             this.fetchUntilEmpty = fetchUntilEmpty;
         }
 
@@ -247,9 +250,19 @@ public abstract class BatchingEventStorageEngine extends AbstractEventStorageEng
                 if (iterator != null && batchSize > sizeOfLastBatch && !fetchUntilEmpty) {
                     return false;
                 }
+                if (contiguousSmallResultSeen) {
+                    return false;
+                }
                 List<? extends T> items = fetchFunction.apply(lastItem);
+                int numItems = items.size();
+                if (numItems > 0 && numItems < smallResultTreshold) {
+                    DomainEventData<T> firstFetchedItem = (DomainEventData<T>)items.get(0);
+                    DomainEventData<T> lastFetchedItem = (DomainEventData<T>)items.get(numItems -1 );
+                    contiguousSmallResultSeen = (lastFetchedItem.getSequenceNumber() - firstFetchedItem.getSequenceNumber()) == (numItems-1);
+                }
+
                 iterator = items.iterator();
-                if ((sizeOfLastBatch = items.size()) == 0) {
+                if ((sizeOfLastBatch = numItems) == 0) {
                     return false;
                 }
             }


### PR DESCRIPTION
… resulting event stream has contigious sequence numbers.

I'm unsure if its a bug or by design, but the current sql support can/will fail if a given aggregate has jumps in sequence numbers that are > batchSize.
This feature requires that batchsize be doubled from its current value to retain existing (somewhat questionable) behaviour.

I will admit that I find the batchSize vs maxGapOffset somewhat confusing (the docs on maxGapOffset are beyond my comprehension).
I somehow perceive batchSize to be at a lower layer controlling interactions with a single store. As such
this termination heuristic is applied at the same level.

It might be that someone needs to rethink the overall architecture somewhat around this.