### PR TITLE
Wire eventSerializer into QuartzEventSchedulerFactoryBean

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -458,6 +458,16 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
             assertNonNull(scheduler, "The Scheduler is a hard requirement and should be provided");
             assertNonNull(eventBus, "The EventBus is a hard requirement and should be provided");
             if (jobDataBinderSupplier == null) {
+                if (serializer == null) {
+                    logger.warn(
+                            "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
+                                    + " the security context of the XStream instance.",
+                            new AxonConfigurationException(
+                                    "A default XStreamSerializer is used, without specifying the security context"
+                            )
+                    );
+                    serializer = XStreamSerializer::defaultSerializer;
+                }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }
         }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -458,16 +458,6 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
             assertNonNull(scheduler, "The Scheduler is a hard requirement and should be provided");
             assertNonNull(eventBus, "The EventBus is a hard requirement and should be provided");
             if (jobDataBinderSupplier == null) {
-                if (serializer == null) {
-                    logger.warn(
-                            "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                    + " the security context of the XStream instance.",
-                            new AxonConfigurationException(
-                                    "A default XStreamSerializer is used, without specifying the security context"
-                            )
-                    );
-                    serializer = XStreamSerializer::defaultSerializer;
-                }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }
         }

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -135,22 +135,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-parameter-names</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- explicitly define transitive dependencies to increase version priority -->
         <!-- see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies -->
         <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2020. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -132,6 +132,22 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,7 @@ package org.axonframework.spring.eventhandling.scheduling.quartz;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.scheduling.quartz.EventJobDataBinder;
 import org.axonframework.eventhandling.scheduling.quartz.QuartzEventScheduler;
+import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
 import org.quartz.JobDataMap;
 import org.quartz.Scheduler;
@@ -46,11 +47,11 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
     private QuartzEventScheduler eventScheduler;
     private Scheduler scheduler;
     private EventBus eventBus;
+    private Serializer serializer;
     private String groupIdentifier;
     private EventJobDataBinder eventJobDataBinder;
     private PlatformTransactionManager transactionManager;
     private TransactionDefinition transactionDefinition;
-
 
     @Override
     public QuartzEventScheduler getObject() {
@@ -75,9 +76,12 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
         if (scheduler == null) {
             scheduler = applicationContext.getBean(Scheduler.class);
         }
+        if (serializer == null) {
+            serializer = applicationContext.getBean("messageSerializer", Serializer.class);
+        }
 
         QuartzEventScheduler.Builder eventSchedulerBuilder =
-                QuartzEventScheduler.builder().scheduler(scheduler).eventBus(eventBus);
+                QuartzEventScheduler.builder().scheduler(scheduler).eventBus(eventBus).serializer(serializer);
         if (eventJobDataBinder != null) {
             eventSchedulerBuilder.jobDataBinder(eventJobDataBinder);
         }
@@ -156,5 +160,15 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
      */
     public void setTransactionDefinition(TransactionDefinition transactionDefinition) {
         this.transactionDefinition = transactionDefinition;
+    }
+
+    /**
+     * Sets the {@link Serializer} used by the {@link EventJobDataBinder}. The {@code EventJobDataBinder} uses the {@code Serializer} to de-/serialize the
+     * scheduled event.
+     *
+     * @param serializer a {@link Serializer} used by the {@link EventJobDataBinder} when serializing events
+     */
+    public void setSerializer(Serializer serializer) {
+        this.serializer = serializer;
     }
 }

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
@@ -77,7 +77,7 @@ public class QuartzEventSchedulerFactoryBean implements FactoryBean<QuartzEventS
             scheduler = applicationContext.getBean(Scheduler.class);
         }
         if (serializer == null) {
-            serializer = applicationContext.getBean("messageSerializer", Serializer.class);
+            serializer = applicationContext.getBean("eventSerializer", Serializer.class);
         }
 
         QuartzEventScheduler.Builder eventSchedulerBuilder =

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.eventhandling.replay.ReplayAwareMessageHandlerWrapper;
-import org.axonframework.eventhandling.scheduling.EventScheduler;
+import org.axonframework.eventhandling.scheduling.quartz.QuartzEventScheduler;
 import org.axonframework.eventsourcing.CachingEventSourcingRepository;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
@@ -74,12 +74,20 @@ import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryResult;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.queryhandling.annotation.MethodQueryMessageHandlerDefinition;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.spring.eventhandling.scheduling.quartz.QuartzEventSchedulerFactoryBean;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.mockito.internal.util.collections.*;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerContext;
+import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -96,6 +104,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.test.StepVerifier;
 
 import java.lang.reflect.Executable;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -186,6 +195,13 @@ public class SpringAxonAutoConfigurerTest {
     @Qualifier("myLockFactory")
     private LockFactory myLockFactory;
 
+    @Autowired
+    private QuartzEventScheduler quartzEventScheduler;
+
+    @Autowired
+    @Qualifier("messageSerializer")
+    private Context.MyMessageSerializer messageSerializer;
+
     @Test
     void contextWiresMainComponents() {
         assertNotNull(axonConfig);
@@ -202,6 +218,7 @@ public class SpringAxonAutoConfigurerTest {
         assertNotNull(tagsConfiguration);
         assertEquals(tagsConfiguration, axonConfig.tags());
         assertNotNull(axonConfig.eventScheduler());
+        assertNotNull(quartzEventScheduler);
     }
 
     @Test
@@ -344,7 +361,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    public void testAggregateCaching() {
+    void testAggregateCaching() {
         FutureCallback<Object, Object> callback1 = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage(new Context.CreateMyCachedAggregateCommand("id")), callback1);
         callback1.getResult();
@@ -365,6 +382,12 @@ public class SpringAxonAutoConfigurerTest {
         commandCallback.getResult();
 
         verify(myLockFactory).obtainLock(expectedAggregateId);
+    }
+
+    @Test
+    void testEventSchedulerUsesMessageSerializer() {
+        quartzEventScheduler.schedule(Instant.now(), "deadline");
+        assertEquals(2, messageSerializer.serializationCount); //This shows we have serialized both the payload and metadata using this serializer
     }
 
     @AnnotationDriven
@@ -432,8 +455,26 @@ public class SpringAxonAutoConfigurerTest {
         }
 
         @Bean
-        public EventScheduler eventScheduler() {
-            return mock(EventScheduler.class);
+        public Scheduler scheduler() throws SchedulerException {
+            Scheduler scheduler = mock(Scheduler.class);
+            when(scheduler.getContext()).thenReturn(mock(SchedulerContext.class));
+            return scheduler;
+        }
+
+        @Bean
+        @Primary
+        public Serializer serializer() {
+            return XStreamSerializer.defaultSerializer();
+        }
+
+        @Bean
+        public Serializer messageSerializer() {
+            return new MyMessageSerializer(JacksonSerializer.builder());
+        }
+
+        @Bean
+        public QuartzEventSchedulerFactoryBean quartzEventSchedulerFactoryBean() {
+            return new QuartzEventSchedulerFactoryBean();
         }
 
         @Bean
@@ -693,6 +734,21 @@ public class SpringAxonAutoConfigurerTest {
                                                                         ParameterResolverFactory parameterResolverFactory) {
                 assertNotNull(commandBus);
                 return Optional.empty();
+            }
+        }
+
+        public static class MyMessageSerializer extends JacksonSerializer {
+
+            private int serializationCount = 0;
+
+            protected MyMessageSerializer(Builder builder) {
+                super(builder);
+            }
+
+            @Override
+            public <T> SerializedObject<T> serialize(Object object, Class<T> expectedRepresentation) {
+                serializationCount++;
+                return super.serialize(object, expectedRepresentation);
             }
         }
     }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -398,8 +398,6 @@ public class SpringAxonAutoConfigurerTest {
     @Configuration
     public static class Context {
 
-        private final Serializer eventSerializer = mock(Serializer.class);
-
         @Bean
         public EventProcessingModule eventProcessingConfiguration(
                 @Qualifier("customSagaStore") SagaStore<? super MySaga> customSagaStore) {
@@ -473,7 +471,7 @@ public class SpringAxonAutoConfigurerTest {
 
         @Bean
         public Serializer eventSerializer() {
-            return eventSerializer;
+            return mock(Serializer.class);
         }
 
         @Bean


### PR DESCRIPTION
Currently, the `QuartzEventSchedulerFactory` uses the default `XStreamSerializer`, which presents issues with the XStream updgrade in Axon Framework 4.5.4.

This PR changes this behaviour to use the `eventSerializer` bean instead.

NOTE/WARNING: This change is not fully backwards compatible. If currently someone uses the `QuartzEventSchedulerFactoryBean`, but has changed the `eventSerializer` into a `JacksonSerializer` (for  example), it will not be able to deserialize any already serialized and scheduled events. This can be resolved by manually setting the serializer to be used by the factory.

This resolves issue #2088 