### PR TITLE
fix: CoordinationTask doesn't reschedule itself when token release claim fails

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -848,7 +848,7 @@ class Coordinator {
             abortWorkPackages(cause).whenComplete(
                     (unused, throwable) -> {
                         if (throwable != null) {
-                            logger.error("An exception occurred during work packages abort on [{}] processor.", name, throwable);
+                            logger.warn("An exception occurred during work packages abort on [{}] processor.", name, throwable);
                         } else {
                             logger.debug("Work packages have aborted successfully.");
                         }
@@ -871,7 +871,12 @@ class Coordinator {
                        })
                        .thenRun(() -> transactionManager.executeInTransaction(
                                () -> tokenStore.releaseClaim(name, work.segment().getSegmentId())
-                       ));
+                       ))
+                       .exceptionally(throwable -> {
+                           logger.info("An exception occurred during the abort of work package for segment [{}] on [{}] processor.",
+                                       work.segment().getSegmentId(), name, throwable);
+                           return null;
+                       });
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -1,0 +1,83 @@
+package org.axonframework.eventhandling.pooled;
+
+import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.Segment;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.messaging.StreamableMessageSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.*;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.axonframework.eventhandling.Segment.computeSegment;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link Coordinator}.
+ *
+ * @author Fabio Couto
+ */
+class CoordinatorTest {
+
+    private static final String PROCESSOR_NAME = "test";
+
+    private Coordinator testSubject;
+
+    private final Segment SEGMENT_ZERO = computeSegment(0);
+    private final int[] SEGMENT_IDS = {0};
+
+    private final TokenStore tokenStore = mock(TokenStore.class);
+    private final WorkPackage workPackage = mock(WorkPackage.class);
+    private final ScheduledThreadPoolExecutor executorService = mock(ScheduledThreadPoolExecutor.class);
+    @SuppressWarnings("unchecked")
+    private final StreamableMessageSource<TrackedEventMessage<?>> messageSource = mock(StreamableMessageSource.class);
+
+    @BeforeEach
+    void setUp() {
+        testSubject = Coordinator.builder()
+                                 .name(PROCESSOR_NAME)
+                                 .tokenStore(tokenStore)
+                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                 .maxClaimedSegments(SEGMENT_IDS.length)
+                                 .transactionManager(NoTransactionManager.instance())
+                                 .executorService(executorService)
+                                 .messageSource(messageSource)
+                                 .build();
+    }
+
+    @Test
+    void testIfCoordinationTaskRescheduledAfterTokenReleaseClaimFails() {
+        //arrange
+        final RuntimeException streamOpenException = new RuntimeException("Some exception during event stream open");
+        final RuntimeException releaseClaimException = new RuntimeException("Some exception during release claim");
+        final GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
+
+        doReturn(SEGMENT_IDS).when(tokenStore).fetchSegments(PROCESSOR_NAME);
+        doReturn(token).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt());
+        doThrow(releaseClaimException).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt());
+        doThrow(streamOpenException).when(messageSource).openStream(any());
+        doReturn(completedFuture(streamOpenException)).when(workPackage).abort(any());
+        doReturn(SEGMENT_ZERO).when(workPackage).segment();
+        doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+        //act
+        testSubject.start();
+
+        //asserts
+        verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    }
+
+    private Answer<Future<Void>> runTaskSync() {
+        return invocationOnMock -> {
+            final Runnable runnable = invocationOnMock.getArgument(0);
+            runnable.run();
+            return completedFuture(null);
+        };
+    }
+}


### PR DESCRIPTION
**Steps to reproduce**

When using a RDBMS as Event Store/Bus and Token Store, and the database goes offline, the scenario below occurs:

1. The CoordinationTask starts abortAndScheduleRetry logic;
2. In abortAndScheduleRetry, the application tries to release claim in token store, but as the database is offline, this throws another exception;
3. The completable future chain is not handling exceptional completation, and because it, the task reschedule are not being executed;
4. When the database comes online again, as the reschedule is not happening and there is no CoordinationTask running, the application does not recover by itself, requiring a restart of the JVM.

**Expected behaviour**

The coordination task reschedule should execute always.
So, when the DB comes online again, the application can reconnect and continue processing events.

**Actual behaviour**

The application does not recover by itself, and does not generate a log record reporting this situation. Also, the related event processor don't handle the new events when the database goes online again, requiring a restart of the JVM.