### PR TITLE
Clear givenWhen state after setting the repository for State-Stored Aggregate testing  

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -311,7 +311,6 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public TestExecutor<T> givenState(Supplier<T> aggregate) {
-        clearGivenWhenState();
         DefaultUnitOfWork.startAndGet(null).execute(() -> {
             if (repository == null) {
                 registerRepository(new InMemoryRepository<>(aggregateType,
@@ -329,6 +328,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                         e);
             }
         });
+        clearGivenWhenState();
         return this;
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,8 @@ class FixtureTest_StateStorage {
         StateStoredAggregate(String id, String message) {
             this.id = id;
             this.message = message;
+            // this event, published during the givenState operation, should not be included in the expectEvents phase
+            apply(new StubDomainEvent());
         }
 
         @CommandHandler


### PR DESCRIPTION
When using the `AggregateTestFixture#givenState` method, any events published by invocation of the provided state object are kept.
This might occur for example if the constructor of a state-stored aggregate publishes an event *and* when the constructor is invoked in the `givenState` method.
This setup wrongfully adds events published in the given phase to the expect phase.

This pull request fixes that issue by invoking (the private) `AggregateTestFixture#clearGivenWhenState` after the repository is configured.