### PR TITLE
Replaced `method.getParametersTypes().length` by `method.getParameterCount())`

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/annotation/AnnotationUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/annotation/AnnotationUtils.java
@@ -246,7 +246,7 @@ public abstract class AnnotationUtils {
                                                                  boolean overrideOnly) {
         Method[] methods = ann.annotationType().getDeclaredMethods();
         for (Method method : methods) {
-            if (method.getParameterTypes().length == 0 && method.getReturnType() != void.class) {
+            if (method.getParameterCount() == 0 && method.getReturnType() != void.class) {
                 try {
                     String key = resolveName(method);
                     Object value = method.invoke(ann);

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotatedParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotatedParameterResolverFactoryTest.java
@@ -66,9 +66,8 @@ class AnnotatedParameterResolverFactoryTest {
     }
 
     private static void testMethod(AbstractAnnotatedParameterResolverFactory<?, ?> factory, Method method, Class<?>[] expectedResolvers) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        for (int param = 0; param < parameterTypes.length; param++) {
-            ParameterResolver resolver = factory.createInstance(method, method.getParameters(), param);
+        for (int param = 0; param < method.getParameterCount(); param++) {
+            ParameterResolver<?> resolver = factory.createInstance(method, method.getParameters(), param);
             assertEquals(expectedResolvers[param], resolver != null ? resolver.getClass() : null, "Result incorrect for param: " + param);
         }
     }

--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -313,8 +313,9 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
                                     .filter(m -> invocation.getMethod().getName().equals(m.getName()))
                                     .filter(m -> m.getParameterCount() == invocation.getArguments().length)
                                     .anyMatch(m -> {
-                                        for (int i = 0; i < m.getParameterTypes().length; i++) {
-                                            if (!m.getParameterTypes()[i].isInstance(invocation.getArguments()[i])) {
+                                        Class<?>[] parameterTypes = m.getParameterTypes();
+                                        for (int i = 0; i < m.getParameterCount(); i++) {
+                                            if (!parameterTypes[i].isInstance(invocation.getArguments()[i])) {
                                                 return false;
                                             }
                                         }


### PR DESCRIPTION
This is a small improvement since `method.getParametersTypes()` will always clone the `parameterTypes` array making it a more costly operation while the other one won't.