### PR TITLE
Separate Integration Tests and Aggregate coverage reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,14 @@ jobs:
             ${{ runner.os }}-maven
 
       - name: Regular Build
+        if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Pcoverage-aggregate clean verify
+          ./mvnw -B -U -Pintegration-test clean verify
+
+      - name: Build with Coverage reports
+        if: matrix.sonar-enabled
+        run: |
+          ./mvnw -B -U -Dcoverage clean verify
 
       - name: Sonar Analysis
         if: matrix.sonar-enabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Regular Build
         run: |
-          ./mvnw -B -U -Pcoverage clean verify
+          ./mvnw -B -U -Pcoverage-aggregate clean verify
 
       - name: Sonar Analysis
         if: matrix.sonar-enabled

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,8 +38,14 @@ jobs:
             ${{ runner.os }}-maven
 
       - name: Regular Build
+        if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Possrh -Pcoverage-aggregate clean verify
+          ./mvnw -B -U -Pintegration-test clean verify
+
+      - name: Build with Coverage reports
+        if: matrix.sonar-enabled
+        run: |
+          ./mvnw -B -U -Possrh -Dcoverage clean verify
 
       - name: Sonar Analysis
         if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Regular Build
         run: |
-          ./mvnw -B -U -Possrh -Pcoverage clean verify
+          ./mvnw -B -U -Possrh -Pcoverage-aggregate clean verify
 
       - name: Sonar Analysis
         if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2021. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework</groupId>
+        <artifactId>axon</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>axon-coverage-report</artifactId>
+
+    <name>Axon Coverage Report</name>
+    <description>Project depending on all modules to construct a combined coverage report</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-server-connector</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-configuration</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-disruptor</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-eventsourcing</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-integrationtests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-legacy</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-metrics</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-micrometer</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-modelling</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-test</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -205,29 +205,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco-maven-plugin.version}</version>
-
-                        <executions>
-                            <execution>
-                                <id>report</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report-aggregate</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -480,8 +480,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!--suppress MavenModelInspection -->
-                    <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
+                    <argLine>-Djava.awt.headless=true</argLine>
                     <systemPropertyVariables>
                         <slf4j.version>${slf4j.version}</slf4j.version>
                         <log4j.version>${log4j.version}</log4j.version>
@@ -631,6 +630,14 @@
 
             <build>
                 <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!--suppress MavenModelInspection -->
+                            <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
+                        </configuration>
+                    </plugin>
+
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-            <sonar.coverage.jacoco.xmlReportPaths>
-                ${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml,
-                ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
-            </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml,
+            ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/integrationtests/target/site/jacoco-aggregate/jacoco.xml
-        </sonar.coverage.jacoco.xmlReportPaths>
-        <pattern.class.test>**/*Test.*</pattern.class.test>
-        <pattern.class.test.int>**/*IntegrationTest.*</pattern.class.test.int>
+            <sonar.coverage.jacoco.xmlReportPaths>
+                ${project.basedir}/coverage-report/target/site/jacoco-aggregate/jacoco.xml,
+                ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
+            </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
@@ -486,18 +485,24 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>${pattern.class.test.int}</exclude>
-                    </excludes>
-                    <includes>
-                        <include>${pattern.class.test}</include>
-                    </includes>
                     <!--suppress MavenModelInspection -->
                     <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
                     <systemPropertyVariables>
                         <slf4j.version>${slf4j.version}</slf4j.version>
                         <log4j.version>${log4j.version}</log4j.version>
                     </systemPropertyVariables>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*Test_*.java</include>
+                        <include>**/*Tests_*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                        <exclude>**/*IntegrationTests.java</exclude>
+                        <exclude>**/*IntegrationTest_*.java</exclude>
+                        <exclude>**/*IntegrationTests_*.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -583,37 +588,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>prepare-unit-test</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>surefireArgLine</propertyName>
-                            <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>report-unit-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>${project.build.directory}/jacoco-ut.exec</dataFile>
-                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-                            <excludes>
-                                <exclude>${pattern.class.test.int}</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -649,27 +623,34 @@
 
         <profile>
             <id>coverage</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>coverage</name>
+                </property>
+            </activation>
+
+            <modules>
+                <module>coverage-report</module>
+            </modules>
+
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco-maven-plugin.version}</version>
 
                         <executions>
                             <execution>
-                                <id>prepare-agent</id>
+                                <id>prepare-agent-for-unit-tests</id>
                                 <phase>initialize</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
+                                <configuration>
+                                    <propertyName>surefireArgLine</propertyName>
+                                    <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -699,49 +680,14 @@
             <id>integration-test</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>coverage</name>
+                </property>
             </activation>
 
             <build>
                 <defaultGoal>verify</defaultGoal>
                 <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>prepare-integration-test</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                                <configuration>
-                                    <propertyName>failsafeArgLine</propertyName>
-                                    <destFile>${project.build.directory}/jacoco-it.exec</destFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report-integration-test</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <configuration>
-                                    <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
-                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
-                                    <excludes>
-                                        <exclude>${pattern.class.test}</exclude>
-                                    </excludes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skipTests>true</skipTests>
-                        </configuration>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
@@ -755,51 +701,41 @@
                                     <!--suppress MavenModelInspection -->
                                     <argLine>-Djava.awt.headless=true ${failsafeArgLine}</argLine>
                                     <includes>
-                                        <include>${pattern.class.test.int}</include>
+                                        <include>**/*IntegrationTest.java</include>
+                                        <include>**/*IntegrationTests.java</include>
+                                        <include>**/*IntegrationTest_*.java</include>
+                                        <include>**/*IntegrationTests_*.java</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>**/*Test.java</exclude>
+                                        <exclude>**/*Tests.java</exclude>
+                                        <exclude>**/*Test_*.java</exclude>
+                                        <exclude>**/*Tests_*.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent-for-integration-test</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafeArgLine</propertyName>
+                                    <destFile>${project.build.directory}/jacoco-it.exec</destFile>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>coverage-aggregate</id>
-            <build>
-                <defaultGoal>verify</defaultGoal>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>report-aggregate</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>report-aggregate</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-            <modules>
-                <module>axon-server-connector</module>
-                <module>config</module>
-                <module>disruptor</module>
-                <module>eventsourcing</module>
-                <module>integrationtests</module>
-                <module>legacy</module>
-                <module>messaging</module>
-                <module>metrics</module>
-                <module>metrics-micrometer</module>
-                <module>modelling</module>
-                <module>spring</module>
-                <module>spring-boot-autoconfigure</module>
-                <module>test</module>
-            </modules>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </licenses>
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/AxonFramework/AxonFramework</url>
+        <url>https://github.com/AxonFramework/AxonFramework/issues</url>
     </issueManagement>
 
     <properties>
@@ -77,11 +77,6 @@
         <micrometer.version>1.8.1</micrometer.version>
         <dropwizard.metrics.version>4.2.7</dropwizard.metrics.version>
         <jackson.version>2.13.1</jackson.version>
-        <!--
-            Please note that there are dependencies between the gRPC and Netty TcNative versions.
-            gRPC is quite specific about the version of Netty TcNative, so check the dependencies on
-            https://github.com/grpc/grpc-java/blob/master/SECURITY.md
-        -->
 
         <!-- Validation -->
         <javax.el-api.version>3.0.1-b06</javax.el-api.version>
@@ -433,7 +428,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,16 +47,16 @@
     </description>
 
     <inceptionYear>2010</inceptionYear>
-    <url>http://www.axonframework.org</url>
+    <url>https://axoniq.io/</url>
     <licenses>
         <license>
             <name>Apache 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
     <issueManagement>
         <system>GitHub</system>
-        <url>http://issues.axonframework.org</url>
+        <url>https://github.com/AxonFramework/AxonFramework</url>
     </issueManagement>
 
     <properties>
@@ -64,6 +64,8 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/integrationtests/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <pattern.class.test>**/*Test.*</pattern.class.test>
+        <pattern.class.test.int>**/*IntegrationTest.*</pattern.class.test.int>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
@@ -400,6 +402,8 @@
     </dependencyManagement>
 
     <build>
+        <defaultGoal>clean package</defaultGoal>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -415,8 +419,26 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -463,14 +485,19 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
                 <configuration>
+                    <excludes>
+                        <exclude>${pattern.class.test.int}</exclude>
+                    </excludes>
                     <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test_*.java</include>
-                        <include>**/*Tests_*.java</include>
+                        <include>${pattern.class.test}</include>
                     </includes>
+                    <!--suppress MavenModelInspection -->
+                    <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
+                    <systemPropertyVariables>
+                        <slf4j.version>${slf4j.version}</slf4j.version>
+                        <log4j.version>${log4j.version}</log4j.version>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -556,6 +583,37 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                            <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-ut.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                            <excludes>
+                                <exclude>${pattern.class.test.int}</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -635,7 +693,113 @@
                     </releases>
                 </repository>
             </repositories>
+        </profile>
 
+        <profile>
+            <id>integration-test</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <defaultGoal>verify</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>prepare-integration-test</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafeArgLine</propertyName>
+                                    <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report-integration-test</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                                    <excludes>
+                                        <exclude>${pattern.class.test}</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>run-integration-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <!--suppress MavenModelInspection -->
+                                    <argLine>-Djava.awt.headless=true ${failsafeArgLine}</argLine>
+                                    <includes>
+                                        <include>${pattern.class.test.int}</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>coverage-aggregate</id>
+            <build>
+                <defaultGoal>verify</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <modules>
+                <module>axon-server-connector</module>
+                <module>config</module>
+                <module>disruptor</module>
+                <module>eventsourcing</module>
+                <module>integrationtests</module>
+                <module>legacy</module>
+                <module>messaging</module>
+                <module>metrics</module>
+                <module>metrics-micrometer</module>
+                <module>modelling</module>
+                <module>spring</module>
+                <module>spring-boot-autoconfigure</module>
+                <module>test</module>
+            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This pull request introduces several changes to the `pom.xml` to separate the unit tests from integration tests and to include aggregated coverage reports.
These changes can be defined as such:

- It adjusts the `maven-surefire-plugin` run to not include integration tests
- It includes a `coverage-report/pom.xml` project that uses the `jacoco:report-aggregate` goal to collect the coverage data from all its dependencies into one report
- It updates the `coverage` profile to attach the `coverage-report` module
- It includes an `integration-test` profile to run the integration tests
- It introduces the `coverage` property that enables both the `coverage` and `integration-test` profiles. This allows a combined coverage report of both unit and integration tests
- It updates the `main.yml` and `pullrequest.yml` to switch between a regular build (for Java 8) and a coverage build (for Java 11), using the `integration-test` profile and `coverage` property respectively

Next to this, a couple of clean-up actions were taken, namely:

- Fix the `url` tag to point to axoniq.io
- Replace `http` for `https` in the `license` tag
- Replace the `issueManagement` `url` tag to point to https://github.com/AxonFramework/AxonFramework
- Removes a comment intended for the `axonserver-connector-java` project
- It adds a default goal of `clean package`
- It adds the `maven-surefire-plugin`, `maven-failsafe-plugin` and `jacoco-maven-plugin` to the `pluginManagement` section 
- It removes the `coverage` profile form the `integerationtests` module