### PR TITLE
Fine tune triggered Deadline validation for Test Fixtures 

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -420,7 +420,7 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectDeadlinesMet(Object... expected);
 
     /**
-     * Asserts that given {@code expected} deadlines have been triggered. Deadlines are compared comparing their type
+     * Asserts that given {@code expected} deadlines have been triggered. Deadlines are compared by their type
      * and fields using "equals".
      *
      * @param expected the sequence of deadlines expected to have been triggered

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,12 +391,22 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectNoScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
 
     /**
-     * Asserts that deadlines match given {@code matcher} have been met (which have passed in time) on this aggregate.
+     * Asserts that deadlines matching the given {@code matcher} have been met (which have passed in time) on this aggregate.
      *
      * @param matcher The matcher that defines the expected list of deadlines
      * @return the current ResultValidator, for fluent interfacing
+     * @deprecated in favor of {@link #expectTriggeredDeadlinesMatching(Matcher)}
      */
+    @Deprecated
     ResultValidator<T> expectDeadlinesMetMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher);
+
+    /**
+     * Asserts that deadlines matching the given {@code matcher} have been triggered for this aggregate.
+     *
+     * @param matcher the matcher that defines the expected list of deadlines
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectTriggeredDeadlinesMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher);
 
     /**
      * Asserts that given {@code expected} deadlines have been met (which have passed in time). Deadlines are compared
@@ -404,8 +414,39 @@ public interface ResultValidator<T> {
      *
      * @param expected The sequence of deadlines expected to be met
      * @return the current ResultValidator, for fluent interfacing
+     * @deprecated in favor of {@link #expectTriggeredDeadlines(Object...)}
      */
+    @Deprecated
     ResultValidator<T> expectDeadlinesMet(Object... expected);
+
+    /**
+     * Asserts that given {@code expected} deadlines have been triggered. Deadlines are compared comparing their type
+     * and fields using "equals".
+     *
+     * @param expected the sequence of deadlines expected to have been triggered
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectTriggeredDeadlines(Object... expected);
+
+    /**
+     * Asserts that the given {@code expectedDeadlineNames} have been triggered. Matches that the given names are
+     * complete, in the same order and match the triggered deadlines by validating with {@link
+     * DeadlineMessage#getDeadlineName()}.
+     *
+     * @param expectedDeadlineNames the sequence of deadline names expected to have been triggered
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectTriggeredDeadlinesWithName(String... expectedDeadlineNames);
+
+    /**
+     * Asserts that the given {@code expectedDeadlineTypes} have been triggered. Matches that the given types are
+     * complete, in the same order and match the triggered deadlines by validating with {@link
+     * DeadlineMessage#getPayloadType()}.
+     *
+     * @param expectedDeadlineTypes the sequence of deadline types expected to have been triggered
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectTriggeredDeadlinesOfType(Class<?>... expectedDeadlineTypes);
 
     /**
      * Asserts that the Aggregate has been marked for deletion.

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,13 +268,39 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectDeadlinesMetMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher) {
-        deadlineManagerValidator.assertDeadlinesMetMatching(matcher);
+        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectTriggeredDeadlinesMatching(
+            Matcher<? extends List<? super DeadlineMessage<?>>> matcher
+    ) {
+        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
         return this;
     }
 
     @Override
     public ResultValidator<T> expectDeadlinesMet(Object... expected) {
-        deadlineManagerValidator.assertDeadlinesMet(expected);
+        deadlineManagerValidator.assertTriggeredDeadlines(expected);
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectTriggeredDeadlines(Object... expected) {
+        deadlineManagerValidator.assertTriggeredDeadlines(expected);
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectTriggeredDeadlinesWithName(String... expectedDeadlineNames) {
+        deadlineManagerValidator.assertTriggeredDeadlinesWithName(expectedDeadlineNames);
+        return this;
+    }
+
+    @Override
+    public ResultValidator<T> expectTriggeredDeadlinesOfType(Class<?>... expectedDeadlineTypes) {
+        deadlineManagerValidator.assertTriggeredDeadlinesOfType(expectedDeadlineTypes);
         return this;
     }
 

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -268,8 +268,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectDeadlinesMetMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher) {
-        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
-        return this;
+        return expectTriggeredDeadlinesMatching(matcher);
     }
 
     @Override
@@ -282,8 +281,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectDeadlinesMet(Object... expected) {
-        deadlineManagerValidator.assertTriggeredDeadlines(expected);
-        return this;
+        return expectTriggeredDeadlines(expected);
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -143,7 +143,7 @@ public interface TestExecutor<T> {
      * @param elapsedTime a {@link Duration} specifying the amount of time that will elapse
      * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
      */
-    ResultValidator whenThenTimeElapses(Duration elapsedTime);
+    ResultValidator<T> whenThenTimeElapses(Duration elapsedTime);
 
     /**
      * Simulates the time advancing in the current given state using an {@link Instant} as the unit of time. This can be
@@ -170,5 +170,5 @@ public interface TestExecutor<T> {
      * @param newPointInTime an {@link Instant} specifying the amount of time to advance the clock to
      * @return a {@link ResultValidator} that can be used to validate the resulting actions of the command execution
      */
-    ResultValidator whenThenTimeAdvancesTo(Instant newPointInTime);
+    ResultValidator<T> whenThenTimeAdvancesTo(Instant newPointInTime);
 }

--- a/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
+++ b/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
@@ -138,7 +138,7 @@ public class DeadlineManagerValidator {
      * @param matcher the matcher that will validate the actual deadlines
      */
     public void assertTriggeredDeadlinesMatching(Matcher<? extends Iterable<?>> matcher) {
-        List<ScheduledDeadlineInfo> deadlinesMet = deadlineManager.getTriggeredDeadlines();
+        List<ScheduledDeadlineInfo> triggeredDeadlines= deadlineManager.getTriggeredDeadlines();
         List<DeadlineMessage<?>> deadlineMessages = deadlinesMet.stream()
                                                                 .map(ScheduledDeadlineInfo::deadlineMessage)
                                                                 .collect(Collectors.toList());

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -480,8 +480,19 @@ public interface FixtureExecutionResult {
      *
      * @param matcher The matcher that defines the expected list of deadlines
      * @return the FixtureExecutionResult for method chaining
+     * @deprecated in favor of {@link #expectTriggeredDeadlinesMatching(Matcher)}
      */
+    @Deprecated
     FixtureExecutionResult expectDeadlinesMetMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher);
+
+
+    /**
+     * Asserts that deadlines matching the given {@code matcher} have been triggered for this aggregate.
+     *
+     * @param matcher the matcher that defines the expected list of deadlines
+     * @return the current FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectTriggeredDeadlinesMatching(Matcher<? extends List<? super DeadlineMessage<?>>> matcher);
 
     /**
      * Assert that the saga published events on the EventBus in the exact sequence of the given {@code expected} events.
@@ -499,6 +510,37 @@ public interface FixtureExecutionResult {
      *
      * @param expected The sequence of deadlines expected to be met
      * @return the FixtureExecutionResult for method chaining
+     * @deprecated in favor of {@link #expectTriggeredDeadlines(Object...)}
      */
+    @Deprecated
     FixtureExecutionResult expectDeadlinesMet(Object... expected);
+
+    /**
+     * Asserts that given {@code expected} deadlines have been triggered. Deadlines are compared comparing their type
+     * and fields using "equals".
+     *
+     * @param expected the sequence of deadlines expected to have been triggered
+     * @return the current FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectTriggeredDeadlines(Object... expected);
+
+    /**
+     * Asserts that the given {@code expectedDeadlineNames} have been triggered. Matches that the given names are
+     * complete, in the same order and match the triggered deadlines by validating with {@link
+     * DeadlineMessage#getDeadlineName()}.
+     *
+     * @param expectedDeadlineNames the sequence of deadline names expected to have been triggered
+     * @return the current FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectTriggeredDeadlinesWithName(String... expectedDeadlineNames);
+
+    /**
+     * Asserts that the given {@code expectedDeadlineTypes} have been triggered. Matches that the given types are
+     * complete, in the same order and match the triggered deadlines by validating with {@link
+     * DeadlineMessage#getPayloadType()}.
+     *
+     * @param expectedDeadlineTypes the sequence of deadline types expected to have been triggered
+     * @return the current FixtureExecutionResult for method chaining
+     */
+    FixtureExecutionResult expectTriggeredDeadlinesOfType(Class<?>... expectedDeadlineTypes);
 }

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -344,7 +344,15 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
     @Override
     public FixtureExecutionResult expectDeadlinesMetMatching(
             Matcher<? extends List<? super DeadlineMessage<?>>> matcher) {
-        deadlineManagerValidator.assertDeadlinesMetMatching(matcher);
+        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
+        return this;
+    }
+
+    @Override
+    public FixtureExecutionResult expectTriggeredDeadlinesMatching(
+            Matcher<? extends List<? super DeadlineMessage<?>>> matcher
+    ) {
+        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
         return this;
     }
 
@@ -356,7 +364,25 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
 
     @Override
     public FixtureExecutionResult expectDeadlinesMet(Object... expected) {
-        deadlineManagerValidator.assertDeadlinesMet(expected);
+        deadlineManagerValidator.assertTriggeredDeadlines(expected);
+        return this;
+    }
+
+    @Override
+    public FixtureExecutionResult expectTriggeredDeadlines(Object... expected) {
+        deadlineManagerValidator.assertTriggeredDeadlines(expected);
+        return this;
+    }
+
+    @Override
+    public FixtureExecutionResult expectTriggeredDeadlinesWithName(String... expectedDeadlineNames) {
+        deadlineManagerValidator.assertTriggeredDeadlinesWithName(expectedDeadlineNames);
+        return this;
+    }
+
+    @Override
+    public FixtureExecutionResult expectTriggeredDeadlinesOfType(Class<?>... expectedDeadlineTypes) {
+        deadlineManagerValidator.assertTriggeredDeadlinesOfType(expectedDeadlineTypes);
         return this;
     }
 }

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -343,9 +343,9 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
 
     @Override
     public FixtureExecutionResult expectDeadlinesMetMatching(
-            Matcher<? extends List<? super DeadlineMessage<?>>> matcher) {
-        deadlineManagerValidator.assertTriggeredDeadlinesMatching(matcher);
-        return this;
+            Matcher<? extends List<? super DeadlineMessage<?>>> matcher
+    ) {
+        return expectTriggeredDeadlinesMatching(matcher);
     }
 
     @Override
@@ -364,8 +364,7 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
 
     @Override
     public FixtureExecutionResult expectDeadlinesMet(Object... expected) {
-        deadlineManagerValidator.assertTriggeredDeadlines(expected);
-        return this;
+        return expectTriggeredDeadlines(expected);
     }
 
     @Override


### PR DESCRIPTION
This pull request makes a minor adjustment and includes some assert option.
Firstly, mentions of `deadlinesMet` have been replaced for `triggeredDeadlines`, as that more closely aligns the description around deadline scheduling and handling.

Secondly, a `expectTriggeredDeadlinesWithName` and `expectTriggeredDeadlinesOfType` method has been included.
This is in line with the other assert options, which also allow asserting deadlines based on name or type.

The triggered deadline validation adjustments have been made for both Aggregate and Saga test fixtures.
Lastly, a small warning was fixed in the Aggregate `TestExecutor`, which didn't include the Aggregate type generic when returning the `ResultValidator` instance.  