### PR TITLE
[#1892] Adjust Upcaster ordering logic in Spring environments

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -18,6 +18,7 @@ package org.axonframework.spring.config;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.common.caching.Cache;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -78,7 +79,8 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.DeferredImportSelector;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -245,14 +247,16 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
     }
 
     private void registerEventUpcasters(Configurer configurer) {
-        //noinspection ConstantConditions - suppressing ConfigurableListableBeanFactory#getType null warning
         Arrays.stream(beanFactory.getBeanNamesForType(EventUpcaster.class))
               .collect(Collectors.toMap(
                       upcasterBeanName -> upcasterBeanName,
-                      upcasterBeanName -> beanFactory.getType(upcasterBeanName)
+                      upcasterBeanName -> ObjectUtils.getOrDefault(
+                              beanFactory.findAnnotationOnBean(upcasterBeanName, Order.class),
+                              Order::value, Ordered.LOWEST_PRECEDENCE
+                      )
               ))
               .entrySet().stream()
-              .sorted(Map.Entry.comparingByValue(AnnotationAwareOrderComparator.INSTANCE))
+              .sorted(Map.Entry.comparingByValue())
               .forEach(upcasterEntry -> configurer.registerEventUpcaster(c -> getBean(upcasterEntry.getKey(), c)));
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
@@ -66,6 +66,7 @@ class UpcasterOrderingTest {
         InOrder upcasterOrder = inOrder(mockStream);
         upcasterOrder.verify(mockStream).sorted(); // Invoked in FirstUpcaster
         upcasterOrder.verify(mockStream).filter(any()); // Invoked in SecondUpcaster
+        upcasterOrder.verify(mockStream).distinct(); // Invoked in ThirdUpcaster
         upcasterOrder.verify(mockStream).map(any()); // Invoked in UnorderedUpcaster
     }
 
@@ -125,6 +126,24 @@ class UpcasterOrderingTest {
                 intermediateRepresentations.filter(ier -> true);
                 return intermediateRepresentations;
             }
+        }
+
+        @Bean
+        @Order(2)
+        public ThirdUpcaster someSecondUpcaster() {
+            return new ThirdUpcaster();
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static class ThirdUpcaster implements EventUpcaster {
+
+        @Override
+        public Stream<IntermediateEventRepresentation> upcast(
+                Stream<IntermediateEventRepresentation> intermediateRepresentations
+        ) {
+            intermediateRepresentations.distinct();
+            return intermediateRepresentations;
         }
     }
 }


### PR DESCRIPTION
The current solution in the `SpringAxonAutoConfigurer` will not check whether a bean creation method has the `@Order` annotation.
It instead only works if the `@Order` annotation is added to the class of the upcaster itself.

Although this works fine, allowing the `@Order` annotation to be paired with the `@Bean` annotation is friendlier.
This pull request adjusts the behavior in the `SpringAxonAutoConfigurer` such that we look for the `@Order` annotation through the `ListableBeanFactory#findAnnotationOnBean(String beanName, Class<A> annotationClass)`.
This method takes bean creation methods into account, hence allowing us to check for the order on those.

With these adjustments, issue #1892 is resolved.