### PR TITLE
Simplified DeadlineManager configuration

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2020. Axon Framework
+  ~ Copyright (c) 2010-2021. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -75,6 +75,12 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
@@ -355,6 +356,15 @@ public interface Configuration {
      */
     default Snapshotter snapshotter() {
         return getComponent(Snapshotter.class);
+    }
+
+    /**
+     * Returns the {@link ScopeAwareProvider} defined in the Configuration.
+     *
+     * @return the {@link ScopeAwareProvider} defined in the Configuration
+     */
+    default ScopeAwareProvider scopeAwareProvider() {
+        return getComponent(ScopeAwareProvider.class);
     }
 
     /**

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.config;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
@@ -474,6 +475,17 @@ public interface Configurer {
      */
     default Configurer configureSnapshotter(Function<Configuration, Snapshotter> snapshotterBuilder) {
         return registerComponent(Snapshotter.class, snapshotterBuilder);
+    }
+
+    /**
+     * Registers a {@link DeadlineManager} instance with this {@link Configurer}. Defaults to a {@link
+     * org.axonframework.deadline.SimpleDeadlineManager} implementation.
+     *
+     * @param deadlineManagerBuilder a builder function for the {@link DeadlineManager}
+     * @return the current instance of the Configurer, for chaining purposes
+     */
+    default Configurer configureDeadlineManager(Function<Configuration, DeadlineManager> deadlineManagerBuilder) {
+        return registerComponent(DeadlineManager.class, deadlineManagerBuilder);
     }
 
     /**

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.HandlerDefinition;
@@ -267,6 +268,8 @@ public class DefaultConfigurer implements Configurer {
         components.put(QueryGateway.class, new Component<>(config, "queryGateway", this::defaultQueryGateway));
         components.put(ResourceInjector.class,
                        new Component<>(config, "resourceInjector", this::defaultResourceInjector));
+        components.put(ScopeAwareProvider.class,
+                       new Component<>(config, "scopeAwareProvider", this::defaultScopeAwareProvider));
         components.put(DeadlineManager.class, new Component<>(config, "deadlineManager", this::defaultDeadlineManager));
         components.put(EventUpcaster.class, upcasterChain);
         components.put(EventGateway.class, new Component<>(config, "eventGateway", this::defaultEventGateway));
@@ -387,6 +390,19 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
+     * Returns a {@link ScopeAwareProvider} that provides {@link org.axonframework.messaging.ScopeAware} instances to be
+     * used by a {@link DeadlineManager}. Uses the given {@code config} to construct the default {@link
+     * ConfigurationScopeAwareProvider}.
+     *
+     * @param config the configuration used to construct the default {@link ConfigurationScopeAwareProvider}
+     * @return a {@link ScopeAwareProvider} that provides {@link org.axonframework.messaging.ScopeAware} instances to be
+     * used by a {@link DeadlineManager}
+     */
+    protected ScopeAwareProvider defaultScopeAwareProvider(Configuration config) {
+        return new ConfigurationScopeAwareProvider(config);
+    }
+
+    /**
      * Provides the default {@link DeadlineManager} implementation. Subclasses may override this method to provide their
      * own default.
      *
@@ -394,7 +410,7 @@ public class DefaultConfigurer implements Configurer {
      * @return The default DeadlineManager to use
      */
     protected DeadlineManager defaultDeadlineManager(Configuration config) {
-        return SimpleDeadlineManager.builder().scopeAwareProvider(new ConfigurationScopeAwareProvider(config)).build();
+        return SimpleDeadlineManager.builder().scopeAwareProvider(defaultScopeAwareProvider(config)).build();
     }
 
     /**

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.SnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandler;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
@@ -192,8 +193,9 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                 () -> genericBeanDefinition(SpringResourceInjector.class).getBeanDefinition()
         );
         configurer.configureResourceInjector(c -> getBean(resourceInjector, c));
-        registerComponent(EventScheduler.class, configurer, Configuration::eventScheduler);
+        registerComponent(ScopeAwareProvider.class, configurer);
         registerComponent(DeadlineManager.class, configurer, Configuration::deadlineManager);
+        registerComponent(EventScheduler.class, configurer, Configuration::eventScheduler);
 
         EventProcessingModule eventProcessingModule = new EventProcessingModule();
         Optional<String> eventProcessingConfigurerOptional = findComponent(EventProcessingConfigurer.class);


### PR DESCRIPTION
This pull request adds a method to configure a `DeadlineManager`. 
This provides a straightforward method, instead of the default `registerComponent` method that would've been required to be used.

As an addition, a default `ScopeAwareProvider` (a requirement for the `DeadlineManager` implementations) is set in the `Configuration` too.
This can be used to further simplify the configuration of a `DeadlineManager` since it will require this component.