### PR TITLE
[#1756] Introduce resolver used to solve duplicate command handling members in Aggregates 

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -471,7 +471,6 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     /**
      * Registers subtypes of this aggregate to support aggregate polymorphism. Command Handlers defined on this subtypes
      * will be considered part of this aggregate's handlers.
-     z
      * @param subtypes subtypes in this polymorphic hierarchy
      * @return this configurer for fluent interfacing
      */

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.integrationtests.commandhandling;
 
-import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.commandhandling.DuplicateCommandHandlingMemberException;
-import org.axonframework.commandhandling.FailingDuplicateCommandHandlingMemberResolver;
-import org.axonframework.commandhandling.LoggingDuplicateCommandHandlingMemberResolver;
+import org.axonframework.commandhandling.*;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.config.AggregateConfigurer;
 import org.axonframework.config.Configuration;
@@ -15,10 +28,16 @@ import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.AggregateLifecycle;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Duplicate command handling members were detected unittests
+ *
+ * @author leechedan
+ * @since 4.5
+ */
 public class DuplicateCommandInSameAggregate {
 
     static Configuration configuration;
@@ -27,39 +46,44 @@ public class DuplicateCommandInSameAggregate {
     public void testLoggingDuplicateHandlingMemberShouldLogging() {
 
         configuration = DefaultConfigurer.defaultConfiguration()
-                                         .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
-                                         .configureAggregate(AggregateConfigurer.defaultConfiguration(MyAggregate.class)
-                                                                                .configureDuplicateCommandHandlingMemberResolver(
-                                                                                        c -> LoggingDuplicateCommandHandlingMemberResolver
-                                                                                                .instance()))
-                                         .start();
+                .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                .configureAggregate(AggregateConfigurer.defaultConfiguration(MyAggregate.class)
+                        .configureDuplicateCommandHandlingMemberResolver(
+                                c -> LoggingDuplicateCommandHandlingMemberResolver
+                                        .instance()))
+                .start();
         CommandGateway commandGateway = configuration.commandGateway();
         commandGateway.sendAndWait(new MyCommand("test"));
-//        commandGateway.sendAndWait(new GenericCommandMessage(GenericCommandMessage.asCommandMessage(new MyCommand("test")),"update"));
+        Object updateResult = commandGateway.sendAndWait(new GenericCommandMessage(GenericCommandMessage.asCommandMessage(new MyCommand("test")), "update"));
+        assertEquals(ReturnType.UPDATE, updateResult, "UPDATE is expected");
     }
 
     @Test
     public void testFailingDuplicateHandlingMemberShouldFailing() {
 
         Configurer configurer = DefaultConfigurer.defaultConfiguration()
-                                                 .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
-                                                 .configureAggregate(AggregateConfigurer
-                                                                             .defaultConfiguration(MyAggregate.class)
-                                                                             .configureDuplicateCommandHandlingMemberResolver(
-                                                                                     c -> FailingDuplicateCommandHandlingMemberResolver
-                                                                                             .instance()));
+                .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                .configureAggregate(AggregateConfigurer
+                        .defaultConfiguration(MyAggregate.class)
+                        .configureDuplicateCommandHandlingMemberResolver(
+                                c -> FailingDuplicateCommandHandlingMemberResolver
+                                        .instance()));
         LifecycleHandlerInvocationException lifecycleHandlerInvocationException = assertThrows(
                 LifecycleHandlerInvocationException.class,
                 () -> configurer.start());
         assertTrue(DuplicateCommandHandlingMemberException.class
-                           .isAssignableFrom(lifecycleHandlerInvocationException.getCause().getCause().getClass()),
-                   "exception not expected");
+                        .isAssignableFrom(lifecycleHandlerInvocationException.getCause().getCause().getClass()),
+                "exception not expected");
     }
 
+    static enum ReturnType {
+        CREATE, UPDATE, INVALIDATE;
+    }
 
     static class MyCommand {
 
-        @TargetAggregateIdentifier String id;
+        @TargetAggregateIdentifier
+        String id;
 
         public MyCommand(String id) {
             this.id = id;
@@ -78,33 +102,32 @@ public class DuplicateCommandInSameAggregate {
 
     static class MyAggregate {
 
-        @AggregateIdentifier String id = "";
+        @AggregateIdentifier
+        String id;
 
         public MyAggregate() {
         }
 
         @CommandHandler
         public MyAggregate(MyCommand myCommand) {
-            System.out.println("MyAggregate MyAggregate command - " + myCommand);
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
         }
 
-        @CommandHandler(commandName="update")
-        public void update(MyCommand myCommand) {
-            System.out.println("MyAggregate update command - " + myCommand);
+        @CommandHandler(commandName = "update")
+        public ReturnType update(MyCommand myCommand) {
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
+            return ReturnType.UPDATE;
         }
 
 
         @CommandHandler
-        public void invalidate(MyCommand myCommand) {
-            System.out.println("MyAggregate invalidate command - " + myCommand);
+        public ReturnType invalidate(MyCommand myCommand) {
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
+            return ReturnType.INVALIDATE;
         }
 
         @EventSourcingHandler
         public void handle(MyEvent myEvent) {
-            System.out.println("MyAggregate EVENT - " + myEvent);
             this.id = myEvent.id;
         }
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
@@ -35,7 +35,7 @@ public class DuplicateCommandInSameAggregate {
                                          .start();
         CommandGateway commandGateway = configuration.commandGateway();
         commandGateway.sendAndWait(new MyCommand("test"));
-        commandGateway.sendAndWait(new MyCommand("test"));
+//        commandGateway.sendAndWait(new GenericCommandMessage(GenericCommandMessage.asCommandMessage(new MyCommand("test")),"update"));
     }
 
     @Test
@@ -85,17 +85,20 @@ public class DuplicateCommandInSameAggregate {
 
         @CommandHandler
         public MyAggregate(MyCommand myCommand) {
+            System.out.println("MyAggregate MyAggregate command - " + myCommand);
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
         }
 
-        @CommandHandler
+        @CommandHandler(commandName="update")
         public void update(MyCommand myCommand) {
+            System.out.println("MyAggregate update command - " + myCommand);
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
         }
 
 
         @CommandHandler
         public void invalidate(MyCommand myCommand) {
+            System.out.println("MyAggregate invalidate command - " + myCommand);
             AggregateLifecycle.apply(new MyEvent(myCommand.id));
         }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/DuplicateCommandInSameAggregate.java
@@ -1,0 +1,108 @@
+package org.axonframework.integrationtests.commandhandling;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.DuplicateCommandHandlingMemberException;
+import org.axonframework.commandhandling.FailingDuplicateCommandHandlingMemberResolver;
+import org.axonframework.commandhandling.LoggingDuplicateCommandHandlingMemberResolver;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.config.AggregateConfigurer;
+import org.axonframework.config.Configuration;
+import org.axonframework.config.Configurer;
+import org.axonframework.config.DefaultConfigurer;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateLifecycle;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DuplicateCommandInSameAggregate {
+
+    static Configuration configuration;
+
+    @Test
+    public void testLoggingDuplicateHandlingMemberShouldLogging() {
+
+        configuration = DefaultConfigurer.defaultConfiguration()
+                                         .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                                         .configureAggregate(AggregateConfigurer.defaultConfiguration(MyAggregate.class)
+                                                                                .configureDuplicateCommandHandlingMemberResolver(
+                                                                                        c -> LoggingDuplicateCommandHandlingMemberResolver
+                                                                                                .instance()))
+                                         .start();
+        CommandGateway commandGateway = configuration.commandGateway();
+        commandGateway.sendAndWait(new MyCommand("test"));
+        commandGateway.sendAndWait(new MyCommand("test"));
+    }
+
+    @Test
+    public void testFailingDuplicateHandlingMemberShouldFailing() {
+
+        Configurer configurer = DefaultConfigurer.defaultConfiguration()
+                                                 .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
+                                                 .configureAggregate(AggregateConfigurer
+                                                                             .defaultConfiguration(MyAggregate.class)
+                                                                             .configureDuplicateCommandHandlingMemberResolver(
+                                                                                     c -> FailingDuplicateCommandHandlingMemberResolver
+                                                                                             .instance()));
+        LifecycleHandlerInvocationException lifecycleHandlerInvocationException = assertThrows(
+                LifecycleHandlerInvocationException.class,
+                () -> configurer.start());
+        assertTrue(DuplicateCommandHandlingMemberException.class
+                           .isAssignableFrom(lifecycleHandlerInvocationException.getCause().getCause().getClass()),
+                   "exception not expected");
+    }
+
+
+    static class MyCommand {
+
+        @TargetAggregateIdentifier String id;
+
+        public MyCommand(String id) {
+            this.id = id;
+        }
+    }
+
+    static class MyEvent {
+
+        String id;
+
+        public MyEvent(String id) {
+            this.id = id;
+        }
+    }
+
+
+    static class MyAggregate {
+
+        @AggregateIdentifier String id = "";
+
+        public MyAggregate() {
+        }
+
+        @CommandHandler
+        public MyAggregate(MyCommand myCommand) {
+            AggregateLifecycle.apply(new MyEvent(myCommand.id));
+        }
+
+        @CommandHandler
+        public void update(MyCommand myCommand) {
+            AggregateLifecycle.apply(new MyEvent(myCommand.id));
+        }
+
+
+        @CommandHandler
+        public void invalidate(MyCommand myCommand) {
+            AggregateLifecycle.apply(new MyEvent(myCommand.id));
+        }
+
+        @EventSourcingHandler
+        public void handle(MyEvent myEvent) {
+            System.out.println("MyAggregate EVENT - " + myEvent);
+            this.id = myEvent.id;
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberException.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.common.AxonNonTransientException;
+import org.axonframework.messaging.MessageHandler;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Exception indicating duplicate Command Handling Members were detected.
+ *
+ * @author leechedan
+ * @since 4.5
+ */
+public class DuplicateCommandHandlingMemberException extends AxonNonTransientException {
+
+    private static final long serialVersionUID = 7168111526309151296L;
+
+    /**
+     * Initialize a duplicate command handling member exception using the given {@code payloadType} and {@code
+     * duplicateHandlerMembers} to form a specific message.
+     *
+     * @param payloadType The payloadType of the command for which the duplicates were detected
+     * @param duplicateHandlerMembers the duplicated {@link MessageHandler}
+     */
+    public <T> DuplicateCommandHandlingMemberException(Class<?> payloadType,
+                                                       List<MessageHandlingMember<? super T>> duplicateHandlerMembers) {
+        this(String.format("Multi command handler members [%s] were found for command [%s].",
+                           duplicateHandlerMembers.stream()
+                                                  .map(item -> item.getTargetMethod() == null ?
+                                                          payloadType.getName() : item.getTargetMethod().toString())
+                                                  .collect(Collectors.joining(",")),
+                           payloadType.getName()));
+    }
+
+    /**
+     * Initializes multi command handling member exception using the given {@code message}.
+     *
+     * @param message the message describing the exception
+     */
+    public DuplicateCommandHandlingMemberException(String message) {
+        super(message);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberException.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberException.java
@@ -37,17 +37,17 @@ public class DuplicateCommandHandlingMemberException extends AxonNonTransientExc
      * Initialize a duplicate command handling member exception using the given {@code payloadType} and {@code
      * duplicateHandlerMembers} to form a specific message.
      *
-     * @param payloadType The payloadType of the command for which the duplicates were detected
+     * @param commandName The name of the command for which the duplicates were detected
      * @param duplicateHandlerMembers the duplicated {@link MessageHandler}
      */
-    public <T> DuplicateCommandHandlingMemberException(Class<?> payloadType,
+    public <T> DuplicateCommandHandlingMemberException(String commandName,
                                                        List<MessageHandlingMember<? super T>> duplicateHandlerMembers) {
         this(String.format("Multi command handler members [%s] were found for command [%s].",
                            duplicateHandlerMembers.stream()
                                                   .map(item -> item.getTargetMethod() == null ?
-                                                          payloadType.getName() : item.getTargetMethod().toString())
+                                                          commandName : item.getTargetMethod().toString())
                                                   .collect(Collectors.joining(",")),
-                           payloadType.getName()));
+                           commandName));
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+import java.util.List;
+
+/**
+ * Functional interface towards resolving the occurrence of a duplicate command handler member. As such it ingests two
+ * {@link MessageHandlingMember} instances and returns another one as the resolution.
+ *
+ * @author leechedan
+ * @since 4.5
+ */
+@FunctionalInterface
+public interface DuplicateCommandHandlingMemberResolver {
+
+    /**
+     * Chooses what to do when multi handling member is detected, returning the handling member that should be selected
+     * for command handling, or otherwise throwing an exception to reject registration altogether.
+     *
+     * @param payloadType               The name of the Command for which the duplicates were detected
+     * @param messageHandlingMemberList the {@link MessageHandlingMember} that is group of handler members handling same
+     *                                  command
+     * @return the resolved {@link MessageHandlingMember}. Could be one of the {@code messageHandlingMemberList} or
+     *         another handling member entirely
+     * @throws RuntimeException when initialize should fail
+     */
+    <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+                                                 List<MessageHandlingMember<? super T>> messageHandlingMemberList);
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberResolver.java
@@ -34,13 +34,13 @@ public interface DuplicateCommandHandlingMemberResolver {
      * Chooses what to do when multi handling member is detected, returning the handling member that should be selected
      * for command handling, or otherwise throwing an exception to reject registration altogether.
      *
-     * @param payloadType               The name of the Command for which the duplicates were detected
+     * @param commandName               The name of the Command for which the duplicates were detected
      * @param messageHandlingMemberList the {@link MessageHandlingMember} that is group of handler members handling same
      *                                  command
      * @return the resolved {@link MessageHandlingMember}. Could be one of the {@code messageHandlingMemberList} or
      *         another handling member entirely
      * @throws RuntimeException when initialize should fail
      */
-    <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+    <T> MessageHandlingMember<? super T> resolve(String commandName,
                                                  List<MessageHandlingMember<? super T>> messageHandlingMemberList);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/FailingDuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/FailingDuplicateCommandHandlingMemberResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+
+import java.util.List;
+
+/**
+ * Implementation of the {@link DuplicateCommandHandlingMemberResolver} that throws a {@link
+ * DuplicateCommandHandlingMemberException} when multi handler members are detected.
+ *
+ * @author leechedan
+ * @since 4.5
+ */
+public class FailingDuplicateCommandHandlingMemberResolver implements DuplicateCommandHandlingMemberResolver {
+
+    private static final FailingDuplicateCommandHandlingMemberResolver INSTANCE =
+            new FailingDuplicateCommandHandlingMemberResolver();
+
+    /**
+     * @return a DuplicateCommandHandlingMemberResolver that throws an exception when multi handler members are detected
+     */
+    public static FailingDuplicateCommandHandlingMemberResolver instance() {
+        return INSTANCE;
+    }
+
+    private FailingDuplicateCommandHandlingMemberResolver() {
+    }
+
+    public <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+                                                        List<MessageHandlingMember<? super T>> messageHandlingMemberList) {
+
+        throw new DuplicateCommandHandlingMemberException(payloadType, messageHandlingMemberList);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/FailingDuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/FailingDuplicateCommandHandlingMemberResolver.java
@@ -42,9 +42,9 @@ public class FailingDuplicateCommandHandlingMemberResolver implements DuplicateC
     private FailingDuplicateCommandHandlingMemberResolver() {
     }
 
-    public <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+    public <T> MessageHandlingMember<? super T> resolve(String commandName,
                                                         List<MessageHandlingMember<? super T>> messageHandlingMemberList) {
 
-        throw new DuplicateCommandHandlingMemberException(payloadType, messageHandlingMemberList);
+        throw new DuplicateCommandHandlingMemberException(commandName, messageHandlingMemberList);
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/LoggingDuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/LoggingDuplicateCommandHandlingMemberResolver.java
@@ -49,14 +49,14 @@ public class LoggingDuplicateCommandHandlingMemberResolver implements DuplicateC
     private LoggingDuplicateCommandHandlingMemberResolver() {
     }
 
-    public <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+    public <T> MessageHandlingMember<? super T> resolve(String commandName,
                                                         List<MessageHandlingMember<? super T>> messageHandlingMemberList) {
 
         String methods = messageHandlingMemberList.stream()
                                                   .map(item -> item.getTargetMethod() == null ?
-                                                          payloadType.getName() : item.getTargetMethod().toString())
+                                                          commandName : item.getTargetMethod().toString())
                                                   .collect(Collectors.joining(","));
-        logger.warn("Duplicate command handler members [{}] were found for command [{}]. ", methods, payloadType.getName());
+        logger.warn("Duplicate command handler members [{}] were found for command [{}]. ", methods, commandName);
         return messageHandlingMemberList.stream().findFirst().get();
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/LoggingDuplicateCommandHandlingMemberResolver.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/LoggingDuplicateCommandHandlingMemberResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of the {@link DuplicateCommandHandlingMemberResolver} that allows initialize to be overridden by
+ * first handler member, but logs this (on WARN level) to a given logger.
+ *
+ * @author leechedan
+ * @since 4.5
+ */
+public class LoggingDuplicateCommandHandlingMemberResolver implements DuplicateCommandHandlingMemberResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingDuplicateCommandHandlingMemberResolver.class);
+    private static final LoggingDuplicateCommandHandlingMemberResolver INSTANCE =
+            new LoggingDuplicateCommandHandlingMemberResolver();
+
+
+    /**
+     * Returns an instance that logs duplicate registrations.
+     *
+     * @return an instance that logs duplicate registrations
+     */
+    public static LoggingDuplicateCommandHandlingMemberResolver instance() {
+        return INSTANCE;
+    }
+
+    private LoggingDuplicateCommandHandlingMemberResolver() {
+    }
+
+    public <T> MessageHandlingMember<? super T> resolve(Class<?> payloadType,
+                                                        List<MessageHandlingMember<? super T>> messageHandlingMemberList) {
+
+        String methods = messageHandlingMemberList.stream()
+                                                  .map(item -> item.getTargetMethod() == null ?
+                                                          payloadType.getName() : item.getTargetMethod().toString())
+                                                  .collect(Collectors.joining(","));
+        logger.warn("Duplicate command handler members [{}] were found for command [{}]. ", methods, payloadType.getName());
+        return messageHandlingMemberList.stream().findFirst().get();
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
@@ -89,6 +89,11 @@ public class AnnotatedMessageHandlingMember<T> implements MessageHandlingMember<
     }
 
     @Override
+    public Executable getTargetMethod() {
+        return executable;
+    }
+
+    @Override
     public Class<?> payloadType() {
         return payloadType;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
@@ -173,4 +173,12 @@ public interface MessageHandlingMember<T> {
     default <R> Optional<R> attribute(String attributeKey) {
         return Optional.empty();
     }
+
+    /**
+     * for logging when multi command handling members were detected
+     * @return command handling member executable default null
+     */
+    default Executable getTargetMethod() {
+        return null;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
@@ -19,6 +19,7 @@ package org.axonframework.messaging.annotation;
 import org.axonframework.messaging.Message;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
 import java.util.Map;
 import java.util.Optional;
 
@@ -98,5 +99,10 @@ public abstract class WrappedMessageHandlingMember<T> implements MessageHandling
     @Override
     public <R> Optional<R> attribute(String attributeKey) {
         return delegate.attribute(attributeKey);
+    }
+
+    @Override
+    public Executable getTargetMethod() {
+        return delegate.getTargetMethod();
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.command.AggregateEntityNotFoundException;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -155,5 +156,10 @@ public class ChildForwardingCommandMessageHandlingMember<P, C> implements Comman
     @Override
     public <R> Optional<R> attribute(String attributeKey) {
         return childHandler.attribute(attributeKey);
+    }
+
+    @Override
+    public Executable getTargetMethod() {
+        return childHandler.getTargetMethod();
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -19,7 +19,9 @@ package org.axonframework.springboot.autoconfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
+import org.axonframework.commandhandling.DuplicateCommandHandlingMemberResolver;
 import org.axonframework.commandhandling.LoggingDuplicateCommandHandlerResolver;
+import org.axonframework.commandhandling.LoggingDuplicateCommandHandlingMemberResolver;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
@@ -331,6 +333,12 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
     @ConditionalOnMissingBean
     public DuplicateCommandHandlerResolver duplicateCommandHandlerResolver() {
         return LoggingDuplicateCommandHandlerResolver.instance();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuplicateCommandHandlingMemberResolver duplicateCommandHandlingMemberResolver() {
+        return LoggingDuplicateCommandHandlingMemberResolver.instance();
     }
 
     @ConditionalOnMissingBean(


### PR DESCRIPTION
Question still need to been confirmed:
1. does [`AnnotationCommandHandlerAdapter`](https://github.com/leechedan/AxonFramework/blob/axon-4.5.x/messaging/src/main/java/org/axonframework/commandhandling/AnnotationCommandHandlerAdapter.java) need to be resolved by [`DuplicateCommandHandlingMemberResolver`](https://github.com/leechedan/AxonFramework/blob/axon-4.5.x/messaging/src/main/java/org/axonframework/commandhandling/DuplicateCommandHandlingMemberResolver.java)?

This pull request resolves #1756 