### PR TITLE
React on patch releases only for bug branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 5
+  ignore:
+    - dependency-name: "*"
+      update-types: [ major, minor ]
   labels:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"
     - "Status: In Progress"
-    - "Target: 4.5.2
+    - "Target: 4.5.2"
   milestone: 62
+  open-pull-requests-limit: 5
   reviewers:
     - "lfgcampos"
     - "m1l4n54v1c"
     - "saratry"
     - "smcvb"
   target-branch: axon-4.5.x
-  ignore:
-    - dependency-name: "*"
-      update-types: [ major, minor ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
   ignore:
     - dependency-name: "*"
-      update-types: [ major, minor ]
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   labels:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"
     - "Status: In Progress"
+    - "Target: 4.5.2
   milestone: 62
   reviewers:
     - "lfgcampos"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,18 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: *
+      update-types: [ major, minor ]
   open-pull-requests-limit: 5
-  # Specify labels for pull requests
   labels:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"
     - "Status: In Progress"
-  # Add reviewers
+  milestone: 62
   reviewers:
     - "lfgcampos"
     - "m1l4n54v1c"
     - "saratry"
     - "smcvb"
-  milestone: 59
+  target-branch: axon-4.5.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  ignore:
-    - dependency-name: "*"
-      update-types: [ major, minor ]
   open-pull-requests-limit: 5
   labels:
     - "Type: Dependency Upgrade"
@@ -20,3 +17,6 @@ updates:
     - "saratry"
     - "smcvb"
   target-branch: axon-4.5.x
+  ignore:
+    - dependency-name: "*"
+      update-types: [ major, minor ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
   ignore:
-    - dependency-name: *
+    - dependency-name: "*"
       update-types: [ major, minor ]
   open-pull-requests-limit: 5
   labels:


### PR DESCRIPTION
This pull request changes the dependabot settings to only react on patch releases. 
This is achieved by ignoring all `major` and `minor` version changes. 

The `target-branch` option is added to point this behavior towards `axon-4.5.x` only, keeping `master` (which constructs our minor versions) as is.
Making this shift thus means that `master` sticks to receive all updates, whereas `axon-4.5.x` will only contain the patch and security releases.