### PR TITLE
Add Aggregate Type to RevisionSnapshotFilter

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
@@ -1,32 +1,141 @@
 package org.axonframework.eventsourcing.snapshotting;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventData;
 
 import java.util.Objects;
 
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
+
 /**
  * A {@link SnapshotFilter} implementation which based on a configurable allowed revision will only {@link
- * #allow(DomainEventData)} {@link DomainEventData} containing that revision.
+ * #allow(DomainEventData)} {@link DomainEventData} containing that revision. True will also be returned if the {@link
+ * DomainEventData#getType()} does not match the given {@code type}, as in compliance with the {@code SnapshotFilter}
+ * documentation.
  *
  * @author Steven van Beelen
  * @since 4.5
  */
 public class RevisionSnapshotFilter implements SnapshotFilter {
 
-    private final String allowedRevision;
+    private final String type;
+    private final String revision;
+
+    /**
+     * Instantiate a Builder to be able to create a {@link RevisionSnapshotFilter}.
+     * <p>
+     * The {@code type} and {@code revision} are <b>hard requirements</b> and as such should be provided.
+     *
+     * @return a Builder to be able to create a {@link RevisionSnapshotFilter}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a {@link RevisionSnapshotFilter} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@code type} and {@code revision} are not {@code null} and will throw an {@link
+     * AxonConfigurationException} if this is the case.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link RevisionSnapshotFilter} instance
+     */
+    protected RevisionSnapshotFilter(Builder builder) {
+        builder.validate();
+        this.type = builder.type;
+        this.revision = builder.revision;
+    }
 
     /**
      * Construct a {@link RevisionSnapshotFilter} which returns {@code true} on {@link #allow(DomainEventData)}
-     * invocations where the {@link DomainEventData} contains the given {@code allowedRevision}.
+     * invocations where the {@link DomainEventData} contains the given {@code revision}.
      *
      * @param allowedRevision the revision which is allowed by this {@link SnapshotFilter}
+     * @deprecated in favor of using the {@link Builder}
      */
+    @Deprecated
     public RevisionSnapshotFilter(String allowedRevision) {
-        this.allowedRevision = allowedRevision;
+        this.revision = allowedRevision;
+        this.type = "no-aggregate-type";
     }
 
     @Override
     public boolean test(DomainEventData<?> domainEventData) {
-        return Objects.equals(domainEventData.getPayload().getType().getRevision(), allowedRevision);
+        String type = domainEventData.getType();
+        String revision = domainEventData.getPayload().getType().getRevision();
+        if (!Objects.equals(type, this.type)) {
+            return true;
+        }
+        return Objects.equals(revision, this.revision);
+    }
+
+    /**
+     * Builder class to instantiate a {@link RevisionSnapshotFilter}.
+     * <p>
+     * The {@code type} and {@code revision} are <b>hard requirements</b> and as such should be provided.
+     */
+    public static class Builder {
+
+        private String type;
+        private String revision;
+
+        /**
+         * Sets the aggregate {@code type} this {@link SnapshotFilter} will allow using the outcome of {@link
+         * Class#getName()} on the given {@code type}. Note that if the {@code type} does not match the {@link
+         * DomainEventData#getType()}, the filter will return {@code true} as per the {@code SnapshotFilter}
+         * documentation.
+         *
+         * @param type defines aggregate type this {@link SnapshotFilter} allows
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder type(Class<?> type) {
+            return type(type.getName());
+        }
+
+        /**
+         * Sets the aggregate {@code type} this {@link SnapshotFilter} will allow. Note that if the {@code type} does
+         * not match the {@link DomainEventData#getType()}, the filter will return {@code true} as per the {@code
+         * SnapshotFilter} documentation.
+         *
+         * @param type defines aggregate type this {@link SnapshotFilter} allows
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder type(String type) {
+            assertNonEmpty(type, "The type may not be null or empty");
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets an aggregate {@code revision} this {@link SnapshotFilter} will allow.
+         *
+         * @param revision the aggregate
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder revision(String revision) {
+            assertNonEmpty(revision, "The revision may not be null or empty");
+            this.revision = revision;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link RevisionSnapshotFilter} as specified through this Builder.
+         *
+         * @return a {@link RevisionSnapshotFilter} as specified through this Builder
+         */
+        public RevisionSnapshotFilter build() {
+            return new RevisionSnapshotFilter(this);
+        }
+
+        /**
+         * Validate whether the fields contained in this Builder as set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        protected void validate() {
+            assertNonEmpty(type, "The type is a hard requirement and should be provided");
+            assertNonEmpty(revision, "The revision is a hard requirement and should be provided");
+        }
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventsourcing.snapshotting;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventData;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
@@ -18,15 +35,23 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class RevisionSnapshotFilterTest {
 
-    private static final String ALLOWED_REVISION = "LET ME IN";
+    private static final String EXPECTED_REVISION = "LET ME IN";
 
     private final Serializer serializer = TestSerializer.secureXStreamSerializer();
-    private final RevisionSnapshotFilter testSubject = new RevisionSnapshotFilter(ALLOWED_REVISION);
 
     @Test
-    void testAllowsDomainEventDataContainingTheAllowedRevision() {
-        DomainEventMessage<RightAggregateVersion> snapshotEvent = new GenericDomainEventMessage<>(
-                RightAggregateVersion.class.getName(), "some-aggregate-id", 0, new RightAggregateVersion("some-state")
+    void testAllowsDomainEventDataContainingTheAllowedAggregateTypeAndRevision() {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(RightAggregateTypeAndRevision.class.getSimpleName())
+                                      .revision(EXPECTED_REVISION)
+                                      .build();
+
+        DomainEventMessage<RightAggregateTypeAndRevision> snapshotEvent = new GenericDomainEventMessage<>(
+                RightAggregateTypeAndRevision.class.getName(),
+                "some-aggregate-id",
+                0,
+                new RightAggregateTypeAndRevision("some-state")
         );
         DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
 
@@ -34,21 +59,77 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testDisallowsDomainEventDataContainingTheAllowedRevision() {
-        DomainEventMessage<WrongAggregateVersion> snapshotEvent = new GenericDomainEventMessage<>(
-                WrongAggregateVersion.class.getName(), "some-aggregate-id", 0, new WrongAggregateVersion("some-state")
+    void testAllowsDomainEventDataContainingTheWrongAggregateTypeAndAllowedRevision() {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(RightAggregateTypeAndRevision.class.getSimpleName())
+                                      .revision(EXPECTED_REVISION)
+                                      .build();
+
+        DomainEventMessage<WrongAggregateType> snapshotEvent = new GenericDomainEventMessage<>(
+                WrongAggregateType.class.getName(), "some-aggregate-id", 0, new WrongAggregateType("some-state")
+        );
+        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
+
+        assertTrue(testSubject.allow(testDomainEventData));
+    }
+
+    @Test
+    void testDisallowsDomainEventDataContainingTheAllowedAggregateTypeAndWrongRevision() {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(RightAggregateTypeAndWrongRevision.class)
+                                      .revision(EXPECTED_REVISION)
+                                      .build();
+
+        DomainEventMessage<RightAggregateTypeAndWrongRevision> snapshotEvent = new GenericDomainEventMessage<>(
+                RightAggregateTypeAndWrongRevision.class.getName(), "some-aggregate-id", 0,
+                new RightAggregateTypeAndWrongRevision("some-state")
         );
         DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
 
         assertFalse(testSubject.allow(testDomainEventData));
     }
 
-    @Revision(ALLOWED_REVISION)
-    private static class RightAggregateVersion {
+    @Test
+    void testBuildWithNullOrEmptyTypeThrowsAxonConfigurationException() {
+        RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.type(""));
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.type((String) null));
+    }
+
+    @Test
+    void testBuildWithNullOrEmptyRevisionThrowsAxonConfigurationException() {
+        RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.revision(""));
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.revision(null));
+    }
+
+    @Test
+    void testBuildWithoutTypeThrowsAxonConfigurationException() {
+        RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder()
+                                                                                  .revision(EXPECTED_REVISION);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void testBuildWithoutRevisionThrowsAxonConfigurationException() {
+        RevisionSnapshotFilter.Builder builderTestSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(RightAggregateTypeAndRevision.class);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Revision(EXPECTED_REVISION)
+    private static class RightAggregateTypeAndRevision {
 
         private final String state;
 
-        private RightAggregateVersion(String state) {
+        private RightAggregateTypeAndRevision(String state) {
             this.state = state;
         }
 
@@ -58,11 +139,25 @@ class RevisionSnapshotFilterTest {
     }
 
     @Revision("some-other-revision")
-    private static class WrongAggregateVersion {
+    private static class WrongAggregateType {
 
         private final String state;
 
-        private WrongAggregateVersion(String state) {
+        private WrongAggregateType(String state) {
+            this.state = state;
+        }
+
+        public String getState() {
+            return state;
+        }
+    }
+
+    @Revision("some-other-revision")
+    private static class RightAggregateTypeAndWrongRevision {
+
+        private final String state;
+
+        private RightAggregateTypeAndWrongRevision(String state) {
             this.state = state;
         }
 


### PR DESCRIPTION
This pull request adds the aggregate type to the RevisionSnapshotFilter.
The type field is required for any SnapshotFilter implementation, as all filters are combined since they're configured on the EventStore level for the time being (issue #1769 marks an adjustment in this process).

By adding the aggregate's type, and setting it for that automatically created RevisionSnapshotFilter by the AggregateConfigurer, we should resolve any problems in the space of filtering out snapshots from other aggregates than where the filter was intended for.