### PR TITLE
Fix duplicate command handler resolver not being used for annotated aggregates

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -19,7 +19,9 @@ package org.axonframework.messaging.annotation;
 import org.axonframework.messaging.Message;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -213,7 +215,12 @@ public class AnnotatedHandlerInspector<T> {
                                              .forEach((key, value) -> value.forEach(h -> registerHandler(key, (MessageHandlingMember<T>) h))));
         superClassInspectors.forEach(sci -> sci.getAllHandlers()
                                                .forEach((key, value) -> value.forEach(h -> {
-                                                   registerHandler(key, h);
+                                                   boolean isAbstract = h.unwrap(Executable.class)
+                                                                       .map(e -> Modifier.isAbstract(e.getModifiers()))
+                                                                       .orElse(false);
+                                                   if (!isAbstract) {
+                                                       registerHandler(key, h);
+                                                   }
                                                    registerHandler(inspectedType, h);
                                                })));
 

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
 import org.mockito.internal.util.collections.*;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +117,15 @@ class AnnotatedHandlerInspectorTest {
                 asList(aOn, bOn, aHandle, bHandle, dHandle, paHandle),
                 unwrapToList(inspector.getHandlers(D.class))
         );
+    }
+
+    @Test
+    void testDoesNotRegisterAbstractHandlersTwice() {
+        AnnotatedHandlerInspector<AB> aaInspector = AnnotatedHandlerInspector.inspectType(AB.class,
+                                                                                          parameterResolverFactory);
+
+        assertEquals(1, aaInspector.getAllHandlers().size());
+        assertEquals(1, (int) aaInspector.getAllHandlers().values().stream().flatMap(Collection::stream).count());
     }
 
     private <T extends MessageHandlingMember<?>> List<AnnotatedMessageHandlingMember<?>> unwrapToList(
@@ -219,6 +229,20 @@ class AnnotatedHandlerInspectorTest {
 
         @CommandHandler
         public void dHandle(String d) {
+        }
+    }
+
+    public static abstract class AA {
+
+        @CommandHandler
+        public abstract String handleAbstractly(String command);
+    }
+
+    public static class AB extends AA {
+
+        @Override
+        public String handleAbstractly(String command) {
+            return "Some result";
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -36,8 +36,10 @@ import org.axonframework.modelling.command.inspection.CreationPolicyMember;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -50,9 +52,13 @@ import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.modelling.command.AggregateCreationPolicy.NEVER;
 
 /**
- * Command handler that handles commands based on {@link CommandHandler} annotations on an aggregate. Those annotations
+ * Command handler that registers a set of {@link CommandHandler} based on annotations of an aggregate. Those annotations
  * may appear on methods, in which case a specific aggregate instance needs to be targeted by the command, or on the
  * constructor. The latter will create a new Aggregate instance, which is then stored in the repository.
+ *
+ * Despite being an {@link CommandMessageHandler} it does not actually handle the commands. During registration to the
+ * {@link CommandBus} it registers the {@link CommandMessageHandler}s directly instead of itself so duplicate command
+ * handlers can be detected and handled correctly.
  *
  * @param <T> the type of aggregate this handler handles commands for
  * @author Allard Buijze
@@ -64,6 +70,7 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
     private final CommandTargetResolver commandTargetResolver;
     private final List<MessageHandler<CommandMessage<?>>> handlers;
     private final Set<String> supportedCommandNames;
+    private final Map<String, Set<MessageHandler<CommandMessage<?>>>> supportedCommandsByName;
 
     /**
      * Instantiate a Builder to be able to create a {@link AggregateAnnotationCommandHandler}.
@@ -100,6 +107,7 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
         this.repository = builder.repository;
         this.commandTargetResolver = builder.commandTargetResolver;
         this.supportedCommandNames = new HashSet<>();
+        this.supportedCommandsByName = new HashMap<>();
         this.handlers = initializeHandlers(builder.buildAggregateModel());
     }
 
@@ -111,10 +119,16 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
      * @return A handle that can be used to unsubscribe
      */
     public Registration subscribe(CommandBus commandBus) {
-        List<Registration> subscriptions = supportedCommandNames()
+        List<Registration> subscriptions = supportedCommandsByName
+                .entrySet()
                 .stream()
-                .map(supportedCommand -> commandBus.subscribe(supportedCommand, this))
-                .filter(Objects::nonNull).collect(Collectors.toList());
+                .flatMap(entry ->
+                    entry.getValue().stream().map(messageHandler ->
+                        commandBus.subscribe(entry.getKey(), messageHandler)
+                    )
+                )
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
         return () -> subscriptions.stream().map(Registration::cancel).reduce(Boolean::logicalOr).orElse(false);
     }
 
@@ -137,30 +151,33 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
             Optional<AggregateCreationPolicy> policy = handler.unwrap(CreationPolicyMember.class)
                                                               .map(CreationPolicyMember::creationPolicy);
 
+            MessageHandler<CommandMessage<?>> messageHandler = null;
             if (cmh.isFactoryHandler()) {
                 assertThat(
                         policy,
                         p -> p.map(AggregateCreationPolicy.ALWAYS::equals).orElse(true),
                         aggregateModel.type() + ": Static methods/constructors can only use creationPolicy ALWAYS"
                 );
-                handlersFound.add(new AggregateConstructorCommandHandler(handler));
+                messageHandler = new AggregateConstructorCommandHandler(handler);
             } else {
                 switch (policy.orElse(NEVER)) {
                     case ALWAYS:
-                        handlersFound.add(new AlwaysCreateAggregateCommandHandler(
+                        messageHandler = new AlwaysCreateAggregateCommandHandler(
                                 handler, aggregateModel.entityClass()::newInstance
-                        ));
+                        );
                         break;
                     case CREATE_IF_MISSING:
-                        handlersFound.add(new AggregateCreateOrUpdateCommandHandler(
+                        messageHandler = new AggregateCreateOrUpdateCommandHandler(
                                 handler, aggregateModel.entityClass()::newInstance
-                        ));
+                        );
                         break;
                     case NEVER:
-                        handlersFound.add(new AggregateCommandHandler(handler));
+                        messageHandler = new AggregateCommandHandler(handler);
                         break;
                 }
             }
+            handlersFound.add(messageHandler);
+            supportedCommandsByName.computeIfAbsent(cmh.commandName(), key -> new HashSet<>()).add(messageHandler);
             supportedCommandNames.add(cmh.commandName());
         });
     }


### PR DESCRIPTION
When the AggregateAnnotationCommandHandler subscribes to the commandBus, it does so once for every payload type. This is independent of how many handlers are present for that type, since it does so using a set. In addition, it passes itself as the handler, making the DuplicateCommandHandlerResolver useless since comparing handlers is impossible (both handler arguments are the AggregateAnnotationCommandHandler itself, instead of the conflicting handlers).

In this PR this has been changed so the AggregateAnnotationCommandHandler subscribes the child command handlers to the CommandBus, instead of itself. This bypasses its handle and canHandle methods (since it is never really subscribed), but then uses these of the handlers in its list.

In addition, this PR solves an issue with the `AnnotatedHandlerInspector`. Even when methods were abstract in a superclass, they were considered a member. This leads to double registrations on the command bus.

Closes #1756 