### PR TITLE
[#1554] Implementation of StubAggregateLifecycleExtension (JUnit 5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,11 +384,6 @@
                 <version>${junit.jupiter.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit.jupiter.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,11 @@
                 <version>${junit.jupiter.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>spring-beans</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
     </dependencies>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2017. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * Implementation of StubAggregateLifecycle that can be used as an {@link org.junit.jupiter.api.extension.RegisterExtension} annotated method or field in a
+ * test class. In that case, the JUnit lifecycle will automatically register and unregister the StubAggregateLifecycle.
+ * <p>
+ * Usage example:
+ * <pre>
+ *     &#064;RegisterExtension
+ *     public StubAggregateLifecycleExtension lifecycle = new StubAggregateLifecycleExtension();
+ *
+ *     &#064;Test
+ *     public void testMethod() {
+ *         ... perform tests ...
+ *
+ *         // get applied events from lifecycle to validate some more
+ *         lifecycle.getAppliedEvents();
+ *     }
+ * </pre>
+ */
+public class StubAggregateLifecycleExtension extends StubAggregateLifecycle
+        implements AfterEachCallback, BeforeEachCallback{
+
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        activate();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        close();
+    }
+
+}

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2017. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package org.axonframework.test.aggregate;
 import org.junit.jupiter.api.extension.*;
 
 /**
- * Implementation of StubAggregateLifecycle that can be used as an {@link org.junit.jupiter.api.extension.RegisterExtension} annotated method or field in a
- * test class. In that case, the JUnit lifecycle will automatically register and unregister the StubAggregateLifecycle.
+ * Implementation of StubAggregateLifecycle that can be used as an {@link org.junit.jupiter.api.extension.RegisterExtension}
+ * annotated method or field in a test class. In that case, the JUnit lifecycle will automatically register and
+ * unregister the StubAggregateLifecycle.
  * <p>
  * Usage example:
  * <pre>
@@ -37,8 +38,7 @@ import org.junit.jupiter.api.extension.*;
  * </pre>
  */
 public class StubAggregateLifecycleExtension extends StubAggregateLifecycle
-        implements AfterEachCallback, BeforeEachCallback{
-
+        implements AfterEachCallback, BeforeEachCallback {
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) throws Exception {
@@ -49,5 +49,4 @@ public class StubAggregateLifecycleExtension extends StubAggregateLifecycle
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         close();
     }
-
 }

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleRule.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleRule.java
@@ -38,7 +38,10 @@ import org.junit.runners.model.Statement;
  *         lifecycle.getAppliedEvents();
  *     }
  * </pre>
+ *
+ * @deprecated in favor of {@link org.junit.jupiter.api.extension.RegisterExtension} which should be used with Junit 5
  */
+@Deprecated
 public class StubAggregateLifecycleRule extends StubAggregateLifecycle implements TestRule {
 
     @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.*;
+
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
+import static org.junit.Assert.*;
+
+public class StubAggregateLifecycleExtensionTest {
+
+    @RegisterExtension
+    static StubAggregateLifecycleExtension testSubject = new StubAggregateLifecycleExtension();
+
+    @Test
+    public void testAppliedEventsArePassedToActiveLifecycle() {
+
+        apply("test");
+
+        assertEquals(1, testSubject.getAppliedEvents().size());
+        assertEquals("test", testSubject.getAppliedEventPayloads().get(0));
+        assertEquals("test", testSubject.getAppliedEvents().get(0).getPayload());
+    }
+
+    @Test
+    public void testMarkDeletedIsRegisteredWithActiveLifecycle() {
+        markDeleted();
+
+        assertEquals(0, testSubject.getAppliedEvents().size());
+        assertTrue(testSubject.isMarkedDeleted());
+    }
+
+}

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 class StubAggregateLifecycleExtensionTest {
 

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package org.axonframework.test.aggregate;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
 import static org.junit.Assert.*;
 
-public class StubAggregateLifecycleExtensionTest {
+class StubAggregateLifecycleExtensionTest {
 
     @RegisterExtension
     static StubAggregateLifecycleExtension testSubject = new StubAggregateLifecycleExtension();
 
     @Test
-    public void testAppliedEventsArePassedToActiveLifecycle() {
-
+    void testAppliedEventsArePassedToActiveLifecycle() {
         apply("test");
 
         assertEquals(1, testSubject.getAppliedEvents().size());
@@ -39,11 +38,10 @@ public class StubAggregateLifecycleExtensionTest {
     }
 
     @Test
-    public void testMarkDeletedIsRegisteredWithActiveLifecycle() {
+    void testMarkDeletedIsRegisteredWithActiveLifecycle() {
         markDeleted();
 
         assertEquals(0, testSubject.getAppliedEvents().size());
         assertTrue(testSubject.isMarkedDeleted());
     }
-
 }


### PR DESCRIPTION
Replacement of the StubAggregateLifecycleRule, which is now deprecated. (used with JUnit 4). The rule implementation is replaced with StubAggregateLifecycleExtension (JUnit 5).