### PR TITLE
Publisher Response Type

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -37,6 +37,7 @@ import org.axonframework.queryhandling.annotation.AnnotationQueryHandlerAdapter;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.junit.jupiter.api.*;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.util.Collections;
@@ -87,8 +88,8 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreaming() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                       ResponseTypes.fluxOf(String.class));
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
+                                                                                            ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -107,8 +108,8 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreamingAndFlowControlMessagesComesBeforeQueryExecution() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                       ResponseTypes.fluxOf(String.class));
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
+                                                                                            ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -127,8 +128,8 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreamingAndCancelMessagesComesBeforeQueryExecution() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                       ResponseTypes.fluxOf(String.class));
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
+                                                                                            ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -146,8 +147,8 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testStreamingQuery() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                       ResponseTypes.fluxOf(String.class));
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
+                                                                                            ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -293,7 +294,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testStreamingQueryWithConcurrentRequests() throws InterruptedException {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage =
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000),
                                           ResponseTypes.fluxOf(String.class));
 
@@ -368,7 +369,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testMultipleInstanceQueryShouldInvokeFlux() {
-        QueryMessage<MultipleInstanceQuery, Flux<String>> queryMessage =
+        QueryMessage<MultipleInstanceQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new MultipleInstanceQuery(1000), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -396,7 +397,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testCancellationOfStreamingFluxQuery() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage =
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -424,7 +425,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testStreamingFluxQueryWhenCancelMessageComesFirst() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage =
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -497,7 +498,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testFluxEmittingErrorAfterAWhile() {
-        QueryMessage<ErroringAfterAWhileFluxQuery, Flux<String>> queryMessage =
+        QueryMessage<ErroringAfterAWhileFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ErroringAfterAWhileFluxQuery(), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -523,7 +524,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testFluxEmittingErrorRightAway() {
-        QueryMessage<ErroringFluxQuery, Flux<String>> queryMessage =
+        QueryMessage<ErroringFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ErroringFluxQuery(), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -548,7 +549,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testFluxHandlerThrowingAnException() {
-        QueryMessage<ThrowingExceptionFluxQuery, Flux<String>> queryMessage =
+        QueryMessage<ThrowingExceptionFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ThrowingExceptionFluxQuery(), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =
@@ -599,7 +600,7 @@ class QueryProcessingTaskIntegrationTest {
 
     @Test
     void testFluxStreamingQueryWhenRequestingTooMany() {
-        QueryMessage<FluxQuery, Flux<String>> queryMessage =
+        QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
 
         QueryRequest request =

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -89,7 +89,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreaming() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                            ResponseTypes.fluxOf(String.class));
+                                                                                            ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -109,7 +109,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreamingAndFlowControlMessagesComesBeforeQueryExecution() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                            ResponseTypes.fluxOf(String.class));
+                                                                                            ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -129,7 +129,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testDirectQueryWhenRequesterDoesntSupportStreamingAndCancelMessagesComesBeforeQueryExecution() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                            ResponseTypes.fluxOf(String.class));
+                                                                                            ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1);
@@ -148,7 +148,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testStreamingQuery() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
-                                                                                            ResponseTypes.fluxOf(String.class));
+                                                                                            ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -296,7 +296,7 @@ class QueryProcessingTaskIntegrationTest {
     void testStreamingQueryWithConcurrentRequests() throws InterruptedException {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000),
-                                          ResponseTypes.fluxOf(String.class));
+                                          ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -370,7 +370,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testMultipleInstanceQueryShouldInvokeFlux() {
         QueryMessage<MultipleInstanceQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new MultipleInstanceQuery(1000), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new MultipleInstanceQuery(1000), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -398,7 +398,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testCancellationOfStreamingFluxQuery() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -426,7 +426,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testStreamingFluxQueryWhenCancelMessageComesFirst() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -499,7 +499,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testFluxEmittingErrorAfterAWhile() {
         QueryMessage<ErroringAfterAWhileFluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new ErroringAfterAWhileFluxQuery(), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new ErroringAfterAWhileFluxQuery(), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)
@@ -525,7 +525,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testFluxEmittingErrorRightAway() {
         QueryMessage<ErroringFluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new ErroringFluxQuery(), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new ErroringFluxQuery(), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1)
@@ -550,7 +550,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testFluxHandlerThrowingAnException() {
         QueryMessage<ThrowingExceptionFluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new ThrowingExceptionFluxQuery(), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new ThrowingExceptionFluxQuery(), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1)
@@ -601,7 +601,7 @@ class QueryProcessingTaskIntegrationTest {
     @Test
     void testFluxStreamingQueryWhenRequestingTooMany() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
-                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.fluxOf(String.class));
+                new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
         QueryRequest request =
                 querySerializer.serializeRequest(queryMessage, DIRECT_QUERY_NUMBER_OF_RESULTS, 1000, 1, true)

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/AbstractResponseType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/AbstractResponseType.java
@@ -19,7 +19,7 @@ package org.axonframework.messaging.responsetypes;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.TypeReflectionUtils;
 import org.axonframework.util.ClasspathResolver;
-import reactor.core.publisher.Flux;
+import org.reactivestreams.Publisher;
 
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -76,12 +76,9 @@ public abstract class AbstractResponseType<R> implements ResponseType<R> {
         return ReflectionUtils.unwrapIfType(type, Future.class);
     }
 
-    protected boolean isFluxOfExpectedType(Type responseType) {
-        if (!projectReactorOnClassPath()) {
-            return false;
-        }
-        Type fluxType = TypeReflectionUtils.getExactSuperType(responseType, Flux.class);
-        return fluxType != null && isParameterizedTypeOfExpectedType(fluxType);
+    protected boolean isPublisherOfExpectedType(Type responseType) {
+        Type publisherType = TypeReflectionUtils.getExactSuperType(responseType, Publisher.class);
+        return publisherType != null && isParameterizedTypeOfExpectedType(publisherType);
     }
 
     protected boolean isIterableOfExpectedType(Type responseType) {

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseType.java
@@ -138,7 +138,7 @@ public class MultipleInstancesResponseType<R> extends AbstractResponseType<List<
                 isStreamOfExpectedType(unwrapped) ||
                 isGenericArrayOfExpectedType(unwrapped) ||
                 isArrayOfExpectedType(unwrapped) ||
-                isFluxOfExpectedType(unwrapped);
+                isPublisherOfExpectedType(unwrapped);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ResponseTypes.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ResponseTypes.java
@@ -69,13 +69,14 @@ public abstract class ResponseTypes {
     }
 
     /**
-     * Specify the desire to retrieve a Flux (reactive stream) of instances of type {@code R} when performing a query.
+     * Specify the desire to retrieve a Publisher (reactive stream) of instances of type {@code R} when performing a
+     * query.
      *
      * @param type the {@code R} which is expected to be the response type
      * @param <R>  the generic type of the instantiated {@link ResponseType}
-     * @return a {@link ResponseType} specifying the desire to retrieve a flux of instances of type {@code R}
+     * @return a {@link ResponseType} specifying the desire to retrieve a publisher of instances of type {@code R}
      */
-    public static <R> ResponseType<Publisher<R>> fluxOf(Class<R> type) {
+    public static <R> ResponseType<Publisher<R>> publisherOf(Class<R> type) {
         return new PublisherResponseType<>(type);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ResponseTypes.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ResponseTypes.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging.responsetypes;
 
-import reactor.core.publisher.Flux;
+import org.reactivestreams.Publisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -75,8 +75,8 @@ public abstract class ResponseTypes {
      * @param <R>  the generic type of the instantiated {@link ResponseType}
      * @return a {@link ResponseType} specifying the desire to retrieve a flux of instances of type {@code R}
      */
-    public static <R> ResponseType<Flux<R>> fluxOf(Class<R> type) {
-        return new FluxResponseType<>(type);
+    public static <R> ResponseType<Publisher<R>> fluxOf(Class<R> type) {
+        return new PublisherResponseType<>(type);
     }
 
     private ResponseTypes() {

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
@@ -19,8 +19,9 @@ package org.axonframework.queryhandling;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.messaging.responsetypes.FluxResponseType;
+import org.axonframework.messaging.responsetypes.PublisherResponseType;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
@@ -34,7 +35,7 @@ import java.util.Map;
  * @author Stefan Dragisic
  * @since 4.6.0
  */
-public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, Flux<R>>
+public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, Publisher<R>>
         implements StreamingQueryMessage<Q, R> {
 
     /**
@@ -45,7 +46,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param responseType The expected response type
      */
     public GenericStreamingQueryMessage(Q payload, Class<R> responseType) {
-        this(payload, new FluxResponseType<>(responseType));
+        this(payload, new PublisherResponseType<>(responseType));
     }
 
     /**
@@ -56,7 +57,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param responseType The expected response type
      */
     public GenericStreamingQueryMessage(Q payload, String queryName, Class<R> responseType) {
-        this(payload, queryName, new FluxResponseType<>(responseType));
+        this(payload, queryName, new PublisherResponseType<>(responseType));
     }
 
     /**
@@ -66,7 +67,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param payload      The payload expressing the query
      * @param responseType The expected response type
      */
-    public GenericStreamingQueryMessage(Q payload, ResponseType<Flux<R>> responseType) {
+    public GenericStreamingQueryMessage(Q payload, ResponseType<Publisher<R>> responseType) {
         super(payload, responseType);
     }
 
@@ -77,7 +78,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param queryName    The name identifying the query to execute
      * @param responseType The expected response type
      */
-    public GenericStreamingQueryMessage(Q payload, String queryName, ResponseType<Flux<R>> responseType) {
+    public GenericStreamingQueryMessage(Q payload, String queryName, ResponseType<Publisher<R>> responseType) {
         this(new GenericMessage<>(payload, MetaData.emptyInstance()), queryName, responseType);
     }
 
@@ -89,7 +90,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param responseType The expected response type
      */
     public GenericStreamingQueryMessage(Message<Q> delegate, String queryName, Class<R> responseType) {
-        this(delegate, queryName, new FluxResponseType<>(responseType));
+        this(delegate, queryName, new PublisherResponseType<>(responseType));
     }
 
     /**
@@ -100,7 +101,7 @@ public class GenericStreamingQueryMessage<Q, R> extends GenericQueryMessage<Q, F
      * @param queryName    The name identifying the query to execute
      * @param responseType The expected response type
      */
-    public GenericStreamingQueryMessage(Message<Q> delegate, String queryName, ResponseType<Flux<R>> responseType) {
+    public GenericStreamingQueryMessage(Message<Q> delegate, String queryName, ResponseType<Publisher<R>> responseType) {
         super(delegate, queryName, responseType);
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -388,9 +388,9 @@ public class SimpleQueryBus implements QueryBus {
         DefaultUnitOfWork<StreamingQueryMessage<Q, R>> uow = DefaultUnitOfWork.startAndGet(query);
         return uow.executeWithResult(() -> {
             Object queryResponse = new DefaultInterceptorChain<>(uow, handlerInterceptors, handler).proceed();
-            return query.getResponseType()
-                        .convert(queryResponse)
-                        .map(GenericQueryResponseMessage::asResponseMessage);
+            return Flux.from(query.getResponseType()
+                                  .convert(queryResponse))
+                       .map(GenericQueryResponseMessage::asResponseMessage);
         });
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
@@ -16,15 +16,16 @@
 
 package org.axonframework.queryhandling;
 
-import org.axonframework.messaging.responsetypes.FluxResponseType;
+import org.axonframework.messaging.responsetypes.PublisherResponseType;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
 
 /**
  * A special type of {@link QueryMessage} used for initiating streaming queries. It's special since it hard codes the
- * response type to {@link FluxResponseType}.
+ * response type to {@link PublisherResponseType}.
  *
  * @param <Q> the type of streaming query payload
  * @param <R> the type of the result streamed via {@link Flux}
@@ -32,10 +33,10 @@ import java.util.Map;
  * @author Stefan Dragisic
  * @since 4.6.0
  */
-public interface StreamingQueryMessage<Q, R> extends QueryMessage<Q, Flux<R>> {
+public interface StreamingQueryMessage<Q, R> extends QueryMessage<Q, Publisher<R>> {
 
     @Override
-    ResponseType<Flux<R>> getResponseType();
+    ResponseType<Publisher<R>> getResponseType();
 
     @Override
     StreamingQueryMessage<Q, R> withMetaData(Map<String, ?> metaData);

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -20,7 +20,6 @@ import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.InstanceResponseType;
-import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -421,9 +420,6 @@ class DefaultQueryGatewayTest {
 
     @Test
     void streamingQueryIsLazy() {
-        QueryMessage<String, Flux<String>> queryMessage =
-                new GenericQueryMessage<>("criteria", "fluxQuery", ResponseTypes.fluxOf(String.class));
-
         Publisher<QueryResponseMessage<Object>> response = Flux.just(
                 new GenericQueryResponseMessage("a"),
                 new GenericQueryResponseMessage("b"),


### PR DESCRIPTION
Switched FluxResponseType to PublisherResponseType due to compatibility with apps that do not have Project Reactor on the classpath.