### PR TITLE
Introduce conditional variants for `ApplyMore`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/ApplyMore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ApplyMore.java
@@ -49,6 +49,27 @@ public interface ApplyMore {
     ApplyMore andThenApply(Supplier<?> payloadOrMessageSupplier);
 
     /**
+     * Conditionally apply a subsequent event to the aggregate after applying another event. When the given {@code
+     * payloadOrMessageSupplier} is asked to provide the subsequent event the initial event has been fully processed by
+     * the aggregate.
+     * <p>
+     * If the given supplier passes an object that is an instance of a {@link org.axonframework.messaging.Message} the
+     * event is applied with the metadata from the message. If the supplied event is not a Message instance it will be
+     * applied as an event without additional metadata.
+     *
+     * @param condition                the condition to evaluate and decide if the payload should be applied
+     * @param payloadOrMessageSupplier The next event message or the payload of the next event
+     * @return an instance of ApplyMore to apply any subsequent events
+     */
+    default ApplyMore andThenApplyIf(Supplier<Boolean> condition, Supplier<?> payloadOrMessageSupplier) {
+        if (condition.get()) {
+            return andThenApply(payloadOrMessageSupplier);
+        } else {
+            return this;
+        }
+    }
+
+    /**
      * Execute the given {@code runnable} after applying the previous event. This {@code runnable} is guaranteed to be
      * invoked when the previous event has been fully applied to the aggregate.
      * <p>
@@ -59,4 +80,23 @@ public interface ApplyMore {
      * @return an instance of ApplyMore to apply any subsequent events
      */
     ApplyMore andThen(Runnable runnable);
+
+    /**
+     * Conditionally execute the given {@code runnable} after applying the previous event. This {@code runnable} is
+     * guaranteed to be invoked when the previous event has been fully applied to the aggregate.
+     * <p>
+     * The given {@code runnable} must not directly alter any state of the aggregate. Instead, it should only decide
+     * if more events should be applied based on the state of the aggregate after the previous event
+     *
+     * @param condition the condition to evaluate and decide if the code should be executed
+     * @param runnable  the code to execute when the previous event was applied
+     * @return an instance of ApplyMore to apply any subsequent events
+     */
+    default ApplyMore andThenIf(Supplier<Boolean> condition, Runnable runnable) {
+        if (condition.get()) {
+            return andThen(runnable);
+        } else {
+            return this;
+        }
+    }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
@@ -21,9 +21,11 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
+import org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregate;
-import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,6 +33,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
@@ -38,6 +42,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
@@ -46,11 +51,15 @@ public class AnnotatedAggregateTest {
     private final String ID = "id";
     private Repository<AggregateRoot> repository;
     private EventBus eventBus;
+    private StubSideEffect sideEffect;
 
     @BeforeEach
     void setUp() {
         eventBus = mock(EventBus.class);
-        repository = StubRepository.builder().eventBus(eventBus).build();
+        sideEffect = mock(StubSideEffect.class);
+        List<Object> resolvableResources = new ArrayList<>();
+        resolvableResources.add(sideEffect);
+        repository = StubRepository.builder(resolvableResources).eventBus(eventBus).build();
     }
 
     // Tests for issue #1248 - https://github.com/AxonFramework/AxonFramework/issues/1248
@@ -87,31 +96,39 @@ public class AnnotatedAggregateTest {
     // Test for issue #1506 - https://github.com/AxonFramework/AxonFramework/issues/1506
     @Test
     void testLastSequenceReturnsNullIfNoEventsHaveBeenPublishedYet() {
-        AnnotatedAggregate<AggregateRoot> testSubject = AnnotatedAggregate.initialize(
-                new AggregateRoot(), AnnotatedAggregateMetaModelFactory.inspectAggregate(AggregateRoot.class), eventBus
-        );
+        final Command command = new Command(ID, 0);
+        DefaultUnitOfWork<CommandMessage<Object>> uow = DefaultUnitOfWork.startAndGet(asCommandMessage(command));
+        AnnotatedAggregate<AggregateRoot> testSubject =
+                (AnnotatedAggregate<AggregateRoot>) uow.executeWithResult(
+                        () -> repository.newInstance(AggregateRoot::new)).getPayload();
 
         assertNull(testSubject.lastSequence());
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testConditionalApplyingEventInHandlerPublishesInRightOrder(boolean applyEvent2) {
-        Command_2 command = new Command_2(ID, 0, applyEvent2);
+    void testConditionalApplyingEventInHandlerPublishesInRightOrder(boolean applyConditional) {
+        Command_2 command = new Command_2(ID, 0, applyConditional);
         DefaultUnitOfWork<CommandMessage<Object>> uow = DefaultUnitOfWork.startAndGet(asCommandMessage(command));
         Aggregate<AggregateRoot> aggregate = uow.executeWithResult(() -> repository
-                .newInstance(() -> new AggregateRoot(command))).getPayload();
+                .newInstance(() -> new AggregateRoot(command, sideEffect))).getPayload();
         assertNotNull(aggregate);
 
-        InOrder inOrder = inOrder(eventBus);
-        inOrder.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_1.class
+        InOrder inOrderEvents = inOrder(eventBus);
+        inOrderEvents.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_1.class
                 .equals(x.getPayloadType())));
-        if (applyEvent2) {
-            inOrder.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_2.class
+        if (applyConditional) {
+            inOrderEvents.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_2.class
                     .equals(x.getPayloadType())));
         }
-        inOrder.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_3.class
+        inOrderEvents.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_3.class
                 .equals(x.getPayloadType())));
+
+        InOrder inOrderSideEffect = inOrder(sideEffect);
+        inOrderSideEffect.verify(sideEffect).doSomething(eq(ID));
+        if (applyConditional) {
+            inOrderSideEffect.verify(sideEffect).doSomethingConditional(ID);
+        }
     }
 
     private static class Command {
@@ -137,7 +154,7 @@ public class AnnotatedAggregateTest {
 
         private final String id;
         private final int value;
-        private boolean condition;
+        private final boolean condition;
 
         private Command_2(String id, int value, boolean condition) {
             this.id = id;
@@ -225,10 +242,12 @@ public class AnnotatedAggregateTest {
         }
 
         @CommandHandler
-        public AggregateRoot(Command_2 command) {
+        public AggregateRoot(Command_2 command, StubSideEffect sideEffect) {
             apply(new Event_1(command.getId(), 0))
-                    .andThenApplyIf(() -> command.condition, () -> new Event_2(id))
-                    .andThenApply(() -> new Event_3(id));
+                    .andThenApplyIf(() -> command.condition, () -> new Event_2(command.getId()))
+                    .andThenApply(() -> new Event_3(id))
+                    .andThen(() -> sideEffect.doSomething(command.getId()))
+                    .andThenIf(() -> command.condition, () -> sideEffect.doSomethingConditional(command.getId()));
         }
 
         @EventHandler
@@ -251,8 +270,13 @@ public class AnnotatedAggregateTest {
 
         private final EventBus eventBus;
 
-        public static Builder builder() {
-            return new Builder();
+        public static Builder builder(Iterable<?> resources) {
+            return (Builder) new Builder()
+                    .parameterResolverFactory(
+                            MultiParameterResolverFactory.ordered(
+                                    new SimpleResourceParameterResolverFactory(resources),
+                                    ClasspathParameterResolverFactory.forClassLoader(Thread.currentThread().getContextClassLoader())
+                            ));
         }
 
         private StubRepository(Builder builder) {
@@ -297,5 +321,11 @@ public class AnnotatedAggregateTest {
                 return new StubRepository(this);
             }
         }
+    }
+
+    public interface StubSideEffect {
+        void doSomething(String id);
+
+        void doSomethingConditional(String id);
     }
 }


### PR DESCRIPTION
The org.axonframework.modelling.command.ApplyMore interface provides the two methods ...#andThenApply and ...#andThen which are used e.g. in the AggregateLifecycle to apply a payload or execute some code in the correct order.

The conditional variants of these two methods provided in this commit make it easier to conditionally apply a payload or execute code in a more fluent api (see example below).

This refers to https://github.com/AxonFramework/AxonFramework/issues/2173