### PR TITLE
Reduce token update frequency

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -219,10 +219,12 @@ class WorkPackage {
             batchProcessor.processBatch(eventBatch, unitOfWork, Collections.singleton(segment));
         } else {
             segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
-            if (lastStoredToken != lastConsumedToken) {
-                transactionManager.executeInTransaction(() -> storeToken(lastConsumedToken));
-            } else if (lastClaimExtension < clock.instant().toEpochMilli() - claimExtensionThreshold) {
-                transactionManager.executeInTransaction(this::extendClaim);
+            if (lastClaimExtension < clock.instant().toEpochMilli() - claimExtensionThreshold) {
+                if (lastStoredToken != lastConsumedToken) {
+                    transactionManager.executeInTransaction(() -> storeToken(lastConsumedToken));
+                } else {
+                    transactionManager.executeInTransaction(this::extendClaim);
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request changes how a token is updated in absence of events to be handled by that segment.

Normally, both the Tracking and Pooled Streaming processor would eagerly update the `TrackingToken` in all scenarios.
Thus, event-full batches (read: events that the segment is in charge of) would update the token, but also event-less batches (read: when the segment is in charge of no events), would incur an immediate token update.

This pull request changes that behavior for both Streaming Processor implementations.
For the Pooled Streaming Processor, the `WorkPackage` now uses the `extensionClaimThreshold` to wait before doing _any_ token update in absence of events it should handle.

The Tracking Processor now also introduces such a deadline.
It uses the "batch processing start time" and adds the `eventAvailabilityTimeout`.
This value is validated, combined with the `hasNextAvailable` check, in a while-loop every time events are added to the batch.