### PR TITLE
Ensure the context is maintained between upcaster invocations in single stream

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
@@ -23,6 +23,7 @@ import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Wrapper around standard Axon Framework serializer that can deserialize Metadata from AxonServer events.
@@ -81,5 +82,22 @@ public final class GrpcMetaDataAwareSerializer implements Serializer {
     @Override
     public Converter getConverter() {
         return delegate.getConverter();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GrpcMetaDataAwareSerializer)) {
+            return false;
+        }
+        GrpcMetaDataAwareSerializer that = (GrpcMetaDataAwareSerializer) o;
+        return delegate.equals(that.delegate) && metaDataConverter.equals(that.metaDataConverter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate, metaDataConverter);
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverter.java
@@ -25,6 +25,7 @@ import org.axonframework.serialization.Serializer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
@@ -137,5 +138,22 @@ public class GrpcMetaDataConverter {
             default:
                 return null;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GrpcMetaDataConverter)) {
+            return false;
+        }
+        GrpcMetaDataConverter that = (GrpcMetaDataConverter) o;
+        return serializer.equals(that.serializer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serializer);
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
@@ -125,7 +125,8 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
         }
         events.stream()
               .filter(e -> e.getAggregateIdentifier().equals(request.getAggregateId()))
-              .filter(e -> snapshot == null || snapshot.getAggregateSequenceNumber() < e.getAggregateSequenceNumber())
+              .filter(e -> e.getAggregateSequenceNumber() >= request.getInitialSequence()
+                      && (snapshot == null || snapshot.getAggregateSequenceNumber() < e.getAggregateSequenceNumber()))
               .forEach(responseObserver::onNext);
         responseObserver.onCompleted();
     }


### PR DESCRIPTION
This commit fixes an issue where a new context was created for each individual event. This caused a context aware upcaster to lose any contextual information while upcasting a single stream of events when loading events for an aggregate.

This commit also fixes an issue where snapshots would be considered when loading an aggregate from its initial position, even when an explicit attempt to load snapshots had already been performed.