### PR TITLE
Skip table creation if already exists

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/PostgresSagaSqlSchema.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/PostgresSagaSqlSchema.java
@@ -46,7 +46,7 @@ public class PostgresSagaSqlSchema extends GenericSagaSqlSchema {
 
     @Override
     public PreparedStatement sql_createTableAssocValueEntry(Connection conn) throws SQLException {
-        final String sql = "create table " + sagaSchema().associationValueEntryTable() + " (\n" +
+        final String sql = "create table if not exists" + sagaSchema().associationValueEntryTable() + " (\n" +
                 "        id bigserial not null,\n" +
                 "        associationKey varchar(255),\n" +
                 "        associationValue varchar(255),\n" +
@@ -59,7 +59,7 @@ public class PostgresSagaSqlSchema extends GenericSagaSqlSchema {
 
     @Override
     public PreparedStatement sql_createTableSagaEntry(Connection conn) throws SQLException {
-        return conn.prepareStatement("create table " + sagaSchema().sagaEntryTable() + " (\n" +
+        return conn.prepareStatement("create table if not exists" + sagaSchema().sagaEntryTable() + " (\n" +
                 "        sagaId varchar(255) not null,\n" +
                 "        revision varchar(255),\n" +
                 "        sagaType varchar(255),\n" +


### PR DESCRIPTION
The event and token table already include `IF NOT EXISTS`.

See [here](https://github.com/AxonFramework/AxonFramework/blob/0bb5e66d5815e4b5a0f5aaf611402940a5275a7a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/GenericTokenTableFactory.java#L40) and [here](https://github.com/AxonFramework/AxonFramework/blob/0bb5e66d5815e4b5a0f5aaf611402940a5275a7a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/AbstractEventTableFactory.java#L35).