### PR TITLE
Added AxonServerEEContainer and AxonServerSEContainer as an easier way for people to write tests

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -80,6 +80,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>optional</scope>
         </dependency>
     </dependencies>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -76,6 +76,11 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -80,7 +80,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>optional</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
@@ -1,0 +1,180 @@
+package org.axonframework.test.server;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.Optional;
+
+/**
+ * Constructs a single node AxonServer Enterprise Edition (EE) for testing.
+ *
+ * @author Lucas Campos
+ * @since 4.6
+ */
+public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> extends GenericContainer<SELF> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver-enterprise");
+    private static final int AXON_SERVER_HTTP_PORT = 8024;
+    private static final int AXON_SERVER_GRPC_PORT = 8124;
+
+    private static final String WAIT_FOR_LOG_MESSAGE = ".*Started AxonServer.*";
+
+    private static final String LICENCE_DEFAULT_LOCATION = "/axonserver/config/axoniq.license";
+    private static final String CONFIGURATION_DEFAULT_LOCATION = "/axonserver/config/axonserver.properties";
+    private static final String CLUSTER_TEMPLATE_DEFAULT_LOCATION = "/axonserver/cluster-template.yml";
+
+    private static final String AXONIQ_LICENSE = "AXONIQ_LICENSE";
+    private static final String AXONIQ_AXONSERVER_NAME = "AXONIQ_AXONSERVER_NAME";
+    private static final String AXONIQ_AXONSERVER_INTERNAL_HOSTNAME = "AXONIQ_AXONSERVER_INTERNAL_HOSTNAME";
+    private static final String AXONIQ_AXONSERVER_HOSTNAME = "AXONIQ_AXONSERVER_HOSTNAME";
+
+    private static final String AXON_SERVER_ADDRESS_TEMPLATE = "%s:%s";
+
+    private String licensePath;
+    private String configurationPath;
+    private String clusterTemplatePath;
+    private String axonServerName;
+    private String axonServerInternalHostname;
+    private String axonServerHostname;
+
+    /**
+     * Initialize AxonServer EE with a given docker image.
+     *
+     * @param dockerImageName name of the docker image
+     */
+    public AxonServerEEContainer(final String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    /**
+     * Initialize AxonServer EE with a given docker image.
+     *
+     * @param dockerImageName name of the docker image
+     */
+    public AxonServerEEContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        withExposedPorts(AXON_SERVER_HTTP_PORT, AXON_SERVER_GRPC_PORT);
+        waitingFor(Wait.forLogMessage(WAIT_FOR_LOG_MESSAGE, 1));
+        withEnv(AXONIQ_LICENSE, LICENCE_DEFAULT_LOCATION);
+    }
+
+    @Override
+    protected void configure() {
+        optionallyCopyResourceToContainer(LICENCE_DEFAULT_LOCATION, licensePath);
+        optionallyCopyResourceToContainer(CONFIGURATION_DEFAULT_LOCATION, configurationPath);
+        optionallyCopyResourceToContainer(CLUSTER_TEMPLATE_DEFAULT_LOCATION, clusterTemplatePath);
+        withOptionalEnv(AXONIQ_AXONSERVER_NAME, axonServerName);
+        withOptionalEnv(AXONIQ_AXONSERVER_HOSTNAME, axonServerHostname);
+        withOptionalEnv(AXONIQ_AXONSERVER_INTERNAL_HOSTNAME, axonServerInternalHostname);
+    }
+
+    /**
+     * Map (effectively replace) directory in Docker with the content of resourceLocation if resource location is not
+     * null
+     * <p>
+     * Protected to allow for changing implementation by extending the class
+     *
+     * @param pathNameInContainer path in docker
+     * @param resourceLocation    relative classpath to resource
+     */
+    protected void optionallyCopyResourceToContainer(String pathNameInContainer, String resourceLocation) {
+        Optional.ofNullable(resourceLocation)
+                .map(MountableFile::forClasspathResource)
+                .ifPresent(mountableFile -> withCopyFileToContainer(mountableFile, pathNameInContainer));
+    }
+
+    /**
+     * Set an environment value if the value is present.
+     * <p>
+     * Protected to allow for changing implementation by extending the class
+     *
+     * @param key   environment key value, usually a constant
+     * @param value environment value to be set
+     */
+    protected void withOptionalEnv(String key, String value) {
+        Optional.ofNullable(value)
+                .ifPresent(v -> withEnv(key, value));
+    }
+
+    /**
+     * Initialize AxonServer EE with a given license.
+     */
+    public SELF withLicense(String licensePath) {
+        this.licensePath = licensePath;
+        return self();
+    }
+
+    /**
+     * Initialize AxonServer EE with a given configuration file.
+     */
+    public SELF withConfiguration(String configurationPath) {
+        this.configurationPath = configurationPath;
+        return self();
+    }
+
+    /**
+     * Initialize AxonServer EE with a given cluster template configuration file.
+     */
+    public SELF withClusterTemplate(String clusterTemplatePath) {
+        this.clusterTemplatePath = clusterTemplatePath;
+        return self();
+    }
+
+    /**
+     * Initialize AxonServer EE with a given Axon Server Name.
+     */
+    public SELF withAxonServerName(String axonServerName) {
+        this.axonServerName = axonServerName;
+        return self();
+    }
+
+    /**
+     * Initialize AxonServer EE with a given Axon Server Internal Hostname.
+     */
+    public SELF withAxonServerInternalHostname(String axonServerInternalHostname) {
+        this.axonServerInternalHostname = axonServerInternalHostname;
+        return self();
+    }
+
+    /**
+     * Initialize AxonServer EE with a given Axon Server Hostname.
+     */
+    public SELF withAxonServerHostname(String axonServerHostname) {
+        this.axonServerHostname = axonServerHostname;
+        return self();
+    }
+
+    /**
+     * Returns the mapped GRPC port used by this Axon Server container.
+     *
+     * @return mapped GRPC port.
+     */
+    public Integer getGrpcPort() {
+        return this.getMappedPort(AXON_SERVER_GRPC_PORT);
+    }
+
+    /**
+     * Returns the IP Address of the Axon Server container.
+     *
+     * @return IP Address of the container.
+     */
+    public String getIPAddress() {
+        return this.getContainerIpAddress();
+    }
+
+    /**
+     * Returns the Axon Server's address container in a host:port format.
+     *
+     * @return address in host:port format.
+     */
+    public String getAxonServerAddress() {
+        return String.format(AXON_SERVER_ADDRESS_TEMPLATE,
+                             this.getContainerIpAddress(),
+                             this.getMappedPort(AXON_SERVER_GRPC_PORT));
+    }
+}

--- a/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.test.server;
 
 import org.testcontainers.containers.GenericContainer;
@@ -103,6 +119,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given license.
+     *
+     * @param licensePath path to the license file.
+     * @return Container itself for fluent API.
      */
     public SELF withLicense(String licensePath) {
         this.licensePath = licensePath;
@@ -111,6 +130,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given configuration file.
+     *
+     * @param configurationPath path to the configuration file.
+     * @return Container itself for fluent API.
      */
     public SELF withConfiguration(String configurationPath) {
         this.configurationPath = configurationPath;
@@ -119,6 +141,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given cluster template configuration file.
+     *
+     * @param clusterTemplatePath path to the cluster template file.
+     * @return Container itself for fluent API.
      */
     public SELF withClusterTemplate(String clusterTemplatePath) {
         this.clusterTemplatePath = clusterTemplatePath;
@@ -127,6 +152,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given Axon Server Name.
+     *
+     * @param axonServerName name of the Axon Server.
+     * @return Container itself for fluent API.
      */
     public SELF withAxonServerName(String axonServerName) {
         this.axonServerName = axonServerName;
@@ -135,6 +163,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given Axon Server Internal Hostname.
+     *
+     * @param axonServerInternalHostname internal hostname of the Axon Server.
+     * @return Container itself for fluent API.
      */
     public SELF withAxonServerInternalHostname(String axonServerInternalHostname) {
         this.axonServerInternalHostname = axonServerInternalHostname;
@@ -143,6 +174,9 @@ public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> ext
 
     /**
      * Initialize AxonServer EE with a given Axon Server Hostname.
+     *
+     * @param axonServerHostname hostname of the Axon Server.
+     * @return Container itself for fluent API.
      */
     public SELF withAxonServerHostname(String axonServerHostname) {
         this.axonServerHostname = axonServerHostname;

--- a/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.test.server;
 
 import org.testcontainers.containers.GenericContainer;
@@ -53,7 +69,10 @@ public class AxonServerSEContainer<SELF extends AxonServerSEContainer<SELF>> ext
     }
 
     /**
-     * Initialize AxonServer EE with a given license.
+     * Initialize AxonServer SE on dev mode.
+     *
+     * @param devMode dev mode. Default value is {@code false}.
+     * @return Container itself for fluent API.
      */
     public SELF withDevMode(boolean devMode) {
         this.devMode = devMode;

--- a/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
@@ -69,7 +69,7 @@ public class AxonServerSEContainer<SELF extends AxonServerSEContainer<SELF>> ext
     }
 
     /**
-     * Initialize AxonServer SE on dev mode.
+     * Initialize AxonServer SE on dev mode. Development mode enables some features for development convenience.
      *
      * @param devMode dev mode. Default value is {@code false}.
      * @return Container itself for fluent API.

--- a/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
@@ -1,0 +1,91 @@
+package org.axonframework.test.server;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Constructs a single node AxonServer Standard Edition (SE) for testing.
+ *
+ * @author Lucas Campos
+ * @since 4.6
+ */
+public class AxonServerSEContainer<SELF extends AxonServerSEContainer<SELF>> extends GenericContainer<SELF> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");
+    private static final int AXON_SERVER_HTTP_PORT = 8024;
+    private static final int AXON_SERVER_GRPC_PORT = 8124;
+
+    private static final String WAIT_FOR_LOG_MESSAGE = ".*Started AxonServer.*";
+
+    private static final String AXONIQ_AXONSERVER_DEVMODE_ENABLED = "AXONIQ_AXONSERVER_DEVMODE_ENABLED";
+
+    private static final String AXON_SERVER_ADDRESS_TEMPLATE = "%s:%s";
+
+    private boolean devMode;
+
+    /**
+     * Initialize AxonServer SE with a given docker image.
+     *
+     * @param dockerImageName name of the docker image
+     */
+    public AxonServerSEContainer(final String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    /**
+     * Initialize AxonServer SE with a given docker image.
+     *
+     * @param dockerImageName name of the docker image
+     */
+    public AxonServerSEContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        withExposedPorts(AXON_SERVER_HTTP_PORT, AXON_SERVER_GRPC_PORT);
+        waitingFor(Wait.forLogMessage(WAIT_FOR_LOG_MESSAGE, 1));
+    }
+
+    @Override
+    protected void configure() {
+        withEnv(AXONIQ_AXONSERVER_DEVMODE_ENABLED, String.valueOf(devMode));
+    }
+
+    /**
+     * Initialize AxonServer EE with a given license.
+     */
+    public SELF withDevMode(boolean devMode) {
+        this.devMode = devMode;
+        return self();
+    }
+
+    /**
+     * Returns the mapped GRPC port used by this Axon Server container.
+     *
+     * @return mapped GRPC port.
+     */
+    public Integer getGrpcPort() {
+        return this.getMappedPort(AXON_SERVER_GRPC_PORT);
+    }
+
+    /**
+     * Returns the IP Address of the Axon Server container.
+     *
+     * @return IP Address of the container.
+     */
+    public String getIPAddress() {
+        return this.getContainerIpAddress();
+    }
+
+    /**
+     * Returns the Axon Server's address container in a host:port format.
+     *
+     * @return address in host:port format.
+     */
+    public String getAxonServerAddress() {
+        return String.format(AXON_SERVER_ADDRESS_TEMPLATE,
+                             this.getContainerIpAddress(),
+                             this.getMappedPort(AXON_SERVER_GRPC_PORT));
+    }
+}

--- a/test/src/test/java/org/axonframework/test/server/AxonServerEEContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerEEContainerTest.java
@@ -1,7 +1,25 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.test.server;
 
 import org.junit.jupiter.api.*;
 import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple test class for AxonServerEEContainer.
@@ -15,6 +33,29 @@ class AxonServerEEContainerTest {
                         new AxonServerEEContainer(DockerImageName.parse("axoniq/axonserver-enterprise:4.5.9-dev"))
         ) {
             axonServerEEContainer.start();
+            assertTrue(axonServerEEContainer.isRunning());
+        }
+    }
+
+    @Test
+    void axonServer_4_5_X_genericTest() {
+        try (
+                final AxonServerEEContainer axonServerEEContainer =
+                        new AxonServerEEContainer(DockerImageName.parse("axoniq/axonserver-enterprise:4.5.9-dev"))
+                                .withAxonServerName("axon-server-name")
+                                .withAxonServerInternalHostname("axon-server-internal-host-name")
+                                .withAxonServerHostname("axon-server-hostname")
+        ) {
+            axonServerEEContainer.start();
+            assertTrue(axonServerEEContainer.isRunning());
+            assertNotNull(axonServerEEContainer.getAxonServerAddress());
+            assertNotNull(axonServerEEContainer.getGrpcPort());
+            assertNotNull(axonServerEEContainer.getIPAddress());
+            assertEquals(2, axonServerEEContainer.getExposedPorts().size());
+            assertEquals("axon-server-name", axonServerEEContainer.getEnvMap().get("AXONIQ_AXONSERVER_NAME"));
+            assertEquals("axon-server-internal-host-name", axonServerEEContainer.getEnvMap().get("AXONIQ_AXONSERVER_INTERNAL_HOSTNAME"));
+            assertEquals("axon-server-hostname", axonServerEEContainer.getEnvMap().get("AXONIQ_AXONSERVER_HOSTNAME"));
+
         }
     }
 }

--- a/test/src/test/java/org/axonframework/test/server/AxonServerEEContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerEEContainerTest.java
@@ -1,0 +1,20 @@
+package org.axonframework.test.server;
+
+import org.junit.jupiter.api.*;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Simple test class for AxonServerEEContainer.
+ */
+class AxonServerEEContainerTest {
+
+    @Test
+    void supportsAxonServer_4_5_X() {
+        try (
+                final AxonServerEEContainer axonServerEEContainer =
+                        new AxonServerEEContainer(DockerImageName.parse("axoniq/axonserver-enterprise:4.5.9-dev"))
+        ) {
+            axonServerEEContainer.start();
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/server/AxonServerSEContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerSEContainerTest.java
@@ -1,7 +1,25 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.test.server;
 
 import org.junit.jupiter.api.*;
 import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple test class for AxonServerSEContainer.
@@ -15,6 +33,7 @@ class AxonServerSEContainerTest {
                         new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:4.4.12"))
         ) {
             axonServerSEContainer.start();
+            assertTrue(axonServerSEContainer.isRunning());
         }
     }
 
@@ -22,9 +41,27 @@ class AxonServerSEContainerTest {
     void supportsAxonServer_4_5_X() {
         try (
                 final AxonServerSEContainer axonServerSEContainer =
-                        new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:4.5.8"))
+                        new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:4.5.8-dev"))
         ) {
             axonServerSEContainer.start();
+            assertTrue(axonServerSEContainer.isRunning());
+        }
+    }
+
+    @Test
+    void axonServer_latest_genericTest() {
+        try (
+                final AxonServerSEContainer axonServerSEContainer =
+                        new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:latest-dev"))
+                                .withDevMode(true)
+        ) {
+            axonServerSEContainer.start();
+            assertTrue(axonServerSEContainer.isRunning());
+            assertNotNull(axonServerSEContainer.getAxonServerAddress());
+            assertNotNull(axonServerSEContainer.getGrpcPort());
+            assertNotNull(axonServerSEContainer.getIPAddress());
+            assertEquals(2, axonServerSEContainer.getExposedPorts().size());
+            assertEquals("true", axonServerSEContainer.getEnvMap().get("AXONIQ_AXONSERVER_DEVMODE_ENABLED"));
         }
     }
 }

--- a/test/src/test/java/org/axonframework/test/server/AxonServerSEContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerSEContainerTest.java
@@ -1,0 +1,30 @@
+package org.axonframework.test.server;
+
+import org.junit.jupiter.api.*;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Simple test class for AxonServerSEContainer.
+ */
+class AxonServerSEContainerTest {
+
+    @Test
+    void supportsAxonServer_4_4_X() {
+        try (
+                final AxonServerSEContainer axonServerSEContainer =
+                        new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:4.4.12"))
+        ) {
+            axonServerSEContainer.start();
+        }
+    }
+
+    @Test
+    void supportsAxonServer_4_5_X() {
+        try (
+                final AxonServerSEContainer axonServerSEContainer =
+                        new AxonServerSEContainer(DockerImageName.parse("axoniq/axonserver:4.5.8"))
+        ) {
+            axonServerSEContainer.start();
+        }
+    }
+}


### PR DESCRIPTION
As a follow up on https://github.com/testcontainers/testcontainers-java/pull/4607, we decided to add the classes to our `test` module ourselves making it easier for people to write end-to-end tests with AxonFramework when using AxonServer.

This PR introduces 2 containers implementations:
- AxonServerSEContainer
  - simpler one with an easy way to enable `devMode` and also some utils methods to get host/port/address
- AxonServerEEContainer
  - more complex one with the possibilities to set lots of AS attributes