### PR TITLE
Close subscription queries on serialization issues

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -365,6 +365,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                     updateEmitter.registerUpdateHandler(subscriptionSerializer.deserialize(query), 1024);
 
             updateHandler.getUpdates()
+                         .map(subscriptionSerializer::serialize)
                          .doOnError(e -> {
                              ErrorMessage error = ExceptionSerializer.serialize(configuration.getClientId(), e);
                              String errorCode = ErrorCode.QUERY_EXECUTION_ERROR.errorCode();
@@ -376,7 +377,6 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                              sendUpdate.complete();
                          })
                          .doOnComplete(sendUpdate::complete)
-                         .map(subscriptionSerializer::serialize)
                          .subscribe(sendUpdate::sendUpdate);
 
             return () -> {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -25,6 +25,7 @@ import io.axoniq.axonserver.connector.query.QueryHandler;
 import io.axoniq.axonserver.grpc.ErrorMessage;
 import io.axoniq.axonserver.grpc.SerializedObject;
 import io.axoniq.axonserver.grpc.query.QueryResponse;
+import io.axoniq.axonserver.grpc.query.QueryUpdate;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ErrorCode;
@@ -34,6 +35,7 @@ import org.axonframework.axonserver.connector.util.ProcessingInstructionHelper;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
 import org.axonframework.common.Registration;
 import org.axonframework.lifecycle.ShutdownInProgressException;
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.responsetypes.InstanceResponseType;
 import org.axonframework.queryhandling.GenericQueryMessage;
@@ -44,9 +46,14 @@ import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.queryhandling.SimpleQueryUpdateEmitter;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
+import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.serialization.Serializer;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -324,6 +331,40 @@ class AxonServerQueryBusTest {
     }
 
     @Test
+    void testSubscriptionQueryCompletesWithExceptionOnUpdateDeserializationError() {
+        when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt()))
+                .thenReturn(new SimpleSubscriptionQueryResult("<string>Hello world</string>", stubUpdate("Not a valid XML object")));
+        SubscriptionQueryResult<QueryResponseMessage<String>, SubscriptionQueryUpdateMessage<String>> queryResult = testSubject.subscriptionQuery(new GenericSubscriptionQueryMessage<>("Say hi", "test", instanceOf(String.class), instanceOf(String.class)));
+        Mono<QueryResponseMessage<String>> initialResult = queryResult.initialResult();
+        Flux<SubscriptionQueryUpdateMessage<String>> updates = queryResult.updates();
+        queryResult.close();
+
+        StepVerifier.create(initialResult)
+                    .expectNextMatches(r -> r.getPayload().equals("Hello world"))
+                    .verifyComplete();
+
+        StepVerifier.create(updates.map(Message::getPayload))
+                    .verifyError();
+    }
+
+    @Test
+    void testSubscriptionQueryCompletesWithExceptionOnInitialResultDeserializationError() {
+        when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt()))
+                .thenReturn(new SimpleSubscriptionQueryResult("Not a valid XML object", stubUpdate("<string>Hello world</string>")));
+        SubscriptionQueryResult<QueryResponseMessage<String>, SubscriptionQueryUpdateMessage<String>> queryResult = testSubject.subscriptionQuery(new GenericSubscriptionQueryMessage<>("Say hi", "test", instanceOf(String.class), instanceOf(String.class)));
+        Mono<QueryResponseMessage<String>> initialResult = queryResult.initialResult();
+        Flux<SubscriptionQueryUpdateMessage<String>> updates = queryResult.updates();
+        queryResult.close();
+
+        StepVerifier.create(initialResult.map(Message::getPayload))
+                    .verifyError();
+
+        StepVerifier.create(updates.map(Message::getPayload))
+                    .expectNextMatches(r -> r.equals("Hello world"))
+                    .verifyComplete();
+    }
+
+    @Test
     void testAfterShutdownDispatchingAnShutdownInProgressExceptionOnSubscriptionQueryInvocation() {
         SubscriptionQueryMessage<String, String, String> testSubscriptionQuery =
                 new GenericSubscriptionQueryMessage<>("some-query", instanceOf(String.class), instanceOf(String.class));
@@ -344,6 +385,15 @@ class AxonServerQueryBusTest {
                             .build();
     }
 
+    private QueryUpdate stubUpdate(String payload) {
+        return QueryUpdate.newBuilder()
+                          .setMessageIdentifier(UUID.randomUUID().toString())
+                          .setPayload(SerializedObject.newBuilder()
+                                                      .setData(ByteString.copyFromUtf8(payload))
+                                                      .setType(String.class.getName()))
+                          .build();
+    }
+
     private QueryResponse stubErrorResponse(String errorCode, @SuppressWarnings("SameParameterValue") String message) {
         return QueryResponse.newBuilder()
                             .setRequestIdentifier("request")
@@ -356,12 +406,12 @@ class AxonServerQueryBusTest {
                             .build();
     }
 
-    private static class StubResultStream implements ResultStream<QueryResponse> {
+    private static class StubResultStream<T> implements ResultStream<T> {
 
-        private final Iterator<QueryResponse> responses;
-        private QueryResponse peeked;
-        private boolean closed;
+        private final Iterator<T> responses;
         private final Throwable error;
+        private T peeked;
+        private boolean closed;
 
         public StubResultStream(Throwable error) {
             this.error = error;
@@ -369,13 +419,13 @@ class AxonServerQueryBusTest {
             this.responses = Collections.emptyIterator();
         }
 
-        public StubResultStream(QueryResponse... responses) {
+        public StubResultStream(T... responses) {
             this.error = null;
             this.responses = Arrays.asList(responses).iterator();
         }
 
         @Override
-        public QueryResponse peek() {
+        public T peek() {
             if (peeked == null && responses.hasNext()) {
                 peeked = responses.next();
             }
@@ -383,9 +433,9 @@ class AxonServerQueryBusTest {
         }
 
         @Override
-        public QueryResponse nextIfAvailable() {
+        public T nextIfAvailable() {
             if (peeked != null) {
-                QueryResponse result = peeked;
+                T result = peeked;
                 peeked = null;
                 return result;
             }
@@ -393,12 +443,12 @@ class AxonServerQueryBusTest {
         }
 
         @Override
-        public QueryResponse nextIfAvailable(long timeout, TimeUnit unit) {
+        public T nextIfAvailable(long timeout, TimeUnit unit) {
             return nextIfAvailable();
         }
 
         @Override
-        public QueryResponse next() {
+        public T next() {
             return nextIfAvailable();
         }
 
@@ -422,6 +472,26 @@ class AxonServerQueryBusTest {
         @Override
         public Optional<Throwable> getError() {
             return Optional.ofNullable(error);
+        }
+    }
+
+    private class SimpleSubscriptionQueryResult implements io.axoniq.axonserver.connector.query.SubscriptionQueryResult {
+        private final StubResultStream<QueryUpdate> updateStubResultStream;
+        private final String payload;
+
+        public SimpleSubscriptionQueryResult(String payload, QueryUpdate... updates) {
+            this.updateStubResultStream = new StubResultStream<>(updates);
+            this.payload = payload;
+        }
+
+        @Override
+        public CompletableFuture<QueryResponse> initialResult() {
+            return CompletableFuture.completedFuture(stubResponse(payload));
+        }
+
+        @Override
+        public ResultStream<QueryUpdate> updates() {
+            return updateStubResultStream;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where subscription queries wouldn't close properly when an update to such query failed to serialize.