### PR TITLE
Ensure the Tracking Tokens are updated for ignored Event Messages

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -174,7 +174,6 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
                                       .name(name)
                                       .messageSource(messageSource)
                                       .tokenStore(tokenStore)
-                                      .claimExtensionThreshold(claimExtensionThreshold)
                                       .transactionManager(transactionManager)
                                       .executorService(builder.coordinatorExecutorBuilder.apply(name))
                                       .workPackageFactory(this::spawnWorker)
@@ -182,6 +181,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
                                       .onMessageIgnored(this::reportIgnored)
                                       .processingStatusUpdater(this::statusUpdater)
                                       .tokenClaimInterval(tokenClaimInterval)
+                                      .claimExtensionThreshold(claimExtensionThreshold)
                                       .clock(clock)
                                       .maxClaimedSegments(maxClaimedSegments)
                                       .build();

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -174,6 +174,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
                                       .name(name)
                                       .messageSource(messageSource)
                                       .tokenStore(tokenStore)
+                                      .claimExtensionThreshold(claimExtensionThreshold)
                                       .transactionManager(transactionManager)
                                       .executorService(builder.coordinatorExecutorBuilder.apply(name))
                                       .workPackageFactory(this::spawnWorker)

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventhandling.pooled;
 
 import org.axonframework.common.transaction.TransactionManager;
@@ -201,8 +217,7 @@ class WorkPackage {
                             segment.getSegmentId(), name, e);
                 abort(e);
             }
-        }
-        else {
+        } else {
             segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
             if (lastStoredToken != lastConsumedToken) {
                 transactionManager.executeInTransaction(() -> storeToken(lastConsumedToken));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -258,16 +258,28 @@ class PooledStreamingEventProcessorTest {
 
         testSubject.start();
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(1, testSubject.processingStatus().size()));
-        assertWithin(100, TimeUnit.MILLISECONDS, () -> assertEquals(1, testSubject.processingStatus().get(0).getCurrentPosition().orElse(0)));
+        assertWithin(
+                100, TimeUnit.MILLISECONDS,
+                () -> assertEquals(1, testSubject.processingStatus().get(0).getCurrentPosition().orElse(0))
+        );
 
         assertEquals(1, stubMessageSource.getIgnoredEvents().size());
     }
 
     @Test
-    void testEventsWhichMustBeIgnoredAreNotHandled() {
-        setTestSubject(createTestSubject(builder -> builder.initialSegmentCount(1)));
+    void testEventsWhichMustBeIgnoredAreNotHandledOnlyValidated() throws Exception {
+        setTestSubject(createTestSubject(
+                builder -> builder.initialSegmentCount(1)
+                       ));
 
-        when(stubEventHandler.canHandle(any(), any())).thenReturn(true);
+        // The custom ArgumentMatcher, for some reason, first runs the assertion with null, failing the current check.
+        // Hence a null check is added to the matcher.
+        when(stubEventHandler.canHandle(
+                argThat(argument -> argument != null && Integer.class.equals(argument.getPayloadType())), any()
+        )).thenReturn(false);
+        when(stubEventHandler.canHandle(
+                argThat(argument -> argument != null && String.class.equals(argument.getPayloadType())), any()
+        )).thenReturn(true);
         when(stubEventHandler.canHandleType(Integer.class)).thenReturn(false);
         when(stubEventHandler.canHandleType(String.class)).thenReturn(true);
 
@@ -285,6 +297,13 @@ class PooledStreamingEventProcessorTest {
         eventsToHandle.add(eventToHandleOne.getPayload());
         eventsToHandle.add(eventToHandleTwo.getPayload());
 
+        List<Object> eventsToValidate = new ArrayList<>();
+        eventsToValidate.add(eventToIgnoreOne.getPayload());
+        eventsToValidate.add(eventToIgnoreTwo.getPayload());
+        eventsToValidate.add(eventToIgnoreThree.getPayload());
+        eventsToValidate.add(eventToHandleOne.getPayload());
+        eventsToValidate.add(eventToHandleTwo.getPayload());
+
         stubMessageSource.publishMessage(eventToIgnoreOne);
         stubMessageSource.publishMessage(eventToIgnoreTwo);
         stubMessageSource.publishMessage(eventToIgnoreThree);
@@ -295,14 +314,23 @@ class PooledStreamingEventProcessorTest {
 
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(1, testSubject.processingStatus().size()));
         // noinspection unchecked
-        ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
-        verify(stubEventHandler, timeout(500).times(2)).canHandle(eventCaptor.capture(), any());
+        ArgumentCaptor<EventMessage<?>> validatedEventCaptor = ArgumentCaptor.forClass(EventMessage.class);
+        verify(stubEventHandler, timeout(500).times(5)).canHandle(validatedEventCaptor.capture(), any());
 
-        List<EventMessage<?>> handledEvents = eventCaptor.getAllValues();
+        List<EventMessage<?>> validatedEvents = validatedEventCaptor.getAllValues();
+        assertEquals(5, validatedEvents.size());
+        for (EventMessage<?> validatedEvent : validatedEvents) {
+            assertTrue(eventsToValidate.contains(validatedEvent.getPayload()));
+        }
+
+        //noinspection unchecked
+        ArgumentCaptor<EventMessage<?>> handledEventsCaptor = ArgumentCaptor.forClass(EventMessage.class);
+        verify(stubEventHandler, timeout(500).times(2)).handle(handledEventsCaptor.capture(), any());
+        List<EventMessage<?>> handledEvents = handledEventsCaptor.getAllValues();
         assertEquals(2, handledEvents.size());
-        for (EventMessage<?> handledEvent : handledEvents) {
+        for (EventMessage<?> validatedEvent : handledEvents) {
             //noinspection SuspiciousMethodCalls
-            assertTrue(eventsToHandle.contains(handledEvent.getPayload()));
+            assertTrue(eventsToHandle.contains(validatedEvent.getPayload()));
         }
 
         List<TrackedEventMessage<?>> ignoredEvents = stubMessageSource.getIgnoredEvents();


### PR DESCRIPTION
Especially the Messages for which no handler for the type of payload was available did not always cause the tokens to be updated. This commit changes that behavior, to ensure that tokens are updated based on every message received, whether handled or not.