### PR TITLE
Shutdown default ExecutorService when stopping PooledStreamingEventProcessor

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -71,7 +71,7 @@ class Coordinator {
     private final int maxClaimedSegments;
 
     private final Map<Integer, WorkPackage> workPackages = new ConcurrentHashMap<>();
-    private final AtomicReference<RunState> runState = new AtomicReference<>(RunState.initial());
+    private final AtomicReference<RunState> runState;
     private final Map<Integer, Instant> releasesDeadlines = new ConcurrentHashMap<>();
     private int errorWaitBackOff = 500;
     private final Queue<CoordinatorTask> coordinatorTasks = new ConcurrentLinkedQueue<>();
@@ -100,6 +100,7 @@ class Coordinator {
         this.tokenClaimInterval = builder.tokenClaimInterval;
         this.clock = builder.clock;
         this.maxClaimedSegments = builder.maxClaimedSegments;
+        this.runState = new AtomicReference<>(RunState.initial(builder.shutdownAction));
     }
 
     /**
@@ -241,24 +242,26 @@ class Coordinator {
         private final boolean isRunning;
         private final boolean wasStarted;
         private final CompletableFuture<Void> shutdownHandle;
+        private final Runnable shutdownAction;
 
-        private RunState(boolean isRunning, boolean wasStarted, CompletableFuture<Void> shutdownHandle) {
+        private RunState(boolean isRunning, boolean wasStarted, CompletableFuture<Void> shutdownHandle, Runnable shutdownAction) {
             this.isRunning = isRunning;
             this.wasStarted = wasStarted;
             this.shutdownHandle = shutdownHandle;
+            this.shutdownAction = shutdownAction;
         }
 
-        public static RunState initial() {
-            return new RunState(false, false, CompletableFuture.completedFuture(null));
+        public static RunState initial(Runnable shutdownAction) {
+            return new RunState(false, false, CompletableFuture.completedFuture(null), shutdownAction);
         }
 
         public RunState attemptStart() {
             if (isRunning) {
                 // It was already started
-                return new RunState(true, false, null);
+                return new RunState(true, false, null, shutdownAction);
             } else if (shutdownHandle.isDone()) {
                 // Shutdown has previously been completed. It's allowed to start
-                return new RunState(true, true, null);
+                return new RunState(true, true, null, shutdownAction);
             } else {
                 // Shutdown is in progress
                 return this;
@@ -266,9 +269,13 @@ class Coordinator {
         }
 
         public RunState attemptStop() {
-            return !isRunning || shutdownHandle != null
-                    ? this // It's already stopped
-                    : new RunState(false, false, new CompletableFuture<>());
+            // It's already stopped
+            if (!isRunning || shutdownHandle != null) {
+                return this;
+            }
+            CompletableFuture<Void> newShutdownHandle = new CompletableFuture<>();
+            newShutdownHandle.whenComplete((r, e) -> shutdownAction.run());
+            return new RunState(false, false, newShutdownHandle, shutdownAction);
         }
 
         public boolean isRunning() {
@@ -653,6 +660,7 @@ class Coordinator {
         private long tokenClaimInterval = 5000;
         private Clock clock = GenericEventMessage.clock;
         private int maxClaimedSegments;
+        private Runnable shutdownAction = () -> {};
 
         /**
          * The name of the processor this service coordinates for.
@@ -793,6 +801,18 @@ class Coordinator {
          */
         Builder maxClaimedSegments(int maxClaimedSegments) {
             this.maxClaimedSegments = maxClaimedSegments;
+            return this;
+        }
+
+        /**
+         * Registers an action to perform when the coordinator shuts down. Will override any previously registered
+         * actions.
+         *
+         * @param action The action to perform when the coordinator is shut down
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder onShutdown(Runnable action) {
+            this.shutdownAction = action;
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -161,7 +161,6 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         this.messageSource = builder.messageSource;
         this.tokenStore = builder.tokenStore;
         this.transactionManager = builder.transactionManager;
-        this.workerExecutor = builder.workerExecutorBuilder.apply(name);
         this.initialSegmentCount = builder.initialSegmentCount;
         this.initialToken = builder.initialToken;
         this.tokenClaimInterval = builder.tokenClaimInterval;
@@ -170,12 +169,17 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         this.batchSize = builder.batchSize;
         this.clock = builder.clock;
 
+        this.workerExecutor = builder.workerExecutorBuilder.apply(name);
+        boolean shutdownWorkerServiceOnStop = builder.shutdownWorkerServiceOnStop;
+
+        ScheduledExecutorService coordinatorExecutor = builder.coordinatorExecutorBuilder.apply(name);
+        boolean shutdownCoordinatorServiceOnStop = builder.shutdownCoordinatorServiceOnStop;
         this.coordinator = Coordinator.builder()
                                       .name(name)
                                       .messageSource(messageSource)
                                       .tokenStore(tokenStore)
                                       .transactionManager(transactionManager)
-                                      .executorService(builder.coordinatorExecutorBuilder.apply(name))
+                                      .executorService(coordinatorExecutor)
                                       .workPackageFactory(this::spawnWorker)
                                       .eventFilter(event -> canHandleType(event.getPayloadType()))
                                       .onMessageIgnored(this::reportIgnored)
@@ -183,6 +187,15 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
                                       .tokenClaimInterval(tokenClaimInterval)
                                       .clock(clock)
                                       .maxClaimedSegments(maxClaimedSegments)
+                                      .onShutdown(() -> {
+                                          if (shutdownWorkerServiceOnStop) {
+                                              workerExecutor.shutdown();
+                                          }
+                                          if (shutdownCoordinatorServiceOnStop) {
+                                              coordinatorExecutor.shutdown();
+                                          }
+
+                                      })
                                       .build();
     }
 
@@ -431,6 +444,8 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         private StreamableMessageSource<TrackedEventMessage<?>> messageSource;
         private TokenStore tokenStore;
         private TransactionManager transactionManager;
+        private boolean shutdownCoordinatorServiceOnStop = true;
+        private boolean shutdownWorkerServiceOnStop = true;
         private Function<String, ScheduledExecutorService> coordinatorExecutorBuilder =
                 n -> Executors.newScheduledThreadPool(1, new AxonThreadFactory("Coordinator[" + n + "]"));
         private Function<String, ScheduledExecutorService> workerExecutorBuilder =
@@ -530,6 +545,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         public Builder coordinatorExecutor(ScheduledExecutorService coordinatorExecutor) {
             assertNonNull(coordinatorExecutor, "The Coordinator's ScheduledExecutorService may not be null");
             this.coordinatorExecutorBuilder = ignored -> coordinatorExecutor;
+            this.shutdownCoordinatorServiceOnStop = false;
             return this;
         }
 
@@ -545,9 +561,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
          */
         @Deprecated
         public Builder workerExecutorService(ScheduledExecutorService workerExecutor) {
-            assertNonNull(workerExecutor, "The Worker's ScheduledExecutorService may not be null");
-            this.workerExecutorBuilder = ignored -> workerExecutor;
-            return this;
+            return workerExecutor(workerExecutor);
         }
 
         /**
@@ -562,6 +576,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         public Builder workerExecutor(ScheduledExecutorService workerExecutor) {
             assertNonNull(workerExecutor, "The Worker's ScheduledExecutorService may not be null");
             this.workerExecutorBuilder = ignored -> workerExecutor;
+            this.shutdownWorkerServiceOnStop = false;
             return this;
         }
 


### PR DESCRIPTION
When using the default Executor Service instances, the framework should shut them down when shutting down the PooledStreamingEventProcessor.
Custom ExecutorServices will not be shut down.

Resolves #1806