### PR TITLE
Fix default implementation of deprecated method

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
@@ -150,7 +150,7 @@ public interface QueryBus extends MessageHandlerInterceptorSupport<QueryMessage<
     default <Q, I, U> SubscriptionQueryResult<QueryResponseMessage<I>, SubscriptionQueryUpdateMessage<U>> subscriptionQuery(
             SubscriptionQueryMessage<Q, I, U> query, SubscriptionQueryBackpressure backpressure, int updateBufferSize
     ) {
-        return subscriptionQuery(query, backpressure, updateBufferSize);
+        return subscriptionQuery(query, updateBufferSize);
     }
 
     /**


### PR DESCRIPTION
The default implementation invoked the same default method on the interface, instead of defaulting to the method recommended in the javadoc.