### PR TITLE
EventProcessingModule should lazily initialize processors

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -206,6 +206,10 @@ class AxonAutoConfigurationTest {
 
             private final List<String> invocations = new ArrayList<>();
 
+            public SomeComponent(org.axonframework.config.Configuration axonConfig) {
+                // just to see if wiring the configuration causes circular dependencies.
+            }
+
             @EventHandler
             public void handle(String event, SomeOtherComponent test, Integer testing) {
                 invocations.add(event);


### PR DESCRIPTION
The eager initialization of event processors can cause circular dependencies when one of the event handlers relies on the configuration. This is espectially the case when using an external dependency injection mechanism to wire some beans.

Event Processors are initialized at the latest when the configuration starts, or earlier when the processors are retrieved from the configuration.