### PR TITLE
Skip FactoryBean instances in bean post processors

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
+++ b/spring/src/main/java/org/axonframework/spring/config/AbstractAnnotationHandlerBeanPostProcessor.java
@@ -31,6 +31,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.util.ClassUtils;
 
@@ -70,7 +71,8 @@ public abstract class AbstractAnnotationHandlerBeanPostProcessor<I, T extends I>
      */
     @Override
     public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
-        if (beanName != null && !isNullBean(bean) && beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName)) {
+        if (bean instanceof FactoryBean
+                || (beanName != null && !isNullBean(bean) && beanFactory.containsBean(beanName) && !beanFactory.isSingleton(beanName))) {
             return bean;
         }
 

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.FactoryBean;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,8 +32,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AnnotationQueryHandlerBeanPostProcessorTest {
 
@@ -79,6 +85,21 @@ class AnnotationQueryHandlerBeanPostProcessorTest {
 
         assertEquals(0, queryHandler.handle(myCommand));
         assertEquals(1, annotatedQueryHandler.getInvocationCount());
+    }
+
+    @Test
+    void testProcessorIgnoresFactoryBeans() {
+        BeanFactory mockBeanFactory = mock(BeanFactory.class);
+        when(mockBeanFactory.containsBean("beanName")).thenReturn(true);
+        FactoryBean mockFactoryBean = mock(FactoryBean.class);
+        testSubject.setBeanFactory(mockBeanFactory);
+        Object result1 = testSubject.postProcessBeforeInitialization(mockFactoryBean, "beanName");
+        Object postProcessedBean = testSubject.postProcessAfterInitialization(mockFactoryBean, "beanName");
+
+        assertSame(mockFactoryBean, result1);
+        assertSame(mockFactoryBean, postProcessedBean);
+        // this call leads to problems in Spring Boot 2.6 when post-processing factory beans, so it needs to be avoided
+        verify(mockBeanFactory, never()).isSingleton(anyString());
     }
 
     public static class AnnotatedQueryHandler {


### PR DESCRIPTION
In Spring 2.6, the default behavior is to disallow getting beans from the application context that are in creation. Since this is what happens when checking whether a factory bean is a singleton through the bean factory.