### PR TITLE
[#1786] Return start position if Token-at-Reset is null

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,7 +53,7 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
      */
     public static TrackingToken createReplayToken(TrackingToken tokenAtReset, TrackingToken startPosition) {
         if (tokenAtReset == null) {
-            return null;
+            return startPosition;
         }
         if (tokenAtReset instanceof ReplayToken) {
             return createReplayToken(((ReplayToken) tokenAtReset).tokenAtReset, startPosition);


### PR DESCRIPTION
This pull request adjusts the `ReplayToken#createReplayToken(TrackingToken, TrackingToken)` to return the `startPosition` if `tokenAtReset` is `null`. 

When the replay mechanism was introduced, we assumed that a replay would *only* be initiated if there was already a token present for the given `StreamingEventProcessor` being replayed. 
It is however perfectly reasonable to reset a Streaming Processor before it has even started. 
If this is the case, the given `tokenAtReset` will be null, as there is no token present yet for that Processor.

Defaulting to `null` in that case means the reset will begin from the start, even if the start position may be in the future.
This PR thus adjusts that behaviour to comply with more current usages of the replay/reset mechanism on the `StreamingEventProcessor`.

Doing to this, this PR resolves #1786 