### PR TITLE
Add test for ConsistentHash.equals

### DIFF
--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
@@ -112,12 +112,9 @@ class ConsistentHashTest {
     }
 
     @Test
-    void testEquals1() throws Exception {
-        ConsistentHash consistentHash = new ConsistentHash((s) -> "fixed").with(member1, 1, AcceptAll.INSTANCE);
-        ConsistentHash consistentHashModified = consistentHash
-                                                            .with(member2, 1, AcceptAll.INSTANCE)
-                                                            .without(member2);
-        Assertions.assertFalse(consistentHashModified.equals(new ConsistentHash()));
+    void testNotEqualsForModifiedInstanceWithDefaultInstance() throws Exception {
+        ConsistentHash consistentHash = new ConsistentHash(s -> "fixed").with(member1, 1, AcceptAll.INSTANCE);
+        assertNotEquals(consistentHash, new ConsistentHash());
     }
 
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
@@ -20,6 +20,7 @@ import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.commandhandling.distributed.commandfilter.AcceptAll;
 import org.axonframework.commandhandling.distributed.commandfilter.CommandNameFilter;
 import org.axonframework.messaging.GenericMessage;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -109,4 +110,14 @@ class ConsistentHashTest {
         assertEquals(member1.name(), consistentHash.getMembers().iterator().next().name());
         assertEquals(consistentHash.getMembers(), consistentHashModified.getMembers());
     }
+
+    @Test
+    void testEquals1() throws Exception {
+        ConsistentHash consistentHash = new ConsistentHash((s) -> "fixed").with(member1, 1, AcceptAll.INSTANCE);
+        ConsistentHash consistentHashModified = consistentHash
+                                                            .with(member2, 1, AcceptAll.INSTANCE)
+                                                            .without(member2);
+        Assertions.assertFalse(consistentHashModified.equals(new ConsistentHash()));
+    }
+
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `consistentHashModified.equals(new ConsistentHash())` is false when `equals` is called with the parameter `o = new ConsistentHash()`.
This tests the method [`ConsistentHash.equals`](https://github.com/AxonFramework/AxonFramework/blob/1577eee6e536719c7f0e4c4f9e21ff75af3c80ad/messaging/src/main/java/org/axonframework/commandhandling/distributed/ConsistentHash.java#L177).
This test is based on the test [`testConflictingHashesDoNotImpactMembership`](https://github.com/AxonFramework/AxonFramework/blob/1577eee6e536719c7f0e4c4f9e21ff75af3c80ad/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java#L104).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))