### PR TITLE
[#1711] Simplify attachment of Lifecycle Operations

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -26,7 +26,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.TagsConfiguration;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 
 import javax.net.ssl.SSLException;
@@ -47,7 +47,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerConnectionManager implements LifecycleAware {
+public class AxonServerConnectionManager implements Lifecycle {
 
     private final Map<String, AxonServerConnection> connections = new ConcurrentHashMap<>();
     private final AxonServerConnectionFactory connectionFactory;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -35,7 +35,7 @@ import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.Registration;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.lifecycle.ShutdownLatch;
 import org.axonframework.messaging.Distributed;
@@ -64,7 +64,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>, LifecycleAware {
+public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -31,7 +31,7 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.eventhandling.scheduling.java.SimpleScheduleToken;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
@@ -58,7 +58,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @author Marc Gathier
  * @since 4.4
  */
-public class AxonServerEventScheduler implements EventScheduler, LifecycleAware {
+public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitor.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitor.java
@@ -17,7 +17,7 @@
 package org.axonframework.axonserver.connector.heartbeat;
 
 import org.axonframework.axonserver.connector.util.Scheduler;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  * connector</a>
  */
 @Deprecated
-public class HeartbeatMonitor implements LifecycleAware {
+public class HeartbeatMonitor implements Lifecycle {
 
     private static final long DEFAULT_INITIAL_DELAY = 10_000;
     private static final long DEFAULT_DELAY = 1_000;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -26,7 +26,7 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
  * @author Sara Pellegrini
  * @since 4.0
  */
-public class EventProcessorControlService implements LifecycleAware {
+public class EventProcessorControlService implements Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(EventProcessorControlService.class);
     private static final String SUBSCRIBING_EVENT_PROCESSOR_MODE = "Subscribing";

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -47,7 +47,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.Registration;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.lifecycle.ShutdownLatch;
 import org.axonframework.messaging.Distributed;
@@ -94,7 +94,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Marc Gathier
  * @since 4.0
  */
-public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, LifecycleAware {
+public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
  * @author Allard Buijze
  * @since 3.0
  */
-public interface Configuration extends LifecycleOperationConfiguration {
+public interface Configuration extends LifecycleOperations {
 
     /**
      * Retrieves the Event Bus defined in this Configuration.

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -43,7 +43,6 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -57,7 +56,7 @@ import java.util.stream.Collectors;
  * @author Allard Buijze
  * @since 3.0
  */
-public interface Configuration {
+public interface Configuration extends LifecycleOperationConfiguration {
 
     /**
      * Retrieves the Event Bus defined in this Configuration.
@@ -373,109 +372,6 @@ public interface Configuration {
      * @return all modules that have been registered with this Configuration
      */
     List<ModuleConfiguration> getModules();
-
-    /**
-     * Registers a {@code startHandler} to be executed in the default phase {@code 0} when this Configuration is
-     * started.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already started is undefined.
-     *
-     * @param startHandler the handler to execute when the configuration is started
-     * @see #start()
-     */
-    default void onStart(Runnable startHandler) {
-        onStart(0, startHandler);
-    }
-
-    /**
-     * Registers a {@code startHandler} to be executed in the given {@code phase} when this Configuration is started.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already started is undefined.
-     *
-     * @param phase        defines a {@code phase} in which the start handler will be invoked during {@link
-     *                     Configuration#start()}. When starting the configuration the given handlers are started in
-     *                     ascending order based on their {@code phase}
-     * @param startHandler the handler to execute when the configuration is started
-     * @see #start()
-     */
-    default void onStart(int phase, Runnable startHandler) {
-        onStart(phase, () -> {
-            try {
-                startHandler.run();
-                return CompletableFuture.completedFuture(null);
-            } catch (Exception e) {
-                CompletableFuture<?> exceptionResult = new CompletableFuture<>();
-                exceptionResult.completeExceptionally(e);
-                return exceptionResult;
-            }
-        });
-    }
-
-    /**
-     * Registers an asynchronous {@code startHandler} to be executed in the given {@code phase} when this Configuration
-     * is started.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already started is undefined.
-     *
-     * @param phase        defines a {@code phase} in which the start handler will be invoked during {@link
-     *                     Configuration#start()}. When starting the configuration the given handlers are started in
-     *                     ascending order based on their {@code phase}
-     * @param startHandler the handler to be executed asynchronously when the configuration is started
-     * @see #start()
-     */
-    void onStart(int phase, LifecycleHandler startHandler);
-
-    /**
-     * Registers a {@code shutdownHandler} to be executed in the default phase {@code 0} when the Configuration is shut
-     * down.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
-     *
-     * @param shutdownHandler the handler to execute when the Configuration is shut down
-     * @see #shutdown()
-     */
-    default void onShutdown(Runnable shutdownHandler) {
-        onShutdown(0, shutdownHandler);
-    }
-
-    /**
-     * Registers a {@code shutdownHandler} to be executed in the given {@code phase} when the Configuration is shut
-     * down.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
-     *
-     * @param phase           defines a phase in which the shutdown handler will be invoked during {@link
-     *                        Configuration#shutdown()}. When shutting down the configuration the given handlers are
-     *                        executing in descending order based on their {@code phase}
-     * @param shutdownHandler the handler to execute when the Configuration is shut down
-     * @see #shutdown()
-     */
-    default void onShutdown(int phase, Runnable shutdownHandler) {
-        onShutdown(phase, () -> {
-            try {
-                shutdownHandler.run();
-                return CompletableFuture.completedFuture(null);
-            } catch (Exception e) {
-                CompletableFuture<?> exceptionResult = new CompletableFuture<>();
-                exceptionResult.completeExceptionally(e);
-                return exceptionResult;
-            }
-        });
-    }
-
-    /**
-     * Registers an asynchronous {@code shutdownHandler} to be executed in the given {@code phase} when the
-     * Configuration is shut down.
-     * <p>
-     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
-     *
-     * @param phase           defines a phase in which the shutdown handler will be invoked during {@link
-     *                        Configuration#shutdown()}. When shutting down the configuration the given handlers are
-     *                        executing in descending order based on their {@code phase}
-     * @param shutdownHandler the handler to be executed asynchronously when the Configuration is shut down
-     * @see #shutdown()
-     */
-    void onShutdown(int phase, LifecycleHandler shutdownHandler);
 
     /**
      * Returns the EventUpcasterChain with all registered upcasters.

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -53,7 +53,7 @@ import java.util.function.Function;
  * @see DefaultConfigurer
  * @since 3.0
  */
-public interface Configurer extends LifecycleOperationConfiguration {
+public interface Configurer extends LifecycleOperations {
 
     /**
      * Registers an upcaster to be used to upcast Events to a newer version

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -53,7 +53,7 @@ import java.util.function.Function;
  * @see DefaultConfigurer
  * @since 3.0
  */
-public interface Configurer {
+public interface Configurer extends LifecycleOperationConfiguration {
 
     /**
      * Registers an upcaster to be used to upcast Events to a newer version

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -692,7 +692,7 @@ public class DefaultConfigurer implements Configurer {
      * lifecycle handlers are registered.
      */
     protected void prepareMessageHandlerRegistrars() {
-        messageHandlerRegistrars.forEach(registrar -> initHandlers.add(config -> registrar.get()));
+        messageHandlerRegistrars.forEach(registrar -> initHandlers.add(cfg -> registrar.get()));
     }
 
     /**
@@ -808,12 +808,12 @@ public class DefaultConfigurer implements Configurer {
 
     @Override
     public void onStart(int phase, LifecycleHandler startHandler) {
-        onInitialize(config -> config.onStart(phase, startHandler));
+        onInitialize(cfg -> cfg.onStart(phase, startHandler));
     }
 
     @Override
     public void onShutdown(int phase, LifecycleHandler shutdownHandler) {
-        onInitialize(config -> config.onShutdown(phase, shutdownHandler));
+        onInitialize(cfg -> cfg.onShutdown(phase, shutdownHandler));
     }
 
     private class ConfigurationImpl implements Configuration {

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -24,7 +24,6 @@ import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.common.BuilderUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -805,6 +804,16 @@ public class DefaultConfigurer implements Configurer {
      */
     public Map<Class<?>, Component<?>> getComponents() {
         return components;
+    }
+
+    @Override
+    public void onStart(int phase, LifecycleHandler startHandler) {
+        onInitialize(config -> config.onStart(phase, startHandler));
+    }
+
+    @Override
+    public void onShutdown(int phase, LifecycleHandler shutdownHandler) {
+        onInitialize(config -> config.onShutdown(phase, shutdownHandler));
     }
 
     private class ConfigurationImpl implements Configuration {

--- a/config/src/main/java/org/axonframework/config/LifecycleHandlerInspector.java
+++ b/config/src/main/java/org/axonframework/config/LifecycleHandlerInspector.java
@@ -19,7 +19,7 @@ package org.axonframework.config;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.annotation.AnnotationUtils;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.lifecycle.StartHandler;
@@ -59,7 +59,7 @@ public abstract class LifecycleHandlerInspector {
     /**
      * Register any lifecycle handlers found on given {@code component} with given {@code configuration}.
      * <p>
-     * If given {@code component} implements {@link LifecycleAware}, will allow it to register lifecycle handlers with
+     * If given {@code component} implements {@link Lifecycle}, will allow it to register lifecycle handlers with
      * the configuration. Otherwise, will resolve {@link StartHandler} and {@link ShutdownHandler} annotated lifecycle
      * handlers in the given {@code component}. If present, they will be registered on the given {@code configuration}
      * through the {@link Configuration#onStart(int, LifecycleHandler)} and
@@ -74,15 +74,15 @@ public abstract class LifecycleHandlerInspector {
             logger.debug("Ignoring [null] component for inspection as it wont participate in the lifecycle");
             return;
         }
-        if (component instanceof LifecycleAware) {
-            ((LifecycleAware) component).registerLifecycleHandlers(new LifecycleAware.LifecycleRegistry() {
+        if (component instanceof Lifecycle) {
+            ((Lifecycle) component).registerLifecycleHandlers(new Lifecycle.LifecycleRegistry() {
                 @Override
-                public void onStart(int phase, LifecycleAware.LifecycleHandler action) {
+                public void onStart(int phase, Lifecycle.LifecycleHandler action) {
                     configuration.onStart(phase, action::run);
                 }
 
                 @Override
-                public void onShutdown(int phase, LifecycleAware.LifecycleHandler action) {
+                public void onShutdown(int phase, Lifecycle.LifecycleHandler action) {
                     configuration.onShutdown(phase, action::run);
                 }
             });

--- a/config/src/main/java/org/axonframework/config/LifecycleOperationConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/LifecycleOperationConfiguration.java
@@ -1,0 +1,121 @@
+package org.axonframework.config;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface describing the configuration of start and shutdown handlers within Axon's configuration.
+ * <p>
+ * Both {@link Runnable Runnables} or {@link LifecycleHandler LifecycleHandlers} can be configured. The invocation order
+ * is defined through the (optional) {@code phase} parameter. The {@link org.axonframework.lifecycle.Phase} enumeration
+ * may be used as a guidance to add operations before/after Axon's regular steps.
+ *
+ * @author Steven van Beelen
+ * @see LifecycleHandler
+ * @see org.axonframework.lifecycle.Phase
+ * @since 4.6.0
+ */
+public interface LifecycleOperationConfiguration {
+
+    /**
+     * Registers a {@code startHandler} to be executed in the default phase {@code 0} when this Configuration is
+     * started.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already started is undefined.
+     *
+     * @param startHandler the handler to execute when the configuration is started
+     * @see Configuration#start()
+     */
+    default void onStart(Runnable startHandler) {
+        onStart(0, startHandler);
+    }
+
+    /**
+     * Registers a {@code startHandler} to be executed in the given {@code phase} when this Configuration is started.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already started is undefined.
+     *
+     * @param phase        defines a {@code phase} in which the start handler will be invoked during {@link
+     *                     Configuration#start()}. When starting the configuration the given handlers are started in
+     *                     ascending order based on their {@code phase}
+     * @param startHandler the handler to execute when the configuration is started
+     * @see Configuration#start()
+     */
+    default void onStart(int phase, Runnable startHandler) {
+        onStart(phase, () -> {
+            try {
+                startHandler.run();
+                return CompletableFuture.completedFuture(null);
+            } catch (Exception e) {
+                CompletableFuture<?> exceptionResult = new CompletableFuture<>();
+                exceptionResult.completeExceptionally(e);
+                return exceptionResult;
+            }
+        });
+    }
+
+    /**
+     * Registers an asynchronous {@code startHandler} to be executed in the given {@code phase} when this Configuration
+     * is started.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already started is undefined.
+     *
+     * @param phase        defines a {@code phase} in which the start handler will be invoked during {@link
+     *                     Configuration#start()}. When starting the configuration the given handlers are started in
+     *                     ascending order based on their {@code phase}
+     * @param startHandler the handler to be executed asynchronously when the configuration is started
+     * @see Configuration#start()
+     */
+    void onStart(int phase, LifecycleHandler startHandler);
+
+    /**
+     * Registers a {@code shutdownHandler} to be executed in the default phase {@code 0} when the Configuration is shut
+     * down.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
+     *
+     * @param shutdownHandler the handler to execute when the Configuration is shut down
+     * @see Configuration#shutdown()
+     */
+    default void onShutdown(Runnable shutdownHandler) {
+        onShutdown(0, shutdownHandler);
+    }
+
+    /**
+     * Registers a {@code shutdownHandler} to be executed in the given {@code phase} when the Configuration is shut
+     * down.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
+     *
+     * @param phase           defines a phase in which the shutdown handler will be invoked during {@link
+     *                        Configuration#shutdown()}. When shutting down the configuration the given handlers are
+     *                        executing in descending order based on their {@code phase}
+     * @param shutdownHandler the handler to execute when the Configuration is shut down
+     * @see Configuration#shutdown()
+     */
+    default void onShutdown(int phase, Runnable shutdownHandler) {
+        onShutdown(phase, () -> {
+            try {
+                shutdownHandler.run();
+                return CompletableFuture.completedFuture(null);
+            } catch (Exception e) {
+                CompletableFuture<?> exceptionResult = new CompletableFuture<>();
+                exceptionResult.completeExceptionally(e);
+                return exceptionResult;
+            }
+        });
+    }
+
+    /**
+     * Registers an asynchronous {@code shutdownHandler} to be executed in the given {@code phase} when the
+     * Configuration is shut down.
+     * <p>
+     * The behavior for handlers that are registered when the Configuration is already shut down is undefined.
+     *
+     * @param phase           defines a phase in which the shutdown handler will be invoked during {@link
+     *                        Configuration#shutdown()}. When shutting down the configuration the given handlers are
+     *                        executing in descending order based on their {@code phase}
+     * @param shutdownHandler the handler to be executed asynchronously when the Configuration is shut down
+     * @see Configuration#shutdown()
+     */
+    void onShutdown(int phase, LifecycleHandler shutdownHandler);
+}

--- a/config/src/main/java/org/axonframework/config/LifecycleOperationConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/LifecycleOperationConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2021. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.config;
 
 import java.util.concurrent.CompletableFuture;

--- a/config/src/main/java/org/axonframework/config/LifecycleOperations.java
+++ b/config/src/main/java/org/axonframework/config/LifecycleOperations.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
  * @see org.axonframework.lifecycle.Phase
  * @since 4.6.0
  */
-public interface LifecycleOperationConfiguration {
+public interface LifecycleOperations {
 
     /**
      * Registers a {@code startHandler} to be executed in the default phase {@code 0} when this Configuration is

--- a/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
+++ b/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
@@ -17,7 +17,7 @@
 package org.axonframework.config;
 
 import org.axonframework.common.Registration;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 
 import java.util.function.BiFunction;
@@ -36,7 +36,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Steven van Beelen
  * @since 4.3
  */
-public class MessageHandlerRegistrar implements LifecycleAware {
+public class MessageHandlerRegistrar implements Lifecycle {
 
     private final Supplier<Configuration> configurationSupplier;
     private final Function<Configuration, Object> messageHandlerBuilder;

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
@@ -66,6 +66,30 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
+    void testStartLifecycleHandlerConfiguredThroughConfigurerAreInvokedInAscendingPhaseOrder() {
+        Configurer testSubject = DefaultConfigurer.defaultConfiguration();
+
+        LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseOneHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseTenHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseOverNineThousandHandler = spy(new LifecycleManagedInstance());
+
+        testSubject.onStart(0, phaseZeroHandler::start);
+        testSubject.onStart(1, phaseOneHandler::start);
+        testSubject.onStart(10, phaseTenHandler::start);
+        testSubject.onStart(9001, phaseOverNineThousandHandler::start);
+
+        testSubject.start();
+
+        InOrder lifecycleOrder =
+                inOrder(phaseZeroHandler, phaseOneHandler, phaseTenHandler, phaseOverNineThousandHandler);
+        lifecycleOrder.verify(phaseZeroHandler).start();
+        lifecycleOrder.verify(phaseOneHandler).start();
+        lifecycleOrder.verify(phaseTenHandler).start();
+        lifecycleOrder.verify(phaseOverNineThousandHandler).start();
+    }
+
+    @Test
     void testStartLifecycleHandlersWillOnlyProceedToFollowingPhaseAfterCurrentPhaseIsFinalized()
             throws InterruptedException {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
@@ -180,6 +204,31 @@ class DefaultConfigurerLifecycleOperationsTest {
         testSubject.start();
 
         testSubject.shutdown();
+
+        InOrder lifecycleOrder =
+                inOrder(phaseOverNineThousandHandler, phaseTenHandler, phaseOneHandler, phaseZeroHandler);
+        lifecycleOrder.verify(phaseOverNineThousandHandler).shutdown();
+        lifecycleOrder.verify(phaseTenHandler).shutdown();
+        lifecycleOrder.verify(phaseOneHandler).shutdown();
+        lifecycleOrder.verify(phaseZeroHandler).shutdown();
+    }
+
+    @Test
+    void testShutdownLifecycleHandlersConfiguredThroughConfigurerAreInvokedInDescendingPhaseOrder() {
+        Configurer testSubject = DefaultConfigurer.defaultConfiguration();
+
+        LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseOneHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseTenHandler = spy(new LifecycleManagedInstance());
+        LifecycleManagedInstance phaseOverNineThousandHandler = spy(new LifecycleManagedInstance());
+
+        testSubject.onShutdown(9001, phaseOverNineThousandHandler::shutdown);
+        testSubject.onShutdown(10, phaseTenHandler::shutdown);
+        testSubject.onShutdown(1, phaseOneHandler::shutdown);
+        testSubject.onShutdown(0, phaseZeroHandler::shutdown);
+        Configuration config = testSubject.start();
+
+        config.shutdown();
 
         InOrder lifecycleOrder =
                 inOrder(phaseOverNineThousandHandler, phaseTenHandler, phaseOneHandler, phaseZeroHandler);

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
@@ -74,10 +74,10 @@ class DefaultConfigurerLifecycleOperationsTest {
         LifecycleManagedInstance phaseTenHandler = spy(new LifecycleManagedInstance());
         LifecycleManagedInstance phaseOverNineThousandHandler = spy(new LifecycleManagedInstance());
 
-        testSubject.onStart(0, phaseZeroHandler::start);
-        testSubject.onStart(1, phaseOneHandler::start);
-        testSubject.onStart(10, phaseTenHandler::start);
         testSubject.onStart(9001, phaseOverNineThousandHandler::start);
+        testSubject.onStart(10, phaseTenHandler::start);
+        testSubject.onStart(1, phaseOneHandler::start);
+        testSubject.onStart(0, phaseZeroHandler::start);
 
         testSubject.start();
 
@@ -222,10 +222,10 @@ class DefaultConfigurerLifecycleOperationsTest {
         LifecycleManagedInstance phaseTenHandler = spy(new LifecycleManagedInstance());
         LifecycleManagedInstance phaseOverNineThousandHandler = spy(new LifecycleManagedInstance());
 
-        testSubject.onShutdown(9001, phaseOverNineThousandHandler::shutdown);
-        testSubject.onShutdown(10, phaseTenHandler::shutdown);
-        testSubject.onShutdown(1, phaseOneHandler::shutdown);
         testSubject.onShutdown(0, phaseZeroHandler::shutdown);
+        testSubject.onShutdown(1, phaseOneHandler::shutdown);
+        testSubject.onShutdown(10, phaseTenHandler::shutdown);
+        testSubject.onShutdown(9001, phaseOverNineThousandHandler::shutdown);
         Configuration config = testSubject.start();
 
         config.shutdown();

--- a/config/src/test/java/org/axonframework/config/LifecycleHandlerInspectorTest.java
+++ b/config/src/test/java/org/axonframework/config/LifecycleHandlerInspectorTest.java
@@ -17,7 +17,7 @@
 package org.axonframework.config;
 
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.lifecycle.ShutdownHandler;
 import org.axonframework.lifecycle.StartHandler;
@@ -86,7 +86,7 @@ class LifecycleHandlerInspectorTest {
 
     @Test
     void lifecycleAwareComponentsRegisterHandlers(@Mock Configuration config) {
-        LifecycleHandlerInspector.registerLifecycleHandlers(config, new ComponentWithLifecycleAware(
+        LifecycleHandlerInspector.registerLifecycleHandlers(config, new ComponentWithLifecycle(
                 r -> {
                     r.onStart(42, () -> {
                     });
@@ -142,11 +142,11 @@ class LifecycleHandlerInspectorTest {
         }
     }
 
-    private static class ComponentWithLifecycleAware implements LifecycleAware {
+    private static class ComponentWithLifecycle implements Lifecycle {
 
         private final Consumer<LifecycleRegistry> registration;
 
-        public ComponentWithLifecycleAware(Consumer<LifecycleRegistry> registration) {
+        public ComponentWithLifecycle(Consumer<LifecycleRegistry> registration) {
             this.registration = registration;
         }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -27,7 +27,7 @@ import org.axonframework.commandhandling.distributed.commandfilter.DenyAll;
 import org.axonframework.commandhandling.distributed.commandfilter.DenyCommandNameFilter;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.Distributed;
 import org.axonframework.messaging.MessageDispatchInterceptor;
@@ -59,7 +59,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Allard Buijze
  * @since 2.0
  */
-public class DistributedCommandBus implements CommandBus, Distributed<CommandBus>, LifecycleAware {
+public class DistributedCommandBus implements CommandBus, Distributed<CommandBus>, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
@@ -21,7 +21,7 @@ import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.GenericEventMessage;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.DefaultInterceptorChain;
 import org.axonframework.messaging.ExecutionException;
@@ -61,7 +61,7 @@ import static org.axonframework.deadline.GenericDeadlineMessage.asDeadlineMessag
  * @author Steven van Beelen
  * @since 3.3
  */
-public class SimpleDeadlineManager extends AbstractDeadlineManager implements LifecycleAware {
+public class SimpleDeadlineManager extends AbstractDeadlineManager implements Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleDeadlineManager.class);
     private static final String THREAD_FACTORY_GROUP_NAME = "deadlineManager";

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -24,7 +24,7 @@ import org.axonframework.deadline.AbstractDeadlineManager;
 import org.axonframework.deadline.DeadlineException;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.deadline.DeadlineMessage;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
@@ -61,7 +61,7 @@ import static org.quartz.JobKey.jobKey;
  * @author Steven van Beelen
  * @since 3.3
  */
-public class QuartzDeadlineManager extends AbstractDeadlineManager implements LifecycleAware {
+public class QuartzDeadlineManager extends AbstractDeadlineManager implements Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(QuartzDeadlineManager.class);
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
@@ -21,7 +21,7 @@ import org.axonframework.common.Registration;
 import org.axonframework.common.io.IOUtils;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.unitofwork.BatchingUnitOfWork;
@@ -45,7 +45,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Rene de Waele
  * @since 3.0
  */
-public class SubscribingEventProcessor extends AbstractEventProcessor implements LifecycleAware {
+public class SubscribingEventProcessor extends AbstractEventProcessor implements Lifecycle {
 
     private final SubscribableMessageSource<? extends EventMessage<?>> messageSource;
     private final EventProcessingStrategy processingStrategy;

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -25,7 +25,7 @@ import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.BatchingUnitOfWork;
@@ -87,7 +87,7 @@ import static org.axonframework.common.io.IOUtils.closeQuietly;
  * @author Christophe Bouhier
  * @since 3.0
  */
-public class TrackingEventProcessor extends AbstractEventProcessor implements StreamingEventProcessor, LifecycleAware {
+public class TrackingEventProcessor extends AbstractEventProcessor implements StreamingEventProcessor, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(TrackingEventProcessor.class);
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -34,7 +34,7 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackerStatus;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.RollbackConfiguration;
@@ -83,7 +83,7 @@ import static org.axonframework.common.BuilderUtils.assertStrictPositive;
  * @author Steven van Beelen
  * @since 4.5
  */
-public class PooledStreamingEventProcessor extends AbstractEventProcessor implements StreamingEventProcessor, LifecycleAware {
+public class PooledStreamingEventProcessor extends AbstractEventProcessor implements StreamingEventProcessor, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
@@ -25,7 +25,7 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -56,7 +56,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @see org.axonframework.eventhandling.scheduling.quartz.QuartzEventScheduler
  * @since 0.7
  */
-public class SimpleEventScheduler implements EventScheduler, LifecycleAware {
+public class SimpleEventScheduler implements EventScheduler, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleEventScheduler.class);
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -26,7 +26,7 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.eventhandling.scheduling.SchedulingException;
-import org.axonframework.lifecycle.LifecycleAware;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
@@ -70,7 +70,7 @@ import static org.quartz.JobKey.jobKey;
  * @see FireEventJob
  * @since 0.7
  */
-public class QuartzEventScheduler implements EventScheduler, LifecycleAware {
+public class QuartzEventScheduler implements EventScheduler, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(QuartzEventScheduler.class);
 

--- a/messaging/src/main/java/org/axonframework/lifecycle/Lifecycle.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/Lifecycle.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Allard Buijze
  * @since 4.6
  */
-public interface LifecycleAware {
+public interface Lifecycle {
 
     /**
      * Registers the activities to be executed in the various phases of an application's lifecycle. This could either

--- a/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
@@ -18,10 +18,10 @@ package org.axonframework.lifecycle;
 
 /**
  * Utility class containing constants which can be used as input for the {@link StartHandler} and {@link
- * ShutdownHandler} annotations, or components implementing the {@link LifecycleAware} interface.
+ * ShutdownHandler} annotations, or components implementing the {@link Lifecycle} interface.
  *
  * @author Steven van Beelen
- * @see LifecycleAware
+ * @see Lifecycle
  * @see StartHandler
  * @see ShutdownHandler
  * @since 4.3


### PR DESCRIPTION
This pull request introduces the `LifecycleOperationConfiguration` interface.
It contains the `onStart` and `onShutdown` methods that original resided on the `Configuration` interface.
The `LifecycleOperationConfiguration` is extended by the `Configuration` and the `Configurer` .

This allows the registration of start and shutdown operations both during configuration of an Axon application (thus, on the `Configurer`) and once the configuration is done (thus, on the `Configuration`).

This pull request resolves #1711.