### PR TITLE
Interface on @AggregateMember should not be allowed

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
@@ -65,6 +65,11 @@ public class AggregateMemberAnnotatedChildEntityCollectionDefinition extends Abs
                     )));
         }
 
+        if (entityType.isInterface()) {
+            throw new AxonConfigurationException(
+                    "Aggregate Member type should be a concrete implementation instead of [" + entityType + "]."
+            );
+        }
         return declaringEntity.modelOf(entityType);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityDefinition.java
@@ -17,6 +17,7 @@
 package org.axonframework.modelling.command.inspection;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.modelling.command.AggregateMember;
@@ -50,6 +51,11 @@ public class AggregateMemberAnnotatedChildEntityDefinition extends AbstractChild
                                                               Map<String, Object> attributes,
                                                               Member member) {
         Class<?> entityClass = ReflectionUtils.getMemberValueType(member);
+        if (entityClass.isInterface()) {
+            throw new AxonConfigurationException(
+                    "Aggregate Member type should be a concrete implementation instead of [" + entityClass + "]."
+            );
+        }
         return declaringEntity.modelOf(entityClass);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
@@ -64,6 +64,11 @@ public class AggregateMemberAnnotatedChildEntityMapDefinition extends AbstractCh
                     )));
         }
 
+        if (entityType.isInterface()) {
+            throw new AxonConfigurationException(
+                    "Aggregate Member type should be a concrete implementation instead of [" + entityType + "]."
+            );
+        }
         return declaringEntity.modelOf(entityType);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -621,12 +622,13 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
             return Collections.unmodifiableMap(allEventHandlers);
         }
 
-        //backwards compatibility - if you don't specify a designated child,
-        //you should at least get handlers of its first registered parent (if any)
+        // Backwards compatibility - if you don't specify a designated child,
+        //  you should at least get handlers of its first registered parent (if any).
         private Stream<MessageHandlingMember<? super T>> handlers(
-                Map<Class<?>, List<MessageHandlingMember<? super T>>> handlers, Class<?> subtype) {
+                Map<Class<?>, List<MessageHandlingMember<? super T>>> handlers, Class<?> subtype
+        ) {
             Class<?> type = subtype;
-            while (!handlers.containsKey(type) && !type.equals(Object.class)) {
+            while (!handlers.containsKey(type) && !Objects.equals(type, Object.class) && type.getSuperclass() != null) {
                 type = type.getSuperclass();
             }
             return handlers.getOrDefault(type, Collections.emptyList()).stream();

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateAggregateMemberMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateAggregateMemberMetaModelFactoryTest.java
@@ -1,0 +1,112 @@
+package org.axonframework.modelling.command.inspection;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.modelling.command.AggregateMember;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the use the {@link AnnotatedAggregateMetaModelFactory} using the {@link
+ * org.axonframework.modelling.command.AggregateMember} annotation. For the time being more specifically through using
+ * this annotation with a collection of members, where the type is an interface.
+ *
+ * @author Steven van Beelen
+ */
+class AnnotatedAggregateAggregateMemberMetaModelFactoryTest {
+
+    @Test
+    void testInterfaceAggregateMemberThrowsAxonConfigurationException() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestAggregate.class)
+        );
+    }
+
+    @Test
+    void testInterfaceAggregateMemberCollectionThrowsAxonConfigurationException() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestCollectionAggregate.class)
+        );
+    }
+
+    @Test
+    void testInterfaceAggregateMemberMapThrowsAxonConfigurationException() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestMapAggregate.class)
+        );
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestAggregate {
+
+        @AggregateMember
+        private AggregateMemberInterface aggregateMember;
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestCollectionAggregate {
+
+        @AggregateMember
+        private List<AggregateMemberInterface> aggregateMembers;
+    }
+
+    @SuppressWarnings("unused")
+    private static class TestMapAggregate {
+
+        @AggregateMember
+        private Map<String, AggregateMemberInterface> aggregateMembers;
+    }
+
+    private interface AggregateMemberInterface {
+
+        @CommandHandler
+        void handle(InterfaceMemberCommand command);
+    }
+
+    @SuppressWarnings("unused")
+    private static class AggregateMemberImplementationOne implements AggregateMemberInterface {
+
+        @Override
+        public void handle(InterfaceMemberCommand command) {
+
+        }
+
+        @CommandHandler
+        public void handle(MemberOneCommand command) {
+
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class AggregateMemberImplementationTwo implements AggregateMemberInterface {
+
+        @Override
+        public void handle(InterfaceMemberCommand command) {
+
+        }
+
+        @CommandHandler
+        public void handle(MemberTwoCommand command) {
+
+        }
+    }
+
+    private static class InterfaceMemberCommand {
+
+    }
+
+    private static class MemberOneCommand {
+
+    }
+
+    private static class MemberTwoCommand {
+
+    }
+}


### PR DESCRIPTION
At this moment, whenever somebody uses an `interface` as the field (generic) type on an `@AggregateMember` annotated element, a `NullPointerException` is thrown.
This occurs due to the fact that the `AnnotatedAggregateMetaModelFactory` is incapable to find the message handlers on the interface/aggregate-member, as a search is done for the superclass of the given type.

Firstly, the `NullPointerException` is resolved by adjusted the while-loop in the `AnnotatedAggregateMetaModelFactory` which checks the given type.
This makes it so that the message handlers present on the interface _will_ be taken into account.
However, this would still mean the message handlers on concrete implementations of the interface are not found at all.
Although this would be nice behaviour to support, as a stopgap solution we should throw an `AxonConfigurationException` instead of the `NullPointerException` and swallowing the problem hole.

That's what this pull request does, by adjusting the three different `ChildEntityDefinition` implementations (for single members, collections and maps) to check whether the type under inspection is an interface. 

Note that this does not rule out that in future releases we will support interfaces as the type used on an `@AggregateMember` annotated field.