### PR TITLE
Make asDomainEventMessage available to subclasses

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -145,7 +145,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
      *
      * @return the message converted to a domain event message
      */
-    private static <T> DomainEventMessage<T> asDomainEventMessage(EventMessage<T> event) {
+    protected static <T> DomainEventMessage<T> asDomainEventMessage(EventMessage<T> event) {
         return event instanceof DomainEventMessage<?>
                ? (DomainEventMessage<T>) event
                : new GenericDomainEventMessage<>(null, event.getIdentifier(), 0L, event, event::getTimestamp);


### PR DESCRIPTION
When using custom DomainEventEntry instances, and thus subclassing the JpaEventStorageEngine, it is useful to still have access to this method

#2065

I noticed there was also a very similar method in the `JdbcEventStorageEngineStatements` class, but since I don't use that I don't know the context of it, nor if it's actually needed if you use JDBC for storage instead of JPA, so I left that alone.