### PR TITLE
[#1898] Empty associationProperty leads to IndexOutOfBoundsException

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
@@ -62,17 +62,27 @@ public class PayloadAssociationResolver implements AssociationResolver {
     }
 
     private <T> Property createProperty(String associationPropertyName, MessageHandlingMember<T> handler) {
+        if (associationPropertyName.isEmpty()) {
+            throw new AxonConfigurationException(format(
+                    "SagaEventHandler %s does not define an association property",
+                    getHandlerName(handler)
+            ));
+        }
+
         Property<?> associationProperty = PropertyAccessStrategy.getProperty(handler.payloadType(),
                                                                              associationPropertyName);
         if (associationProperty == null) {
-            String handlerName = handler.unwrap(Executable.class).map(Executable::toGenericString).orElse("unknown");
             throw new AxonConfigurationException(format(
                     "SagaEventHandler %s defines a property %s that is not defined on the Event it declares to handle (%s)",
-                    handlerName,
+                    getHandlerName(handler),
                     associationPropertyName,
                     handler.payloadType().getName()
             ));
         }
         return associationProperty;
+    }
+
+    private String getHandlerName(MessageHandlingMember<?> handler) {
+        return handler.unwrap(Executable.class).map(Executable::toGenericString).orElse("unknown");
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -72,6 +72,14 @@ class AnnotatedSagaTest {
     }
 
     @Test
+    void testInvokeSaga_AssociationPropertyEmpty() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> new AnnotationSagaMetaModelFactory().modelOf(SagaAssociationPropertyEmpty.class)
+        );
+    }
+
+    @Test
     void testInvokeSaga_MetaDataAssociationResolver() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         Map<String, Object> metaData = new HashMap<>();
@@ -198,6 +206,15 @@ class AnnotatedSagaTest {
             super.handleStubDomainEvent(event);
             removeAssociationWith("propertyName", event.getPropertyName());
         }
+    }
+
+    private static class SagaAssociationPropertyEmpty {
+
+        @SuppressWarnings("unused")
+        @SagaEventHandler(associationProperty = "")
+        public void handleStubDomainEvent(EventWithoutProperties event) {
+        }
+
     }
 
     private static class RegularEvent {


### PR DESCRIPTION
This is a pull request for issue #1898.

Signed-off-by: Nils Christian Ehmke <nils@rhocas.de>