### PR TITLE
Move init of default XStream Serializer to the init()-Method

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -358,7 +358,7 @@ public class JpaSagaStore implements SagaStore<Object> {
     public static class Builder {
 
         private EntityManagerProvider entityManagerProvider;
-        private Supplier<Serializer> serializer = XStreamSerializer::defaultSerializer;
+        private Supplier<Serializer> serializer;
 
         /**
          * Sets the {@link EntityManagerProvider} which provides the {@link EntityManager} used to access the
@@ -404,6 +404,10 @@ public class JpaSagaStore implements SagaStore<Object> {
         protected void validate() throws AxonConfigurationException {
             assertNonNull(entityManagerProvider,
                           "The EntityManagerProvider is a hard requirement and should be provided");
+
+            if (serializer == null) {
+                serializer = XStreamSerializer::defaultSerializer;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes  #1931
Supersedes #1932
XStream-Dependency was hard coded therefore it could not be excluded. Now it is initialized lazy if no serializer was provided.

Based on Axon 4.5.x