### PR TITLE
Flux response type rank matching

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/FluxResponseType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/FluxResponseType.java
@@ -22,6 +22,12 @@ import java.util.stream.Stream;
  */
 public class FluxResponseType<R> extends AbstractResponseType<Flux<R>> {
 
+    /**
+     * Indicates that the response matches with the {@link java.lang.reflect.Type} while returning a flux result.
+     *
+     * @see ResponseType#MATCH
+     * @see ResponseType#NO_MATCH
+     */
     public static final int FLUX_MATCH = 2048;
     private final ResponseType<?> multipleInstanceResponseType;
 

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/FluxResponseType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/FluxResponseType.java
@@ -22,6 +22,9 @@ import java.util.stream.Stream;
  */
 public class FluxResponseType<R> extends AbstractResponseType<Flux<R>> {
 
+    public static final int FLUX_MATCH = 2048;
+    private final ResponseType<?> multipleInstanceResponseType;
+
     /**
      * Instantiate a {@link FluxResponseType} with the given
      * {@code expectedResponseType} as the type to be matched against and to which the query response should be
@@ -31,6 +34,7 @@ public class FluxResponseType<R> extends AbstractResponseType<Flux<R>> {
      */
     public FluxResponseType(Class<?> expectedResponseType) {
         super(expectedResponseType);
+        multipleInstanceResponseType = new MultipleInstancesResponseType<>(expectedResponseType);
     }
 
     /**
@@ -43,7 +47,15 @@ public class FluxResponseType<R> extends AbstractResponseType<Flux<R>> {
      */
     @Override
     public boolean matches(Type responseType) {
-        return true;
+        return matchRank(responseType) > ResponseType.NO_MATCH;
+    }
+
+    @Override
+    public Integer matchRank(Type responseType) {
+        if (isFluxOfExpectedType(responseType)) {
+            return FLUX_MATCH;
+        }
+        return multipleInstanceResponseType.matchRank(responseType);
     }
 
     @SuppressWarnings("unchecked")

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseType.java
@@ -93,38 +93,35 @@ public class MultipleInstancesResponseType<R> extends AbstractResponseType<List<
      * @param responseType the response {@link java.lang.reflect.Type} of the query handler which is matched against
      * @return true for arrays, generic arrays and {@link java.lang.reflect.ParameterizedType}s (like a {@link
      * java.lang.Iterable}) for which the contained type is assignable to the expected type, {@link
-     * ResponseType#MATCHES_SINGLE} for matching single instances and {@link ResponseType#NO_MATCH} for non-matches
+     * ResponseType#MATCH} for matching single instances and {@link ResponseType#NO_MATCH} for non-matches
      */
     @Override
     public boolean matches(Type responseType) {
-        if (isMatchingIterable(responseType)) {
-            return true;
-        }
-        return instanceResponseType.matches(responseType);
+        return matchRank(responseType) > ResponseType.NO_MATCH;
     }
 
     /**
      * Match the query handler its response {@link Type} with this implementation its responseType {@code R}. Will
      * return a value greater than 0 in the following scenarios:
      * <ul>
-     * <li>{@link ResponseType#ITERABLE_MATCH}: If the response type is an array of the expected type. For example a {@code ExpectedType[]}</li>
-     * <li>{@link ResponseType#ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.GenericArrayType} of the expected type.
+     * <li>{@link #ITERABLE_MATCH}: If the response type is an array of the expected type. For example a {@code ExpectedType[]}</li>
+     * <li>{@link #ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.GenericArrayType} of the expected type.
      * For example a {@code <E extends ExpectedType> E[]}</li>
-     * <li>{@link ResponseType#ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.ParameterizedType} containing a single
+     * <li>{@link #ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.ParameterizedType} containing a single
      * {@link java.lang.reflect.TypeVariable} which is assignable to the response type, taking generic types into
      * account. For example a {@code List<ExpectedType>} or {@code <E extends ExpectedType> List<E>}.</li>
-     * <li>{@link ResponseType#ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.ParameterizedType} containing a single
+     * <li>{@link #ITERABLE_MATCH}: If the response type is a {@link java.lang.reflect.ParameterizedType} containing a single
      * {@link java.lang.reflect.WildcardType} which is assignable to the response type, taking generic types into
      * account. For example a {@code <E extends ExpectedType> List<? extends E>}.</li>
-     * <li>{@link ResponseType#MATCHES_SINGLE}: If the responseType is a single instance type matching the given {@link Type}.</li>
+     * <li>{@link ResponseType#MATCH}: If the responseType is a single instance type matching the given {@link Type}.</li>
      * </ul>
      * <p>
      * If there is no match at all, it will return {@link ResponseType#NO_MATCH} to indicate a non-match.
      *
      * @param responseType the response {@link java.lang.reflect.Type} of the query handler which is matched against
-     * @return {@link ResponseType#ITERABLE_MATCH} for arrays, generic arrays and {@link
+     * @return {@link #ITERABLE_MATCH} for arrays, generic arrays and {@link
      * java.lang.reflect.ParameterizedType}s (like a {@link java.lang.Iterable}) for which the contained type is
-     * assignable to the expected type, {@link ResponseType#MATCHES_SINGLE} for matching single instances and {@link
+     * assignable to the expected type, {@link ResponseType#MATCH} for matching single instances and {@link
      * ResponseType#NO_MATCH} for non-matches
      */
     @Override


### PR DESCRIPTION
`FluxResponseType` should conform to the new way of `ResponseType` matching using ranks.

Besides the beforementioned change. I noticed that getting handlers was not implemented correctly, we were getting matches only for the highest ranks, and not for all of them. It doesn't have to mean that the highest will work, it's fine to have a fallback.