### PR TITLE
Spring event for indication that Axon has started

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
@@ -18,7 +18,10 @@ package org.axonframework.spring.config;
 
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
+import org.axonframework.spring.event.AxonStartedEvent;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.lang.NonNull;
 
@@ -40,6 +43,7 @@ public class SpringAxonConfiguration implements FactoryBean<Configuration>, Smar
     private final Configurer configurer;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final AtomicReference<Configuration> configuration = new AtomicReference<>();
+    private ApplicationContext applicationContext;
 
     /**
      * Initialize this {@link Configuration} instance.
@@ -70,6 +74,7 @@ public class SpringAxonConfiguration implements FactoryBean<Configuration>, Smar
     public void start() {
         if (isRunning.compareAndSet(false, true)) {
             getObject().start();
+            this.applicationContext.publishEvent(new AxonStartedEvent());
         }
     }
 
@@ -84,5 +89,10 @@ public class SpringAxonConfiguration implements FactoryBean<Configuration>, Smar
     @Override
     public boolean isRunning() {
         return isRunning.get();
+    }
+
+    @Autowired
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
     }
 }

--- a/spring/src/main/java/org/axonframework/spring/event/AxonStartedEvent.java
+++ b/spring/src/main/java/org/axonframework/spring/event/AxonStartedEvent.java
@@ -21,7 +21,7 @@ package org.axonframework.spring.event;
  * and can handle all commands, events and queries.
  *
  * @author Mitchell Herrijgers
- * @since 4.6
+ * @since 4.6.0
  */
 public class AxonStartedEvent {
 

--- a/spring/src/main/java/org/axonframework/spring/event/AxonStartedEvent.java
+++ b/spring/src/main/java/org/axonframework/spring/event/AxonStartedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.event;
+
+/**
+ * Event published after initialization of Axon through the Spring event mechanism. Indicates that Axon is fully started
+ * and can handle all commands, events and queries.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6
+ */
+public class AxonStartedEvent {
+
+}

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.config;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.config.Configurer;
+import org.axonframework.spring.event.AxonStartedEvent;
+import org.junit.jupiter.api.*;
+import org.springframework.context.ApplicationContext;
+
+import static org.mockito.Mockito.*;
+
+class SpringAxonConfigurationTest {
+
+    @Test
+    void testAxonStartedEventIsPublished() {
+        Configurer configurer = mock(Configurer.class);
+        ApplicationContext context = mock(ApplicationContext.class);
+        Configuration configuration = mock(Configuration.class);
+        when(configurer.buildConfiguration()).thenReturn(configuration);
+
+        SpringAxonConfiguration springAxonConfiguration = new SpringAxonConfiguration(configurer);
+        springAxonConfiguration.setApplicationContext(context);
+
+        springAxonConfiguration.start();
+        verify(context).publishEvent(isA(AxonStartedEvent.class));
+    }
+}


### PR DESCRIPTION
Publishes an `AxonStartedEvent` when the Configuration module has fully started. This means that Event processors are up and running, command handlers are registered and all other things Axon provides. 