### PR TITLE
Fix for EventTypeUpcaster

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/EventTypeUpcaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
 
 package org.axonframework.serialization.upcasting.event;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
 import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.SimpleSerializedType;
-import org.dom4j.Document;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -123,17 +120,9 @@ public class EventTypeUpcaster extends SingleEventUpcaster {
 
     @Override
     protected IntermediateEventRepresentation doUpcast(IntermediateEventRepresentation intermediateRepresentation) {
-        if (intermediateRepresentation.canConvertDataTo(JsonNode.class)) {
-            return intermediateRepresentation.upcastPayload(upcastedType(), JsonNode.class, Function.identity());
-        } else if (intermediateRepresentation.canConvertDataTo(Document.class)) {
-            return intermediateRepresentation.upcastPayload(upcastedType(), Document.class, (doc) -> {
-                final Document newDoc = (Document) doc.clone();
-                newDoc.getRootElement().setName(new XmlFriendlyNameCoder().encodeNode(upcastedPayloadType));
-                return newDoc;
-            });
-        } else {
-            return intermediateRepresentation.upcastPayload(upcastedType(), Object.class, Function.identity());
-        }
+        return intermediateRepresentation.upcastPayload(upcastedType(),
+                                                        intermediateRepresentation.getContentType(),
+                                                        Function.identity());
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentation.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,9 @@ import java.util.function.Supplier;
  */
 public class InitialEventRepresentation implements IntermediateEventRepresentation {
 
-    private final SerializedType type;
     private final SerializedObject<Object> data;
+    private final SerializedType type;
+    private final Class<?> contentType;
     private final LazyDeserializingObject<MetaData> metaData;
     private final String eventIdentifier;
     private final Supplier<Instant> timestamp;
@@ -68,8 +69,9 @@ public class InitialEventRepresentation implements IntermediateEventRepresentati
      */
     @SuppressWarnings("unchecked")
     public InitialEventRepresentation(EventData<?> eventData, Serializer serializer) {
-        type = eventData.getPayload().getType();
         data = (SerializedObject<Object>) eventData.getPayload();
+        type = data.getType();
+        contentType = data.getContentType();
         metaData = new LazyDeserializingObject<>(eventData.getMetaData(), serializer);
         eventIdentifier = eventData.getEventIdentifier();
         timestamp = CachingSupplier.of(eventData::getTimestamp);
@@ -112,6 +114,11 @@ public class InitialEventRepresentation implements IntermediateEventRepresentati
     @Override
     public <D> SerializedObject<D> getData(Class<D> requiredType) {
         return serializer.getConverter().convert(data, requiredType);
+    }
+
+    @Override
+    public Class<?> getContentType() {
+        return contentType;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/IntermediateEventRepresentation.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/IntermediateEventRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,15 @@ public interface IntermediateEventRepresentation {
      * @return the data representation of the object converted to the required type
      */
     <D> SerializedObject<D> getData(Class<D> requiredType);
+
+    /**
+     * Returns the type of this representation's {@link #getData() data}.
+     *
+     * @return The type of this representation's {@link #getData() data}.
+     */
+    default Class<?> getContentType() {
+        return getData().getContentType();
+    }
 
     /**
      * Returns the identifier of the message wrapping the object to upcast.

--- a/messaging/src/main/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentation.java
+++ b/messaging/src/main/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,11 @@ public class UpcastedEventRepresentation<T> implements IntermediateEventRepresen
     @Override
     public <D> SerializedObject<D> getData(Class<D> requiredType) {
         return converter.convert(getData(), requiredType);
+    }
+
+    @Override
+    public Class<?> getContentType() {
+        return requiredType;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,9 @@ class EventTypeUpcasterTest {
     public static final String UPCASTED_PAYLOAD_TYPE = RenamedTestEvent.class.getName();
     public static final String UPCASTED_REVISION = "2";
 
-    private final EventTypeUpcaster testSubject =
-            new EventTypeUpcaster(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
-
     private static final String SOURCE_METHOD_NAME = "provideSerializers";
+
+    @SuppressWarnings("unused") // Used by all parameterized tests
     private static Stream<Arguments> provideSerializers() {
         return Stream.of(
                 Arguments.of(TestSerializer.XSTREAM.getSerializer()),
@@ -58,6 +57,9 @@ class EventTypeUpcasterTest {
                 Arguments.of(TestSerializer.JACKSON_ONLY_ACCEPT_CONSTRUCTOR_PARAMETERS.getSerializer())
         );
     }
+
+    private final EventTypeUpcaster testSubject =
+            new EventTypeUpcaster(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
 
     @Test
     void testUpcasterBuilderFailsForNullExpectedPayloadTypeClass() {
@@ -163,7 +165,9 @@ class EventTypeUpcasterTest {
 
         final IntermediateEventRepresentation result = testSubject.doUpcast(testRepresentation);
 
-        assertInstanceOf(RenamedTestEvent.class, serializer.deserialize(result.getData()));
+        Object deserialize = serializer.deserialize(result.getData());
+
+        assertEquals(RenamedTestEvent.class, deserialize.getClass());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentationTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+import org.axonframework.eventhandling.EventData;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.TestSerializer;
+import org.axonframework.utils.StubDomainEvent;
+import org.axonframework.utils.TestDomainEventEntry;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit test class validating the {@link IntermediateEventRepresentation}.
+ *
+ * @author Steven van Beelen
+ */
+class InitialEventRepresentationTest {
+
+    private static final String SOURCE_METHOD_NAME = "serializer";
+
+    @SuppressWarnings("unused") // Used by parameterized test "testContentType"
+    private static Stream<Arguments> serializer() {
+        return Stream.of(
+                Arguments.of(TestSerializer.XSTREAM.getSerializer()),
+                Arguments.of(TestSerializer.JACKSON.getSerializer()),
+                Arguments.of(TestSerializer.JACKSON_ONLY_ACCEPT_CONSTRUCTOR_PARAMETERS.getSerializer())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(SOURCE_METHOD_NAME)
+    void testContentType(Serializer serializer) {
+        GenericDomainEventMessage<StubDomainEvent> event = new GenericDomainEventMessage<>(
+                "test", "aggregateId", 0, new StubDomainEvent("some-name"), MetaData.emptyInstance()
+        );
+        EventData<String> eventData = new TestDomainEventEntry(event, serializer);
+
+        InitialEventRepresentation testSubject =
+                new InitialEventRepresentation(eventData, serializer);
+
+        assertEquals(eventData.getPayload().getContentType(), testSubject.getContentType());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentationTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.upcasting.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit test class validating the {@link UpcastedEventRepresentation}.
+ *
+ * @author Steven van Beelen
+ */
+class UpcastedEventRepresentationTest {
+
+    private static final String SOURCE_METHOD_NAME = "serializer";
+
+    @SuppressWarnings("unused") // Used by parameterized test "testContentType"
+    private static Stream<Arguments> serializer() {
+        return Stream.of(
+                Arguments.of(TestSerializer.XSTREAM.getSerializer()),
+                Arguments.of(TestSerializer.JACKSON.getSerializer()),
+                Arguments.of(TestSerializer.JACKSON_ONLY_ACCEPT_CONSTRUCTOR_PARAMETERS.getSerializer())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(SOURCE_METHOD_NAME)
+    void testContentType(Serializer serializer) {
+        Class<JsonNode> expectedContentType = JsonNode.class;
+
+        UpcastedEventRepresentation<JsonNode> testSubject = new UpcastedEventRepresentation<>(
+                mock(SerializedType.class), mock(IntermediateEventRepresentation.class),
+                o -> o, m -> m, expectedContentType, serializer.getConverter()
+        );
+
+        assertEquals(expectedContentType, testSubject.getContentType());
+    }
+}


### PR DESCRIPTION
As [dakr0013](https://github.com/dakr0013) mentioned in #2169, the `EventTypeUpcaster` causes issues further down the upcasting chain as it expects the intermediate type `Object`.
Using this as the `expectedRepresentationType` causes the intermediate representation to become a concrete type.
This obstructs further upcasters that, for example, expect `JsonNode`, to break.

This pull request uses earlier commits from [dakr0013](https://github.com/dakr0013) but solves the search for the `expectedRepresentationType` differently.
I have expanded the `IntermediateEventRepresentation` with the `getContentType` method.
This method returns the representation type of the contained payload.
This method is in turn used by the `EventTypeUpcaster` to **not** change the intermediate type, allowing upcasters further down the chain to perform their work.