### PR TITLE
Remove unnecessary validation of aggregate identifier

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -429,15 +429,7 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
             String commandMessageAggregateId = commandMessageVersionedId.getIdentifier();
 
             Aggregate<T> instance = repository.loadOrCreate(commandMessageAggregateId, factoryMethod);
-            Object commandResult = instance.handle(command);
-            Object aggregateId = instance.identifier();
-
-            assertThat(
-                    aggregateId,
-                    id -> id != null && id.toString() != null && id.toString().equals(commandMessageAggregateId),
-                    "Identifier must be set after handling the message"
-            );
-            return commandResult;
+            return instance.handle(command);
         }
 
         @Override


### PR DESCRIPTION
During a pair programming session yesterday, @smcvb got into a discussion about a validation that was present in the `AggregateCreateOrUpdateCommandHandler`, which is triggered by an `AggregateCreationPolicy` annotation with value `CREATE_IF_MISSING`. 

We found that:
- Other command handlers do not validate this. 
- It's valid not to have an identifier set, by not applying an event at all (thus the aggregate not being created). 
- Setting the identifier explicitly to null later will throw an error in the EventStore when applying events.

Because of this, we removed the validation, also fixing the issue a customer had. 