### PR TITLE
[#2189] Validate primitive types differently in the EqualFieldsMatcher

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -492,6 +492,25 @@ public abstract class ReflectionUtils {
         throw new IllegalStateException(
                 String.format(UNSUPPORTED_MEMBER_TYPE_EXCEPTION_MESSAGE, member.getClass().getName())
         );
+    }
+
+    /**
+     * Check whether the given Object is a primitive types. Validates both boxed and unboxed instances.
+     *
+     * @param o The Object to check whether it's a primitive type.
+     * @return {@code true} if the given Object is a primitive, {@code false} otherwise.
+     */
+    public static boolean isPrimitive(Object o) {
+        return o.getClass().isPrimitive()
+                || o.getClass().isAssignableFrom(Boolean.class)
+                || o.getClass().isAssignableFrom(Byte.class)
+                || o.getClass().isAssignableFrom(Character.class)
+                || o.getClass().isAssignableFrom(Short.class)
+                || o.getClass().isAssignableFrom(Integer.class)
+                || o.getClass().isAssignableFrom(Float.class)
+                || o.getClass().isAssignableFrom(Double.class)
+                || o.getClass().isAssignableFrom(Long.class)
+                || o.getClass().isAssignableFrom(String.class);
     }
 
     private ReflectionUtils() {

--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -495,7 +495,9 @@ public abstract class ReflectionUtils {
     }
 
     /**
-     * Check whether the given Object is a primitive types. Validates both boxed and unboxed instances.
+     * Check whether the given Object is a primitive type. Validates both boxed and unboxed instances.
+     * <p>
+     * Note that this check includes {@link String} as well.
      *
      * @param o The Object to check whether it's a primitive type.
      * @return {@code true} if the given Object is a primitive, {@code false} otherwise.

--- a/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,6 +292,55 @@ class ReflectionUtilsTest {
         Constructor<SomeTypeWithMethods> constructor = SomeTypeWithMethods.class.getDeclaredConstructor();
         String memberGenericString = getMemberGenericString(constructor);
         assertEquals(constructor.toGenericString(), memberGenericString);
+    }
+
+    @Test
+    void testIsPrimitive() {
+        boolean bool = true;
+        assertTrue(ReflectionUtils.isPrimitive(bool));
+        Boolean boxedBool = true;
+        assertTrue(ReflectionUtils.isPrimitive(boxedBool));
+
+        byte b = (byte) 42;
+        assertTrue(ReflectionUtils.isPrimitive(b));
+        Byte boxedByte = (byte) 42;
+        assertTrue(ReflectionUtils.isPrimitive(boxedByte));
+
+        char c = 'a';
+        assertTrue(ReflectionUtils.isPrimitive(c));
+        Character boxedChar = 'a';
+        assertTrue(ReflectionUtils.isPrimitive(boxedChar));
+
+        short s = (short) 42;
+        assertTrue(ReflectionUtils.isPrimitive(s));
+        Short boxedShort = (short) 42;
+        assertTrue(ReflectionUtils.isPrimitive(boxedShort));
+
+        int i = 42;
+        assertTrue(ReflectionUtils.isPrimitive(i));
+        Integer boxedInteger = 42;
+        assertTrue(ReflectionUtils.isPrimitive(boxedInteger));
+
+        float f = 42F;
+        assertTrue(ReflectionUtils.isPrimitive(f));
+        Float boxedFloat = 42F;
+        assertTrue(ReflectionUtils.isPrimitive(boxedFloat));
+
+        double d = 42.42;
+        assertTrue(ReflectionUtils.isPrimitive(d));
+        Double boxedDouble = 42.42;
+        assertTrue(ReflectionUtils.isPrimitive(boxedDouble));
+
+        long l = 42L;
+        assertTrue(ReflectionUtils.isPrimitive(l));
+        Long boxedLong = 42L;
+        assertTrue(ReflectionUtils.isPrimitive(boxedLong));
+
+        String sampleString = "some-text";
+        assertTrue(ReflectionUtils.isPrimitive(sampleString));
+
+        SomeType nonPrimitive = new SomeType();
+        assertFalse(ReflectionUtils.isPrimitive(nonPrimitive));
     }
 
     @SuppressWarnings("FieldCanBeLocal")

--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -195,15 +195,35 @@ public class Reporter {
     }
 
     /**
+     * Report an error due to a difference between the primitive message payloads.
+     *
+     * @param messageType The (runtime) type of the message the difference was found in.
+     * @param actual      The actual value of the payload.
+     * @param expected    The expected value of the payload.
+     */
+    public void reportDifferentPrimitivePayloads(Class<?> messageType, Object actual, Object expected) {
+        throw new AxonAssertionError("One of the messages contained a different payload than expected"
+                                             + NEWLINE + NEWLINE
+                                             + "The message of type [" + messageType.getSimpleName() + "], "
+                                             + "was not as expected."
+                                             + NEWLINE
+                                             + "Expected <" //NOSONAR
+                                             + nullSafeToString(expected)
+                                             + "> but got <"
+                                             + nullSafeToString(actual)
+                                             + ">"
+                                             + NEWLINE);
+    }
+
+    /**
      * Report an error due to a difference in one of the fields of the message payload.
      *
-     * @param messageType The (runtime) type of the message the difference was found in
-     * @param field       The field that contains the difference
-     * @param actual      The actual value of the field
-     * @param expected    The expected value of the field
+     * @param messageType The (runtime) type of the message the difference was found in.
+     * @param field       The field that contains the difference.
+     * @param actual      The actual value of the field.
+     * @param expected    The expected value of the field.
      */
-    public void reportDifferentPayloads(Class<?> messageType, Field field, Object actual,
-                                        Object expected) {
+    public void reportDifferentPayloads(Class<?> messageType, Field field, Object actual, Object expected) {
         StringBuilder sb = new StringBuilder("One of the messages contained different values than expected");
         sb.append(NEWLINE)
           .append(NEWLINE)

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -30,6 +30,7 @@ import org.axonframework.test.deadline.StubDeadlineManager;
 import org.axonframework.test.matchers.EqualFieldsMatcher;
 import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.matchers.MapEntryMatcher;
+import org.axonframework.test.matchers.Matchers;
 import org.axonframework.test.matchers.PayloadMatcher;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
@@ -442,12 +443,18 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
         if (!expectedPayload.getClass().equals(actualPayload.getClass())) {
             return false;
         }
-        EqualFieldsMatcher<Object> matcher = new EqualFieldsMatcher<>(expectedPayload, fieldFilter);
+        EqualFieldsMatcher<Object> matcher = Matchers.equalTo(expectedPayload, fieldFilter);
         if (!matcher.matches(actualPayload)) {
-            reporter.reportDifferentPayloads(expectedPayload.getClass(),
-                                             matcher.getFailedField(),
-                                             matcher.getFailedFieldActualValue(),
-                                             matcher.getFailedFieldExpectedValue());
+            if (matcher.isFailedPrimitive()) {
+                reporter.reportDifferentPrimitivePayloads(expectedPayload.getClass(),
+                                                          matcher.getFailedFieldActualValue(),
+                                                          matcher.getFailedFieldExpectedValue());
+            } else {
+                reporter.reportDifferentPayloads(expectedPayload.getClass(),
+                                                 matcher.getFailedField(),
+                                                 matcher.getFailedFieldActualValue(),
+                                                 matcher.getFailedFieldExpectedValue());
+            }
         }
         return true;
     }

--- a/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,8 @@ import org.hamcrest.Description;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
+import static org.axonframework.common.ReflectionUtils.isPrimitive;
+
 /**
  * Matcher that will match an Object if all the fields on that Object contain values equal to the same field in the
  * expected instance.
@@ -37,10 +39,11 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
     private Field failedField;
     private Object failedFieldExpectedValue;
     private Object failedFieldActualValue;
+    private boolean failedPrimitive;
 
     /**
-     * Initializes an EqualFieldsMatcher that will match an object with equal properties as the given
-     * {@code expected} object.
+     * Initializes an EqualFieldsMatcher that will match an object with equal properties as the given {@code expected}
+     * object.
      *
      * @param expected The expected object
      */
@@ -49,8 +52,8 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
     }
 
     /**
-     * Initializes an EqualFieldsMatcher that will match an object with equal properties as the given
-     * {@code expected} object.
+     * Initializes an EqualFieldsMatcher that will match an object with equal properties as the given {@code expected}
+     * object.
      *
      * @param expected The expected object
      * @param filter   The filter describing the fields to include in the comparison
@@ -60,13 +63,22 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
         this.filter = filter;
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
-    public boolean matches(Object item) {
-        return expected.getClass().isInstance(item) && matchesSafely(item);
+    public boolean matches(Object actual) {
+        return expected.getClass().isInstance(actual) && matchesSafely(actual);
     }
 
     private boolean matchesSafely(Object actual) {
+        if ((isPrimitive(expected) || isPrimitive(actual))) {
+            if (expected.equals(actual)) {
+                return true;
+            } else {
+                failedPrimitive = true;
+                failedFieldExpectedValue = expected;
+                failedFieldActualValue = actual;
+                return false;
+            }
+        }
         return expected.getClass().equals(actual.getClass())
                 && fieldsMatch(expected.getClass(), expected, actual);
     }
@@ -107,8 +119,8 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
     }
 
     /**
-     * Returns the expected value of a failed field comparison, if any. This value is only populated after {@link
-     * #matches(Object)} is called and a mismatch has been detected.
+     * Returns the expected value of a failed field comparison, if any. This value is only populated after
+     * {@link #matches(Object)} is called and a mismatch has been detected.
      *
      * @return the expected value of the field that failed comparison, if any
      */
@@ -117,13 +129,22 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
     }
 
     /**
-     * Returns the actual value of a failed field comparison, if any. This value is only populated after {@link
-     * #matches(Object)} is called and a mismatch has been detected.
+     * Returns the actual value of a failed field comparison, if any. This value is only populated after
+     * {@link #matches(Object)} is called and a mismatch has been detected.
      *
      * @return the actual value of the field that failed comparison, if any
      */
     public Object getFailedFieldActualValue() {
         return failedFieldActualValue;
+    }
+
+    /**
+     * Returns whether this matcher failed matching primitive types.
+     *
+     * @return {@code true} if this matcher failed matching primitive types, {@code false} otherwise.
+     */
+    public boolean isFailedPrimitive() {
+        return failedPrimitive;
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/EqualFieldsMatcher.java
@@ -140,6 +140,8 @@ public class EqualFieldsMatcher<T> extends BaseMatcher<T> {
 
     /**
      * Returns whether this matcher failed matching primitive types.
+     * <p>
+     * Note that this may include an expected or actual of type {@link String}.
      *
      * @return {@code true} if this matcher failed matching primitive types, {@code false} otherwise.
      */

--- a/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2014. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,7 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.matchers.EqualFieldsMatcher;
 import org.axonframework.test.matchers.FieldFilter;
+import org.axonframework.test.matchers.Matchers;
 import org.axonframework.test.utils.RecordingCommandBus;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -130,15 +131,23 @@ public class CommandValidator {
                                                     expected.getClass().getSimpleName(),
                                                     actual.getClass().getSimpleName()));
             }
-            EqualFieldsMatcher<Object> matcher = new EqualFieldsMatcher<>(expected, fieldFilter);
+            EqualFieldsMatcher<Object> matcher = Matchers.equalTo(expected, fieldFilter);
             if (!matcher.matches(actual)) {
-                throw new AxonAssertionError(format("Unexpected command at index %s (0-based). "
-                                                            + "Field value of '%s.%s', expected <%s>, but got <%s>",
-                                                    commandIndex,
-                                                    expected.getClass().getSimpleName(),
-                                                    matcher.getFailedField().getName(),
-                                                    matcher.getFailedFieldExpectedValue(),
-                                                    matcher.getFailedFieldActualValue()));
+                if (matcher.isFailedPrimitive()) {
+                    throw new AxonAssertionError(format("Unexpected primitive typed command at index %s (0-based). "
+                                                                + "Expected <%s>, but got <%s>",
+                                                        commandIndex,
+                                                        matcher.getFailedFieldExpectedValue(),
+                                                        matcher.getFailedFieldActualValue()));
+                } else {
+                    throw new AxonAssertionError(format("Unexpected command at index %s (0-based). "
+                                                                + "Field value of '%s.%s', expected <%s>, but got <%s>",
+                                                        commandIndex,
+                                                        expected.getClass().getSimpleName(),
+                                                        matcher.getFailedField().getName(),
+                                                        matcher.getFailedFieldExpectedValue(),
+                                                        matcher.getFailedFieldActualValue()));
+                }
             }
         }
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,15 +19,19 @@ package org.axonframework.test.aggregate;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.matchers.MatchAllFieldFilter;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 
 import static java.util.Collections.*;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating the {@link ResultValidatorImpl}.
+ *
+ * @author bliessens
+ */
 class ResultValidatorImplTest {
 
     private ResultValidator<?> validator = new ResultValidatorImpl<>(actualEvents(),
@@ -50,7 +54,7 @@ class ResultValidatorImplTest {
     }
 
     @Test
-    void shouldSuccesfullyCompareEqualMetadata() {
+    void shouldSuccessfullyCompareEqualMetadata() {
         EventMessage<?> expected = actualEvents().iterator().next().andMetaData(singletonMap("key1", "value1"));
 
         validator.expectEvents(expected);
@@ -66,15 +70,34 @@ class ResultValidatorImplTest {
         String s2 = String.valueOf(0);
         assertEquals(s1, s2);
 
-        // the hash code is cached in a String
+        //noinspection unused -> the hash code is cached in a String
         int ignored = s1.hashCode();
 
         validator.expectEvents(s2);
+    }
+
+    @Test
+    void shouldReportFailureForFailedPrimitiveMatching() {
+        validator = new ResultValidatorImpl<>(singletonList(asEventMessage("some-string")),
+                                              new MatchAllFieldFilter(emptyList()),
+                                              () -> null,
+                                              null);
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectEvents("some-other-string"));
+    }
+
+    @Test
+    void shouldReportFailureForFailedFieldMatching() {
+        validator = new ResultValidatorImpl<>(singletonList(asEventMessage(new MyEvent("some-string", 1))),
+                                              new MatchAllFieldFilter(emptyList()),
+                                              () -> null,
+                                              null);
+
+        assertThrows(AxonAssertionError.class, () -> validator.expectEvents(new MyEvent("some-other-string", 1)));
     }
 
     private List<EventMessage<?>> actualEvents() {
         return singletonList(asEventMessage(new MyEvent("aggregateId", 123))
                                      .andMetaData(singletonMap("key1", "value1")));
     }
-
 }

--- a/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2012. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,19 +19,20 @@ package org.axonframework.test.matchers;
 import org.axonframework.test.aggregate.MyEvent;
 import org.axonframework.test.aggregate.MyOtherEvent;
 import org.hamcrest.StringDescription;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * Test class validating the {@link EqualFieldsMatcher}.
+ *
  * @author Allard Buijze
  */
 class EqualFieldsMatcherTest {
 
     private EqualFieldsMatcher<MyEvent> testSubject;
     private MyEvent expectedEvent;
-    private String aggregateId = "AggregateId";
+    private final String aggregateId = "AggregateId";
 
     @BeforeEach
     void setUp() {
@@ -94,5 +95,57 @@ class EqualFieldsMatcherTest {
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
         assertEquals("org.axonframework.test.aggregate.MyEvent (failed on field 'someValue')", description.toString());
+    }
+
+    /**
+     * This test is introduced to validate whether the matcher doesn't delve into the boxed primitives, since reflective
+     * access is restricted for e.g. JDK 17.
+     */
+    @Test
+    void testMatchesReturnsTrueForPrimitives() {
+        EqualFieldsMatcher<Boolean> booleanMatcher = Matchers.equalTo(false);
+        assertTrue(booleanMatcher.matches(false));
+        assertFalse(booleanMatcher.matches(true));
+        assertTrue(booleanMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Byte> byteMatcher = Matchers.equalTo((byte) 42);
+        assertTrue(byteMatcher.matches((byte) 42));
+        assertFalse(byteMatcher.matches((byte) 24));
+        assertTrue(byteMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Character> charMatcher = Matchers.equalTo('a');
+        assertTrue(charMatcher.matches('a'));
+        assertFalse(charMatcher.matches('z'));
+        assertTrue(charMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Short> shortMatcher = Matchers.equalTo((short) 42);
+        assertTrue(shortMatcher.matches((short) 42));
+        assertFalse(shortMatcher.matches((short) 24));
+        assertTrue(shortMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Integer> integerMatcher = Matchers.equalTo(42);
+        assertTrue(integerMatcher.matches(42));
+        assertFalse(integerMatcher.matches(24));
+        assertTrue(integerMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Float> floatMatcher = Matchers.equalTo(42F);
+        assertTrue(floatMatcher.matches(42F));
+        assertFalse(floatMatcher.matches(24F));
+        assertTrue(floatMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Double> doubleMatcher = Matchers.equalTo(42.42);
+        assertTrue(doubleMatcher.matches(42.42));
+        assertFalse(doubleMatcher.matches(24.24));
+        assertTrue(doubleMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<Long> longMatcher = Matchers.equalTo(42L);
+        assertTrue(longMatcher.matches(42L));
+        assertFalse(longMatcher.matches(24L));
+        assertTrue(longMatcher.isFailedPrimitive());
+
+        EqualFieldsMatcher<String> stringMatcher = Matchers.equalTo("foo");
+        assertTrue(stringMatcher.matches("foo"));
+        assertFalse(stringMatcher.matches("bar"));
+        assertTrue(stringMatcher.isFailedPrimitive());
     }
 }

--- a/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.test.saga;
 
 import org.axonframework.commandhandling.CommandMessage;
@@ -15,6 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Test class validating the {@link CommandValidator}.
+ *
+ * @author Tom Soete
+ */
 class CommandValidatorTest {
 
     private CommandValidator testSubject;
@@ -48,6 +69,13 @@ class CommandValidatorTest {
         assertThrows(AxonAssertionError.class, () -> testSubject.assertDispatchedEqualTo(new SomeCommand("test")));
     }
 
+    @Test
+    void testMatchPrimitiveTypedCommands() {
+        when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage("some-string"));
+
+        assertThrows(AxonAssertionError.class, () -> testSubject.assertDispatchedEqualTo("some-other-string"));
+    }
+
     private List<CommandMessage<?>> emptyCommandMessageList() {
         return Collections.emptyList();
     }
@@ -56,8 +84,7 @@ class CommandValidatorTest {
         return Collections.singletonList(GenericCommandMessage.asCommandMessage(msg));
     }
 
-
-    private class SomeCommand {
+    private static class SomeCommand {
 
         private final Object value;
 


### PR DESCRIPTION
JDK17 does not allow reflective access to `java.lang` class, like the primitives and `String`. 
Due to this, if a user uses a primitive type in commands, events, queries, and deadlines, as we frequently do in our tests, the `EqualFieldsMatcher` will throw an exception. 

Ideally, the `EqualFieldsMatcher` wouldn't be exposed through the `Matchers` utility directly, since that would allow us to attach an equals check before proceeding with the fields equals. 
However, the `ResultValidatorImpl` and `CommandValidator` rely on the `Matchers` return type being the `EqualFieldsMatcher` for error descriptions.

Due to this, this pull request changes the `EqualFieldsMatcher` to check if it deals with a primitive "expected" or "actual" type.
If this is the case, a regular `equals` check is done instead of the reflective field equals.

To keep correctly describing error scenarios, the `EqualFieldsMatcher` has a `isFailedPrimitive` method.
The `ResultValidatorImpl` and `CommandValidator` use the `isFailedPrimitive` method to report these assertion errors differently.

This pull request resolves #2189.