### PR TITLE
Updated command dispatching Javadoc

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -48,9 +48,9 @@ public interface CommandBus extends MessageHandlerInterceptorSupport<CommandMess
      * Dispatch the given {@code command} to the CommandHandler subscribed to the given {@code command}'s name. When the
      * command is processed, one of the callback's methods is called, depending on the result of the processing.
      * <p/>
-     * When the method returns, the only guarantee provided by the CommandBus implementation is that the command has
-     * been successfully received. Implementations are highly recommended to perform basic validation of the command
-     * before returning from this method call.
+     * There are no guarantees about the successful completion of command dispatching or handling after the method
+     * returns. Implementations are highly recommended to perform basic validation of the command before returning
+     * from this method call.
      * <p/>
      * Implementations must start a UnitOfWork when before dispatching the command, and either commit or rollback after
      * a successful or failed execution, respectively.

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -19,6 +19,7 @@ package org.axonframework.commandhandling.gateway;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.distributed.CommandDispatchException;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDispatchInterceptorSupport;
 
@@ -55,7 +56,8 @@ public interface CommandGateway extends MessageDispatchInterceptorSupport<Comman
      * Sends the given {@code command} and wait for it to execute. The result of the execution is returned when
      * available. This method will block indefinitely, until a result is available, or until the Thread is interrupted.
      * When the thread is interrupted, this method returns {@code null}. If command execution resulted in an exception,
-     * it is wrapped in a {@link CommandExecutionException}.
+     * it is wrapped in a {@link CommandExecutionException}. If command dispatching failed,
+     * {@link CommandDispatchException} is thrown instead.
      * <p/>
      * The given {@code command} is wrapped as the payload of the {@link CommandMessage} that is eventually posted on
      * the {@link org.axonframework.commandhandling.CommandBus}, unless the {@code command} already implements {@link
@@ -69,6 +71,7 @@ public interface CommandGateway extends MessageDispatchInterceptorSupport<Comman
      * @return the result of command execution, or {@code null} if the thread was interrupted while waiting for the
      * command to execute
      * @throws CommandExecutionException when an exception occurred while processing the command
+     * @throws CommandDispatchException when an exception occurred while dispatching the command
      */
     <R> R sendAndWait(Object command);
 
@@ -77,6 +80,7 @@ public interface CommandGateway extends MessageDispatchInterceptorSupport<Comman
      * available. This method will block until a result is available, or the given {@code timeout} was reached, or until
      * the Thread is interrupted. When the timeout is reached or the thread is interrupted, this method returns {@code
      * null}. If command execution resulted in an exception, it is wrapped in a {@link CommandExecutionException}.
+     * If command dispatching failed, {@link CommandDispatchException} is thrown instead.
      * <p/>
      * The given {@code command} is wrapped as the payload of the {@link CommandMessage} that is eventually posted on
      * the {@link org.axonframework.commandhandling.CommandBus}, unless the {@code command} already implements {@link
@@ -92,6 +96,7 @@ public interface CommandGateway extends MessageDispatchInterceptorSupport<Comman
      * @return the result of command execution, or {@code null} if the thread was interrupted while waiting for the
      * command to execute
      * @throws CommandExecutionException when an exception occurred while processing the command
+     * @throws CommandDispatchException when an exception occurred while dispatching the command
      */
     <R> R sendAndWait(Object command, long timeout, TimeUnit unit);
 


### PR DESCRIPTION
This PR attempts to clarify the command processing guarantees in `CommandBus#dispatch` Javadoc. For more info, you can read [this discussion](https://discuss.axoniq.io/t/detecting-whether-command-was-posted-to-command-bus-axonserver/2997).

P.S. this is my first PR to this repo, do I need to sign the CLA? If yes, is [this](https://www.clahub.com/agreements/AxonFramework/AxonFramework) site supposed to let me do it? It looks like a default page from the hosting provider. **UPDATE:** I was able to sign the CLA via the button below after creating a PR.