### PR TITLE
Use equals() first for aggregate state check

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.axonframework.common.ObjectUtils.getOrDefault;
@@ -150,11 +151,12 @@ public abstract class ReflectionUtils {
      */
     @SuppressWarnings("unchecked")
     public static boolean explicitlyUnequal(Object value, Object otherValue) {
-        if (value == otherValue) { // NOSONAR (The == comparison is intended here)
+        if (Objects.equals(value, otherValue)) {
             return false;
         } else if (value == null || otherValue == null) {
             return true;
         } else if (value instanceof Comparable) {
+            //noinspection rawtypes
             return ((Comparable) value).compareTo(otherValue) != 0;
         } else if (hasEqualsMethod(value.getClass())) {
             return !value.equals(otherValue);

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This avoids performing reflection on classes that may not be declared
open to the module that contains the fixtures. Typically, these classes
would implement a suitable equals method.

This change will test equality using equals first, before attempting to
check fields. If equals returns false, it will still check whether an
equals method is explicitly implemented. Only when that is not the case,
a field-to-field comparison is performed using the same approach for
each individual field.