### PR TITLE
[#1963] Adjust secured type search approach in for the XStreamAutoConfiguration

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/XStreamAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/XStreamAutoConfiguration.java
@@ -52,7 +52,7 @@ public class XStreamAutoConfiguration {
     @Conditional(XStreamConfiguredCondition.class)
     public XStream defaultAxonXStream(ApplicationContext applicationContext) {
         XStream xStream = new XStream(new CompactDriver());
-        XStreamSecurityTypeUtility.allowTypesFromComponentScanAnnotatedBeans(applicationContext, xStream);
+        XStreamSecurityTypeUtility.allowEntityTypesFrom(applicationContext, xStream);
         return xStream;
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
@@ -16,26 +16,17 @@
 
 package org.axonframework.springboot.util;
 
-import com.thoughtworks.xstream.XStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.ApplicationContext;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Objects;
 
 /**
- * Utility class exposing an operation that searches the {@link ApplicationContext} for entity types and packages and
- * adds them to an {@link XStream} instance. It prefers {@link EntityScan} annotated beans. In absence of these it
- * defaults to the output from the {@link AutoConfigurationPackages#get(BeanFactory)} method.
- * <p>
- * The {@link EntityScan} annotation on these beans defines the base classes and base packages of types used within a
- * Spring application. These thus reflect a reasonable default of types that {@link XStream} should allow.
+ * Utility class exposing an operation that searches the {@link ApplicationContext} for auto-configuration base
+ * packages.
  *
  * @author Steven van Beelen
  * @since 4.5.4
@@ -47,80 +38,31 @@ public abstract class XStreamSecurityTypeUtility {
     private static final String PACKAGES_AND_SUBPACKAGES_WILDCARD = ".**";
 
     /**
-     * Searches the {@link ApplicationContext} for entity types or package names to allow for the given {@code xStream}
-     * instance. This method prefers {@link EntityScan} annotated beans. In absence of the {@code EntityScan} we use the
-     * output from {@link AutoConfigurationPackages#get(BeanFactory)}.
+     * Retrieves the auto-configuration base packages from {@link AutoConfigurationPackages#get(BeanFactory)}. These can
+     * be used to define the security context of an {@link com.thoughtworks.xstream.XStream} instance.
      * <p>
-     * Will add the {@link EntityScan#basePackageClasses()} and {@link EntityScan#basePackages()} ({@link
-     * EntityScan#value()} is used instead if not specified) to the given {@code xStream}, through {@link
-     * XStream#allowTypes(Class[])} and {@link XStream#allowTypesByWildcard(String[])} respectively. If both the base
-     * package classes and base packages of the {@code EntityScan} are not set, the package of the {@code EntityScan}
-     * annotated bean is included.
-     * <p>
-     * We use the {@code AutoConfigurationPackages#get(BeanFactory)} outcome as the default, since Spring Boot uses this
-     * too. This default will include the package names of {@link javax.persistence.Entity} and {@link
-     * org.springframework.boot.autoconfigure.EnableAutoConfiguration} annotated beans.
+     * This method will return the package names of {@link javax.persistence.Entity} and {@link
+     * org.springframework.boot.autoconfigure.EnableAutoConfiguration} annotated beans, attaching a wildcard ({@code
+     * ".**"}) to the package for XStream's convenience.
      *
-     * @param applicationContext the {@link ApplicationContext} to retrieve {@link EntityScan} beans from
-     * @param xStream            the {@link XStream} to set allow types and type wildcards for
+     * @param applicationContext the {@link ApplicationContext} to retrieve the auto-configuration base packages from
+     * @return the auto-configuration base packages with {@code ".**"} appended to them
      */
-    public static void allowEntityTypesFrom(ApplicationContext applicationContext, XStream xStream) {
-        Map<String, Object> entityScanAnnotatedBeans = applicationContext.getBeansWithAnnotation(EntityScan.class);
-        if (!entityScanAnnotatedBeans.isEmpty()) {
-            entityScanAnnotatedBeans.forEach(
-                    (beanName, bean) -> extractAllowedTypesFrom(beanName, bean, applicationContext, xStream)
-            );
-        } else {
-            extractAllowedTypesFromAutoConfigPackages(applicationContext, xStream);
-        }
-    }
-
-    private static void extractAllowedTypesFromAutoConfigPackages(ApplicationContext applicationContext,
-                                                                  XStream xStream) {
+    public static String[] autoConfigBasePackages(ApplicationContext applicationContext) {
         if (AutoConfigurationPackages.has(applicationContext)) {
-            allowPackages(xStream, AutoConfigurationPackages.get(applicationContext).toArray(new String[]{}));
+            return AutoConfigurationPackages.get(applicationContext)
+                                            .stream()
+                                            .map(basePackage -> {
+                                                logger.info("Constructing wildcard type for base package [{}].",
+                                                            basePackage);
+                                                return basePackage + PACKAGES_AND_SUBPACKAGES_WILDCARD;
+                                            })
+                                            .toArray(String[]::new);
         } else {
-            logger.warn("Cannot extract allowed types for XStream, because the provided ApplicationContext "
+            logger.warn("Cannot extract types, because the provided ApplicationContext "
                                 + "does not contain any @EnableAutoConfiguration annotated beans.");
+            return new String[]{};
         }
-    }
-
-    private static void setAllowedTypesFrom(String beanName,
-                                                Object bean,
-                                                ApplicationContext applicationContext,
-                                                XStream xStream) {
-        EntityScan ann = applicationContext.findAnnotationOnBean(beanName, EntityScan.class);
-        if (!Objects.nonNull(ann)) {
-            throw new IllegalArgumentException(
-                    "The ApplicationContext retrieved a bean of name [" + beanName + "] and type"
-                            + " [" + bean.getClass() + "] for the EntityScan annotation "
-                            + "which does not contain the EntityScan annotation."
-            );
-        }
-
-        if (isEmptyAnnotation(ann)) {
-            xStream.allowTypesByWildcard(new String[]{
-                    bean.getClass().getPackage().getName() + PACKAGES_AND_SUBPACKAGES_WILDCARD
-            });
-        } else {
-            xStream.allowTypes(ann.basePackageClasses());
-            if (ann.basePackages().length != 0) {
-                allowPackages(xStream, ann.basePackages());
-            } else {
-                allowPackages(xStream, ann.value());
-            }
-        }
-    }
-
-    private static boolean isEmptyAnnotation(EntityScan ann) {
-        return ann.basePackageClasses().length == 0 && ann.basePackages().length == 0 && ann.value().length == 0;
-    }
-
-    private static void allowPackages(XStream xStream, String[] basePackages) {
-        String[] typeWildcards = Arrays.stream(basePackages)
-                                       .map(basePackage -> basePackage + PACKAGES_AND_SUBPACKAGES_WILDCARD)
-                                       .toArray(String[]::new);
-        xStream.allowTypesByWildcard(typeWildcards);
     }
 
     private XStreamSecurityTypeUtility() {

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
@@ -85,7 +85,7 @@ public abstract class XStreamSecurityTypeUtility {
         }
     }
 
-    private static void extractAllowedTypesFrom(String beanName,
+    private static void setAllowedTypesFrom(String beanName,
                                                 Object bean,
                                                 ApplicationContext applicationContext,
                                                 XStream xStream) {

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
@@ -17,17 +17,24 @@
 package org.axonframework.springboot.util;
 
 import com.thoughtworks.xstream.XStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.ComponentScan;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * Utility class exposing an operation that searches the {@link ApplicationContext} for {@link ComponentScan} annotated
- * beans and adds the contained types and packages to an {@link XStream} instance.
+ * Utility class exposing an operation that searches the {@link ApplicationContext} for entity types and packages and
+ * adds them to an {@link XStream} instance. It prefers {@link EntityScan} annotated beans. In absence of these it
+ * defaults to the output from the {@link AutoConfigurationPackages#get(BeanFactory)} method.
  * <p>
- * The {@link ComponentScan} annotation on these beans defines the base classes and base packages of types used within a
+ * The {@link EntityScan} annotation on these beans defines the base classes and base packages of types used within a
  * Spring application. These thus reflect a reasonable default of types that {@link XStream} should allow.
  *
  * @author Steven van Beelen
@@ -35,51 +42,77 @@ import java.util.Objects;
  */
 public abstract class XStreamSecurityTypeUtility {
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static final String PACKAGES_AND_SUBPACKAGES_WILDCARD = ".**";
 
     /**
-     * Searches the {@link ApplicationContext} for {@link ComponentScan} annotated beans to allow the contained types
-     * for the given {@code xStream} instance.
+     * Searches the {@link ApplicationContext} for entity types or package names to allow for the given {@code xStream}
+     * instance. This method prefers {@link EntityScan} annotated beans. In absence of the {@code EntityScan} we use the
+     * output from {@link AutoConfigurationPackages#get(BeanFactory)}.
      * <p>
-     * Will add the {@link ComponentScan#basePackageClasses()} and {@link ComponentScan#basePackages()} ({@link
-     * ComponentScan#value() is used instead if not specified} to the given {@code xStream}, through {@link
+     * Will add the {@link EntityScan#basePackageClasses()} and {@link EntityScan#basePackages()} ({@link
+     * EntityScan#value() is used instead if not specified} to the given {@code xStream}, through {@link
      * XStream#allowTypes(Class[])} and {@link XStream#allowTypesByWildcard(String[])} respectively. If both the base
-     * package classes and base packages of the {@link ComponentScan} are not set, the package of the {@link
-     * ComponentScan} annotated bean is included.
+     * package classes and base packages of the {@code EntityScan} are not set, the package of the {@code EntityScan}
+     * annotated bean is included.
+     * <p>
+     * We use the {@code AutoConfigurationPackages#get(BeanFactory)} outcome as the default, since Spring Boot uses this
+     * too. This default will include the package names of {@link javax.persistence.Entity} and {@link
+     * org.springframework.boot.autoconfigure.EnableAutoConfiguration} annotated beans.
      *
-     * @param applicationContext the {@link ApplicationContext} to retrieve {@link ComponentScan} beans from
+     * @param applicationContext the {@link ApplicationContext} to retrieve {@link EntityScan} beans from
      * @param xStream            the {@link XStream} to set allow types and type wildcards for
      */
-    public static void allowTypesFromComponentScanAnnotatedBeans(ApplicationContext applicationContext,
-                                                                 XStream xStream) {
-        applicationContext.getBeansWithAnnotation(ComponentScan.class)
-                          .forEach((beanName, bean) -> {
-                              ComponentScan ann =
-                                      applicationContext.findAnnotationOnBean(beanName, ComponentScan.class);
-                              if (!Objects.nonNull(ann)) {
-                                  throw new IllegalArgumentException(
-                                          "The ApplicationContext retrieved a bean of name [" + beanName + "] and type"
-                                                  + " [" + bean.getClass() + "] for the ComponentScan annotation "
-                                                  + "which does not contain the ComponentScan annotation."
-                                  );
-                              }
-
-                              if (isEmptyAnnotation(ann)) {
-                                  xStream.allowTypesByWildcard(new String[]{
-                                          bean.getClass().getPackage().getName() + PACKAGES_AND_SUBPACKAGES_WILDCARD
-                                  });
-                              } else {
-                                  xStream.allowTypes(ann.basePackageClasses());
-                                  if (ann.basePackages().length != 0) {
-                                      allowPackages(xStream, ann.basePackages());
-                                  } else {
-                                      allowPackages(xStream, ann.value());
-                                  }
-                              }
-                          });
+    public static void allowEntityTypesFrom(ApplicationContext applicationContext, XStream xStream) {
+        Map<String, Object> entityScanAnnotatedBeans = applicationContext.getBeansWithAnnotation(EntityScan.class);
+        if (!entityScanAnnotatedBeans.isEmpty()) {
+            entityScanAnnotatedBeans.forEach(
+                    (beanName, bean) -> extractAllowedTypesFrom(beanName, bean, applicationContext, xStream)
+            );
+        } else {
+            extractAllowedTypesFromAutoConfigPackages(applicationContext, xStream);
+        }
     }
 
-    private static boolean isEmptyAnnotation(ComponentScan ann) {
+    private static void extractAllowedTypesFromAutoConfigPackages(ApplicationContext applicationContext,
+                                                                  XStream xStream) {
+        if (AutoConfigurationPackages.has(applicationContext)) {
+            allowPackages(xStream, AutoConfigurationPackages.get(applicationContext).toArray(new String[]{}));
+        } else {
+            logger.warn("Cannot extract allowed types for XStream, because the provided ApplicationContext "
+                                + "does not contain any @EnableAutoConfiguration annotated beans.");
+        }
+    }
+
+    private static void extractAllowedTypesFrom(String beanName,
+                                                Object bean,
+                                                ApplicationContext applicationContext,
+                                                XStream xStream) {
+        EntityScan ann = applicationContext.findAnnotationOnBean(beanName, EntityScan.class);
+        if (!Objects.nonNull(ann)) {
+            throw new IllegalArgumentException(
+                    "The ApplicationContext retrieved a bean of name [" + beanName + "] and type"
+                            + " [" + bean.getClass() + "] for the EntityScan annotation "
+                            + "which does not contain the EntityScan annotation."
+            );
+        }
+
+        if (isEmptyAnnotation(ann)) {
+            xStream.allowTypesByWildcard(new String[]{
+                    bean.getClass().getPackage().getName() + PACKAGES_AND_SUBPACKAGES_WILDCARD
+            });
+        } else {
+            xStream.allowTypes(ann.basePackageClasses());
+            if (ann.basePackages().length != 0) {
+                allowPackages(xStream, ann.basePackages());
+            } else {
+                allowPackages(xStream, ann.value());
+            }
+        }
+    }
+
+    private static boolean isEmptyAnnotation(EntityScan ann) {
         return ann.basePackageClasses().length == 0 && ann.basePackages().length == 0 && ann.value().length == 0;
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
@@ -52,7 +52,7 @@ public abstract class XStreamSecurityTypeUtility {
      * output from {@link AutoConfigurationPackages#get(BeanFactory)}.
      * <p>
      * Will add the {@link EntityScan#basePackageClasses()} and {@link EntityScan#basePackages()} ({@link
-     * EntityScan#value() is used instead if not specified} to the given {@code xStream}, through {@link
+     * EntityScan#value()} is used instead if not specified) to the given {@code xStream}, through {@link
      * XStream#allowTypes(Class[])} and {@link XStream#allowTypesByWildcard(String[])} respectively. If both the base
      * package classes and base packages of the {@code EntityScan} are not set, the package of the {@code EntityScan}
      * annotated bean is included.

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/XStreamSecurityTypeUtility.java
@@ -41,9 +41,9 @@ public abstract class XStreamSecurityTypeUtility {
      * Retrieves the auto-configuration base packages from {@link AutoConfigurationPackages#get(BeanFactory)}. These can
      * be used to define the security context of an {@link com.thoughtworks.xstream.XStream} instance.
      * <p>
-     * This method will return the package names of {@link javax.persistence.Entity} and {@link
-     * org.springframework.boot.autoconfigure.EnableAutoConfiguration} annotated beans, attaching a wildcard ({@code
-     * ".**"}) to the package for XStream's convenience.
+     * This method will return the package names of the {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration}
+     * annotated beans. After retrieval this method attaches a wildcard ({@code ".**"}) to the packages for XStream's
+     * convenience.
      *
      * @param applicationContext the {@link ApplicationContext} to retrieve the auto-configuration base packages from
      * @return the auto-configuration base packages with {@code ".**"} appended to them

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
@@ -17,13 +17,9 @@
 package org.axonframework.springboot.util;
 
 import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.EnableMBeanExport;
-import org.springframework.jmx.support.RegistrationPolicy;
-import org.springframework.test.context.ContextConfiguration;
 
 import static org.axonframework.springboot.util.XStreamSecurityTypeUtility.autoConfigBasePackages;
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,105 +32,25 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class XStreamSecurityTypeUtilityTest {
 
-    private ApplicationContextRunner testApplicationContext;
-
-    @BeforeEach
-    void setUp() {
-        testApplicationContext = new ApplicationContextRunner().withPropertyValues("axon.axonserver.enabled:false");
-    }
-
     @Test
     void testAutoConfigBasePackages() {
+        // Axon packages are added through the default ApplicationContextRunner that adds Axon's DefaultEntityRegistrar.
         String[] expected = new String[]{
                 "org.axonframework.springboot.util.**",
                 "org.axonframework.eventhandling.tokenstore.**",
                 "org.axonframework.modelling.saga.repository.jpa.**",
                 "org.axonframework.eventsourcing.eventstore.jpa.**"
         };
-        testApplicationContext.withUserConfiguration(TestContextWithSpringBootApplication.class)
-                              .run(context -> {
-                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
-                                  assertArrayEquals(expected, result);
-                              });
+        new ApplicationContextRunner().withPropertyValues("axon.axonserver.enabled:false")
+                                      .withConfiguration(AutoConfigurations.of(TestContext.class))
+                                      .run(context -> {
+                                          String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
+                                          assertArrayEquals(expected, result);
+                                      });
     }
 
-    @Test
-    void testAutoConfigBasePackagesWithCustomScanBasePackagesDoesNotChangeOutcome() {
-        String[] expected = new String[]{
-                "org.axonframework.springboot.util.**",
-                "org.axonframework.eventhandling.tokenstore.**",
-                "org.axonframework.modelling.saga.repository.jpa.**",
-                "org.axonframework.eventsourcing.eventstore.jpa.**"
-        };
-        testApplicationContext.withUserConfiguration(TestContextWithSpringBootApplicationWithCustomBasePackages.class)
-                              .run(context -> {
-                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
-                                  assertArrayEquals(expected, result);
-                              });
-    }
-
-    @Test
-    void testAutoConfigBasePackagesWithCustomScanBasePackageClassesDoesNotChangeOutcome() {
-        String[] expected = new String[]{
-                "org.axonframework.springboot.util.**",
-                "org.axonframework.eventhandling.tokenstore.**",
-                "org.axonframework.modelling.saga.repository.jpa.**",
-                "org.axonframework.eventsourcing.eventstore.jpa.**"
-        };
-        testApplicationContext.withUserConfiguration(
-                                      TestContextWithSpringBootApplicationWithCustomBasePackageClasses.class
-                              )
-                              .run(context -> {
-                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
-                                  assertArrayEquals(expected, result);
-                              });
-    }
-
-    @ContextConfiguration
     @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithSpringBootApplication {
+    static class TestContext {
 
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @SpringBootApplication
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithSpringBootApplicationWithCustomBasePackages {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @SpringBootApplication(scanBasePackages = "org.axonframework.springboot.util")
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithSpringBootApplicationWithCustomBasePackageClasses {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @SpringBootApplication(scanBasePackageClasses = XStreamSecurityTypeUtilityTest.class)
-        private static class MainClass {
-
-        }
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
@@ -16,19 +16,17 @@
 
 package org.axonframework.springboot.util;
 
-import com.thoughtworks.xstream.XStream;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.mockito.AdditionalMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.axonframework.springboot.util.XStreamSecurityTypeUtility.autoConfigBasePackages;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class validating the {@link XStreamSecurityTypeUtility} through the {@link ApplicationContextRunner}. This
@@ -39,93 +37,15 @@ import static org.mockito.Mockito.*;
 class XStreamSecurityTypeUtilityTest {
 
     private ApplicationContextRunner testApplicationContext;
-    private XStream testSubject;
 
     @BeforeEach
     void setUp() {
         testApplicationContext = new ApplicationContextRunner().withPropertyValues("axon.axonserver.enabled:false");
-        testSubject = spy(new XStream());
     }
 
     @Test
-    void testEmptyEntityScanAnnotatedBeanAllowsBeanPackageNameAsWildcard() {
-        String expectedPackageWildcard = "org.axonframework.springboot.util.**";
-        testApplicationContext.withUserConfiguration(TestContextWithEmptyEntityScan.class)
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypesByWildcard(aryEq(new String[]{expectedPackageWildcard}));
-                              });
-    }
-
-    @Test
-    void testBasePackageClassesEntityScanAnnotatedBeanAllowsTypes() {
-        Class<String> expectedType = String.class;
-        testApplicationContext.withUserConfiguration(TestContextWithBasePackageClassesEntityScan.class)
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypes(aryEq(new Class[]{expectedType}));
-                              });
-    }
-
-    @Test
-    void testBasePackagesEntityScanAnnotatedBeanAllowsTypeByWildcard() {
-        String expectedPackageWildcard = "foo.bar.**";
-        testApplicationContext.withUserConfiguration(TestContextWithBasePackagesEntityScan.class)
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypesByWildcard(aryEq(new String[]{expectedPackageWildcard}));
-                              });
-    }
-
-    @Test
-    void testBasePackagesAndClassesEntityScanAnnotatedBeanAllowsTypesAndAllowsTypesByWildcard() {
-        Class<Integer> expectedType = Integer.class;
-        String expectedPackageWildcard = "foo.bar.baz.**";
-        testApplicationContext.withUserConfiguration(
-                                      TestContextWithBasePackageClassesAndBasePackagesEntityScan.class
-                              )
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypes(aryEq(new Class[]{expectedType}));
-                                  verify(testSubject).allowTypesByWildcard(aryEq(new String[]{expectedPackageWildcard}));
-                              });
-    }
-
-    @Test
-    void testValuesEntityScanAnnotatedBeanAllowsTypeByWildcard() {
-        String expectedPackageWildcard = "bar.baz.**";
-        testApplicationContext.withUserConfiguration(TestContextWithValuesEntityScan.class)
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypesByWildcard(aryEq(new String[]{expectedPackageWildcard}));
-                              });
-    }
-
-    @Test
-    void testSpringBootApplicationAnnotatedBeanIsIgnoredInFavorOfEntityScanAnnotatedBean() {
-        String expectedPackageWildcard = "foo.bar.**";
-        testApplicationContext.withUserConfiguration(TestContextWithSpringBootApplicationAndEntityScan.class)
-                              .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypesByWildcard(aryEq(new String[]{expectedPackageWildcard}));
-                              });
-    }
-
-    @Test
-    void testSpringBootApplicationAnnotatedBeanAllowsBeanPackageNameAsWildcardAsDefault() {
-        String[] expectedPackageWildcards = new String[]{
+    void testAutoConfigBasePackages() {
+        String[] expected = new String[]{
                 "org.axonframework.springboot.util.**",
                 "org.axonframework.eventhandling.tokenstore.**",
                 "org.axonframework.modelling.saga.repository.jpa.**",
@@ -133,117 +53,9 @@ class XStreamSecurityTypeUtilityTest {
         };
         testApplicationContext.withUserConfiguration(TestContextWithSpringBootApplication.class)
                               .run(context -> {
-                                  XStreamSecurityTypeUtility.allowEntityTypesFrom(
-                                          context.getSourceApplicationContext(), testSubject
-                                  );
-                                  verify(testSubject).allowTypesByWildcard(aryEq(expectedPackageWildcards));
+                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
+                                  assertArrayEquals(expected, result);
                               });
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithEmptyEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @EntityScan
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithBasePackageClassesEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @EntityScan(basePackageClasses = String.class)
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithBasePackagesEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @EntityScan(basePackages = "foo.bar")
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithBasePackageClassesAndBasePackagesEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @EntityScan(basePackageClasses = Integer.class, basePackages = "foo.bar.baz")
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithValuesEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @EntityScan(value = "bar.baz")
-        private static class MainClass {
-
-        }
-    }
-
-    @ContextConfiguration
-    @EnableAutoConfiguration
-    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-    private static class TestContextWithSpringBootApplicationAndEntityScan {
-
-        @Bean
-        private MainClass mainClass() {
-            return new MainClass();
-        }
-
-        @Bean
-        private EntityConfiguration entityConfiguration() {
-            return new EntityConfiguration();
-        }
-
-        @SpringBootApplication
-        private static class MainClass {
-
-        }
-
-        @EntityScan(basePackages = "foo.bar")
-        private static class EntityConfiguration {
-
-        }
     }
 
     @ContextConfiguration
@@ -260,6 +72,5 @@ class XStreamSecurityTypeUtilityTest {
         private static class MainClass {
 
         }
-
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
@@ -58,6 +58,38 @@ class XStreamSecurityTypeUtilityTest {
                               });
     }
 
+    @Test
+    void testAutoConfigBasePackagesWithCustomScanBasePackagesDoesNotChangeOutcome() {
+        String[] expected = new String[]{
+                "org.axonframework.springboot.util.**",
+                "org.axonframework.eventhandling.tokenstore.**",
+                "org.axonframework.modelling.saga.repository.jpa.**",
+                "org.axonframework.eventsourcing.eventstore.jpa.**"
+        };
+        testApplicationContext.withUserConfiguration(TestContextWithSpringBootApplicationWithCustomBasePackages.class)
+                              .run(context -> {
+                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
+                                  assertArrayEquals(expected, result);
+                              });
+    }
+
+    @Test
+    void testAutoConfigBasePackagesWithCustomScanBasePackageClassesDoesNotChangeOutcome() {
+        String[] expected = new String[]{
+                "org.axonframework.springboot.util.**",
+                "org.axonframework.eventhandling.tokenstore.**",
+                "org.axonframework.modelling.saga.repository.jpa.**",
+                "org.axonframework.eventsourcing.eventstore.jpa.**"
+        };
+        testApplicationContext.withUserConfiguration(
+                                      TestContextWithSpringBootApplicationWithCustomBasePackageClasses.class
+                              )
+                              .run(context -> {
+                                  String[] result = autoConfigBasePackages(context.getSourceApplicationContext());
+                                  assertArrayEquals(expected, result);
+                              });
+    }
+
     @ContextConfiguration
     @EnableAutoConfiguration
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
@@ -69,6 +101,38 @@ class XStreamSecurityTypeUtilityTest {
         }
 
         @SpringBootApplication
+        private static class MainClass {
+
+        }
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class TestContextWithSpringBootApplicationWithCustomBasePackages {
+
+        @Bean
+        private MainClass mainClass() {
+            return new MainClass();
+        }
+
+        @SpringBootApplication(scanBasePackages = "org.axonframework.springboot.util")
+        private static class MainClass {
+
+        }
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class TestContextWithSpringBootApplicationWithCustomBasePackageClasses {
+
+        @Bean
+        private MainClass mainClass() {
+            return new MainClass();
+        }
+
+        @SpringBootApplication(scanBasePackageClasses = XStreamSecurityTypeUtilityTest.class)
         private static class MainClass {
 
         }


### PR DESCRIPTION
Sadly, using the `ComponentScan` annotation is not recommended by the Spring team, as can be found [here](https://stackoverflow.com/questions/50808941/how-to-get-basepackages-of-componentscan-programatically-at-runtime). 

Instead, the team recommends basing ourselves around the `EntityScan` annotation. 
Added, in the absence of the `EntityScan` annotation, we should use the outcome from the `AutoConfigurationPackages#get(BeanFactory)` method to set the packages.

The description above is exactly what this pull request adjusts in the framework. 
It adjusts the `XStreamSecurityTypeUtility` to prefer `EntityScan` annotated beans to set the secured types.
In the absence of this annotation, the outcome from `AutoConfigurationPackages#get(BeanFactory)` is used.

This pull request resolves #1963