### PR TITLE
fix: pooled event processor - coordination tasks not scheduled when releaseClaim throws exception

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -847,8 +847,11 @@ class Coordinator {
             logger.info("Releasing claims and scheduling a new coordination task in {}ms", errorWaitBackOff);
 
             errorWaitBackOff = Math.min(errorWaitBackOff * 2, 60000);
-            abortWorkPackages(cause).thenRun(
-                    () -> {
+            abortWorkPackages(cause).whenComplete(
+                    (unused, throwable) -> {
+                        if (throwable != null) {
+                            logger.error(String.format("An exception occurred during abortWorkPackage on [%s] processor.", name), throwable);
+                        }
                         logger.debug("Work packages have aborted. Scheduling new coordination task to run in {}ms",
                                      errorWaitBackOff);
                         // Construct a new CoordinationTask, thus abandoning the old task and it's progress entirely.

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -1,0 +1,85 @@
+package org.axonframework.eventhandling.pooled;
+
+import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.Segment;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.messaging.StreamableMessageSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.axonframework.eventhandling.Segment.computeSegment;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link Coordinator}.
+ *
+ * @author Fabio Couto
+ */
+class CoordinatorTest {
+
+    private static final String PROCESSOR_NAME = "test";
+
+    private Coordinator testSubject;
+
+    private final Segment segment = computeSegment(0);
+    private final List<Segment> segments = singletonList(segment);
+
+    private final TokenStore tokenStore = mock(TokenStore.class);
+    private final WorkPackage workPackage = mock(WorkPackage.class);
+    private final ScheduledThreadPoolExecutor executorService = mock(ScheduledThreadPoolExecutor.class);
+    @SuppressWarnings("unchecked")
+    private final StreamableMessageSource<TrackedEventMessage<?>> messageSource = mock(StreamableMessageSource.class);
+
+    @BeforeEach
+    void setUp() {
+        testSubject = Coordinator.builder()
+                                 .name(PROCESSOR_NAME)
+                                 .tokenStore(tokenStore)
+                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                 .maxClaimedSegments(segments.size())
+                                 .transactionManager(NoTransactionManager.instance())
+                                 .executorService(executorService)
+                                 .messageSource(messageSource)
+                                 .build();
+    }
+
+    @Test
+    void testIfNewCoordinationTaskCanBeSchedulledAfterTokenReleaseClaimFails() {
+        //arrange
+        final RuntimeException streamOpenException = new RuntimeException("Some exception during event stream open");
+        final RuntimeException releaseClaimException = new RuntimeException("Some exception during release claim");
+        final GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
+
+        doReturn(segments).when(tokenStore).fetchAvailableSegments(PROCESSOR_NAME);
+        doReturn(token).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt());
+        doThrow(releaseClaimException).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt());
+        doThrow(streamOpenException).when(messageSource).openStream(any());
+        doReturn(completedFuture(releaseClaimException)).when(workPackage).abort(any());
+        doReturn(segment).when(workPackage).segment();
+        doAnswer(runTask()).when(executorService).submit(any(Runnable.class));
+
+        //act
+        testSubject.start();
+
+        //asserts
+        verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    }
+
+    private Answer<Future<Integer>> runTask() {
+        return invocationOnMock -> {
+            final Runnable runnable = invocationOnMock.getArgument(0);
+            runnable.run();
+            return completedFuture(0);
+        };
+    }
+}


### PR DESCRIPTION
### Basic information

* Axon Framework version: 4.5.x
* JDK version:  11.0.13

### Steps to reproduce

When using a RDBMS as Event Store, Event Bus and Token Store, and the database goes offline, the scenario below occurs:

1. The CoordinationTask from Pooled Event Processor cannot read more events from stream, so it starts the abortAndScheduleRetry logic;
2. In abortAndScheduleRetry, the application tries to release claim in token store, but as the database is offline, this throws another exception;
3. The completable future chain are not handling exceptional completation, and because it, the task reschedule and the wait back off logic are not being executed;
4. When the database comes online again, as the reschedule is not happening, the application does not recover by itself, requiring a restart of the JVM.

### Expected behaviour

The coordination task reschedule should execute always (respecting the error wait back off intervals).
So, when the DB comes online again, the application can reconnect and continue processing events.

### Actual behaviour

The application does not recover by itself, does not throw exceptions, and does not generate a log record reporting this situation. Also, the related event processors don't handle the new events, requiring a restart of the service.
