### PR TITLE
[#1490] Simplify LockFactory configuration for Aggregates

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -23,6 +23,9 @@ import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.common.caching.Cache;
 import org.axonframework.common.caching.WeakReferenceCache;
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.lock.LockFactory;
+import org.axonframework.common.lock.NullLockFactory;
+import org.axonframework.common.lock.PessimisticLockFactory;
 import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventsourcing.AggregateFactory;
@@ -59,10 +62,10 @@ import static java.lang.String.format;
 import static org.axonframework.common.Assert.state;
 
 /**
- * Axon Configuration API extension that allows the definition of an Aggregate. This component will automatically setup
+ * Axon Configuration API extension that allows the definition of an Aggregate. This component will automatically set up
  * all components required for the Aggregate to operate.
  *
- * @param <A> The type of Aggregate configured
+ * @param <A> the type of Aggregate configured
  * @author Allard Buijze
  * @since 3.0
  */
@@ -74,6 +77,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     private final Component<Repository<A>> repository;
     private final Component<Cache> cache;
     private final Component<AggregateFactory<A>> aggregateFactory;
+    private final Component<LockFactory> lockFactory;
     private final Component<SnapshotTriggerDefinition> snapshotTriggerDefinition;
     private final Component<SnapshotFilter> snapshotFilter;
     private final Component<CommandTargetResolver> commandTargetResolver;
@@ -112,7 +116,8 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
      * @return An AggregateConfigurer instance for further configuration of the Aggregate
      */
     public static <A> AggregateConfigurer<A> jpaMappedConfiguration(Class<A> aggregateType) {
-        AggregateConfigurer<A> configurer = new AggregateConfigurer<>(aggregateType);
+        AggregateConfigurer<A> configurer = new AggregateConfigurer<>(aggregateType)
+                .configureLockFactory(config -> NullLockFactory.INSTANCE);
         return configurer.configureRepository(
                 c -> {
                     EntityManagerProvider entityManagerProvider = c.getComponent(
@@ -128,6 +133,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                             });
                     return GenericJpaRepository.builder(aggregateType)
                                                .aggregateModel(configurer.metaModel.get())
+                                               .lockFactory(configurer.lockFactory.get())
                                                .entityManagerProvider(entityManagerProvider)
                                                .eventBus(c.eventBus())
                                                .repositoryProvider(c::repository)
@@ -147,10 +153,12 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
      */
     public static <A> AggregateConfigurer<A> jpaMappedConfiguration(Class<A> aggregateType,
                                                                     EntityManagerProvider entityManagerProvider) {
-        AggregateConfigurer<A> configurer = new AggregateConfigurer<>(aggregateType);
+        AggregateConfigurer<A> configurer = new AggregateConfigurer<>(aggregateType)
+                .configureLockFactory(config -> NullLockFactory.INSTANCE);
         return configurer.configureRepository(
                 c -> GenericJpaRepository.builder(aggregateType)
                                          .aggregateModel(configurer.metaModel.get())
+                                         .lockFactory(configurer.lockFactory.get())
                                          .entityManagerProvider(entityManagerProvider)
                                          .eventBus(c.eventBus())
                                          .repositoryProvider(c::repository)
@@ -180,6 +188,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                         () -> AnnotationCommandTargetResolver.builder().build()
                 )
         );
+        lockFactory = new Component<>(() -> parent, name("lockFactory"), c -> PessimisticLockFactory.usingDefaults());
         snapshotTriggerDefinition = new Component<>(() -> parent, name("snapshotTriggerDefinition"),
                                                     c -> NoSnapshotTriggerDefinition.INSTANCE);
         snapshotFilter = new Component<>(() -> parent, name("snapshotFilter"), c -> {
@@ -227,11 +236,12 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                     EventSourcingRepository.Builder<A> builder =
                             EventSourcingRepository.builder(aggregate)
                                                    .aggregateModel(metaModel.get())
-                                                   .aggregateFactory(aggregateFactory.get())
+                                                   .lockFactory(lockFactory.get())
                                                    .eventStore(c.eventStore())
                                                    .snapshotTriggerDefinition(snapshotTriggerDefinition.get())
-                                                   .cache(cache.get())
-                                                   .repositoryProvider(c::repository);
+                                                   .aggregateFactory(aggregateFactory.get())
+                                                   .repositoryProvider(c::repository)
+                                                   .cache(cache.get());
                     if (eventStreamFilter.get() != null) {
                         builder = builder.eventStreamFilter(eventStreamFilter.get());
                     } else if (filterEventsByType.get()) {
@@ -281,7 +291,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     }
 
     /**
-     * Defines the factory to use to to create new Aggregates instances of the type under configuration.
+     * Defines the factory to use to create new Aggregates instances of the type under configuration.
      *
      * @param aggregateFactoryBuilder The builder function for the AggregateFactory
      * @return this configurer instance for chaining
@@ -289,6 +299,19 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     public AggregateConfigurer<A> configureAggregateFactory(
             Function<Configuration, AggregateFactory<A>> aggregateFactoryBuilder) {
         aggregateFactory.update(aggregateFactoryBuilder);
+        return this;
+    }
+
+    /**
+     * Defines the {@link LockFactory} to use in the {@link Repository} for the aggregate under configuration. Defaults
+     * to the {@link PessimisticLockFactory} for the {@link EventSourcingRepository} and {@link NullLockFactory} for a
+     * {@link GenericJpaRepository}.
+     *
+     * @param lockFactory a {@link Function} building the {@link LockFactory} to use based on the {@link Configuration}
+     * @return this configurer instance for chaining
+     */
+    public AggregateConfigurer<A> configureLockFactory(Function<Configuration, LockFactory> lockFactory) {
+        this.lockFactory.update(lockFactory);
         return this;
     }
 

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonAutoConfigurer.java
@@ -419,6 +419,13 @@ public class SpringAxonAutoConfigurer implements ImportBeanDefinitionRegistrar, 
                         aggregateConfigurer.configureCache(c -> beanFactory.getBean(cacheBeanName, Cache.class));
                     }
 
+                    String lockFactoryBeanName = aggregateAnnotation.lockFactory();
+                    if (nonEmptyBeanName(lockFactoryBeanName)) {
+                        aggregateConfigurer.configureLockFactory(
+                                c -> beanFactory.getBean(lockFactoryBeanName, LockFactory.class)
+                        );
+                    }
+
                     if (AnnotationUtils.isAnnotationPresent(aggregateType, "javax.persistence.Entity")) {
                         aggregateConfigurer.configureRepository(
                                 c -> GenericJpaRepository.builder(aggregateType)

--- a/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
+++ b/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,4 +90,16 @@ public @interface Aggregate {
      * created, unless explicitly configured on the referenced repository.
      */
     String cache() default "";
+
+    /**
+     * Sets the name of the bean providing the {@link org.axonframework.common.lock.LockFactory}. If none is provided,
+     * the {@link org.axonframework.modelling.command.Repository} implementation's default is used, unless explicitly
+     * configured on the referenced repository.
+     * <p>
+     * Note that the use of {@link #repository()}, or adding a {@link org.axonframework.modelling.command.Repository}
+     * bean to the Spring context with the default naming scheme overrides this setting, as a Repository explicitly defines
+     * the snapshot trigger definition. The default name corresponds to {@code "[aggregate-name]Repository"}, thus a
+     * {@code Trade} Aggregate would by default create/look for a bean named {@code "tradeRepository"}.
+     */
+    String lockFactory() default "";
 }


### PR DESCRIPTION
This change introduces two features.

Firstly, it allows configuration of the `LockFactory` through the `AggregateConfigurer`.
Doing so enables users to utilize the `configureLockFactory` method to define the `LockFactory` used by the aggregate `Repository`, instead of having to configure a complete `Repository` from scratch.

Secondly, it enables defining a `LockFactory` bean name on the `@Aggregate` annotation.
Axon's auto-configuration checks the Application Context for a bean with the defined name of type `LockFactory`, and in turn uses the `configureLockFactory` to configure it for a given Aggregate.

This pull request resolves #1490.