### PR TITLE
Make the `PooledStreamingEventProcessor` compatible with an `EventMultiUpcaster`

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -779,19 +779,16 @@ class Coordinator {
                  fetched < WorkPackage.BUFFER_SIZE && isSpaceAvailable() && eventStream.hasNextAvailable();
                  fetched++) {
                 TrackedEventMessage<?> event = eventStream.nextAvailable();
-
-                boolean anyScheduled = false;
-                for (WorkPackage workPackage : workPackages.values()) {
-                    boolean scheduled = workPackage.scheduleEvent(event);
-                    anyScheduled = anyScheduled || scheduled;
-                }
-                if (!anyScheduled) {
-                    ignoredMessageHandler.accept(event);
-                    if (!eventFilter.canHandleTypeOf(event)) {
-                        eventStream.skipMessagesWithPayloadTypeOf(event);
-                    }
-                }
+                offerEventToWorkPackages(event);
                 lastScheduledToken = event.trackingToken();
+
+                // Make sure all subsequent events with the same token as the last are added as well.
+                // These are the result of upcasting and should always be processed in the same batch.
+                while (eventStream.peek()
+                                  .filter(e -> lastScheduledToken.equals(e.trackingToken()))
+                                  .isPresent()) {
+                    offerEventToWorkPackages(eventStream.nextAvailable());
+                }
             }
 
             // If a work package has been aborted by something else than the Coordinator. We should abandon it.
@@ -802,6 +799,20 @@ class Coordinator {
             // Chances are no events were scheduled at all. Scheduling regardless will ensure the token claim is held.
             workPackages.values()
                         .forEach(WorkPackage::scheduleWorker);
+        }
+
+        private void offerEventToWorkPackages(TrackedEventMessage<?> event) {
+            boolean anyScheduled = false;
+            for (WorkPackage workPackage : workPackages.values()) {
+                boolean scheduled = workPackage.scheduleEvent(event);
+                anyScheduled = anyScheduled || scheduled;
+            }
+            if (!anyScheduled) {
+                ignoredMessageHandler.accept(event);
+                if (!eventFilter.canHandleTypeOf(event)) {
+                    eventStream.skipMessagesWithPayloadTypeOf(event);
+                }
+            }
         }
 
         private void scheduleImmediateCoordinationTask() {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.axonframework.config.ConfigurerModule;
+import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedType;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.upcasting.event.ContextAwareEventMultiUpcaster;
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.beans.ConstructorProperties;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.axonframework.springboot.utils.AssertUtils.assertWithin;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for the {@link PooledStreamingEventProcessor}. Tests, for example, that all events from an {@link
+ * org.axonframework.serialization.upcasting.event.EventMultiUpcaster} are read.
+ *
+ * @author Steven van Beelen
+ */
+class PooledStreamingEventProcessorIntegrationTest {
+
+    private ApplicationContextRunner testApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        testApplicationContext = new ApplicationContextRunner().withPropertyValues("axon.axonserver.enabled:false")
+                                                               .withUserConfiguration(Context.class);
+    }
+
+    @Test
+    void testAllEventsFromMultiUpcasterAreHandled() {
+        testApplicationContext.run(context -> {
+            EventProcessingConfiguration processingConfig = context.getBean(EventProcessingConfiguration.class);
+            Optional<PooledStreamingEventProcessor> optionalProcessor =
+                    processingConfig.eventProcessor("upcaster-test", PooledStreamingEventProcessor.class);
+
+            assertTrue(optionalProcessor.isPresent());
+            PooledStreamingEventProcessor processor = optionalProcessor.get();
+            processor.shutDown();
+
+            EventGateway eventGateway = context.getBean(EventGateway.class);
+            eventGateway.publish(new OriginalEvent("my-text"));
+            processor.start();
+            assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(1, processor.processingStatus().size()));
+
+            EventHandlingComponent eventHandlingComponent =
+                    context.getBean(EventHandlingComponent.class);
+
+            assertNotNull(eventHandlingComponent);
+            assertWithin(500, TimeUnit.MILLISECONDS,
+                         () -> assertEquals(0, eventHandlingComponent.getOriginalEventCounter().get()));
+            assertWithin(500, TimeUnit.MILLISECONDS,
+                         () -> assertEquals(2, eventHandlingComponent.getUpcastedEventCounter().get()));
+        });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class Context {
+
+        @Bean
+        @Qualifier("eventSerializer")
+        public Serializer eventSerializer() {
+            return JacksonSerializer.defaultSerializer();
+        }
+
+        @Bean
+        public ConfigurerModule defaultToPooledStreaming() {
+            return configurer -> configurer.eventProcessing()
+                                           .usingPooledStreamingEventProcessors()
+                                           .registerPooledStreamingEventProcessorConfiguration(
+                                                   (config, builder) -> builder.initialSegmentCount(1)
+                                           );
+        }
+
+        @Bean
+        public MultiUpcaster multiUpcaster() {
+            return new MultiUpcaster();
+        }
+
+        @Bean
+        public EventHandlingComponent eventHandlingComponent() {
+            return new EventHandlingComponent();
+        }
+    }
+
+    private static class MultiUpcaster extends ContextAwareEventMultiUpcaster<Map<Object, Object>> {
+
+        @Override
+        protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation,
+                                    Map<Object, Object> context) {
+            return intermediateRepresentation.getType().getName().equals(OriginalEvent.class.getName());
+        }
+
+        @Override
+        protected Stream<IntermediateEventRepresentation> doUpcast(
+                IntermediateEventRepresentation intermediateRepresentation,
+                Map<Object, Object> context
+        ) {
+            return Stream.of(
+                    intermediateRepresentation.upcastPayload(
+                            new SimpleSerializedType(UpcastedEvent.class.getName(), null),
+                            JsonNode.class,
+                            // We keep the event the same, only change the type
+                            node -> node
+                    ),
+                    intermediateRepresentation.upcastPayload(
+                            new SimpleSerializedType(UpcastedEvent.class.getName(), null),
+                            JsonNode.class,
+                            // We keep the event the same, only change the type
+                            node -> node
+                    )
+            );
+        }
+
+        @Override
+        protected Map<Object, Object> buildContext() {
+            return new HashMap<>();
+        }
+    }
+
+    @ProcessingGroup("upcaster-test")
+    private static class EventHandlingComponent {
+
+        private final AtomicInteger originalEventCounter = new AtomicInteger(0);
+        private final AtomicInteger upcastedEventCounter = new AtomicInteger(0);
+
+        @EventHandler
+        public void on(@SuppressWarnings("unused") OriginalEvent event) {
+            originalEventCounter.incrementAndGet();
+        }
+
+        @EventHandler
+        public void on(@SuppressWarnings("unused") UpcastedEvent event) {
+            upcastedEventCounter.incrementAndGet();
+        }
+
+        public AtomicInteger getOriginalEventCounter() {
+            return originalEventCounter;
+        }
+
+        public AtomicInteger getUpcastedEventCounter() {
+            return upcastedEventCounter;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class OriginalEvent {
+
+        private final String textField;
+
+        @ConstructorProperties({"textField"})
+        private OriginalEvent(String textField) {
+            this.textField = textField;
+        }
+
+        public String getTextField() {
+            return textField;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class UpcastedEvent {
+
+        private final String textField;
+
+        @ConstructorProperties({"textField"})
+        private UpcastedEvent(String textField) {
+            this.textField = textField;
+        }
+
+        public String getTextField() {
+            return textField;
+        }
+    }
+}

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/utils/AssertUtils.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/utils/AssertUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot.utils;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class providing additional forms of assertions, mainly involving time based checks.
+ *
+ * @author Sara Pellegrini
+ * @author Steven van Beelen
+ */
+public abstract class AssertUtils {
+
+    private AssertUtils() {
+        // Utility class
+    }
+
+    /**
+     * Assert that the given {@code assertion} succeeds with the given {@code time} and {@code unit}.
+     *
+     * @param time      an {@code int} which paired with the {@code unit} specifies the time in which the assertion must
+     *                  pass
+     * @param unit      a {@link TimeUnit} in which {@code time} is expressed
+     * @param assertion a {@link Runnable} containing the assertion to succeed within the deadline
+     */
+    @SuppressWarnings("Duplicates")
+    public static void assertWithin(int time, TimeUnit unit, Runnable assertion) {
+        long now = System.currentTimeMillis();
+        long deadline = now + unit.toMillis(time);
+        do {
+            try {
+                assertion.run();
+                break;
+            } catch (AssertionError e) {
+                if (now >= deadline) {
+                    throw e;
+                }
+            }
+            Thread.yield();
+            now = System.currentTimeMillis();
+        } while (true);
+    }
+}


### PR DESCRIPTION
The `PooledStreamingEventProcessor` (PSEP) ignores upcasted events from an `EventMultiUpcaster` due to the `TrackingToken#covers` validation within the `WorkPackage#scheduleEvent` method. 
Just as the `TrackingEventProcessor` (TEP), the PSEP should include events with the same token in the same batch *and* handle them.

This warrants changes in both the `Coordinator` and the `WorkPackage`.
The `Coordinator` should `peek` the event stream to validate if following events contain the same `TrackingToken`.
If so, they should be scheduled on the work packages.
For the `WorkPackage`, the validation within the `schedulEvent` method should ignore the event in case it covers the event *and* if it isn't equal to the `lastDeliveredToken` (read: the last event).

This pull request includes a unit test for the `WorkPackage's` change and an integration test that uses an `EventMultiUpcaster`.
The `AssertUtils` included for the integration test are copied from a different module.