### PR TITLE
Added an option to create a fixture for a state stored aggregate

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -123,6 +123,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     private final EventStore eventStore;
     private final List<FieldFilter> fieldFilters = new ArrayList<>();
     private final List<Object> resources = new ArrayList<>();
+    private boolean useStateStorage;
     private RepositoryProvider repositoryProvider;
     private IdentifierValidatingRepository<T> repository;
     private final StubDeadlineManager deadlineManager;
@@ -168,12 +169,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public FixtureConfiguration<T> useStateStorage() {
-        return this.registerRepository(new InMemoryRepository<>(aggregateType,
-                                                                subtypes,
-                                                                eventStore,
-                                                                getParameterResolverFactory(),
-                                                                getHandlerDefinition(),
-                                                                getRepositoryProvider()));
+        this.useStateStorage = true;
+        return this;
     }
 
     @Override
@@ -321,11 +318,13 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public TestExecutor<T> givenState(Supplier<T> aggregate) {
+        if(this.repository == null) {
+            this.useStateStorage();
+        }
+
+        ensureRepositoryConfiguration();
         clearGivenWhenState();
         DefaultUnitOfWork.startAndGet(null).execute(() -> {
-            if (repository == null) {
-                this.useStateStorage();
-            }
             try {
                 repository.newInstance(aggregate::get);
             } catch (Exception e) {
@@ -511,16 +510,28 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     private void ensureRepositoryConfiguration() {
-        if (repository == null) {
+        if(repository != null) {
+            return;
+        }
+
+        if(this.useStateStorage) {
+            this.registerRepository(new InMemoryRepository<>(
+                    aggregateType,
+                    subtypes,
+                    eventStore,
+                    getParameterResolverFactory(),
+                    getHandlerDefinition(),
+                    getRepositoryProvider()));
+        } else {
             AggregateModel<T> aggregateModel = aggregateModel();
-            registerRepository(EventSourcingRepository.builder(aggregateType)
-                                                      .aggregateModel(aggregateModel)
-                                                      .aggregateFactory(new GenericAggregateFactory<>(aggregateModel))
-                                                      .eventStore(eventStore)
-                                                      .parameterResolverFactory(getParameterResolverFactory())
-                                                      .handlerDefinition(getHandlerDefinition())
-                                                      .repositoryProvider(getRepositoryProvider())
-                                                      .build());
+            this.registerRepository(EventSourcingRepository.builder(aggregateType)
+                    .aggregateModel(aggregateModel)
+                    .aggregateFactory(new GenericAggregateFactory<>(aggregateModel))
+                    .eventStore(eventStore)
+                    .parameterResolverFactory(getParameterResolverFactory())
+                    .handlerDefinition(getHandlerDefinition())
+                    .repositoryProvider(getRepositoryProvider())
+                    .build());
         }
     }
 

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -318,7 +318,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public TestExecutor<T> givenState(Supplier<T> aggregate) {
-        if(this.repository == null) {
+        if (this.repository == null) {
             this.useStateStorage();
         }
 
@@ -510,11 +510,11 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     private void ensureRepositoryConfiguration() {
-        if(repository != null) {
+        if (repository != null) {
             return;
         }
 
-        if(this.useStateStorage) {
+        if (this.useStateStorage) {
             this.registerRepository(new InMemoryRepository<>(
                     aggregateType,
                     subtypes,
@@ -525,13 +525,14 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         } else {
             AggregateModel<T> aggregateModel = aggregateModel();
             this.registerRepository(EventSourcingRepository.builder(aggregateType)
-                    .aggregateModel(aggregateModel)
-                    .aggregateFactory(new GenericAggregateFactory<>(aggregateModel))
-                    .eventStore(eventStore)
-                    .parameterResolverFactory(getParameterResolverFactory())
-                    .handlerDefinition(getHandlerDefinition())
-                    .repositoryProvider(getRepositoryProvider())
-                    .build());
+                                                           .aggregateModel(aggregateModel)
+                                                           .aggregateFactory(new GenericAggregateFactory<>(
+                                                                   aggregateModel))
+                                                           .eventStore(eventStore)
+                                                           .parameterResolverFactory(getParameterResolverFactory())
+                                                           .handlerDefinition(getHandlerDefinition())
+                                                           .repositoryProvider(getRepositoryProvider())
+                                                           .build());
         }
     }
 

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -24,6 +24,7 @@ import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.common.Assert;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.deadline.DeadlineMessage;
@@ -313,7 +314,9 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public TestExecutor<T> givenNoPriorActivity() {
-        return given(Collections.emptyList());
+        ensureRepositoryConfiguration();
+        clearGivenWhenState();
+        return this;
     }
 
     @Override
@@ -345,6 +348,11 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public TestExecutor<T> andGiven(List<?> domainEvents) {
+        if (this.useStateStorage) {
+            throw new AxonConfigurationException(
+                    "Given events not supported, because the fixture is configured to use state storage");
+        }
+
         for (Object event : domainEvents) {
             Object payload = event;
             MetaData metaData = null;

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -106,6 +106,14 @@ public interface FixtureConfiguration<T> {
     FixtureConfiguration<T> withSubtypes(Class<? extends T>... subtypes);
 
     /**
+     * Configures the fixture for state stored aggregates.
+     * This will register an {@link org.axonframework.test.aggregate.AggregateTestFixture.InMemoryRepository} with the fixture
+     *
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    FixtureConfiguration<T> useStateStorage();
+
+    /**
      * Registers an arbitrary {@code repository} with the fixture. The repository must be wired
      * with the Event Store of this test fixture.
      * <p/>

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -107,8 +107,8 @@ public interface FixtureConfiguration<T> {
 
     /**
      * Configures the fixture for state stored aggregates.
-     * This will register an {@link org.axonframework.test.aggregate.AggregateTestFixture.InMemoryRepository} with the fixture
-     * Should be used before calling {@link FixtureConfiguration#givenState(Supplier)} or {@link FixtureConfiguration#givenCommands(List)} (Supplier)}
+     * This will register an in-memory {@link org.axonframework.commandhandling.model.Repository} with this fixture.
+     * Should be used before calling {@link FixtureConfiguration#givenState(Supplier)} or {@link FixtureConfiguration#givenCommands(List)} (Supplier)}.
      *
      * @return the current FixtureConfiguration, for fluent interfacing
      */

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -332,8 +332,8 @@ public interface FixtureConfiguration<T> {
     TestExecutor<T> givenState(Supplier<T> aggregateState);
 
     /**
-     * Indicates that no relevant activity has occurred in the past. The behavior of this method is identical to giving
-     * no events in the {@link #given(java.util.List)} method.
+     * Indicates that no relevant activities like commands or events have occurred in the past.
+     * This also means that no previous state is present in the repository.
      *
      * @return a TestExecutor instance that can execute the test with this configuration
      *

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -108,6 +108,7 @@ public interface FixtureConfiguration<T> {
     /**
      * Configures the fixture for state stored aggregates.
      * This will register an {@link org.axonframework.test.aggregate.AggregateTestFixture.InMemoryRepository} with the fixture
+     * Should be used before calling {@link FixtureConfiguration#givenState(Supplier)} or {@link FixtureConfiguration#givenCommands(List)} (Supplier)}
      *
      * @return the current FixtureConfiguration, for fluent interfacing
      */

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -43,7 +43,7 @@ class FixtureTest_StateStorage {
 
     @BeforeEach
     void setUp() {
-        fixture = new AggregateTestFixture<>(StateStoredAggregate.class);
+        fixture = new AggregateTestFixture<>(StateStoredAggregate.class, true);
     }
 
     @AfterEach
@@ -59,6 +59,14 @@ class FixtureTest_StateStorage {
                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                .expectEvents(new StubDomainEvent())
                .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
+    }
+
+    @Test
+    void testCreateStateStoredAggregateWithCommand() {
+        fixture.givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
+                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
+                .expectEvents(new StubDomainEvent())
+                .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -65,23 +65,21 @@ class FixtureTest_StateStorage {
 
     @Test
     void testGivenCommandsForStateStoredAggregate() {
-        fixture
-                .useStateStorage()
-                .givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
-                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
-                .expectEvents(new StubDomainEvent())
-                .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
+        fixture.useStateStorage()
+               .givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
+               .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
+               .expectEvents(new StubDomainEvent())
+               .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
     }
 
 
     @Test
     void testCreateStateStoredAggregateWithCommand() {
-        fixture
-                .useStateStorage()
-                .givenNoPriorActivity()
-                .when(new InitializeCommand(AGGREGATE_ID, "message"))
-                .expectEvents(new StubDomainEvent())
-                .expectState(aggregate -> assertEquals("message", aggregate.getMessage()));
+        fixture.useStateStorage()
+               .givenNoPriorActivity()
+               .when(new InitializeCommand(AGGREGATE_ID, "message"))
+               .expectEvents(new StubDomainEvent())
+               .expectState(aggregate -> assertEquals("message", aggregate.getMessage()));
     }
 
     @Test
@@ -130,8 +128,7 @@ class FixtureTest_StateStorage {
 
     @Test
     void testGivenWithStateStorageException() {
-        fixture
-                .useStateStorage();
+        fixture.useStateStorage();
 
         assertThrows(
                 AxonConfigurationException.class,
@@ -141,8 +138,7 @@ class FixtureTest_StateStorage {
 
     @Test
     void testGivenWithEventListAndStateStorageExpectException() {
-        fixture
-                .useStateStorage();
+        fixture.useStateStorage();
 
         assertThrows(
                 AxonConfigurationException.class,

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -17,11 +17,13 @@
 package org.axonframework.test.aggregate;
 
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import org.junit.jupiter.api.*;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
@@ -62,13 +64,24 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testCreateStateStoredAggregateWithCommand() {
+    void testGivenCommandsForStateStoredAggregate() {
         fixture
                 .useStateStorage()
                 .givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
                 .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                 .expectEvents(new StubDomainEvent())
                 .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));
+    }
+
+
+    @Test
+    void testCreateStateStoredAggregateWithCommand() {
+        fixture
+                .useStateStorage()
+                .givenNoPriorActivity()
+                .when(new InitializeCommand(AGGREGATE_ID, "message"))
+                .expectEvents(new StubDomainEvent())
+                .expectState(aggregate -> assertEquals("message", aggregate.getMessage()));
     }
 
     @Test
@@ -113,6 +126,28 @@ class FixtureTest_StateStorage {
                .expectEvents(new StubDomainEvent());
 
         verify(testResource).difficultOperation(expectedMessage);
+    }
+
+    @Test
+    void testGivenWithStateStorageException() {
+        fixture
+                .useStateStorage();
+
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> fixture.given(new StubDomainEvent())
+        );
+    }
+
+    @Test
+    void testGivenWithEventListAndStateStorageExpectException() {
+        fixture
+                .useStateStorage();
+
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> fixture.given(Collections.singletonList(new StubDomainEvent()))
+        );
     }
 
     private static class InitializeCommand {
@@ -210,6 +245,7 @@ class FixtureTest_StateStorage {
         @CommandHandler
         public StateStoredAggregate(InitializeCommand cmd) {
             this.id = cmd.getId();
+            this.message = cmd.getMessage();
             apply(new StubDomainEvent());
         }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -43,7 +43,7 @@ class FixtureTest_StateStorage {
 
     @BeforeEach
     void setUp() {
-        fixture = new AggregateTestFixture<>(StateStoredAggregate.class, true);
+        fixture = new AggregateTestFixture<>(StateStoredAggregate.class);
     }
 
     @AfterEach
@@ -63,7 +63,9 @@ class FixtureTest_StateStorage {
 
     @Test
     void testCreateStateStoredAggregateWithCommand() {
-        fixture.givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
+        fixture
+                .useStateStorage()
+                .givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
                 .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                 .expectEvents(new StubDomainEvent())
                 .expectState(aggregate -> assertEquals("message2", aggregate.getMessage()));


### PR DESCRIPTION
Adds an option to explicitly create an AggregateTestFixture for a state stored aggregate.

This enables the usage of givenCommands() in connection with a constructor handling the command for state stored aggregates.

P.S. Since this is my first PR to this repository, I would be grateful for any feedback or comments.