### PR TITLE
Fix `StreamingEventProcessor#maxCapacity` for the `TrackingEventProcessor`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/StreamingEventProcessorInfoMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/StreamingEventProcessorInfoMessage.java
@@ -58,7 +58,7 @@ public class StreamingEventProcessorInfoMessage {
                                  .setTokenStoreIdentifier(eventProcessor.getTokenStoreIdentifier())
                                  .setMode(defineMode(eventProcessor.getClass()))
                                  .setActiveThreads(eventProcessor.processingStatus().size())
-                                 .setAvailableThreads(eventProcessor.maxCapacity())
+                                 .setAvailableThreads(eventProcessor.maxCapacity()-eventProcessor.processingStatus().size())
                                  .setRunning(eventProcessor.isRunning())
                                  .setError(eventProcessor.isError())
                                  .addAllSegmentStatus(segmentStatuses)

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -268,6 +268,14 @@ class TrackingEventProcessorTest {
     }
 
     @Test
+    void testSequenceMaxCapacity() {
+        testSubject.start();
+        assertEquals(1, testSubject.maxCapacity());
+        assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(0, testSubject.availableProcessorThreads()));
+        assertEquals(1, testSubject.activeProcessorThreads());
+    }
+
+    @Test
     void testPublishedEventsGetPassedToHandler() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         doAnswer(invocation -> {

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -111,6 +111,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
     private final AtomicInteger availableThreads;
     private final long tokenClaimInterval;
     private final AtomicReference<String> tokenStoreIdentifier = new AtomicReference<>();
+    private final int maxThreadCount;
 
     private final ConcurrentMap<Integer, List<Instruction>> instructions = new ConcurrentHashMap<>();
     private final boolean storeTokenBeforeProcessing;
@@ -142,6 +143,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
         this.transactionManager = builder.transactionManager;
 
         this.availableThreads = new AtomicInteger(config.getMaxThreadCount());
+        this.maxThreadCount = config.getMaxThreadCount();
         this.threadFactory = config.getThreadFactory(builder.name);
         this.workerTerminationTimeout = config.getWorkerTerminationTimeout();
         this.segmentIdResourceKey = "Processor[" + builder.name + "]/SegmentId";
@@ -731,7 +733,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
 
     @Override
     public int maxCapacity() {
-        return availableProcessorThreads();
+        return maxThreadCount;
     }
 
     /**


### PR DESCRIPTION
Let maxCapacity for tracking event processor return the total number of threads, availableProcessorThreads returns the still available threads.