### PR TITLE
Fix issue where exception in creation handler causes NPE

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregate<AR> {
 
     private final A wrappedAggregate;
-    private final Supplier<Lock> lockSupplier;
+    private final LockSupplier lock;
 
     /**
      * Initializes a new {@link LockAwareAggregate} for given {@code wrappedAggregate} and {@code lock}.
@@ -44,7 +44,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
      */
     public LockAwareAggregate(A wrappedAggregate, Lock lock) {
         this.wrappedAggregate = wrappedAggregate;
-        this.lockSupplier = () -> lock;
+        this.lock = () -> lock;
     }
 
     /**
@@ -56,7 +56,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
      */
     public LockAwareAggregate(A wrappedAggregate, Supplier<Lock> lock) {
         this.wrappedAggregate = wrappedAggregate;
-        this.lockSupplier = lock;
+        this.lock = lock::get;
     }
 
     /**
@@ -74,7 +74,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
      * @return {@code true} if the lock is held, {@code false} otherwise
      */
     public boolean isLockHeld() {
-        return this.lockSupplier.get().isHeld();
+        return this.lock.acquire().isHeld();
     }
 
     @Override
@@ -96,7 +96,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
     public Object handle(Message<?> message) throws Exception {
         Object result = wrappedAggregate.handle(message);
         // we need to ensure the lock is acquired, as this may not have happened earlier
-        lockSupplier.get();
+        lock.acquire();
         return result;
     }
 
@@ -104,7 +104,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
     public <R> R invoke(Function<AR, R> invocation) {
         R result = wrappedAggregate.invoke(invocation);
         // we need to ensure the lock is acquired, as this may not have happened earlier
-        lockSupplier.get();
+        lock.acquire();
 
         return result;
     }
@@ -114,7 +114,7 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
         try {
             wrappedAggregate.execute(invocation);
         } finally {
-            lockSupplier.get();
+            lock.acquire();
         }
     }
 
@@ -126,5 +126,13 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
     @Override
     public Class<? extends AR> rootType() {
         return wrappedAggregate.rootType();
+    }
+
+    @FunctionalInterface
+    private interface LockSupplier extends Supplier<Lock> {
+
+        default Lock acquire() {
+            return this.get();
+        }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockAwareAggregate.java
@@ -94,20 +94,19 @@ public class LockAwareAggregate<AR, A extends Aggregate<AR>> implements Aggregat
 
     @Override
     public Object handle(Message<?> message) throws Exception {
-        try {
-            return wrappedAggregate.handle(message);
-        } finally {
-            lockSupplier.get();
-        }
+        Object result = wrappedAggregate.handle(message);
+        // we need to ensure the lock is acquired, as this may not have happened earlier
+        lockSupplier.get();
+        return result;
     }
 
     @Override
     public <R> R invoke(Function<AR, R> invocation) {
-        try {
-            return wrappedAggregate.invoke(invocation);
-        } finally {
-            lockSupplier.get();
-        }
+        R result = wrappedAggregate.invoke(invocation);
+        // we need to ensure the lock is acquired, as this may not have happened earlier
+        lockSupplier.get();
+
+        return result;
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -284,13 +284,13 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
         StringDescription actualDescription = new StringDescription();
         PayloadMatcher<CommandResultMessage<?>> expectedMatcher =
                 new PayloadMatcher<>(CoreMatchers.equalTo(expectedPayload));
-        PayloadMatcher<CommandResultMessage<?>> actualMatcher =
-                new PayloadMatcher<>(CoreMatchers.equalTo(actualReturnValue.getPayload()));
         expectedMatcher.describeTo(expectedDescription);
-        actualMatcher.describeTo(actualDescription);
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
         } else if (!verifyPayloadEquality(expectedPayload, actualReturnValue.getPayload())) {
+            PayloadMatcher<CommandResultMessage<?>> actualMatcher =
+                    new PayloadMatcher<>(CoreMatchers.equalTo(actualReturnValue.getPayload()));
+            actualMatcher.describeTo(actualDescription);
             reporter.reportWrongResult(actualDescription, expectedDescription);
         }
         return this;


### PR DESCRIPTION
The NPE would be caused by the LockingRepository being unable to get the aggregate identifier of an aggregate whose creation attempt resulted in an exception.

A similar NPE would occur in the test fixtures. This has been addressed too.