### PR TITLE
Splitted builds into pr and not pr, added ghactions to dependabot and other minors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  labels:
+    - "Type: Dependency Upgrade"
+    - "Priority 1: Must"
+    - "Status: In Progress"
+    - "Target: 4.6.0"
+  milestone: 59
   reviewers:
     - "lfgcampos"
     - "m1l4n54v1c"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  reviewers:
+    - "lfgcampos"
+    - "m1l4n54v1c"
+    - "saratry"
+    - "smcvb"
 - package-ecosystem: maven
   directory: "/"
   schedule:

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,16 +1,12 @@
-releasenotes:
+changelog:
   sections:
-    - title: "Features"
-      emoji: ":star:"
+    - title: ":star: Features"
       labels: [ "Type: Feature" ]
-    - title: "Enhancements"
-      emoji: ":chart_with_upwards_trend:"
+    - title: ":chart_with_upwards_trend: Enhancements"
       labels: [ "Type: Enhancement" ]
-    - title: "Bug Fixes"
-      emoji: ":beetle:"
+    - title: ":beetle: Bug Fixes"
       labels: [ "Type: Bug" ]
-    - title: "Dependency Upgrade"
-      emoji: ":hammer_and_wrench:"
+    - title: ":hammer_and_wrench: Dependency Upgrade"
       labels: [ "Type: Dependency Upgrade" ]
   issues:
     exclude:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,40 +3,37 @@ name: Axon Framework
 on:
   push:
     branches:
+      - main
       - master
       - axon-*.*.x
-  pull_request:
 
 jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         include:
           - java-version: 8
             sonar-enabled: false
-            deploy: true
           - java-version: 11
             sonar-enabled: true
-            deploy: false
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2.1.0
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
           server-id: sonatype
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
       - name: Cache .m2
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2.1.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -64,8 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Sonatype
-        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: success()
         run: |
           ./mvnw -B -U -Possrh deploy -DskipTests=true
         env:
@@ -74,8 +70,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASS }}
 
       - name: Notify success to Slack
-        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if:  ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: success()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2
@@ -85,8 +80,7 @@ jobs:
           color: good
 
       - name: Notify failure to Slack
-        # The github.repository validation ensures this job is not invoked for forked branches, since those don't have access to the secrets.
-        if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1.1.2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,57 @@
+name: Axon Framework
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test and Build on JDK ${{ matrix.java-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - java-version: 8
+            sonar-enabled: false
+          - java-version: 11
+            sonar-enabled: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
+          server-id: sonatype
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Cache .m2
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven
+
+      - name: Maven operation with Sonar
+        if: matrix.sonar-enabled
+        run: |
+          mvn -B -U -Possrh -Pcoverage \
+          clean verify \
+          sonar:sonar \
+          -Dsonar.projectKey=AxonFramework_AxonFramework \
+          -Dsonar.organization=axonframework \
+          -Dsonar.host.url=https://sonarcloud.io \
+          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Maven operation without Sonar
+        if: matrix.sonar-enabled != true
+        run: |
+          mvn -B -U -Possrh clean verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@master
     - name: Create Release Notes Markdown
-      uses: docker://decathlon/release-notes-generator-action:2.1.0
+      uses: docker://decathlon/release-notes-generator-action:3.1.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         OUTPUT_FOLDER: temp_release_notes


### PR DESCRIPTION
This PR splits our current approach for building into 2.
- master
  - build on master/main/tags
  - will deploy to sonatype
- pullrequest
  - build on PRs only
  - won't deploy to sonatype

Also added a small improvement to dependabot to also check for new versions of our GHActions.
Also updated some outdated action versions.