### PR TITLE
Update XStream version to 1.4.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <axonserver-connector-java.version>4.5.4</axonserver-connector-java.version>
         <hamcrest.version>2.2</hamcrest.version>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <xstream.version>1.4.18</xstream.version>
+        <xstream.version>1.4.19</xstream.version>
 
         <!-- plugin versions -->
         <felix.maven-bundle-plugin.version>5.1.4</felix.maven-bundle-plugin.version>


### PR DESCRIPTION
This pull request updates the version of XStream to 1.4.19.
By doing so, we resolve any possible security predicaments, as described in [CVE-2021-43859](https://x-stream.github.io/CVE-2021-43859.html).