### PR TITLE
Added jdk17-ea on our build workflow for early feedback

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "*"
+      update-types: [ "version-update:semver-patch" ]
   open-pull-requests-limit: 5
   labels:
     - "Type: Dependency Upgrade"
@@ -33,7 +36,7 @@ updates:
     - "m1l4n54v1c"
     - "saratry"
     - "smcvb"
-  # Patch and security updates for patch branches
+# Patch and security updates for patch branches
 - package-ecosystem: maven
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     - "m1l4n54v1c"
     - "saratry"
     - "smcvb"
+# Updates for `master`
 - package-ecosystem: maven
   directory: "/"
   schedule:
@@ -32,3 +33,24 @@ updates:
     - "m1l4n54v1c"
     - "saratry"
     - "smcvb"
+  # Patch and security updates for patch branches
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  ignore:
+    - dependency-name: "*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  labels:
+    - "Type: Dependency Upgrade"
+    - "Priority 1: Must"
+    - "Status: In Progress"
+    - "Target: 4.5.4"
+  milestone: 65
+  open-pull-requests-limit: 5
+  reviewers:
+    - "lfgcampos"
+    - "m1l4n54v1c"
+    - "saratry"
+    - "smcvb"
+  target-branch: "axon-4.5.x"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.2.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             sonar-enabled: false
           - java-version: 11
             sonar-enabled: true
-          - java-version: 17-ea
+          - java-version: 17
             sonar-enabled: false
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    continue-on-error: true # do not fail the whole job if one of the steps fails
     strategy:
       matrix:
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
             sonar-enabled: false
           - java-version: 11
             sonar-enabled: true
+          - java-version: 17-ea
+            sonar-enabled: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2.1.0
+        uses: actions/setup-java@v2.2.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    continue-on-error: true # do not fail the whole job if one of the steps fails
     strategy:
       matrix:
         include:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -15,7 +15,7 @@ jobs:
             sonar-enabled: false
           - java-version: 11
             sonar-enabled: true
-          - java-version: 17-ea
+          - java-version: 17
             sonar-enabled: false
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,6 +14,8 @@ jobs:
             sonar-enabled: false
           - java-version: 11
             sonar-enabled: true
+          - java-version: 17-ea
+            sonar-enabled: false
 
     steps:
       - name: Checkout code

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
@@ -22,6 +22,9 @@ import org.axonframework.messaging.RemoteHandlingException;
 
 /**
  * Exception indicating a problem that was reported by the remote end of a connection.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 4.0
@@ -38,7 +41,18 @@ public class AxonServerRemoteCommandHandlingException extends RemoteHandlingExce
      * @param errorMessage the message describing the exception on the remote end
      */
     public AxonServerRemoteCommandHandlingException(String errorCode, ErrorMessage errorMessage) {
-        super(new RemoteExceptionDescription(errorMessage.getDetailsList()));
+        this(errorCode, errorMessage, false);
+    }
+
+    /**
+     * Initialize the exception with given {@code errorCode}, {@code errorMessage} and {@code writableStackTrace}.
+     *
+     * @param errorCode          the code reported by the server
+     * @param errorMessage       the message describing the exception on the remote end
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public AxonServerRemoteCommandHandlingException(String errorCode, ErrorMessage errorMessage, boolean writableStackTrace) {
+        super(new RemoteExceptionDescription(errorMessage.getDetailsList()), writableStackTrace);
         this.errorCode = errorCode;
         this.server = errorMessage.getLocation();
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
@@ -22,6 +22,9 @@ import org.axonframework.messaging.RemoteHandlingException;
 
 /**
  * An AxonServer Exception which is thrown on a Query Handling exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 4.0
@@ -40,7 +43,18 @@ public class AxonServerRemoteQueryHandlingException extends RemoteHandlingExcept
      * @param message   an {@link ErrorMessage} describing the exception
      */
     public AxonServerRemoteQueryHandlingException(String errorCode, ErrorMessage message) {
-        super(new RemoteExceptionDescription(message.getDetailsList()));
+        this(errorCode, message, false);
+    }
+
+    /**
+     * Initialize a Query Handling exception from a remote source.
+     *
+     * @param errorCode          a {@link String} defining the error code of this exception
+     * @param message            an {@link ErrorMessage} describing the exception
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false}
+     */
+    public AxonServerRemoteQueryHandlingException(String errorCode, ErrorMessage message, boolean writableStackTrace) {
+        super(new RemoteExceptionDescription(message.getDetailsList()), writableStackTrace);
         this.errorCode = errorCode;
         this.server = message.getLocation();
     }

--- a/database.trace.db
+++ b/database.trace.db
@@ -1,0 +1,26 @@
+2021-07-29 13:26:04 jdbc[3]: exception
+java.sql.SQLClientInfoException: Client info name 'ApplicationName' not supported.
+	at org.h2.jdbc.JdbcConnection.setClientInfo(JdbcConnection.java:1749)
+	at com.intellij.database.remote.jdbc.impl.RemoteConnectionImpl.setClientInfo(RemoteConnectionImpl.java:470)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
+	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:359)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
+	at java.base/java.security.AccessController.doPrivileged(Native Method)
+	at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:562)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:796)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:677)
+	at java.base/java.security.AccessController.doPrivileged(Native Method)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:676)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
+	at java.base/java.lang.Thread.run(Thread.java:829)
+2021-07-29 13:26:04 jdbc[3]: exception
+org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "TOKEN_ENTRY" not found; SQL statement:
+SELECT t.*
+FROM PUBLIC.TOKEN_ENTRY t
+LIMIT 501 [42102-200]

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,10 +82,15 @@ import static org.axonframework.common.DateTimeUtils.formatInstant;
 import static org.axonframework.common.jdbc.JdbcUtils.*;
 
 /**
- * EventStorageEngine implementation that uses JDBC to store and fetch events.
+ * An {@link org.axonframework.eventsourcing.eventstore.EventStorageEngine} implementation that uses JDBC to store and
+ * fetch events.
  * <p>
- * By default the payload of events is stored as a serialized blob of bytes. Other columns are used to store meta-data
- * that allow quick finding of DomainEvents for a specific aggregate in the correct order.
+ * By default, it stores the payload of events as a serialized blob of bytes. It uses other columns to store meta-data
+ * that allows quick finding of DomainEvents for a specific aggregate in the correct order.
+ * <p>
+ * Before using this store make sure the database contains a table named {@link EventSchema#domainEventTable()} and
+ * {@link EventSchema#snapshotTable()} in which to store events and snapshots in respectively. For convenience, these
+ * tables can be constructed through the {@link JdbcEventStorageEngine#createSchema(EventTableFactory)} operation.
  *
  * @author Rene de Waele
  * @since 3.0

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/JpaStorageEngineInsertionReadOrderTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/JpaStorageEngineInsertionReadOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.integrationtests.eventsourcing.eventstore.benchmark;
 
+import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -24,94 +25,115 @@ import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
+import org.axonframework.integrationtests.utils.TestSerializer;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.beans.PropertyVetoException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
 
 import static org.axonframework.eventsourcing.utils.EventStoreTestUtils.AGGREGATE;
 import static org.axonframework.eventsourcing.utils.EventStoreTestUtils.createEvent;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * Integration test class validating the insertion order of events for the {@link JpaEventStorageEngine}.
+ *
  * @author Rene de Waele
  */
 @ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-@ContextConfiguration(locations = "classpath:/META-INF/spring/insertion-read-order-test-context.xml")
+@ContextConfiguration(classes = JpaStorageEngineInsertionReadOrderTest.TestContext.class)
 class JpaStorageEngineInsertionReadOrderTest {
 
     private static final Logger logger = LoggerFactory.getLogger(JpaStorageEngineInsertionReadOrderTest.class);
 
-    private final Serializer serializer = XStreamSerializer.builder().build();
+    private final Serializer serializer = TestSerializer.secureXStreamSerializer();
 
     @PersistenceContext
     private EntityManager entityManager;
-
     @Inject
     private PlatformTransactionManager tx;
+    private TransactionTemplate txTemplate;
 
     private BatchingEventStorageEngine testSubject;
-    private TransactionTemplate txTemplate;
 
     @BeforeEach
     void setUp() {
         txTemplate = new TransactionTemplate(tx);
-        txTemplate.execute(ts -> {
-            entityManager.createQuery("DELETE FROM DomainEventEntry").executeUpdate();
-            return null;
-        });
         testSubject = JpaEventStorageEngine.builder()
                                            .snapshotSerializer(serializer)
                                            .eventSerializer(serializer)
-                                           .batchSize(20)
                                            .entityManagerProvider(new SimpleEntityManagerProvider(entityManager))
                                            .transactionManager(new SpringTransactionManager(tx))
                                            .build();
     }
 
+    @AfterEach
+    void tearDown() {
+        txTemplate.execute(ts -> {
+            entityManager.createQuery("DELETE FROM DomainEventEntry").executeUpdate();
+            return null;
+        });
+    }
+
     @Test
     @Timeout(value = 30)
     void testInsertConcurrentlyAndCheckReadOrder() throws Exception {
-        int threadCount = 10, eventsPerThread = 100, inverseRollbackRate = 7, rollbacksPerThread =
-                (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
+        int threadCount = 10;
+        int eventsPerThread = 100;
+        int inverseRollbackRate = 7;
+        int rollbacksPerThread = (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
         int expectedEventCount = threadCount * eventsPerThread - rollbacksPerThread * threadCount;
+
         Thread[] writerThreads = storeEvents(threadCount, eventsPerThread, inverseRollbackRate);
         List<TrackedEventMessage<?>> readEvents = readEvents(expectedEventCount);
         for (Thread thread : writerThreads) {
             thread.join();
         }
+
         assertEquals(expectedEventCount, readEvents.size(),
-                "The actually read list of events is shorted than the expected value");
+                     "The actually read list of events is shorted than the expected value");
     }
 
     @Test
     @Timeout(value = 10)
     void testInsertConcurrentlyAndReadUsingBlockingStreams() throws Exception {
-        int threadCount = 10, eventsPerThread = 100, inverseRollbackRate = 2, rollbacksPerThread =
-                (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
+        int threadCount = 10;
+        int eventsPerThread = 100;
+        int inverseRollbackRate = 2;
+        int rollbacksPerThread = (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
         int expectedEventCount = threadCount * eventsPerThread - rollbacksPerThread * threadCount;
-        Thread[] writerThreads = storeEvents(threadCount, eventsPerThread, inverseRollbackRate);
+
         EmbeddedEventStore embeddedEventStore = EmbeddedEventStore.builder().storageEngine(testSubject).build();
+        Thread[] writerThreads = storeEvents(threadCount, eventsPerThread, inverseRollbackRate);
         TrackingEventStream readEvents = embeddedEventStore.openStream(null);
+
         int counter = 0;
         while (counter < expectedEventCount) {
             if (readEvents.hasNextAvailable()) {
@@ -121,35 +143,34 @@ class JpaStorageEngineInsertionReadOrderTest {
         for (Thread thread : writerThreads) {
             thread.join();
         }
+
         assertEquals(expectedEventCount, counter,
-                "The actually read list of events is shorted than the expected value");
+                     "The actually read list of events is shorted than the expected value");
     }
 
     @Test
     @Timeout(value = 30)
     void testInsertConcurrentlyAndReadUsingBlockingStreams_SlowConsumer() throws Exception {
-        // Increase batch size to 100, which is the default of the JpaEventStorageEngine
-        testSubject = JpaEventStorageEngine.builder()
-                                           .snapshotSerializer(serializer)
-                                           .eventSerializer(serializer)
-                                           .entityManagerProvider(new SimpleEntityManagerProvider(entityManager))
-                                           .transactionManager(new SpringTransactionManager(tx))
-                                           .build();
-        int threadCount = 4, eventsPerThread = 100, inverseRollbackRate = 2, rollbacksPerThread =
-                (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
+        int threadCount = 4;
+        int eventsPerThread = 100;
+        int inverseRollbackRate = 2;
+        int rollbacksPerThread = (eventsPerThread + inverseRollbackRate - 1) / inverseRollbackRate;
         int expectedEventCount = threadCount * eventsPerThread - rollbacksPerThread * threadCount;
-        Thread[] writerThreads = storeEvents(threadCount, eventsPerThread, inverseRollbackRate);
+
         EmbeddedEventStore embeddedEventStore = EmbeddedEventStore.builder()
                                                                   .storageEngine(testSubject)
                                                                   .cachedEvents(20)
                                                                   .fetchDelay(100)
                                                                   .cleanupDelay(1000)
                                                                   .build();
+        Thread[] writerThreads = storeEvents(threadCount, eventsPerThread, inverseRollbackRate);
         TrackingEventStream readEvents = embeddedEventStore.openStream(null);
+
         int counter = 0;
         while (counter < expectedEventCount) {
             readEvents.nextAvailable();
             counter++;
+            logger.info("SLOW_CONSUMER Handling event #[{}]", counter);
             if (counter % 50 == 0) {
                 Thread.sleep(200);
             }
@@ -157,8 +178,9 @@ class JpaStorageEngineInsertionReadOrderTest {
         for (Thread thread : writerThreads) {
             thread.join();
         }
+
         assertEquals(expectedEventCount, counter,
-                "The actually read list of events is shorted than the expected value");
+                     "The actually read list of events is shorted than the expected value");
     }
 
     private Thread[] storeEvents(int threadCount, int eventsPerThread, int inverseRollbackRate) {
@@ -170,8 +192,9 @@ class JpaStorageEngineInsertionReadOrderTest {
                     final int s = j;
                     try {
                         txTemplate.execute(ts -> {
-                            testSubject.appendEvents(
-                                    createEvent(AGGREGATE, threadIndex * eventsPerThread + s, "Thread" + threadIndex));
+                            testSubject.appendEvents(createEvent(
+                                    AGGREGATE, (long) threadIndex * eventsPerThread + s, "Thread" + threadIndex
+                            ));
                             if (s % inverseRollbackRate == 0) {
                                 throw new RuntimeException("Rolling back on purpose");
                             }
@@ -207,5 +230,53 @@ class JpaStorageEngineInsertionReadOrderTest {
             }
         }
         return result;
+    }
+
+    @Configuration
+    public static class TestContext {
+
+        @Bean
+        public ComboPooledDataSource dataSource() throws PropertyVetoException {
+            ComboPooledDataSource dataSource = new ComboPooledDataSource();
+            dataSource.setDriverClass("org.hsqldb.jdbcDriver");
+            dataSource.setJdbcUrl("jdbc:hsqldb:mem:address-book");
+            dataSource.setUser("sa");
+            dataSource.setMaxPoolSize(50);
+            dataSource.setMinPoolSize(1);
+            Properties dataSourceProperties = new Properties();
+            dataSourceProperties.setProperty("hsqldb.log_size", "0");
+            dataSource.setProperties(dataSourceProperties);
+            return dataSource;
+        }
+
+        @Bean
+        public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+            LocalContainerEntityManagerFactoryBean entityManagerFactory = new LocalContainerEntityManagerFactoryBean();
+            entityManagerFactory.setPersistenceUnitName("integrationtest");
+
+            HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+            vendorAdapter.setDatabasePlatform("org.hibernate.dialect.HSQLDialect");
+            vendorAdapter.setShowSql(false);
+            entityManagerFactory.setJpaVendorAdapter(vendorAdapter);
+
+            HashMap<String, Object> jpaProperties = new HashMap<>();
+            jpaProperties.put("javax.persistence.schema-generation.database.action", "drop-and-create");
+            jpaProperties.put("hibernate.id.new_generator_mappings", true);
+            entityManagerFactory.setJpaPropertyMap(jpaProperties);
+
+            entityManagerFactory.setDataSource(dataSource);
+
+            return entityManagerFactory;
+        }
+
+        @Bean
+        public JpaTransactionManager transactionManager() {
+            return new JpaTransactionManager();
+        }
+
+        @Bean
+        public PersistenceAnnotationBeanPostProcessor persistenceAnnotationBeanPostProcessor() {
+            return new PersistenceAnnotationBeanPostProcessor();
+        }
     }
 }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jdbc/Oracle11EventTableFactoryTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jdbc/Oracle11EventTableFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ class Oracle11EventTableFactoryTest {
     private static final String PASSWORD = "oracle";
 
     @Container
-    private static final OracleContainer ORACLE_CONTAINER = new OracleContainer("gautamsaggar/oracle11g:v2");
+    private static final OracleContainer ORACLE_CONTAINER =
+            new OracleContainer("gvenzl/oracle-xe").withPassword(PASSWORD)
+                                                   .withEnv("ORACLE_PASSWORD", PASSWORD);
 
     private Oracle11EventTableFactory testSubject;
     private Connection connection;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/saga/repository/jdbc/Oracle11SagaSqlSchemaTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/saga/repository/jdbc/Oracle11SagaSqlSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ class Oracle11SagaSqlSchemaTest {
     private static final String PASSWORD = "oracle";
 
     @Container
-    private static final OracleContainer ORACLE_CONTAINER = new OracleContainer("gautamsaggar/oracle11g:v2");
+    private static final OracleContainer ORACLE_CONTAINER =
+            new OracleContainer("gvenzl/oracle-xe").withPassword(PASSWORD)
+                                                   .withEnv("ORACLE_PASSWORD", PASSWORD);
 
     private Oracle11SagaSqlSchema testSubject;
     private Connection connection;

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
@@ -22,6 +22,9 @@ import org.axonframework.messaging.HandlerExecutionException;
 /**
  * Indicates that an exception has occurred while handling a command. Typically, this class is used to wrap checked
  * exceptions that have been thrown from a Command Handler while processing an incoming command.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Allard Buijze
  * @since 1.3
@@ -50,5 +53,18 @@ public class CommandExecutionException extends HandlerExecutionException {
      */
     public CommandExecutionException(String message, Throwable cause, Object details) {
         super(message, cause, details);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, an object providing application-specific
+     * {@code details}, and {@code writableStackTrace}
+     *
+     * @param message            The message describing the exception
+     * @param cause              The cause of the exception
+     * @param details            An object providing more error details (may be {@code null})
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public CommandExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, details, writableStackTrace);
     }
 }

--- a/messaging/src/main/java/org/axonframework/common/AxonException.java
+++ b/messaging/src/main/java/org/axonframework/common/AxonException.java
@@ -44,4 +44,15 @@ public abstract class AxonException extends RuntimeException {
     public AxonException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Initializes the exception using the given {@code message}, {@code cause} and {@code writableStackTrace}.
+     *
+     * @param message            The message describing the exception
+     * @param cause              The underlying cause of the exception
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public AxonException(String message, Throwable cause, boolean writableStackTrace) {
+        super(message, cause, true, writableStackTrace);
+    }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -1042,7 +1042,9 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                 int[] tokenStoreCurrentSegments;
 
                 try {
-                    tokenStoreCurrentSegments = tokenStore.fetchSegments(processorName);
+                    tokenStoreCurrentSegments = transactionManager.fetchInTransaction(
+                            () -> tokenStore.fetchSegments(processorName)
+                    );
 
                     // When in an initial stage, split segments to the requested number.
                     if (tokenStoreCurrentSegments.length == 0 && segmentsSize > 0) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,15 +51,14 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
-import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
-import static org.axonframework.common.jdbc.JdbcUtils.executeQuery;
-import static org.axonframework.common.jdbc.JdbcUtils.executeUpdate;
-import static org.axonframework.common.jdbc.JdbcUtils.executeUpdates;
-import static org.axonframework.common.jdbc.JdbcUtils.listResults;
+import static org.axonframework.common.jdbc.JdbcUtils.*;
 
 /**
- * Implementation of a token store that uses JDBC to save and load tokens. Before using this store make sure the
- * database contains a table named {@link TokenSchema#tokenTable()} in which to store the tokens.
+ * A {@link TokenStore} implementation that uses JDBC to save and load {@link TrackingToken} instances.
+ * <p>
+ * Before using this store make sure the database contains a table named {@link TokenSchema#tokenTable()} in which to
+ * store the tokens. For convenience, this table can be constructed through the {@link
+ * JdbcTokenStore#createSchema(TokenTableFactory)} operation.
  *
  * @author Rene de Waele
  * @since 3.0

--- a/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
@@ -24,6 +24,9 @@ import java.util.Optional;
  * Base exception for exceptions raised by Handler methods. Besides standard exception information (such as message and
  * cause), these exception may optionally carry an object with additional application-specific details about the
  * exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Allard Buize
  * @since 4.2
@@ -63,7 +66,20 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param details An object providing application-specific details of the exception
      */
     public HandlerExecutionException(String message, Throwable cause, Object details) {
-        super(message, cause);
+        this(message, cause, details, false);
+    }
+
+    /**
+     * Initializes an execution exception with given {@code message}, {@code cause}, application-specific
+     * {@code details}, and {@code writableStackTrace}
+     *
+     * @param message            A message describing the exception
+     * @param cause              The cause of the execution exception
+     * @param details            An object providing application-specific details of the exception
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public HandlerExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, writableStackTrace);
         this.details = details;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
@@ -23,6 +23,9 @@ import java.util.List;
 /**
  * Exception indicating that an error has occurred while remotely handling a message.
  * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
+ * <p/>
  * The sender of the message <strong>cannot</strong> assume that the message has not been handled. It may, if the type
  * of message or the infrastructure allows it, try to dispatch the message again.
  *
@@ -41,7 +44,17 @@ public class RemoteHandlingException extends AxonException {
      * @param exceptionDescription a {@link String} describing the remote exceptions
      */
     public RemoteHandlingException(RemoteExceptionDescription exceptionDescription) {
-        super("An exception was thrown by the remote message handling component: " + exceptionDescription.toString());
+        this(exceptionDescription, false);
+    }
+
+    /**
+     * Initializes the exception using the given {@code exceptionDescription} and {@code writableStackTrace}.
+     *
+     * @param exceptionDescription a {@link String} describing the remote exceptions
+     * @param writableStackTrace   whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public RemoteHandlingException(RemoteExceptionDescription exceptionDescription, boolean writableStackTrace) {
+        super("An exception was thrown by the remote message handling component: " + exceptionDescription.toString(), null, writableStackTrace);
         this.exceptionDescriptions = exceptionDescription.getDescriptions();
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
@@ -18,7 +18,10 @@ package org.axonframework.queryhandling;
 import org.axonframework.messaging.HandlerExecutionException;
 
 /**
- * Exception indicating that the execution of a Query Handler has resulted in an exception
+ * Exception indicating that the execution of a Query Handler has resulted in an exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 3.1
@@ -38,13 +41,26 @@ public class QueryExecutionException extends HandlerExecutionException {
     }
 
     /**
-     * Initializes the exception with given {@code message} and {@code cause} and {@code details}.
+     * Initializes the exception with given {@code message}, {@code cause} and {@code details}.
      *
      * @param message Message explaining the context of the error
      * @param cause   The underlying cause of the invocation failure
-     * @param details An object providing more error details (may be {@code null}
+     * @param details An object providing more error details (may be {@code null})
      */
     public QueryExecutionException(String message, Throwable cause, Object details) {
         super(message, cause, details);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, {@code details} and
+     * {@code writableStackTrace}
+     *
+     * @param message            Message explaining the context of the error
+     * @param cause              The underlying cause of the invocation failure
+     * @param details            An object providing more error details (may be {@code null})
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public QueryExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, details, writableStackTrace);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HandlerExecutionExceptionTest {
 
@@ -47,6 +48,24 @@ class HandlerExecutionExceptionTest {
         assertFalse(HandlerExecutionException.resolveDetails(new RuntimeException()).isPresent());
     }
 
+    @Test
+    void testStackTracePresence() {
+        Exception exception = new StubHandlerExecutionException("Some message");
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException());
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details");
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details", false);
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details", true);
+        assertTrue(exception.getStackTrace().length > 0);
+    }
+
     private static class StubHandlerExecutionException extends HandlerExecutionException {
 
         public StubHandlerExecutionException(String message) {
@@ -59,6 +78,10 @@ class HandlerExecutionExceptionTest {
 
         public StubHandlerExecutionException(String message, Throwable cause, Object details) {
             super(message, cause, details);
+        }
+
+        public StubHandlerExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+            super(message, cause, details, writableStackTrace);
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
@@ -62,17 +62,27 @@ public class PayloadAssociationResolver implements AssociationResolver {
     }
 
     private <T> Property createProperty(String associationPropertyName, MessageHandlingMember<T> handler) {
+        if (associationPropertyName.isEmpty()) {
+            throw new AxonConfigurationException(format(
+                    "SagaEventHandler %s does not define an association property",
+                    getHandlerName(handler)
+            ));
+        }
+
         Property<?> associationProperty = PropertyAccessStrategy.getProperty(handler.payloadType(),
                                                                              associationPropertyName);
         if (associationProperty == null) {
-            String handlerName = handler.unwrap(Executable.class).map(Executable::toGenericString).orElse("unknown");
             throw new AxonConfigurationException(format(
                     "SagaEventHandler %s defines a property %s that is not defined on the Event it declares to handle (%s)",
-                    handlerName,
+                    getHandlerName(handler),
                     associationPropertyName,
                     handler.payloadType().getName()
             ));
         }
         return associationProperty;
+    }
+
+    private String getHandlerName(MessageHandlingMember<?> handler) {
+        return handler.unwrap(Executable.class).map(Executable::toGenericString).orElse("unknown");
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,6 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
 import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -40,13 +39,18 @@ import java.sql.SQLException;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Supplier;
+import javax.sql.DataSource;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
 
-
 /**
- * Jdbc implementation of the {@link SagaStore}.
+ * A {@link SagaStore} implementation that uses JDBC to store and find Saga instances.
+ * <p>
+ * Before using this store make sure the database contains an association value- and saga entry table. These can be
+ * constructed with {@link SagaSqlSchema#sql_createTableAssocValueEntry(Connection)} and {@link
+ * SagaSqlSchema#sql_createTableSagaEntry(Connection)} respectively. For convenience, these tables can be constructed
+ * through the {@link JdbcSagaStore#createSchema()} operation.
  *
  * @author Allard Buijze
  * @author Kristian Rosenvold
@@ -280,9 +284,9 @@ public class JdbcSagaStore implements SagaStore<Object> {
     }
 
     /**
-     * Creates the SQL Schema required to store Sagas and their associations,.
+     * Creates the SQL Schema required to store Sagas and their associations.
      *
-     * @throws SQLException When an error occurs preparing of executing the required statements
+     * @throws SQLException when an error occurs preparing of executing the required statements
      */
     public void createSchema() throws SQLException {
         final Connection connection = connectionProvider.getConnection();

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -72,6 +72,14 @@ class AnnotatedSagaTest {
     }
 
     @Test
+    void testInvokeSaga_AssociationPropertyEmpty() {
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> new AnnotationSagaMetaModelFactory().modelOf(SagaAssociationPropertyEmpty.class)
+        );
+    }
+
+    @Test
     void testInvokeSaga_MetaDataAssociationResolver() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         Map<String, Object> metaData = new HashMap<>();
@@ -198,6 +206,15 @@ class AnnotatedSagaTest {
             super.handleStubDomainEvent(event);
             removeAssociationWith("propertyName", event.getPropertyName());
         }
+    }
+
+    private static class SagaAssociationPropertyEmpty {
+
+        @SuppressWarnings("unused")
+        @SagaEventHandler(associationProperty = "")
+        public void handleStubDomainEvent(EventWithoutProperties event) {
+        }
+
     }
 
     private static class RegularEvent {

--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,13 @@
         </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- dependency versions -->
-        <slf4j.version>1.7.31</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.14.1</log4j.version>
         <spring.version>5.3.9</spring.version>
         <spring-security.version>5.5.1</spring-security.version>
         <spring.boot.version>2.5.2</spring.boot.version>
         <mockito.version>3.11.2</mockito.version>
-        <projectreactor.version>3.4.8</projectreactor.version>
+        <projectreactor.version>3.4.9</projectreactor.version>
         <micrometer.version>1.7.2</micrometer.version>
         <dropwizard.metrics.version>4.2.3</dropwizard.metrics.version>
         <jackson.version>2.12.4</jackson.version>
@@ -94,11 +94,11 @@
         <javax.persistence-api.version>2.2</javax.persistence-api.version>
         <javax.jaxb-api.version>2.3.1</javax.jaxb-api.version>
         <disruptor.version>3.4.4</disruptor.version>
-        <mysql-connector-java.version>8.0.25</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.26</mysql-connector-java.version>
         <ehcache.version>2.10.9.2</ehcache.version>
         <quartz.version>2.3.2</quartz.version>
         <c3p0.version>0.9.1.2</c3p0.version>
-        <hsqldb.version>2.5.0</hsqldb.version>
+        <hsqldb.version>2.5.2</hsqldb.version>
         <hibernate-entitymanager.version>5.5.3.Final</hibernate-entitymanager.version>
         <byte-buddy.version>1.11.8</byte-buddy.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <postgresql.version>42.2.23</postgresql.version>
         <junit4.version>4.13.2</junit4.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
-        <axonserver-connector-java.version>4.5.1</axonserver-connector-java.version>
+        <axonserver-connector-java.version>4.5.2</axonserver-connector-java.version>
         <hamcrest.version>2.2</hamcrest.version>
         <testcontainers.version>1.15.3</testcontainers.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <axonserver-connector-java.version>4.5.2</axonserver-connector-java.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.16.0</testcontainers.version>
 
         <!-- plugin versions -->
         <felix.maven-bundle-plugin.version>5.1.2</felix.maven-bundle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <mockito.version>3.11.2</mockito.version>
         <projectreactor.version>3.4.8</projectreactor.version>
         <micrometer.version>1.7.2</micrometer.version>
-        <dropwizard.metrics.version>4.2.2</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.2.3</dropwizard.metrics.version>
         <jackson.version>2.12.4</jackson.version>
         <!--
             Please note that there are dependencies between the gRPC and Netty TcNative versions.

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <c3p0.version>0.9.1.2</c3p0.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <hibernate-entitymanager.version>5.5.3.Final</hibernate-entitymanager.version>
-        <byte-buddy.version>1.11.7</byte-buddy.version>
+        <byte-buddy.version>1.11.8</byte-buddy.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
         <commons-io.version>2.11.0</commons-io.version>
         <javassist.version>3.28.0-GA</javassist.version>

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -18,6 +18,7 @@ package org.axonframework.spring.config;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.common.caching.Cache;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -79,7 +80,8 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.DeferredImportSelector;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -247,14 +249,16 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
     }
 
     private void registerEventUpcasters(Configurer configurer) {
-        //noinspection ConstantConditions - suppressing ConfigurableListableBeanFactory#getType null warning
         Arrays.stream(beanFactory.getBeanNamesForType(EventUpcaster.class))
               .collect(Collectors.toMap(
                       upcasterBeanName -> upcasterBeanName,
-                      upcasterBeanName -> beanFactory.getType(upcasterBeanName)
+                      upcasterBeanName -> ObjectUtils.getOrDefault(
+                              beanFactory.findAnnotationOnBean(upcasterBeanName, Order.class),
+                              Order::value, Ordered.LOWEST_PRECEDENCE
+                      )
               ))
               .entrySet().stream()
-              .sorted(Map.Entry.comparingByValue(AnnotationAwareOrderComparator.INSTANCE))
+              .sorted(Map.Entry.comparingByValue())
               .forEach(upcasterEntry -> configurer.registerEventUpcaster(c -> getBean(upcasterEntry.getKey(), c)));
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
@@ -66,6 +66,7 @@ class UpcasterOrderingTest {
         InOrder upcasterOrder = inOrder(mockStream);
         upcasterOrder.verify(mockStream).sorted(); // Invoked in FirstUpcaster
         upcasterOrder.verify(mockStream).filter(any()); // Invoked in SecondUpcaster
+        upcasterOrder.verify(mockStream).distinct(); // Invoked in ThirdUpcaster
         upcasterOrder.verify(mockStream).map(any()); // Invoked in UnorderedUpcaster
     }
 
@@ -125,6 +126,24 @@ class UpcasterOrderingTest {
                 intermediateRepresentations.filter(ier -> true);
                 return intermediateRepresentations;
             }
+        }
+
+        @Bean
+        @Order(2)
+        public ThirdUpcaster someSecondUpcaster() {
+            return new ThirdUpcaster();
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static class ThirdUpcaster implements EventUpcaster {
+
+        @Override
+        public Stream<IntermediateEventRepresentation> upcast(
+                Stream<IntermediateEventRepresentation> intermediateRepresentations
+        ) {
+            intermediateRepresentations.distinct();
+            return intermediateRepresentations;
         }
     }
 }

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -324,9 +324,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         if (this.repository == null) {
             this.useStateStorage();
         }
-
         ensureRepositoryConfiguration();
-        clearGivenWhenState();
+
         DefaultUnitOfWork.startAndGet(null).execute(() -> {
             try {
                 repository.newInstance(aggregate::get);
@@ -336,6 +335,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                         e);
             }
         });
+
+        clearGivenWhenState();
         return this;
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,6 +236,8 @@ class FixtureTest_StateStorage {
         StateStoredAggregate(String id, String message) {
             this.id = id;
             this.message = message;
+            // this event, published during the givenState operation, should not be included in the expectEvents phase
+            apply(new StubDomainEvent());
         }
 
         @CommandHandler


### PR DESCRIPTION
Adding `jdk17-ea` to our build workflow to have early feedback about the compatibility between the framework and jdk17.

If the jdk17 build fails, it shouldn't at any moment block us from merging and going forward at this moment but it can be used as a point of investigation.

---

From logs:
>Java configuration:
  Distribution: zulu
  Version: 17.0.0+33

---

Updated from `17-ea` to `17` (ga)