### PR TITLE
Allow insertion of `MetaData` on the `CommandGateway`'s API

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,22 +31,30 @@ import java.util.Map;
  * @since 2.0
  */
 public class GenericCommandMessage<T> extends MessageDecorator<T> implements CommandMessage<T> {
+
     private static final long serialVersionUID = 3282528436414939876L;
     private final String commandName;
 
     /**
-     * Returns the given command as a CommandMessage. If {@code command} already implements CommandMessage, it is
-     * returned as-is. Otherwise, the given {@code command} is wrapped into a GenericCommandMessage as its
-     * payload.
+     * Returns the given command as a {@link CommandMessage}. If {@code command} already implements {@code
+     * CommandMessage}, it is returned as-is. When the {@code command} is another implementation of {@link Message}, the
+     * {@link Message#getPayload()} and {@link Message#getMetaData()} are used as input for a new {@link
+     * GenericCommandMessage}. Otherwise, the given {@code command} is wrapped into a {@code GenericCommandMessage} as
+     * its payload.
      *
-     * @param command the command to wrap as CommandMessage
-     * @return a CommandMessage containing given {@code command} as payload, or {@code command} if it already implements
-     * CommandMessage.
+     * @param command The command to wrap as {@link CommandMessage}.
+     * @return A {@link CommandMessage} containing given {@code command} as payload, a {@code command} if it already
+     * implements {@code CommandMessage}, or a {@code CommandMessage} based on the result of {@link
+     * Message#getPayload()} and {@link Message#getMetaData()} for other {@link Message} implementations.
      */
     @SuppressWarnings("unchecked")
     public static <C> CommandMessage<C> asCommandMessage(Object command) {
-        if (CommandMessage.class.isInstance(command)) {
+        if (command instanceof CommandMessage) {
             return (CommandMessage<C>) command;
+        } else if (command instanceof Message) {
+            return new GenericCommandMessage<>(
+                    (C) ((Message<?>) command).getPayload(), ((Message<?>) command).getMetaData()
+            );
         }
         return new GenericCommandMessage<>((C) command, MetaData.emptyInstance());
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.axonframework.commandhandling;
 
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -26,6 +28,8 @@ import static org.axonframework.commandhandling.GenericCommandMessage.asCommandM
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * Test class validating the {@link GenericCommandMessage}.
+ *
  * @author Allard Buijze
  */
 class GenericCommandMessageTest {
@@ -95,5 +99,45 @@ class GenericCommandMessageTest {
         assertTrue(actual.contains("'key2'->'13'"), "Wrong output: " + actual);
         assertTrue(actual.endsWith("', commandName='java.lang.String'}"), "Wrong output: " + actual);
         assertEquals(173, actual.length(), "Wrong output: " + actual);
+    }
+
+    @Test
+    void testAsCommandMessageWrapsPayload() {
+        String expectedPayload = "some-payload";
+
+        CommandMessage<Object> result = asCommandMessage(expectedPayload);
+
+        assertEquals(expectedPayload, result.getPayload());
+        assertTrue(result.getMetaData().isEmpty());
+        assertNotNull(result.getIdentifier());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getCommandName());
+    }
+
+    @Test
+    void testAsCommandMessageReturnsCommandMessageAsIs() {
+        CommandMessage<String> expected = new GenericCommandMessage<>("some-payload", MetaData.with("key", "value"));
+
+        CommandMessage<Object> result = asCommandMessage(expected);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testAsCommandMessageRetrievesPayloadAndMetaDataFromMessageImplementations() {
+        String expectedPayload = "some-payload";
+        MetaData expectedMetaData = MetaData.with("key", "value");
+
+        String testIdentifier = "some-identifier";
+        Message<String> testMessage =
+                new GenericMessage<>(testIdentifier, expectedPayload, expectedMetaData);
+
+        CommandMessage<Object> result = asCommandMessage(testMessage);
+
+        assertEquals(expectedPayload, result.getPayload());
+        assertEquals(expectedMetaData, result.getMetaData());
+        assertNotEquals(testIdentifier, result.getIdentifier());
+        assertEquals(String.class, result.getPayloadType());
+        assertEquals(String.class.getName(), result.getCommandName());
     }
 }


### PR DESCRIPTION
This pull request introduces new `default` methods for the `CommandGateway`.
Namely:

* `<R> CompletableFuture<R> send(Object command, MetaData metaData)`
* `<R> R sendAndWait(Object command, MetaData metaData)`
* `<R> R sendAndWait(Object command, MetaData metaData, long timeout, TimeUnit unit)`

Each of these uses the `GenericCommandMessage#asCommandMessage` method to first construct a `CommandMessage` and then attach the given `metaData` through `Message#andMetaData`.

This change allows for a friendlier API when users, for example, require to attach the correlation data directly to the command they want to dispatch.

Additionally, the `GenericCommandMessage#asCommandMessage` method is updated to include a `Message` branch.
This addition is in line with the JavaDoc of the `CommandGateway`, which states that Axon carries over the payload and `MetaData` of a `Message` implementation into the `CommandMessage` under construction.