### PR TITLE
fix javadoc: default port is 8124, not 8123

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -49,7 +49,7 @@ public class AxonServerConfiguration {
 
     /**
      * Comma separated list of AxonServer servers. Each element is hostname or hostname:grpcPort. When no grpcPort is
-     * specified, default port 8123 is used.
+     * specified, default port 8124 is used.
      */
     private String servers = DEFAULT_SERVERS;
 


### PR DESCRIPTION
There was a mismatch between the configured constant

`private static final int DEFAULT_GRPC_PORT = 8124;``

and the statement in the javadoc.