### PR TITLE
[#1587] Added Creation Policy support for DisruptorCommandBus

### DIFF
--- a/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvoker.java
+++ b/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvoker.java
@@ -303,9 +303,9 @@ public class CommandHandlerInvoker implements EventHandler<CommandHandlingEntry>
                 return load(aggregateIdentifier);
             } catch (AggregateNotFoundException ex) {
                 return newInstance(factoryMethod);
-            } catch (Throwable ex) {
-                logger.debug("Exception occurred while trying to load/create an aggregate. ", ex);
-                throw ex;
+            } catch (Exception e) {
+                logger.debug("Exception occurred while trying to load/create an aggregate. ", e);
+                throw e;
             }
         }
 

--- a/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvoker.java
+++ b/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvoker.java
@@ -297,6 +297,18 @@ public class CommandHandlerInvoker implements EventHandler<CommandHandlingEntry>
             return aggregate;
         }
 
+        @Override
+        public Aggregate<T> loadOrCreate(String aggregateIdentifier, Callable<T> factoryMethod) throws Exception {
+            try {
+                return load(aggregateIdentifier);
+            } catch (AggregateNotFoundException ex) {
+                return newInstance(factoryMethod);
+            } catch (Throwable ex) {
+                logger.debug("Exception occurred while trying to load/create an aggregate. ", ex);
+                throw ex;
+            }
+        }
+
         private void removeFromCache(String aggregateIdentifier) {
             EventSourcedAggregate<T> removed = firstLevelCache.remove(aggregateIdentifier);
             if (removed != null) {

--- a/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBus.java
+++ b/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBus.java
@@ -975,6 +975,11 @@ public class DisruptorCommandBus implements CommandBus {
         }
 
         @Override
+        public Aggregate<T> loadOrCreate(String aggregateIdentifier, Callable<T> factoryMethod) throws Exception {
+            return CommandHandlerInvoker.<T>getRepository(type).loadOrCreate(aggregateIdentifier, factoryMethod);
+        }
+
+        @Override
         public void send(Message<?> message, ScopeDescriptor scopeDescription) throws Exception {
             CompletableFuture future = new CompletableFuture();
             send(message, scopeDescription, future);

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -435,16 +435,16 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
             String commandMessageAggregateId = commandMessageVersionedId.getIdentifier();
 
             AtomicReference<Object> resultReference = new AtomicReference<>();
-            AtomicBoolean newInstanceCreated = new AtomicBoolean(false);
+            AtomicBoolean commandHandled = new AtomicBoolean(false);
 
             Aggregate<T> instance = repository.loadOrCreate(commandMessageAggregateId, () -> {
                 T newInstance = factoryMethod.call();
                 resultReference.set(handler.handle(command, newInstance));
-                newInstanceCreated.set(true);
+                commandHandled.set(true);
                 return newInstance;
             });
 
-            Object commandResult = newInstanceCreated.get() ? resultReference.get() : instance.handle(command);
+            Object commandResult = commandHandled.get() ? resultReference.get() : instance.handle(command);
             Object aggregateId = instance.identifier();
 
             assertThat(

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -433,8 +434,17 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
             VersionedAggregateIdentifier commandMessageVersionedId = commandTargetResolver.resolveTarget(command);
             String commandMessageAggregateId = commandMessageVersionedId.getIdentifier();
 
-            Aggregate<T> instance = repository.loadOrCreate(commandMessageAggregateId, factoryMethod);
-            Object commandResult = instance.handle(command);
+            AtomicReference<Object> resultReference = new AtomicReference<>();
+            AtomicBoolean newInstanceCreated = new AtomicBoolean(false);
+
+            Aggregate<T> instance = repository.loadOrCreate(commandMessageAggregateId, () -> {
+                T newInstance = factoryMethod.call();
+                resultReference.set(handler.handle(command, newInstance));
+                newInstanceCreated.set(true);
+                return newInstance;
+            });
+
+            Object commandResult = newInstanceCreated.get() ? resultReference.get() : instance.handle(command);
             Object aggregateId = instance.identifier();
 
             assertThat(
@@ -443,6 +453,13 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
                     "Identifier must be set after handling the message"
             );
             return commandResult;
+        }
+
+        public boolean handlerHasVoidReturnType() {
+            return handler.unwrap(Method.class)
+                          .map(Method::getReturnType)
+                          .filter(void.class::equals)
+                          .isPresent();
         }
 
         @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -455,13 +455,6 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
             return commandResult;
         }
 
-        public boolean handlerHasVoidReturnType() {
-            return handler.unwrap(Method.class)
-                          .map(Method::getReturnType)
-                          .filter(void.class::equals)
-                          .isPresent();
-        }
-
         @Override
         public boolean canHandle(CommandMessage<?> message) {
             return handler.canHandle(message);


### PR DESCRIPTION
Implemented Repository#loadOrCreate on the DisruptorCommandBus.DisruptorRepository, so that the Creation Policy feature can be used in conjunction with the DisruptorCommandBus.

This issue resolves #1587.