### PR TITLE
PooledStreamingEventProcessor fails when a single token entry is null

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -617,8 +617,10 @@ class Coordinator {
                     for (Map.Entry<Segment, TrackingToken> entry : newSegments.entrySet()) {
                         Segment segment = entry.getKey();
                         TrackingToken token = entry.getValue();
-                        streamStartPosition = streamStartPosition == null
-                                ? null : streamStartPosition.lowerBound(WrappedToken.unwrapLowerBound(token));
+                        TrackingToken otherUnwrapped = WrappedToken.unwrapLowerBound(token);
+
+                        streamStartPosition = streamStartPosition == null || otherUnwrapped == null
+                                ? null : streamStartPosition.lowerBound(otherUnwrapped);
                         logger.debug("Processor [{}] claimed {} for processing.", name, segment);
                         workPackages.computeIfAbsent(segment.getSegmentId(),
                                                      wp -> workPackageFactory.apply(segment, token));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -315,6 +315,21 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
+    void testTokenStoreReturningSingleNullToken() {
+        when(stubEventHandler.canHandle(any(), any())).thenReturn(false);
+        when(stubEventHandler.canHandleType(Integer.class)).thenReturn(false);
+
+        tokenStore.initializeTokenSegments(testSubject.getName(), 2);
+        tokenStore.storeToken(new GlobalSequenceTrackingToken(0), testSubject.getName(), 1);
+
+        testSubject.start();
+
+        assertWithin(1, TimeUnit.SECONDS, () -> {
+            assertEquals(2, testSubject.processingStatus().size());
+        });
+    }
+
+    @Test
     void testEventsWhichMustBeIgnoredAreNotHandledOnlyValidated() throws Exception {
         setTestSubject(createTestSubject(builder -> builder.initialSegmentCount(1)));
 


### PR DESCRIPTION
When the token store contains a token for some, but not all, segments, the processor fails when trying to calculate the lower bound of these tokens.

This commit fixed that, accepting a null token as the lowerbound, instead of attempting to continue calculating it.