### PR TITLE
Align junit jupiter versions between 

### DIFF
--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2020. Axon Framework
+  ~ Copyright (c) 2010-2021. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -81,6 +81,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Explicitly set the junit-jupiter-api version to override any alternative version pulled in by the testcontainers junit 5 extension -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2020. Axon Framework
+  ~ Copyright (c) 2010-2021. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -109,6 +109,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- Explicitly set the junit-jupiter-api version to override any alternative version pulled in by the testcontainers junit 5 extension -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
This PR explicitly sets the `junit-jupiter-api` version to override any alternative version pulled in by the testcontainers junit 5 extension wherever the latter is used. This should avoid version mismatches in the future if JUnit is updated without updating the testcontainers JUnit extension.