### PR TITLE
Rethrow known gRPC exceptions

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/PlatformService.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/PlatformService.java
@@ -99,6 +99,7 @@ public class PlatformService extends PlatformServiceGrpc.PlatformServiceImplBase
             @Override
             public void onCompleted() {
                 completedCounter.incrementAndGet();
+                responseObserver.onCompleted();
             }
         };
     }


### PR DESCRIPTION
If the `AxonServerEventStore` fails with reading a snapshot event, the implementation will currently start reading with events.
Sometimes, however, the exception might be a known exception for which it doesn't make sense to proceed.

Thus, this pull request validates whether the received exception carries a `Status.Code` that **does not** equal `UNKNOWN`.
If this is the case, the exception is rethrown inside an `EventStoreException`.
If this isn't the case, we proceed with the regular flow.

A test case has been added to validate this behavior.
Additionally, the stub server implementations have received some improvements to increase the testing speed.