### PR TITLE
Fail Aggregate Fixture if there's no exception while `ResultValidator#expectExceptionMessage` is invoked.

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -353,8 +353,13 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
             reporter.reportWrongExceptionMessage(actualException, emptyMatcherDescription);
             return this;
         }
+
         StringDescription description = new StringDescription();
         exceptionMessageMatcher.describeTo(description);
+
+        if (actualException == null) {
+            reporter.reportUnexpectedReturnValue(actualReturnValue.getPayload(), description);
+        }
         if (actualException != null && !exceptionMessageMatcher.matches(actualException.getMessage())) {
             reporter.reportWrongExceptionMessage(actualException, description);
         }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
+import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.FixtureExecutionException;
 import org.junit.jupiter.api.*;
 
@@ -35,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Patrick Haas
  */
 class FixtureTest_ExceptionHandling {
+
+    private static final String AGGREGATE_ID = "1";
 
     private final FixtureConfiguration<MyAggregate> fixture = new AggregateTestFixture<>(MyAggregate.class);
 
@@ -107,6 +110,16 @@ class FixtureTest_ExceptionHandling {
                         new CreateMyAggregateCommand("1"),
                         new ValidMyAggregateCommand("2")
                 )
+        );
+    }
+
+    @Test
+    void testExpectExceptionMessageThrowsFixtureExecutionExceptionWhenNoExceptionIsThrown() {
+        assertThrows(
+                AxonAssertionError.class,
+                () -> fixture.given(new MyAggregateCreatedEvent(AGGREGATE_ID))
+                             .when(new ValidMyAggregateCommand(AGGREGATE_ID))
+                             .expectExceptionMessage("some-exception-message")
         );
     }
 


### PR DESCRIPTION
The `ResultValidator#expectExceptionMessage` would complete successfully if there's no exception present while using the `AggregateTestFixture`. 
This is off, as expecting an "exception message" means the user expects an exception to be present. 
This pull request makes the minor adjustment of a null-check for the existence of an exception at all.