### PR TITLE
[#1645] Introduce ObjectNode-to/from-JsonNode `ContentTypeConverter` for the `JacksonSerializer`

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2021. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.MetaData;
@@ -120,14 +119,16 @@ public class JacksonSerializer implements Serializer {
     }
 
     /**
-     * Registers converters with the given {@code converter} which depend on the actual contents of the
-     * serialized for to represent a JSON format.
+     * Registers converters with the given {@code converter} which depend on the actual contents of the serialized for
+     * to represent a JSON format.
      *
      * @param converter The ChainingConverter instance to register the converters with.
      */
     protected void registerConverters(ChainingConverter converter) {
         converter.registerConverter(new JsonNodeToByteArrayConverter(objectMapper));
         converter.registerConverter(new ByteArrayToJsonNodeConverter(objectMapper));
+        converter.registerConverter(new JsonNodeToObjectNodeConverter());
+        converter.registerConverter(new ObjectNodeToJsonNodeConverter());
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -119,7 +119,7 @@ public class JacksonSerializer implements Serializer {
     }
 
     /**
-     * Registers converters with the given {@code converter} which depend on the actual contents of the serialized for
+     * Registers converters with the given {@code converter} which depend on the actual contents of the serialized form
      * to represent a JSON format.
      *
      * @param converter The ChainingConverter instance to register the converters with.

--- a/messaging/src/main/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.SerializationException;
+
+/**
+ * A {@link ContentTypeConverter} implementation that converts a {@link JsonNode} object into an {@link ObjectNode}.
+ * Intended to simplify JSON-typed event upcasters, which generally deal with an {@code ObjectNode} as the event.
+ * <p>
+ * Will succeed if the {@code JsonNode} has a node type of {@link JsonNodeType#OBJECT}.
+ *
+ * @author Steven van Beelen
+ * @since 4.6.0
+ */
+public class JsonNodeToObjectNodeConverter implements ContentTypeConverter<JsonNode, ObjectNode> {
+
+    @Override
+    public Class<JsonNode> expectedSourceType() {
+        return JsonNode.class;
+    }
+
+    @Override
+    public Class<ObjectNode> targetType() {
+        return ObjectNode.class;
+    }
+
+    @Override
+    public ObjectNode convert(JsonNode original) {
+        JsonNodeType originalNodeType = original.getNodeType();
+        if (originalNodeType.equals(JsonNodeType.OBJECT)) {
+            return ((ObjectNode) original);
+        } else {
+            throw new SerializationException(
+                    "Cannot convert from JsonNode to ObjectNode because the node type is [" + originalNodeType + "]"
+            );
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverter.java
@@ -46,7 +46,7 @@ public class JsonNodeToObjectNodeConverter implements ContentTypeConverter<JsonN
     @Override
     public ObjectNode convert(JsonNode original) {
         JsonNodeType originalNodeType = original.getNodeType();
-        if (originalNodeType.equals(JsonNodeType.OBJECT)) {
+        if (JsonNodeType.OBJECT.equals(originalNodeType)) {
             return ((ObjectNode) original);
         } else {
             throw new SerializationException(

--- a/messaging/src/main/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.axonframework.serialization.ContentTypeConverter;
+
+/**
+ * A {@link ContentTypeConverter} implementation that converts an {@link ObjectNode} object into a {@link JsonNode}.
+ * Intended to simplify JSON-typed event upcasters, which generally deal with an {@code ObjectNode} as the event.
+ * <p>
+ * Will succeed converting at all times as an {@code ObjectNode} is a {@code JsonNode} by definition.
+ *
+ * @author Steven van Beelen
+ * @since 4.6.0
+ */
+public class ObjectNodeToJsonNodeConverter implements ContentTypeConverter<ObjectNode, JsonNode> {
+
+    @Override
+    public Class<ObjectNode> expectedSourceType() {
+        return ObjectNode.class;
+    }
+
+    @Override
+    public Class<JsonNode> targetType() {
+        return JsonNode.class;
+    }
+
+    @Override
+    public JsonNode convert(ObjectNode original) {
+        return original;
+    }
+}

--- a/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.axonframework.serialization.SerializationException;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link JsonNodeToObjectNodeConverter}.
+ *
+ * @author Steven van Beelen
+ */
+class JsonNodeToObjectNodeConverterTest {
+
+    private final JsonNodeToObjectNodeConverter testSubject = new JsonNodeToObjectNodeConverter();
+
+    @Test
+    void testExpectedSourceType() {
+        assertEquals(JsonNode.class, testSubject.expectedSourceType());
+    }
+
+    @Test
+    void testTargetType() {
+        assertEquals(ObjectNode.class, testSubject.targetType());
+    }
+
+    @Test
+    void testConvert() {
+        JsonNode expectedJsonNode = new ObjectNode(JsonNodeFactory.instance);
+
+        ObjectNode result = testSubject.convert(expectedJsonNode);
+
+        assertEquals(expectedJsonNode, result);
+    }
+
+    @Test
+    void testConvertThrowsException() {
+        JsonNode testJsonNode = new TextNode("some-text");
+
+        assertThrows(SerializationException.class, () -> testSubject.convert(testJsonNode));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link ObjectNodeToJsonNodeConverter}.
+ *
+ * @author Steven van Beelen
+ */
+class ObjectNodeToJsonNodeConverterTest {
+
+    private final ObjectNodeToJsonNodeConverter testSubject = new ObjectNodeToJsonNodeConverter();
+
+    @Test
+    void testExpectedSourceType() {
+        assertEquals(ObjectNode.class, testSubject.expectedSourceType());
+    }
+
+    @Test
+    void testTargetType() {
+        assertEquals(JsonNode.class, testSubject.targetType());
+    }
+
+    @Test
+    void testConvert() {
+        ObjectNode expectedJsonNode = new ObjectNode(JsonNodeFactory.instance);
+
+        JsonNode result = testSubject.convert(expectedJsonNode);
+
+        assertEquals(expectedJsonNode, result);
+    }
+}


### PR DESCRIPTION
This pull request introduces two new `ContentTypeConverter` instances:

1. the `ObjectNodeToJsonNodeConverter`, and
2. the `JsonNodeToObjectNodeConverter`.

Both are registered with the `JacksonSerializer`.
This allows the `JacksonSerializer` to deserialize/serialize directly to the `ObjectNode` type.

This is beneficial for writing `EventUpcasters`, as 9 out of 10 the serialized JSON event format *is* an `ObjectNode`.
Furthermore, adjusting the contents of a serialized JSON event requires working with an `ObjectNode`.
With these converters in place, users do not have to cast the `JsonNode` to  `ObjectNode` before making any changes to the event format.

This PR resolves #1645 