### PR TITLE
Fix #2187: Cannot send two creational commands in same unit of work w…

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -76,6 +77,13 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
 
     @Override
     public A newInstance(Callable<T> factoryMethod) throws Exception {
+        return newInstance(factoryMethod, a -> {
+        });
+    }
+
+    @Override
+    public A newInstance(Callable<T> factoryMethod, Consumer<Aggregate<T>> initMethod)
+            throws Exception {
         UnitOfWork<?> uow = CurrentUnitOfWork.get();
         AtomicReference<A> aggregateReference = new AtomicReference<>();
         // a constructor may apply events, and the persistence of an aggregate must take precedence over publishing its events.
@@ -88,6 +96,7 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
         });
 
         A aggregate = doCreateNew(factoryMethod);
+        initMethod.accept(aggregate);
         aggregateReference.set(aggregate);
         Assert.isTrue(aggregateModel.entityClass().isAssignableFrom(aggregate.rootType()),
                       () -> "Unsuitable aggregate for this repository: wrong type");

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -394,9 +395,22 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
 
         @Override
         public Object handle(CommandMessage<?> command) throws Exception {
-            Aggregate<T> aggregate = repository.newInstance(factoryMethod);
-            Object response = aggregate.handle(command);
-            return handlerHasVoidReturnType() ? resolveReturnValue(command, aggregate) : response;
+            AtomicReference<Object> response = new AtomicReference<>();
+            AtomicReference<Exception> exceptionDuringInit = new AtomicReference<>();
+
+            Aggregate<T> aggregate = repository.newInstance(factoryMethod, agg -> {
+                try {
+                    response.set(agg.handle(command));
+                } catch (Exception e) {
+                    exceptionDuringInit.set(e);
+                }
+            });
+
+            if (exceptionDuringInit.get() != null) {
+                throw exceptionDuringInit.get();
+            }
+
+            return handlerHasVoidReturnType() ? resolveReturnValue(command, aggregate) : response.get();
         }
 
         public boolean handlerHasVoidReturnType() {

--- a/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.modelling.command;
 import org.axonframework.messaging.ScopeAware;
 
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 /**
  * The repository provides an abstraction of the storage of aggregates.
@@ -59,6 +60,22 @@ public interface Repository<T> extends ScopeAware {
      * @throws Exception when the factoryMethod throws an exception
      */
     Aggregate<T> newInstance(Callable<T> factoryMethod) throws Exception;
+
+    /**
+     * Creates a new managed instance for the aggregate, using the given {@code factoryMethod} to instantiate the
+     * aggregate's root, and then applying the {@code initMethod} consumer to it to perform additional
+     * initialization.
+     *
+     * @param factoryMethod The method to create the aggregate's root instance
+     * @param initMethod    The consumer to initialize the aggregate instance further
+     * @return an Aggregate instance describing the aggregate's state
+     * @throws Exception when the factoryMethod throws an exception
+     */
+    default Aggregate<T> newInstance(Callable<T> factoryMethod, Consumer<Aggregate<T>> initMethod) throws Exception {
+        Aggregate<T> aggregate = newInstance(factoryMethod);
+        initMethod.accept(aggregate);
+        return aggregate;
+    }
 
     /**
      * Loads an aggregate from the repository. If the aggregate is not found it creates the aggregate using the


### PR DESCRIPTION
…hen using CreationPolicy.ALWAYS.

Moves caching of aggregate creation to `onPrepareCommit` of the `CurrentUnitOfWork`. This makes sure that the aggregate is initialized, regardless of whether a constructor command handler, or creational command handler is used to create the instance. 

Resolves #2187