### PR TITLE
Feature/1466 Additional deadline validation methods

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -389,6 +389,50 @@ public interface ResultValidator<T> {
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectNoScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
+
+    /**
+     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param matcher the matcher defining the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher);
+
+    /**
+     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadline the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
+
+    /**
+     * Asserts that <b>no</b> deadline with the given {@code type} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
+     * a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadlineType the type of the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType);
+
+    /**
+     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadlineName the name of the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    ResultValidator<T> expectNoScheduledDeadlineWithName(Instant from, Instant to, String deadlineName);
 
     /**
      * Asserts that deadlines matching the given {@code matcher} have been met (which have passed in time) on this aggregate.

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -391,44 +391,44 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectNoScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
 
     /**
-     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times, where {@code to} and
+     * {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param matcher the matcher defining the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher);
 
     /**
-     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadline the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
-     * a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadlineType the type of the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     ResultValidator<T> expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadlineName the name of the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -413,7 +413,7 @@ public interface ResultValidator<T> {
     ResultValidator<T> expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code type} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
+     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
      * a deadline has never been set or has been canceled within a given timeframe.
      *
      * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,6 +264,29 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
                 scheduledTime,
                 matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
         );
+    }
+
+    @Override
+    public ResultValidator<T> expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher) {
+        return expectNoScheduledDeadlineMatching(matches(
+                deadlineMessage -> !(deadlineMessage.getTimestamp().isBefore(from) || deadlineMessage.getTimestamp().isAfter(to))
+                        && matcher.matches(deadlineMessage)
+        ));
+    }
+
+    @Override
+    public ResultValidator<T> expectNoScheduledDeadline(Instant from, Instant to, Object deadline) {
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(equalTo(deadline, fieldFilter)));
+    }
+
+    @Override
+    public ResultValidator<T> expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType) {
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(any(deadlineType)));
+    }
+
+    @Override
+    public ResultValidator<T> expectNoScheduledDeadlineWithName(Instant from, Instant to, String deadlineName) {
+        return expectNoScheduledDeadlineMatching(from, to, matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName)));
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -465,6 +465,50 @@ public interface FixtureExecutionResult {
      * @return the FixtureExecutionResult for method chaining
      */
     FixtureExecutionResult expectNoScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
+
+    /**
+     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param matcher the matcher defining the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    FixtureExecutionResult expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher);
+
+    /**
+     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadline the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    FixtureExecutionResult expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
+
+    /**
+     * Asserts that <b>no</b> deadline with the given {@code type} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
+     * a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadlineType the type of the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    FixtureExecutionResult expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType);
+
+    /**
+     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times. Can be used to
+     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     *
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param deadlineName the name of the deadline which should not be scheduled
+     * @return the current ResultValidator, for fluent interfacing
+     */
+    FixtureExecutionResult expectNoScheduledDeadlineWithName(Instant from, Instant to, String deadlineName);
 
     /**
      * Assert that the saga published events on the EventBus as defined by the given {@code matcher}. Only events

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -489,7 +489,7 @@ public interface FixtureExecutionResult {
     FixtureExecutionResult expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code type} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
+     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
      * a deadline has never been set or has been canceled within a given timeframe.
      *
      * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -467,44 +467,44 @@ public interface FixtureExecutionResult {
     FixtureExecutionResult expectNoScheduledDeadlineWithName(Instant scheduledTime, String deadlineName);
 
     /**
-     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline matching the given {@code matcher} has been scheduled between the {@code to} and {@code from} times, where {@code to} and
+     * {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from    the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to      the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param matcher the matcher defining the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     FixtureExecutionResult expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher);
 
     /**
-     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadline the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     FixtureExecutionResult expectNoScheduledDeadline(Instant from, Instant to, Object deadline);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times. Can be used to validate if
-     * a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadlineType the type of the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */
     FixtureExecutionResult expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType);
 
     /**
-     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times. Can be used to
-     * validate if a deadline has never been set or has been canceled within a given timeframe.
+     * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times, where {@code to}
+     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
-     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled
-     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled
+     * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
+     * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param deadlineName the name of the deadline which should not be scheduled
      * @return the current ResultValidator, for fluent interfacing
      */

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResult.java
@@ -479,7 +479,7 @@ public interface FixtureExecutionResult {
 
     /**
      * Asserts that <b>no</b> deadline equal to the given {@code deadline} has been scheduled between the {@code to} and {@code from} times, where {@code to}
-     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
      * @param from     the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param to       the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
@@ -490,7 +490,7 @@ public interface FixtureExecutionResult {
 
     /**
      * Asserts that <b>no</b> deadline with the given {@code deadlineType} has been scheduled between the {@code to} and {@code from} times, where {@code to}
-     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
      * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
@@ -501,7 +501,7 @@ public interface FixtureExecutionResult {
 
     /**
      * Asserts that <b>no</b> deadline with the given {@code deadlineName} has been scheduled between the {@code to} and {@code from} times, where {@code to}
-     * and {@code from} are inclusiv. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
+     * and {@code from} are inclusive. Can be used to validate if a deadline has never been set or has been canceled within a given timeframe.
      *
      * @param from         the time from which no deadline equal to the given {@code deadline} should be scheduled (inclusive)
      * @param to           the time until which no deadline equal to the given {@code deadline} should be scheduled (inclusive)

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,6 +332,29 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
                 scheduledTime,
                 matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName))
         );
+    }
+
+    @Override
+    public FixtureExecutionResult expectNoScheduledDeadlineMatching(Instant from, Instant to, Matcher<? super DeadlineMessage<?>> matcher) {
+        return expectNoScheduledDeadlineMatching(matches(
+                deadlineMessage -> !(deadlineMessage.getTimestamp().isBefore(from) || deadlineMessage.getTimestamp().isAfter(to))
+                        && matcher.matches(deadlineMessage)
+        ));
+    }
+
+    @Override
+    public FixtureExecutionResult expectNoScheduledDeadline(Instant from, Instant to, Object deadline) {
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(equalTo(deadline, fieldFilter)));
+    }
+
+    @Override
+    public FixtureExecutionResult expectNoScheduledDeadlineOfType(Instant from, Instant to, Class<?> deadlineType) {
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(any(deadlineType)));
+    }
+
+    @Override
+    public FixtureExecutionResult expectNoScheduledDeadlineWithName(Instant from, Instant to, String deadlineName) {
+        return expectNoScheduledDeadlineMatching(from, to, matches(deadlineMessage -> deadlineMessage.getDeadlineName().equals(deadlineName)));
     }
 
     @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -130,29 +130,29 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
-        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(expiryTime);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test
     void noDeadlineInTimeframeWithDeadlineAtFrom() {
-        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowFrom);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test
     void noDeadlineInTimeframeWithDeadlineAtTo() {
-        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowTo);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.*;
 class ResultValidatorImplTest {
 
     @Mock
-    private StubDeadlineManager stubDeadlineManager;
+    private StubDeadlineManager deadlineManager;
     private ResultValidator<?> validator;
 
     private final Instant deadlineWindowFrom = Instant.now();
@@ -56,7 +56,7 @@ class ResultValidatorImplTest {
         validator = new ResultValidatorImpl<>(actualEvents(),
                                               AllFieldsFilter.instance(),
                                               () -> null,
-                                              stubDeadlineManager);
+                                              deadlineManager);
     }
 
     @Test
@@ -99,21 +99,21 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineMatchingInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
     }
 
     @Test
     void noDeadlineMatchingInTimeframeWithDeadlineAtFrom() {
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
     }
 
     @Test
     void noDeadlineMatchingInTimeframeWithDeadlineAtTo() {
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowTo)));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowTo)));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
     }
@@ -122,7 +122,7 @@ class ResultValidatorImplTest {
     void noDeadlineMatchingInTimeframeWithDeadlinesOutsideWindow() {
         ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
         validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything());
     }
@@ -131,7 +131,7 @@ class ResultValidatorImplTest {
     void noDeadlineInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
         ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class,
                      () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
@@ -140,7 +140,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class,
                      () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
@@ -149,7 +149,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtTo() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class,
                      () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
@@ -159,7 +159,7 @@ class ResultValidatorImplTest {
     void noDeadlineInTimeframeWithDeadlinesOutsideWindow() {
         ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
         validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload());
         validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload());
@@ -169,7 +169,7 @@ class ResultValidatorImplTest {
     void noDeadlineOfTypeInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
         ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
     }
@@ -177,7 +177,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineOfTypeInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
     }
@@ -185,7 +185,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineOfTypeInTimeframeWithDeadlineAtTo() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
     }
@@ -194,7 +194,7 @@ class ResultValidatorImplTest {
     void noDeadlineOfTypeInTimeframeWithDeadlinesOutsideWindow() {
         ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
         validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class);
     }
@@ -203,7 +203,7 @@ class ResultValidatorImplTest {
     void noDeadlineWithNameInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
         ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
     }
@@ -211,7 +211,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineWithNameInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
     }
@@ -219,7 +219,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineWithNameInTimeframeWithDeadlineAtTo() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
     }
@@ -228,7 +228,7 @@ class ResultValidatorImplTest {
     void noDeadlineWithNameInTimeframeWithDeadlinesOutsideWindow() {
         ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
-        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
         validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName");
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,24 +16,48 @@
 
 package org.axonframework.test.aggregate;
 
+import org.axonframework.deadline.DeadlineMessage;
+import org.axonframework.deadline.GenericDeadlineMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.test.AxonAssertionError;
+import org.axonframework.test.deadline.ScheduledDeadlineInfo;
+import org.axonframework.test.deadline.StubDeadlineManager;
+import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.matchers.MatchAllFieldFilter;
-import org.junit.jupiter.api.Test;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.*;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class ResultValidatorImplTest {
 
-    private ResultValidator<?> validator = new ResultValidatorImpl<>(actualEvents(),
-                                                                     new MatchAllFieldFilter(emptyList()),
-                                                                     () -> null,
-                                                                     null);
+    @Mock
+    private StubDeadlineManager stubDeadlineManager;
+    private ResultValidator<?> validator;
+
+    private final Instant deadlineWindowFrom = Instant.now();
+    private final Instant deadlineWindowTo = Instant.now().plus(2, ChronoUnit.DAYS);
+
+    @BeforeEach
+    void setup() {
+        validator = new ResultValidatorImpl<>(actualEvents(),
+                                              AllFieldsFilter.instance(),
+                                              () -> null,
+                                              stubDeadlineManager);
+    }
 
     @Test
     void shouldCompareValuesForEquality() {
@@ -72,9 +96,150 @@ class ResultValidatorImplTest {
         validator.expectEvents(s2);
     }
 
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineAtFrom() {
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineAtTo() {
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowTo)));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything());
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload());
+        validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload());
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class);
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(stubDeadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName");
+    }
+
     private List<EventMessage<?>> actualEvents() {
         return singletonList(asEventMessage(new MyEvent("aggregateId", 123))
                                      .andMetaData(singletonMap("key1", "value1")));
     }
 
+    private ScheduledDeadlineInfo createDeadline(Instant expiryTime) {
+        DeadlineMessage<String> deadlineMessage = GenericDeadlineMessage.asDeadlineMessage("deadlineName", "payload", expiryTime);
+        return new ScheduledDeadlineInfo(expiryTime, "deadlineName", "1", 0, deadlineMessage, null);
+    }
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -105,6 +105,14 @@ class ResultValidatorImplTest {
     }
 
     @Test
+    void noDeadlineMatchingInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.nullValue()));
+    }
+
+    @Test
     void noDeadlineMatchingInTimeframeWithDeadlineAtFrom() {
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
 
@@ -135,6 +143,14 @@ class ResultValidatorImplTest {
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, new Object()));
     }
 
     @Test
@@ -175,6 +191,14 @@ class ResultValidatorImplTest {
     }
 
     @Test
+    void noDeadlineOfTypeInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, Integer.class));
+    }
+
+    @Test
     void noDeadlineOfTypeInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
@@ -202,10 +226,17 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineWithNameInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
-        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
 
         assertThrows(AxonAssertionError.class, () -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "otherName"));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -124,7 +124,7 @@ class ResultValidatorImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything());
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
     }
 
     @Test
@@ -161,8 +161,8 @@ class ResultValidatorImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload());
-        validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload());
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload()));
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload()));
     }
 
     @Test
@@ -196,7 +196,7 @@ class ResultValidatorImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class);
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
     }
 
     @Test
@@ -230,7 +230,7 @@ class ResultValidatorImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName");
+        assertDoesNotThrow(() -> validator.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
     }
 
     private List<EventMessage<?>> actualEvents() {

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -426,29 +426,29 @@ class FixtureExecutionResultImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
-        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(expiryTime);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test
     void noDeadlineInTimeframeWithDeadlineAtFrom() {
-        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowFrom);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test
     void noDeadlineInTimeframeWithDeadlineAtTo() {
-        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
-        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+        ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowTo);
+        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
-        assertThrows(AxonAssertionError.class,
-                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -420,7 +420,7 @@ class FixtureExecutionResultImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything());
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
     }
 
     @Test
@@ -457,8 +457,8 @@ class FixtureExecutionResultImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload());
-        testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload());
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload()));
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload()));
     }
 
     @Test
@@ -492,7 +492,7 @@ class FixtureExecutionResultImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class);
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
     }
 
     @Test
@@ -526,7 +526,7 @@ class FixtureExecutionResultImplTest {
         ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
 
-        testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName");
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
     }
 
     private ScheduledDeadlineInfo createDeadline(Instant expiryTime) {

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -401,6 +401,14 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
+    void noDeadlineMatchingInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.nullValue()));
+    }
+
+    @Test
     void noDeadlineMatchingInTimeframeWithDeadlineAtFrom() {
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
 
@@ -431,6 +439,14 @@ class FixtureExecutionResultImplTest {
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, new Object()));
     }
 
     @Test
@@ -471,6 +487,14 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
+    void noDeadlineOfTypeInTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, Integer.class));
+    }
+
+    @Test
     void noDeadlineOfTypeInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
@@ -502,6 +526,14 @@ class FixtureExecutionResultImplTest {
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameTimeframeWithOtherDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "otherName"));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,31 @@
 package org.axonframework.test.saga;
 
 import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.deadline.DeadlineMessage;
+import org.axonframework.deadline.GenericDeadlineMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.modelling.saga.AssociationValue;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.axonframework.test.AxonAssertionError;
+import org.axonframework.test.deadline.ScheduledDeadlineInfo;
 import org.axonframework.test.deadline.StubDeadlineManager;
 import org.axonframework.test.eventscheduler.StubEventScheduler;
 import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.utils.RecordingCommandBus;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -40,29 +50,34 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.axonframework.test.matchers.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class to verify correct execution of the {@link FixtureExecutionResultImpl}.
  *
  * @author Allard Buijze
  */
+@ExtendWith(MockitoExtension.class)
 class FixtureExecutionResultImplTest {
 
     private FixtureExecutionResultImpl<StubSaga> testSubject;
     private RecordingCommandBus commandBus;
     private SimpleEventBus eventBus;
     private StubEventScheduler eventScheduler;
+    @Mock
     private StubDeadlineManager deadlineManager;
     private InMemorySagaStore sagaStore;
     private TimerTriggeredEvent applicationEvent;
     private String identifier;
+
+    private final Instant deadlineWindowFrom = Instant.now();
+    private final Instant deadlineWindowTo = Instant.now().plus(2, ChronoUnit.DAYS);
 
     @BeforeEach
     void setUp() {
         commandBus = new RecordingCommandBus();
         eventBus = SimpleEventBus.builder().build();
         eventScheduler = new StubEventScheduler();
-        deadlineManager = new StubDeadlineManager();
         sagaStore = new InMemorySagaStore();
         testSubject = new FixtureExecutionResultImpl<>(
                 sagaStore, eventScheduler, deadlineManager, eventBus, commandBus, StubSaga.class,
@@ -375,6 +390,148 @@ class FixtureExecutionResultImplTest {
         testSubject.startRecording();
 
         assertThat(startRecordingCallbackInvocations.get(), equalTo(1));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(expiryTime)));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineAtFrom() {
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowFrom)));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlineAtTo() {
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(createDeadline(deadlineWindowTo)));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything()));
+    }
+
+    @Test
+    void noDeadlineMatchingInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        testSubject.expectNoScheduledDeadlineMatching(deadlineWindowFrom, deadlineWindowTo, Matchers.anything());
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class,
+                     () -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadline.deadlineMessage().getPayload()));
+    }
+
+    @Test
+    void noDeadlineInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineBefore.deadlineMessage().getPayload());
+        testSubject.expectNoScheduledDeadline(deadlineWindowFrom, deadlineWindowTo, deadlineAfter.deadlineMessage().getPayload());
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class));
+    }
+
+    @Test
+    void noDeadlineOfTypeInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        testSubject.expectNoScheduledDeadlineOfType(deadlineWindowFrom, deadlineWindowTo, String.class);
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineInsideWindow() {
+        Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
+        ScheduledDeadlineInfo deadline = createDeadline(expiryTime);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineAtFrom() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowFrom);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlineAtTo() {
+        ScheduledDeadlineInfo deadline = createDeadline(deadlineWindowTo);
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadline));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName"));
+    }
+
+    @Test
+    void noDeadlineWithNameInTimeframeWithDeadlinesOutsideWindow() {
+        ScheduledDeadlineInfo deadlineBefore = createDeadline(deadlineWindowFrom.minus(1, ChronoUnit.DAYS));
+        ScheduledDeadlineInfo deadlineAfter = createDeadline(deadlineWindowTo.plus(1, ChronoUnit.DAYS));
+        when(deadlineManager.getScheduledDeadlines()).thenReturn(Arrays.asList(deadlineBefore, deadlineAfter));
+
+        testSubject.expectNoScheduledDeadlineWithName(deadlineWindowFrom, deadlineWindowTo, "deadlineName");
+    }
+
+    private ScheduledDeadlineInfo createDeadline(Instant expiryTime) {
+        DeadlineMessage<String> deadlineMessage = GenericDeadlineMessage.asDeadlineMessage("deadlineName", "payload", expiryTime);
+        return new ScheduledDeadlineInfo(expiryTime, "deadlineName", "1", 0, deadlineMessage, null);
     }
 
     private static class SimpleCommand {


### PR DESCRIPTION
Added some additional validation methods to the `ResultValidator` and `FixtureExecutionResult`, allowing to check for the absence of a deadline within a certain timeframe instead of only at a specific `Instant`.

Since there is already a large amount of test methods for deadlines, the new methods add this new functionality in the simplest manner posible, to avoid having an exessive amount of methods, which could cause more confusion to users instead.

This PR resolves issue https://github.com/AxonFramework/AxonFramework/issues/1466