### PR TITLE
Error Handling Fix

### DIFF
--- a/core/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
+++ b/core/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
@@ -116,7 +116,7 @@ public abstract class AbstractEventProcessor implements EventProcessor {
     protected boolean canHandle(EventMessage<?> eventMessage, Segment segment) throws Exception {
         try {
             return eventHandlerInvoker.canHandle(eventMessage, segment);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             errorHandler.handleError(new ErrorContext(getName(), e, Collections.singletonList(eventMessage)));
             return false;
         }
@@ -150,7 +150,7 @@ public abstract class AbstractEventProcessor implements EventProcessor {
                     }
                 }).proceed();
             }, rollbackConfiguration);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             if (unitOfWork.isRolledBack()) {
                 errorHandler.handleError(new ErrorContext(getName(), e, eventMessages));
             } else {

--- a/core/src/main/java/org/axonframework/eventhandling/ErrorContext.java
+++ b/core/src/main/java/org/axonframework/eventhandling/ErrorContext.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public class ErrorContext {
     private final String eventProcessor;
-    private final Exception error;
+    private final Throwable error;
     private final List<? extends EventMessage<?>> failedEvents;
 
     /**
@@ -30,7 +30,7 @@ public class ErrorContext {
      * @param error          The error that was raised during processing
      * @param failedEvents   The list of events that triggered the error
      */
-    public ErrorContext(String eventProcessor, Exception error, List<? extends EventMessage<?>> failedEvents) {
+    public ErrorContext(String eventProcessor, Throwable error, List<? extends EventMessage<?>> failedEvents) {
         this.eventProcessor = eventProcessor;
         this.error = error;
         this.failedEvents = failedEvents;
@@ -51,7 +51,11 @@ public class ErrorContext {
      * @return the error that was raised in the processor
      */
     public Exception error() {
-        return error;
+        if (error instanceof Exception) {
+            return (Exception) error;
+        } else {
+            return new RuntimeException(error);
+        }
     }
 
     /**

--- a/core/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
+++ b/core/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
@@ -173,8 +173,10 @@ public class SimpleEventHandlerInvoker implements EventHandlerInvoker {
         for (EventListener listener : wrappedEventListeners) {
             try {
                 listener.handle(message);
-            } catch(Exception e) {
+            } catch (Exception e) {
                 listenerInvocationErrorHandler.onError(e, message, listener);
+            } catch (Throwable e) {
+                listenerInvocationErrorHandler.onError(new RuntimeException(e), message, listener);
             }
         }
     }

--- a/core/src/main/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWork.java
+++ b/core/src/main/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWork.java
@@ -73,12 +73,12 @@ public class BatchingUnitOfWork<T extends Message<?>> extends AbstractUnitOfWork
         Assert.state(phase() == Phase.STARTED,
                      () -> String.format("The UnitOfWork has an incompatible phase: %s", phase()));
         R result = null;
-        Exception exception = null;
+        Throwable exception = null;
         for (MessageProcessingContext<T> processingContext : processingContexts) {
             this.processingContext = processingContext;
             try {
                 result = task.call();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 if (rollbackConfiguration.rollBackOn(e)) {
                     rollback(e);
                     throw e;
@@ -95,7 +95,11 @@ public class BatchingUnitOfWork<T extends Message<?>> extends AbstractUnitOfWork
         }
         commit();
         if (exception != null) {
-            throw exception;
+            if (exception instanceof Exception) {
+                throw (Exception) exception;
+            } else {
+                throw new RuntimeException(exception);
+            }
         }
         return result;
     }


### PR DESCRIPTION
When Error (non-Exception-typed throwable) is thrown inside the event handler during command processing,
the UnitOfWork would be in strange state as below, and ultimately makes the system unusable.

```
java.lang.IllegalStateException: Could not clear this UnitOfWork. It is not the active one.
	at org.axonframework.messaging.unitofwork.CurrentUnitOfWork.clear(CurrentUnitOfWork.java:139)
	at org.axonframework.messaging.unitofwork.AbstractUnitOfWork.commit(AbstractUnitOfWork.java:75)
	at org.axonframework.messaging.unitofwork.DefaultUnitOfWork.executeWithResult(DefaultUnitOfWork.java:80)
	at org.axonframework.commandhandling.SimpleCommandBus.handle(SimpleCommandBus.java:148)
	at org.axonframework.commandhandling.SimpleCommandBus.doDispatch(SimpleCommandBus.java:121)
	at org.axonframework.commandhandling.SimpleCommandBus.dispatch(SimpleCommandBus.java:85)
	at org.axonframework.commandhandling.gateway.AbstractCommandGateway.send(AbstractCommandGateway.java:79)
	at org.axonframework.commandhandling.gateway.DefaultCommandGateway.send(DefaultCommandGateway.java:95)
	at org.axonframework.commandhandling.gateway.DefaultCommandGateway.sendAndWait(DefaultCommandGateway.java:113)
```

This PR tries to fix the above mentioned problem.