### PR TITLE
Removed deprecated code by updating the default serializer initialization

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -17,6 +17,7 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import com.google.protobuf.ByteString;
+import com.thoughtworks.xstream.XStream;
 import io.axoniq.axonserver.connector.event.EventChannel;
 import io.axoniq.axonserver.grpc.InstructionAck;
 import io.axoniq.axonserver.grpc.event.Event;
@@ -36,6 +37,7 @@ import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -319,7 +321,9 @@ public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = XStreamSerializer::defaultSerializer;
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
             }
             assertNonNull(axonServerConnectionManager,
                           "The AxonServerConnectionManager is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -349,7 +349,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                 );
                 snapshotSerializer = () -> XStreamSerializer.builder()
                                                             .xStream(new XStream(new CompactDriver()))
-                                                            .build();;
+                                                            .build();
             }
             if (eventSerializer == null) {
                 logger.warn(
@@ -362,7 +362,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                 );
                 eventSerializer = () -> XStreamSerializer.builder()
                                                          .xStream(new XStream(new CompactDriver()))
-                                                         .build();;
+                                                         .build();
             }
 
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -17,6 +17,7 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import com.google.protobuf.ByteString;
+import com.thoughtworks.xstream.XStream;
 import io.axoniq.axonserver.connector.event.AggregateEventStream;
 import io.axoniq.axonserver.connector.event.AppendEventsTransaction;
 import io.axoniq.axonserver.connector.event.EventChannel;
@@ -54,6 +55,7 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -345,7 +347,9 @@ public class AxonServerEventStore extends AbstractEventStore {
                                         + " without specifying the security context"
                         )
                 );
-                snapshotSerializer = XStreamSerializer::defaultSerializer;
+                snapshotSerializer = () -> XStreamSerializer.builder()
+                                                            .xStream(new XStream(new CompactDriver()))
+                                                            .build();;
             }
             if (eventSerializer == null) {
                 logger.warn(
@@ -356,7 +360,9 @@ public class AxonServerEventStore extends AbstractEventStore {
                                         + " without specifying the security context"
                         )
                 );
-                eventSerializer = XStreamSerializer::defaultSerializer;
+                eventSerializer = () -> XStreamSerializer.builder()
+                                                         .xStream(new XStream(new CompactDriver()))
+                                                         .build();;
             }
 
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.eventhandling.DomainEventData;
@@ -30,6 +31,7 @@ import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -364,7 +366,9 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
                                         + " without specifying the security context"
                         )
                 );
-                snapshotSerializer = XStreamSerializer::defaultSerializer;
+                snapshotSerializer = () -> XStreamSerializer.builder()
+                                                            .xStream(new XStream(new CompactDriver()))
+                                                            .build();
             }
             if (eventSerializer == null) {
                 logger.warn(
@@ -375,7 +379,9 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
                                         + " without specifying the security context"
                         )
                 );
-                eventSerializer = XStreamSerializer::defaultSerializer;
+                eventSerializer = () -> XStreamSerializer.builder()
+                                                         .xStream(new XStream(new CompactDriver()))
+                                                         .build();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.deadline.quartz;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonNonTransientException;
 import org.axonframework.common.transaction.NoTransactionManager;
@@ -29,6 +30,7 @@ import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
@@ -339,7 +341,9 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager implements Li
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = XStreamSerializer::defaultSerializer;
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventhandling.scheduling.quartz;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.NoTransactionManager;
@@ -32,6 +33,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
@@ -460,7 +462,9 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
                                     "A default XStreamSerializer is used, without specifying the security context"
                             )
                     );
-                    serializer = XStreamSerializer::defaultSerializer;
+                    serializer = () -> XStreamSerializer.builder()
+                                                        .xStream(new XStream(new CompactDriver()))
+                                                        .build();
                 }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/SingleEventUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/SingleEventUpcasterTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.*;
  */
 class SingleEventUpcasterTest {
 
-    private final Serializer serializer = TestSerializer.XSTREAM.getSerializer();;
+    private final Serializer serializer = TestSerializer.XSTREAM.getSerializer();
 
     @Test
     void testUpcastsKnownType() {

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.saga.repository.jdbc;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.DataSourceConnectionProvider;
@@ -27,6 +28,7 @@ import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.SagaEntry;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -400,7 +402,9 @@ public class JdbcSagaStore implements SagaStore<Object> {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = XStreamSerializer::defaultSerializer;
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.saga.repository.jpa;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.modelling.saga.AssociationValue;
@@ -23,6 +24,7 @@ import org.axonframework.modelling.saga.AssociationValues;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -412,7 +414,9 @@ public class JpaSagaStore implements SagaStore<Object> {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = XStreamSerializer::defaultSerializer;
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
             }
         }
     }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -16,6 +16,19 @@
 
 package org.axonframework.spring.config;
 
+import com.thoughtworks.xstream.XStream;
+import java.lang.reflect.Executable;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import org.axonframework.commandhandling.AsynchronousCommandBus;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
@@ -79,12 +92,14 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.eventhandling.scheduling.quartz.QuartzEventSchedulerFactoryBean;
 import org.axonframework.spring.stereotype.Aggregate;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.*;
-import org.mockito.internal.util.collections.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.internal.util.collections.Sets;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerContext;
 import org.quartz.SchedulerException;
@@ -103,25 +118,23 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.test.StepVerifier;
 
-import java.lang.reflect.Executable;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-
 import static org.axonframework.commandhandling.GenericCommandMessage.asCommandMessage;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class validating the {@link SpringAxonAutoConfigurer}.
@@ -472,7 +485,9 @@ public class SpringAxonAutoConfigurerTest {
         @Bean
         @Primary
         public Serializer serializer() {
-            return XStreamSerializer.defaultSerializer();
+            return XStreamSerializer.builder()
+                                    .xStream(new XStream(new CompactDriver()))
+                                    .build();
         }
 
         @Bean


### PR DESCRIPTION
The intention of this PR is to remove the usage of the `XStreamSerializer::defaultSerializer` deprecated method.

By doing that, we are now using up to date methods (and Builders) but also removed a double `warn` message, before logged by both the Component using it but also the Serializer itself.