### PR TITLE
Take into account the result of the `equals` method before attempting…

### DIFF
--- a/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
@@ -63,7 +63,7 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
     @SuppressWarnings({"unchecked"})
     @Override
     public boolean matches(Object item) {
-        return expected.getClass().isInstance(item) && matchesSafely(item);
+        return expected.equals(item) || expected.getClass().isInstance(item) && matchesSafely(item);
     }
 
     private boolean matchesSafely(Object actual) {

--- a/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
@@ -39,7 +39,15 @@ class EqualFieldsMatcherTest {
     }
 
     @Test
-    void testMatches_SameInstance() {
+    void testMatches_SameInstanceByEqualsMethod() {
+        AlwaysEqualsEvent firstEvent = new AlwaysEqualsEvent("value");
+        AlwaysEqualsEvent secondEvent = new AlwaysEqualsEvent("anotherValue");
+        EqualFieldsMatcher<AlwaysEqualsEvent> testSubject = Matchers.equalTo(firstEvent);
+        assertTrue(testSubject.matches(secondEvent));
+    }
+
+    @Test
+    void testMatches_SameInstanceByMatchingFields() {
         assertTrue(testSubject.matches(expectedEvent));
     }
 
@@ -93,5 +101,24 @@ class EqualFieldsMatcherTest {
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
         assertEquals("org.axonframework.test.aggregate.MyEvent (failed on field 'someValue')", description.toString());
+    }
+
+    private static class AlwaysEqualsEvent {
+
+        private final String value;
+
+        AlwaysEqualsEvent(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
… to compare fields reflectively while asserting a test result

The deadline manager allows an arbitrary object for a payload, including types from the `java.lang` package like `String`. `SagaTestFixture` allows asserting deadline manager's payloads and achieves it through the reflection mechanism for the user's convenience. For these reasons, the `EqualFieldsMatcher` may inspect the `java.lang.String`, and make its internal fields accessible. Java 17 denies such access by default since [JEP 403](https://openjdk.java.net/jeps/403). Verifying the result of equals before reflectively comparing fields allows avoiding breaking the strong encapsulation of `java.lang` types.