### PR TITLE
[#2154] Fix missing propagation of ReplayToken to UnitOfWork for PooledStreamingEventProcessor

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -228,7 +228,10 @@ class WorkPackage {
             ProcessingEntry entry = processingQueue.poll();
             lastConsumedToken = WrappedToken.advance(lastConsumedToken, entry.eventMessage().trackingToken());
             if (entry.canHandle()) {
-                eventBatch.add(entry.eventMessage());
+                eventBatch.add(
+                        entry.eventMessage()
+                             .withTrackingToken(lastConsumedToken)
+                );
             }
         }
 


### PR DESCRIPTION
Unlike the TEP, the PSEP does not propagate the WrappedToken instance to the handling UoW. This causes `ReplayStatus` injections to have the wrong value, as well as the `@DisallowReplay` annotation not to work. 

This PR resolves #2154.