### PR TITLE
Creation Policy Always now invokes Command Handler Interceptors and Event Sourcing Handlers

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,5 +120,18 @@ public abstract class ObjectUtils {
         long leftTimeout = deadline - System.currentTimeMillis();
         leftTimeout = leftTimeout < 0 ? 0 : leftTimeout;
         return leftTimeout;
+    }
+
+    /**
+     * Constructs a {@link Supplier} for an {@code instance} of type {@code T}. If the given {@code instance} is {@code
+     * null}, the {@code defaultSupplier} is given.
+     *
+     * @param instance        the instance to wrap in a {@link Supplier} if it is not {@code null}
+     * @param defaultSupplier the instance {@link Supplier} to return if {@code instance} is {@code null}
+     * @param <T>             the instance type returned by the constructed {@link Supplier}
+     * @return a supplier of an object of type {@code T}
+     */
+    public static <T> Supplier<T> supplyOrDefault(T instance, Supplier<T> defaultSupplier) {
+        return () -> getOrDefault(instance, defaultSupplier);
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,5 +38,11 @@ class ObjectUtilsTest {
         Function<String, String> valueProvider = o -> o;
         assertEquals(DEFAULT_VALUE, ObjectUtils.getOrDefault(NULL_INSTANCE, valueProvider, DEFAULT_VALUE));
         assertEquals(INSTANCE, ObjectUtils.getOrDefault(INSTANCE, valueProvider, DEFAULT_VALUE));
+    }
+
+    @Test
+    void testSupplyOrDefault() {
+        assertEquals(INSTANCE, ObjectUtils.supplyOrDefault(INSTANCE, () -> DEFAULT_VALUE).get());
+        assertEquals(DEFAULT_VALUE, ObjectUtils.supplyOrDefault(NULL_INSTANCE, () -> DEFAULT_VALUE).get());
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
@@ -19,6 +19,7 @@ package org.axonframework.common;
 import org.junit.jupiter.api.*;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,8 +42,8 @@ class ObjectUtilsTest {
     }
 
     @Test
-    void testSupplyOrDefault() {
-        assertEquals(INSTANCE, ObjectUtils.supplyOrDefault(INSTANCE, () -> DEFAULT_VALUE).get());
-        assertEquals(DEFAULT_VALUE, ObjectUtils.supplyOrDefault(NULL_INSTANCE, () -> DEFAULT_VALUE).get());
+    void testSupplySameInstance() {
+        Supplier<Object> testSubject = ObjectUtils.sameInstanceSupplier(Object::new);
+        assertSame(testSubject.get(), testSubject.get());
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -395,13 +394,9 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
 
         @Override
         public Object handle(CommandMessage<?> command) throws Exception {
-            AtomicReference<Object> resultReference = new AtomicReference<>();
-            Aggregate<T> aggregate = repository.newInstance(() -> {
-                T newInstance = factoryMethod.call();
-                resultReference.set(handler.handle(command, newInstance));
-                return newInstance;
-            });
-            return handlerHasVoidReturnType() ? resolveReturnValue(command, aggregate) : resultReference.get();
+            Aggregate<T> aggregate = repository.newInstance(factoryMethod);
+            Object response = aggregate.handle(command);
+            return handlerHasVoidReturnType() ? resolveReturnValue(command, aggregate) : response;
         }
 
         public boolean handlerHasVoidReturnType() {

--- a/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
@@ -94,17 +94,29 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
 
     @Override
     public Object handle(Message<?> message) throws Exception {
-        return wrappedAggregate.handle(message);
+        try {
+            return wrappedAggregate.handle(message);
+        } finally {
+            lockSupplier.get();
+        }
     }
 
     @Override
     public <R> R invoke(Function<AR, R> invocation) {
-        return wrappedAggregate.invoke(invocation);
+        try {
+            return wrappedAggregate.invoke(invocation);
+        } finally {
+            lockSupplier.get();
+        }
     }
 
     @Override
     public void execute(Consumer<AR> invocation) {
-        wrappedAggregate.execute(invocation);
+        try {
+            wrappedAggregate.execute(invocation);
+        } finally {
+            lockSupplier.get();
+        }
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
@@ -91,14 +91,7 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends
             lockSupplier = () -> lock;
         } else {
             // The aggregate identifier hasn't been set yet, so the lock should be created in the supplier.
-            AtomicReference<Lock> lockRef = new AtomicReference<>();
-            // Using the AtomicReference ensures the lock is only created once for the supplier's invocations.
-
-            lockSupplier = ObjectUtils.supplyOrDefault(lockRef.get(), () -> {
-                Lock lock = lockFactory.obtainLock(aggregate.identifierAsString());
-                lockRef.set(lock);
-                return lock;
-            });
+            lockSupplier = ObjectUtils.sameInstanceSupplier(() -> lockFactory.obtainLock(aggregate.identifierAsString()));
         }
 
         try {

--- a/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,7 @@
 package org.axonframework.modelling.command;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.lock.Lock;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.PessimisticLockFactory;
@@ -27,7 +28,10 @@ import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -80,17 +84,35 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends
     protected LockAwareAggregate<T, A> doCreateNew(Callable<T> factoryMethod) throws Exception {
         A aggregate = doCreateNewForLock(factoryMethod);
         final String aggregateIdentifier = aggregate.identifierAsString();
-        Lock lock = lockFactory.obtainLock(aggregateIdentifier);
+
+        Supplier<Lock> lockSupplier;
+        if (!Objects.isNull(aggregateIdentifier)) {
+            Lock lock = lockFactory.obtainLock(aggregateIdentifier);
+            lockSupplier = () -> lock;
+        } else {
+            // The aggregate identifier hasn't been set yet, so the lock should be created in the supplier.
+            AtomicReference<Lock> lockRef = new AtomicReference<>();
+            // Using the AtomicReference ensures the lock is only created once for the supplier's invocations.
+
+            lockSupplier = ObjectUtils.supplyOrDefault(lockRef.get(), () -> {
+                Lock lock = lockFactory.obtainLock(aggregate.identifierAsString());
+                lockRef.set(lock);
+                return lock;
+            });
+        }
+
         try {
-            CurrentUnitOfWork.get().onCleanup(u -> lock.release());
+            CurrentUnitOfWork.get().onCleanup(u -> lockSupplier.get().release());
         } catch (Throwable ex) {
+            Lock lock = lockSupplier.get();
             if (lock != null) {
                 logger.debug("Exception occurred while trying to add an aggregate. Releasing lock.", ex);
                 lock.release();
             }
             throw ex;
         }
-        return new LockAwareAggregate<>(aggregate, lock);
+
+        return new LockAwareAggregate<>(aggregate, lockSupplier);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a lingering bug that causes the `ALWAYS` creation policy to not invoke `@CommandHandlerInterceptor` or `@EventSourcingHandler` annotated functions during the command handling process.
This follows from the fact the handle method is invoked directly on the message handler instead of the constructed Aggregate.

To enable this, the `LockingRepository` and `LockAwareAggregat` now use a `Lock` `Supplier`.
The `Lock` needs to be constructed at the exact moment it is required since the factory method used by the `ALWAYS` creation policy does not construct an aggregate identifier just yet.

The `FixtureTest_CreationPolicy` is expanded to contain interceptor validation and a test case that expects the event sourcing handler to be invoked for the command handling result.
Lastly, a utility class is added to the `ObjectUtils`, called `supplyOrDefault`.
