### PR TITLE
Extracted lambdas to inner static classes

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -67,6 +67,7 @@ import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
+import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.queryhandling.StreamingQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryBackpressure;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
@@ -81,6 +82,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
@@ -254,6 +256,21 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                    .subscribeOn(Schedulers.fromExecutorService(queryExecutor));
     }
 
+    /**
+     * Ends a streaming query activity.
+     * <p>
+     * The reason for this static class to exist at all is the ability of instantiating {@link AxonServerQueryBus} even
+     * without Project Reactor on the classpath.
+     * </p>
+     * <p>
+     * If we had Project Reactor on the classpath, this class would be replaced with a lambda (which would compile into
+     * inner class). But, inner classes have a reference to an outer class making a single unit together with it. If an
+     * inner or outer class had a method with a parameter that belongs to a library which is not on the classpath,
+     * instantiation would fail.
+     * </p>
+     *
+     * @author Milan Savic
+     */
     private static class ActivityFinisher implements Consumer<SignalType> {
 
         private final ShutdownLatch.ActivityHandle activity;

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -227,6 +227,23 @@ public class SimpleQueryBus implements QueryBus {
                    ).contextWrite(new MonitorCallbackContextWriter(messageMonitor, query));
     }
 
+    /**
+     * Reports result of streaming query execution to the
+     * {@link org.axonframework.monitoring.MessageMonitor.MonitorCallback} (assuming that a monitor callback is attached
+     * to the context).
+     * <p>
+     * The reason for this static class to exist at all is the ability of instantiating {@link SimpleQueryBus} even
+     * without Project Reactor on the classpath.
+     * </p>
+     * <p>
+     * If we had Project Reactor on the classpath, this class would be replaced with a lambda (which would compile into
+     * inner class). But, inner classes have a reference to an outer class making a single unit together with it. If an
+     * inner or outer class had a method with a parameter that belongs to a library which is not on the classpath,
+     * instantiation would fail.
+     * </p>
+     *
+     * @author Milan Savic
+     */
     private static class SuccessReporter implements Consumer<Signal<?>> {
 
         @Override
@@ -241,6 +258,22 @@ public class SimpleQueryBus implements QueryBus {
         }
     }
 
+    /**
+     * Attaches {@link org.axonframework.monitoring.MessageMonitor.MonitorCallback} to the Project Reactor's
+     * {@link Context}.
+     * <p>
+     * The reason for this static class to exist at all is the ability of instantiating {@link SimpleQueryBus} even
+     * without Project Reactor on the classpath.
+     * </p>
+     * <p>
+     * If we had Project Reactor on the classpath, this class would be replaced with a lambda (which would compile into
+     * inner class). But, inner classes have a reference to an outer class making a single unit together with it. If an
+     * inner or outer class had a method with a parameter that belongs to a library which is not on the classpath,
+     * instantiation would fail.
+     * </p>
+     *
+     * @author Milan Savic
+     */
     private static class MonitorCallbackContextWriter implements UnaryOperator<Context> {
 
         private final MessageMonitor<? super QueryMessage<?, ?>> messageMonitor;

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -58,6 +58,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -240,7 +241,7 @@ public class SimpleQueryBus implements QueryBus {
         }
     }
 
-    private static class MonitorCallbackContextWriter implements Function<Context, Context> {
+    private static class MonitorCallbackContextWriter implements UnaryOperator<Context> {
 
         private final MessageMonitor<? super QueryMessage<?, ?>> messageMonitor;
         private final StreamingQueryMessage<?, ?> query;

--- a/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
@@ -19,7 +19,6 @@ package org.axonframework.queryhandling;
 import org.axonframework.messaging.responsetypes.PublisherResponseType;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 
 import java.util.Map;
 
@@ -28,7 +27,7 @@ import java.util.Map;
  * response type to {@link PublisherResponseType}.
  *
  * @param <Q> the type of streaming query payload
- * @param <R> the type of the result streamed via {@link Flux}
+ * @param <R> the type of the result streamed via {@link Publisher}
  * @author Milan Savic
  * @author Stefan Dragisic
  * @since 4.6.0

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>spring-boot-starter</module>
         <module>integrationtests</module>
         <module>legacy</module>
+        <module>reactorless-test</module>
     </modules>
     <packaging>pom</packaging>
 

--- a/reactorless-test/pom.xml
+++ b/reactorless-test/pom.xml
@@ -26,6 +26,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>axon-reactorless-test</artifactId>
+    <name>Axon Reactor-less tests</name>
+    <description>
+        Module containing Axon Framework tests without Project Reactor present on the classpath. Does not contain any
+        production code.
+    </description>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/reactorless-test/pom.xml
+++ b/reactorless-test/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2022. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>axon</artifactId>
+        <groupId>org.axonframework</groupId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>axon-reactorless-test</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/reactorless-test/src/main/java/org/axonframework/reactorlesstest/ReactorlessStartup.java
+++ b/reactorless-test/src/main/java/org/axonframework/reactorlesstest/ReactorlessStartup.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.reactorlesstest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Dummy spring boot app just wire up Axon beans without Project Reactor on classpath.
+ */
+@SpringBootApplication
+public class ReactorlessStartup {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReactorlessStartup.class, args);
+    }
+}

--- a/reactorless-test/src/test/java/org/axonframework/reactorlesstest/ReactorlessStartupTest.java
+++ b/reactorless-test/src/test/java/org/axonframework/reactorlesstest/ReactorlessStartupTest.java
@@ -16,8 +16,12 @@
 
 package org.axonframework.reactorlesstest;
 
+import org.axonframework.queryhandling.QueryBus;
 import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests starting a spring boot app without Project Reactor on classpath.
@@ -25,7 +29,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ReactorlessStartupTest {
 
+    @Autowired
+    private QueryBus queryBus;
+
     @Test
-    void contextLoads() {
+    void contextLoadsWithQueryBus() {
+        assertNotNull(queryBus);
     }
 }

--- a/reactorless-test/src/test/java/org/axonframework/reactorlesstest/ReactorlessStartupTest.java
+++ b/reactorless-test/src/test/java/org/axonframework/reactorlesstest/ReactorlessStartupTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.reactorlesstest;
+
+import org.junit.jupiter.api.*;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Tests starting a spring boot app without Project Reactor on classpath.
+ */
+@SpringBootTest
+class ReactorlessStartupTest {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
Rationale: lambdas are compiled into inner classes. If they have a reference to Project Reactor types, it is not possible to create a bean of an outer class. Static inner classes have no reference to outer class, hence, they don't have this problem.

Food for thought: Currently, there aren't any tests (but `axon-minimal` project created by @gklijs) confirming these changes. We could create a new test module without Reactor dep. I am wondering whether we want to have something like this, having in mind that Reactor will become a required dependency pretty soon.

Resolves #2238 