### PR TITLE
Introduce LifecycleAware interface for managing component lifecycle

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -26,10 +26,10 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.TagsConfiguration;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
-import org.axonframework.lifecycle.StartHandler;
 
+import javax.net.ssl.SSLException;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import javax.net.ssl.SSLException;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -48,7 +47,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerConnectionManager {
+public class AxonServerConnectionManager implements LifecycleAware {
 
     private final Map<String, AxonServerConnection> connections = new ConcurrentHashMap<>();
     private final AxonServerConnectionFactory connectionFactory;
@@ -86,12 +85,17 @@ public class AxonServerConnectionManager {
         return new Builder();
     }
 
+    @Override
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS, this::start);
+        lifecycle.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::shutdown);
+    }
+
     /**
      * Starts the {@link AxonServerConnectionManager}. Will enable heartbeat messages to be send to the connected Axon
      * Server instance in the {@link Phase#INSTRUCTION_COMPONENTS} phase, if this has been enabled through the {@link
      * AxonServerConfiguration.HeartbeatConfiguration#isEnabled()}.
      */
-    @StartHandler(phase = Phase.INSTRUCTION_COMPONENTS)
     public void start() {
         if (heartbeatEnabled) {
             getConnection().controlChannel()
@@ -134,7 +138,6 @@ public class AxonServerConnectionManager {
      * Stops the Connection Manager, closing any active connections and preventing new connections from being created.
      * This shutdown operation is performed in the {@link Phase#EXTERNAL_CONNECTIONS} phase.
      */
-    @ShutdownHandler(phase = Phase.EXTERNAL_CONNECTIONS)
     public void shutdown() {
         connectionFactory.shutdown();
         disconnect();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -26,8 +26,8 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.StartHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
  * @author Sara Pellegrini
  * @since 4.0
  */
-public class EventProcessorControlService {
+public class EventProcessorControlService implements LifecycleAware {
 
     private static final Logger logger = LoggerFactory.getLogger(EventProcessorControlService.class);
     private static final String SUBSCRIBING_EVENT_PROCESSOR_MODE = "Subscribing";
@@ -88,13 +88,17 @@ public class EventProcessorControlService {
         this.context = context;
     }
 
+    @Override
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS, this::start);
+    }
+
     /**
      * Add {@link java.util.function.Consumer}s to the {@link AxonServerConnectionManager} for several {@link
      * PlatformOutboundInstruction}s. Will be started in phase {@link Phase#INBOUND_EVENT_CONNECTORS}, to ensure the
      * event processors this service provides control over have been started.
      */
     @SuppressWarnings("Duplicates")
-    @StartHandler(phase = Phase.INSTRUCTION_COMPONENTS)
     public void start() {
         if (axonServerConnectionManager != null && eventProcessingConfiguration != null) {
             ControlChannel controlChannel = axonServerConnectionManager.getConnection(context)

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -47,10 +47,9 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.Registration;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.lifecycle.ShutdownLatch;
-import org.axonframework.lifecycle.StartHandler;
 import org.axonframework.messaging.Distributed;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
@@ -95,7 +94,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
+public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, LifecycleAware {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -122,22 +121,6 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     private final String context;
 
     /**
-     * Instantiate a Builder to be able to create an {@link AxonServerQueryBus}.
-     * <p>
-     * The {@link QueryPriorityCalculator} is defaulted to {@link QueryPriorityCalculator#defaultQueryPriorityCalculator()}
-     * and the {@link TargetContextResolver} defaults to a lambda returning the {@link
-     * AxonServerConfiguration#getContext()} as the context. The {@link ExecutorServiceBuilder} defaults to {@link
-     * ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}. The {@link AxonServerConnectionManager}, the {@link
-     * AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and generic
-     * {@link Serializer}s are <b>hard requirements</b> and as such should be provided.
-     *
-     * @return a Builder to be able to create a {@link AxonServerQueryBus}
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
      * Instantiate a {@link AxonServerQueryBus} based on the fields contained in the {@link Builder}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link AxonServerQueryBus} instance
@@ -160,9 +143,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                 QUERY_QUEUE_CAPACITY,
                 Comparator.comparingLong(
                         r -> r instanceof QueryProcessingTask ? ((QueryProcessingTask) r).getPriority() :
-                                r instanceof ResponseProcessingTask
-                                        ? ((ResponseProcessingTask<?>) r).getPriority()
-                                        : DEFAULT_PRIORITY
+                             r instanceof ResponseProcessingTask
+                             ? ((ResponseProcessingTask<?>) r).getPriority()
+                             : DEFAULT_PRIORITY
                 ).reversed()
         );
         queryExecutor = builder.executorServiceBuilder.apply(configuration, queryProcessQueue);
@@ -170,9 +153,33 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
     }
 
     /**
+     * Instantiate a Builder to be able to create an {@link AxonServerQueryBus}.
+     * <p>
+     * The {@link QueryPriorityCalculator} is defaulted to {@link QueryPriorityCalculator#defaultQueryPriorityCalculator()}
+     * and the {@link TargetContextResolver} defaults to a lambda returning the {@link
+     * AxonServerConfiguration#getContext()} as the context. The {@link ExecutorServiceBuilder} defaults to {@link
+     * ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}. The {@link AxonServerConnectionManager}, the
+     * {@link
+     * AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and
+     * generic
+     * {@link Serializer}s are <b>hard requirements</b> and as such should be provided.
+     *
+     * @return a Builder to be able to create a {@link AxonServerQueryBus}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.INBOUND_QUERY_CONNECTOR, this::start);
+        lifecycle.onShutdown(Phase.INBOUND_QUERY_CONNECTOR, this::disconnect);
+        lifecycle.onShutdown(Phase.OUTBOUND_QUERY_CONNECTORS, this::shutdownDispatching);
+    }
+
+    /**
      * Start the Axon Server {@link QueryBus} implementation.
      */
-    @StartHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
     public void start() {
         shutdownLatch.initialize();
     }
@@ -325,7 +332,6 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
      * Disconnect the query bus from Axon Server, by unsubscribing all known query handlers. This shutdown operation is
      * performed in the {@link Phase#INBOUND_QUERY_CONNECTOR} phase.
      */
-    @ShutdownHandler(phase = Phase.INBOUND_QUERY_CONNECTOR)
     public void disconnect() {
         if (axonServerConnectionManager.isConnected(context)) {
             axonServerConnectionManager.getConnection(context).queryChannel().prepareDisconnect();
@@ -339,51 +345,8 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
      *
      * @return a completable future which is resolved once all query dispatching activities are completed
      */
-    @ShutdownHandler(phase = Phase.OUTBOUND_QUERY_CONNECTORS)
     public CompletableFuture<Void> shutdownDispatching() {
         return shutdownLatch.initiateShutdown();
-    }
-
-    /**
-     * A {@link QueryHandler} implementation serving as a wrapper around the local {@link QueryBus} to push through the
-     * message handling and subscription query registration.
-     */
-    private class LocalSegmentAdapter implements QueryHandler {
-
-        @Override
-        public void handle(QueryRequest query, ReplyChannel<QueryResponse> responseHandler) {
-            QueryProcessingTask processingTask = new QueryProcessingTask(
-                    localSegment, query, responseHandler, serializer, configuration.getClientId()
-            );
-            queryExecutor.submit(processingTask);
-        }
-
-        @Override
-        public io.axoniq.axonserver.connector.Registration registerSubscriptionQuery(SubscriptionQuery query,
-                                                                                     UpdateHandler sendUpdate) {
-            UpdateHandlerRegistration<Object> updateHandler =
-                    updateEmitter.registerUpdateHandler(subscriptionSerializer.deserialize(query), 1024);
-
-            updateHandler.getUpdates()
-                         .doOnError(e -> {
-                             ErrorMessage error = ExceptionSerializer.serialize(configuration.getClientId(), e);
-                             String errorCode = ErrorCode.getQueryExecutionErrorCode(e).errorCode();
-                             QueryUpdate queryUpdate = QueryUpdate.newBuilder()
-                                                                  .setErrorMessage(error)
-                                                                  .setErrorCode(errorCode)
-                                                                  .build();
-                             sendUpdate.sendUpdate(queryUpdate);
-                             sendUpdate.complete();
-                         })
-                         .doOnComplete(sendUpdate::complete)
-                         .map(subscriptionSerializer::serialize)
-                         .subscribe(sendUpdate::sendUpdate);
-
-            return () -> {
-                updateHandler.getRegistration().close();
-                return CompletableFuture.completedFuture(null);
-            };
-        }
     }
 
     /**
@@ -468,8 +431,10 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
      * The {@link QueryPriorityCalculator} is defaulted to {@link QueryPriorityCalculator#defaultQueryPriorityCalculator()}
      * and the {@link TargetContextResolver} defaults to a lambda returning the {@link
      * AxonServerConfiguration#getContext()} as the context. The {@link ExecutorServiceBuilder} defaults to {@link
-     * ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}. The {@link AxonServerConnectionManager}, the {@link
-     * AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and generic
+     * ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}. The {@link AxonServerConnectionManager}, the
+     * {@link
+     * AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and
+     * generic
      * {@link Serializer}s are <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
@@ -492,6 +457,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param axonServerConnectionManager an {@link AxonServerConnectionManager} used to create connections between
          *                                    this application and an Axon Server instance
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder axonServerConnectionManager(AxonServerConnectionManager axonServerConnectionManager) {
@@ -506,6 +472,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param configuration an {@link AxonServerConfiguration} used to configure several components within the Axon
          *                      Server Query Bus
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder configuration(AxonServerConfiguration configuration) {
@@ -518,6 +485,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          * Sets the local {@link QueryBus} used to dispatch incoming queries to the local environment.
          *
          * @param localSegment a {@link QueryBus} used to dispatch incoming queries to the local environment
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder localSegment(QueryBus localSegment) {
@@ -531,6 +499,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          * {@link QueryBus#queryUpdateEmitter()} contract.
          *
          * @param updateEmitter a {@link QueryUpdateEmitter} which can be used to emit updates to queries
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder updateEmitter(QueryUpdateEmitter updateEmitter) {
@@ -544,6 +513,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param messageSerializer a {@link Serializer} used to de-/serialize incoming and outgoing queries and query
          *                          responses
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder messageSerializer(Serializer messageSerializer) {
@@ -558,6 +528,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param genericSerializer a {@link Serializer} used to de-/serialize incoming and outgoing query {@link
          *                          org.axonframework.messaging.responsetypes.ResponseType} implementations.
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder genericSerializer(Serializer genericSerializer) {
@@ -573,6 +544,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param priorityCalculator a {@link QueryPriorityCalculator} used to deduce the priority of an incoming query
          *                           among other queries
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder priorityCalculator(QueryPriorityCalculator priorityCalculator) {
@@ -588,6 +560,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param targetContextResolver a {@link TargetContextResolver} used to resolve the target (bounded) context of
          *                              an ingested {@link QueryMessage}
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder targetContextResolver(TargetContextResolver<? super QueryMessage<?, ?>> targetContextResolver) {
@@ -609,6 +582,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          *
          * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
          *                               based on the {@link AxonServerConfiguration} and a {@link BlockingQueue}
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         @SuppressWarnings("unused")
@@ -623,6 +597,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          * UpstreamAwareStreamObserver#getRequestStream()}.
          *
          * @param requestStreamFactory factory that creates a request stream based on upstream
+         *
          * @return the current Builder instance, for fluent interfacing
          * @deprecated in through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">AxonServer
          * java connector</a>
@@ -639,6 +614,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
          * DefaultInstructionAckSource}.
          *
          * @param instructionAckSource used to send instruction acknowledgements
+         *
          * @return the current Builder instance, for fluent interfacing
          * @deprecated in through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">AxonServer
          * java connector</a>
@@ -797,6 +773,48 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
         @Override
         public int characteristics() {
             return Spliterator.DISTINCT & Spliterator.IMMUTABLE & Spliterator.NONNULL;
+        }
+    }
+
+    /**
+     * A {@link QueryHandler} implementation serving as a wrapper around the local {@link QueryBus} to push through the
+     * message handling and subscription query registration.
+     */
+    private class LocalSegmentAdapter implements QueryHandler {
+
+        @Override
+        public void handle(QueryRequest query, ReplyChannel<QueryResponse> responseHandler) {
+            QueryProcessingTask processingTask = new QueryProcessingTask(
+                    localSegment, query, responseHandler, serializer, configuration.getClientId()
+            );
+            queryExecutor.submit(processingTask);
+        }
+
+        @Override
+        public io.axoniq.axonserver.connector.Registration registerSubscriptionQuery(SubscriptionQuery query,
+                                                                                     UpdateHandler sendUpdate) {
+            UpdateHandlerRegistration<Object> updateHandler =
+                    updateEmitter.registerUpdateHandler(subscriptionSerializer.deserialize(query), 1024);
+
+            updateHandler.getUpdates()
+                         .doOnError(e -> {
+                             ErrorMessage error = ExceptionSerializer.serialize(configuration.getClientId(), e);
+                             String errorCode = ErrorCode.getQueryExecutionErrorCode(e).errorCode();
+                             QueryUpdate queryUpdate = QueryUpdate.newBuilder()
+                                                                  .setErrorMessage(error)
+                                                                  .setErrorCode(errorCode)
+                                                                  .build();
+                             sendUpdate.sendUpdate(queryUpdate);
+                             sendUpdate.complete();
+                         })
+                         .doOnComplete(sendUpdate::complete)
+                         .map(subscriptionSerializer::serialize)
+                         .subscribe(sendUpdate::sendUpdate);
+
+            return () -> {
+                updateHandler.getRegistration().close();
+                return CompletableFuture.completedFuture(null);
+            };
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
@@ -21,8 +21,8 @@ import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.messaging.DefaultInterceptorChain;
 import org.axonframework.messaging.ExecutionException;
 import org.axonframework.messaging.InterceptorChain;
@@ -61,7 +61,7 @@ import static org.axonframework.deadline.GenericDeadlineMessage.asDeadlineMessag
  * @author Steven van Beelen
  * @since 3.3
  */
-public class SimpleDeadlineManager extends AbstractDeadlineManager {
+public class SimpleDeadlineManager extends AbstractDeadlineManager implements LifecycleAware {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleDeadlineManager.class);
     private static final String THREAD_FACTORY_GROUP_NAME = "deadlineManager";
@@ -161,13 +161,12 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Will shutdown in the {@link Phase#INBOUND_EVENT_CONNECTORS} phase.
-     */
     @Override
-    @ShutdownHandler(phase = Phase.INBOUND_EVENT_CONNECTORS)
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onShutdown(Phase.INBOUND_EVENT_CONNECTORS, this::shutdown);
+    }
+
+    @Override
     public void shutdown() {
         scheduledExecutorService.shutdown();
     }

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -24,8 +24,8 @@ import org.axonframework.deadline.AbstractDeadlineManager;
 import org.axonframework.deadline.DeadlineException;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.deadline.DeadlineMessage;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.serialization.Serializer;
@@ -61,7 +61,7 @@ import static org.quartz.JobKey.jobKey;
  * @author Steven van Beelen
  * @since 3.3
  */
-public class QuartzDeadlineManager extends AbstractDeadlineManager {
+public class QuartzDeadlineManager extends AbstractDeadlineManager implements LifecycleAware {
 
     private static final Logger logger = LoggerFactory.getLogger(QuartzDeadlineManager.class);
 
@@ -211,13 +211,12 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager {
                              .build();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Will shutdown in the {@link Phase#INBOUND_EVENT_CONNECTORS} phase.
-     */
     @Override
-    @ShutdownHandler(phase = Phase.INBOUND_EVENT_CONNECTORS)
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onShutdown(Phase.INBOUND_EVENT_CONNECTORS, this::shutdown);
+    }
+
+    @Override
     public void shutdown() {
         try {
             scheduler.shutdown(true);

--- a/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
@@ -21,9 +21,8 @@ import org.axonframework.common.Registration;
 import org.axonframework.common.io.IOUtils;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
-import org.axonframework.lifecycle.StartHandler;
 import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.unitofwork.BatchingUnitOfWork;
 import org.axonframework.messaging.unitofwork.RollbackConfiguration;
@@ -46,29 +45,13 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Rene de Waele
  * @since 3.0
  */
-public class SubscribingEventProcessor extends AbstractEventProcessor {
+public class SubscribingEventProcessor extends AbstractEventProcessor implements LifecycleAware {
 
     private final SubscribableMessageSource<? extends EventMessage<?>> messageSource;
     private final EventProcessingStrategy processingStrategy;
     private final TransactionManager transactionManager;
 
     private volatile Registration eventBusRegistration;
-
-    /**
-     * Instantiate a Builder to be able to create a {@link SubscribingEventProcessor}.
-     * <p>
-     * The {@link RollbackConfigurationType} defaults to a {@link RollbackConfigurationType#ANY_THROWABLE}, the
-     * {@link ErrorHandler} is defaulted to a {@link PropagatingErrorHandler}, the {@link MessageMonitor} defaults to a
-     * {@link NoOpMessageMonitor}, the {@link EventProcessingStrategy} defaults to a
-     * {@link DirectEventProcessingStrategy} and the {@link TransactionManager} defaults to the
-     * {@link NoTransactionManager#INSTANCE}. The Event Processor {@code name}, {@link EventHandlerInvoker} and
-     * {@link SubscribableMessageSource} are <b>hard requirements</b> and as such should be provided.
-     *
-     * @return a Builder to be able to create a {@link SubscribingEventProcessor}
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
 
     /**
      * Instantiate a {@link SubscribingEventProcessor} based on the fields contained in the {@link Builder}.
@@ -87,13 +70,34 @@ public class SubscribingEventProcessor extends AbstractEventProcessor {
     }
 
     /**
+     * Instantiate a Builder to be able to create a {@link SubscribingEventProcessor}.
+     * <p>
+     * The {@link RollbackConfigurationType} defaults to a {@link RollbackConfigurationType#ANY_THROWABLE}, the
+     * {@link ErrorHandler} is defaulted to a {@link PropagatingErrorHandler}, the {@link MessageMonitor} defaults to a
+     * {@link NoOpMessageMonitor}, the {@link EventProcessingStrategy} defaults to a
+     * {@link DirectEventProcessingStrategy} and the {@link TransactionManager} defaults to the
+     * {@link NoTransactionManager#INSTANCE}. The Event Processor {@code name}, {@link EventHandlerInvoker} and
+     * {@link SubscribableMessageSource} are <b>hard requirements</b> and as such should be provided.
+     *
+     * @return a Builder to be able to create a {@link SubscribingEventProcessor}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public void registerLifecycleHandlers(LifecycleRegistry handle) {
+        handle.onStart(Phase.LOCAL_MESSAGE_HANDLER_REGISTRATIONS, this::start);
+        handle.onShutdown(Phase.LOCAL_MESSAGE_HANDLER_REGISTRATIONS, this::shutDown);
+    }
+
+    /**
      * Start this processor. This will register the processor with the {@link EventBus}.
      * <p>
      * Upon start up of an application, this method will be invoked in the {@link Phase#LOCAL_MESSAGE_HANDLER_REGISTRATIONS}
      * phase.
      */
     @Override
-    @StartHandler(phase = Phase.LOCAL_MESSAGE_HANDLER_REGISTRATIONS)
     public void start() {
         if (eventBusRegistration != null) {
             // This event processor has already been started
@@ -140,7 +144,6 @@ public class SubscribingEventProcessor extends AbstractEventProcessor {
      * phase.
      */
     @Override
-    @ShutdownHandler(phase = Phase.LOCAL_MESSAGE_HANDLER_REGISTRATIONS)
     public void shutDown() {
         IOUtils.closeQuietly(eventBusRegistration);
         eventBusRegistration = null;
@@ -215,6 +218,7 @@ public class SubscribingEventProcessor extends AbstractEventProcessor {
          * @param messageSource the {@link SubscribableMessageSource} (e.g. the {@link EventBus}) to which this
          *                      {@link EventProcessor} implementation will subscribe itself to receive
          *                      {@link EventMessage}s
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder messageSource(SubscribableMessageSource<? extends EventMessage<?>> messageSource) {
@@ -229,6 +233,7 @@ public class SubscribingEventProcessor extends AbstractEventProcessor {
          *
          * @param processingStrategy the {@link EventProcessingStrategy} determining whether events are processed
          *                           directly or asynchronously
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder processingStrategy(EventProcessingStrategy processingStrategy) {
@@ -241,6 +246,7 @@ public class SubscribingEventProcessor extends AbstractEventProcessor {
          * Sets the {@link TransactionManager} used when processing {@link EventMessage}s.
          *
          * @param transactionManager the {@link TransactionManager} used when processing {@link EventMessage}s
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder transactionManager(TransactionManager transactionManager) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -23,10 +23,11 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.eventhandling.scheduling.SchedulingException;
+import org.axonframework.lifecycle.LifecycleAware;
 import org.axonframework.lifecycle.Phase;
-import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
@@ -50,8 +51,15 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.*;
-import static org.axonframework.messaging.Headers.*;
+import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.EVENT_BUS_KEY;
+import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.EVENT_JOB_DATA_BINDER_KEY;
+import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.TRANSACTION_MANAGER_KEY;
+import static org.axonframework.messaging.Headers.MESSAGE_ID;
+import static org.axonframework.messaging.Headers.MESSAGE_METADATA;
+import static org.axonframework.messaging.Headers.MESSAGE_REVISION;
+import static org.axonframework.messaging.Headers.MESSAGE_TIMESTAMP;
+import static org.axonframework.messaging.Headers.MESSAGE_TYPE;
+import static org.axonframework.messaging.Headers.SERIALIZED_MESSAGE_PAYLOAD;
 import static org.quartz.JobKey.jobKey;
 
 /**
@@ -62,7 +70,7 @@ import static org.quartz.JobKey.jobKey;
  * @see FireEventJob
  * @since 0.7
  */
-public class QuartzEventScheduler implements org.axonframework.eventhandling.scheduling.EventScheduler {
+public class QuartzEventScheduler implements EventScheduler, LifecycleAware {
 
     private static final Logger logger = LoggerFactory.getLogger(QuartzEventScheduler.class);
 
@@ -204,13 +212,12 @@ public class QuartzEventScheduler implements org.axonframework.eventhandling.sch
         this.groupIdentifier = groupIdentifier;
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Will shutdown in the {@link Phase#INBOUND_EVENT_CONNECTORS} phase.
-     */
     @Override
-    @ShutdownHandler(phase = Phase.INBOUND_EVENT_CONNECTORS)
+    public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+        lifecycle.onShutdown(Phase.INBOUND_EVENT_CONNECTORS, this::shutdown);
+    }
+
+    @Override
     public void shutdown() {
         try {
             scheduler.shutdown(true);

--- a/messaging/src/main/java/org/axonframework/lifecycle/LifecycleAware.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/LifecycleAware.java
@@ -1,0 +1,30 @@
+package org.axonframework.lifecycle;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface LifecycleAware {
+
+    void registerLifecycleHandlers(LifecycleRegistry handle);
+
+    interface LifecycleRegistry {
+
+        default void onStartup(int phase, Runnable action) {
+            onStartup(phase, () -> {
+                action.run();
+                return CompletableFuture.completedFuture(null);
+            });
+        }
+
+        void onShutdown(int phase, Runnable action);
+
+        void onStartup(int phase, LifecycleHandler action);
+
+        void onShutdown(int phase, LifecycleHandler action);
+
+    }
+
+    interface LifecycleHandler {
+
+        CompletableFuture<?> run();
+    }
+}

--- a/messaging/src/main/java/org/axonframework/lifecycle/LifecycleAware.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/LifecycleAware.java
@@ -2,29 +2,129 @@ package org.axonframework.lifecycle;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Interface for components that can be started and shut down as part of the Application lifecycle.
+ *
+ * @author Allard Buijze
+ * @since 4.6
+ */
 public interface LifecycleAware {
 
-    void registerLifecycleHandlers(LifecycleRegistry handle);
+    /**
+     * Registers the activities to be executed in the various phases of an application's lifecycle. This could either
+     * be at startup, shutdown, or both.
+     *
+     * @param lifecycle the lifecycle instance to register the handlers with
+     *
+     * @see LifecycleRegistry#onShutdown(int, Runnable)
+     * @see LifecycleRegistry#onShutdown(int, LifecycleHandler)
+     * @see LifecycleRegistry#onStart(int, Runnable)
+     * @see LifecycleRegistry#onStart(int, LifecycleHandler)
+     */
+    void registerLifecycleHandlers(LifecycleRegistry lifecycle);
 
+    /**
+     * Interface towards the registry that holds all lifecycle handlers for components.
+     * <p>
+     * Component may register activities to be executed at startup or shutdown. These activities may be executed
+     * <ul>
+     *     <li>synchronously - see {@link #onStart(int, Runnable)} and {@link  #onShutdown(int, Runnable)}. With this
+     *     approach, the lifecycle action is considered completed when the method returns.</li>
+     *     <li>asynchronously - see {@link #onStart(int, LifecycleHandler)} and
+     *     {@link  #onShutdown(int, LifecycleHandler)}. This approach expects handler methods to return a
+     *     {@link CompletableFuture} that completes when the lifecycle action is completed</li>
+     * </ul>
+     */
     interface LifecycleRegistry {
 
-        default void onStartup(int phase, Runnable action) {
-            onStartup(phase, () -> {
-                action.run();
-                return CompletableFuture.completedFuture(null);
+        /**
+         * Registers the given {@code action} to run during the given {@code phase} during startup. Lower {@code phase}s
+         * are executed before higher {@code phase}s.
+         *
+         * @param phase  The phase in which to execute this action
+         * @param action The action to perform
+         *
+         * @see Phase
+         */
+        default void onStart(int phase, Runnable action) {
+            onStart(phase, () -> {
+                try {
+                    action.run();
+                    return CompletableFuture.completedFuture(null);
+                } catch (Exception e) {
+                    CompletableFuture<Void> cf = new CompletableFuture<>();
+                    cf.completeExceptionally(e);
+                    return cf;
+                }
             });
         }
 
-        void onShutdown(int phase, Runnable action);
+        /**
+         * Registers the given {@code action} to run during the given {@code phase} during shutdown. Higher {@code
+         * phase}s are executed before lower {@code phase}s.
+         *
+         * @param phase  The phase in which to execute this action
+         * @param action The action to perform
+         *
+         * @see Phase
+         */
+        default void onShutdown(int phase, Runnable action) {
+            onShutdown(phase, () -> {
+                try {
+                    action.run();
+                    return CompletableFuture.completedFuture(null);
+                } catch (Exception e) {
+                    CompletableFuture<Void> cf = new CompletableFuture<>();
+                    cf.completeExceptionally(e);
+                    return cf;
+                }
+            });
+        }
 
-        void onStartup(int phase, LifecycleHandler action);
+        /**
+         * Registers the given {@code action} to run during the given {@code phase} during startup. Lower {@code phase}s
+         * are executed before higher {@code phase}s.
+         * <p>
+         * Various handlers for the same phase may be executed concurrently, but handlers for subsequent phases will
+         * only be invoked when the returned {@link CompletableFuture} completes (normally or exceptionally).
+         *
+         * @param phase  The phase in which to execute this action
+         * @param action The action to perform
+         *
+         * @see Phase
+         */
+        void onStart(int phase, LifecycleHandler action);
 
+        /**
+         * Registers the given {@code action} to run during the given {@code phase} during shutdown. Higher
+         * {@code phase}s are executed before lower {@code phase}s.
+         * <p>
+         * Various handlers for the same phase may be executed concurrently, but handlers for subsequent phases will
+         * only be invoked when the returned {@link CompletableFuture} completes (normally or exceptionally).
+         *
+         * @param phase  The phase in which to execute this action
+         * @param action The action to perform
+         *
+         * @see Phase
+         */
         void onShutdown(int phase, LifecycleHandler action);
 
     }
 
+    /**
+     * Functional interface for lifecycle activities that may run asynchronously
+     */
+    @FunctionalInterface
     interface LifecycleHandler {
 
-        CompletableFuture<?> run();
+        /**
+         * Execute the lifecycle activity.
+         * <p>
+         * Implementations preferably do not throw exceptions, but return a {@link CompletableFuture} with an
+         * exceptional result instead.
+         *
+         * @return a CompletableFuture that completes when the activity completes.
+         */
+        CompletableFuture<Void> run();
     }
 }

--- a/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
@@ -18,9 +18,10 @@ package org.axonframework.lifecycle;
 
 /**
  * Utility class containing constants which can be used as input for the {@link StartHandler} and {@link
- * ShutdownHandler} annotations.
+ * ShutdownHandler} annotations, or components implementing the {@link LifecycleAware} interface.
  *
  * @author Steven van Beelen
+ * @see LifecycleAware
  * @see StartHandler
  * @see ShutdownHandler
  * @since 4.3


### PR DESCRIPTION
Instead of relying on annotations out of the box, using an interface makes it easier to configure and tune the lifecycles.

The annotations can still be used for custom components. The Axon-provided components all use the LifecycleAware interface.