### PR TITLE
Make public final GrpcMetaDataAwareSerializer.

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * @author Marc Gathier
  * @since 4.0
  */
-class GrpcMetaDataAwareSerializer implements Serializer {
+public final class GrpcMetaDataAwareSerializer implements Serializer {
 
     private final Serializer delegate;
     private final GrpcMetaDataConverter metaDataConverter;


### PR DESCRIPTION
In order to make GrpcMetaDataAwareSerializer available, if needed for custom configuration of the communication with AxonServer.