### PR TITLE
Check attribute filter deep equals

### DIFF
--- a/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
@@ -83,7 +83,8 @@ public class DeepEqualsMatcher<T> extends BaseMatcher<T> {
         if (Objects.equals(expected, actual)) {
             return true;
         }
-        if (hasEqualsMethod(actual.getClass()) && (!containsIgnoreFieldFilter())) {
+        // If the default filter is used, we may deduce no reflective equals is desired by the user.
+        if (hasEqualsMethod(actual.getClass()) && defaultFilterUsed()) {
             // Expected does not equal actual, and equals is implemented. Hence, we should not perform field equality.
             noneMatchingEquals = true;
             return false;
@@ -95,9 +96,10 @@ public class DeepEqualsMatcher<T> extends BaseMatcher<T> {
         return expected.getClass().isInstance(actual) && expected.getClass().equals(actual.getClass());
     }
 
-    private boolean containsIgnoreFieldFilter(){
-        return filter instanceof MatchAllFieldFilter && ((MatchAllFieldFilter) filter).containsIgnoreFieldFilter();
+    private boolean defaultFilterUsed() {
+        return filter == AllFieldsFilter.instance();
     }
+
     private boolean matchingFields(Class<?> aClass, Object expectedValue, Object actual) {
         boolean match = true;
         for (Field field : aClass.getDeclaredFields()) {

--- a/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
@@ -83,7 +83,7 @@ public class DeepEqualsMatcher<T> extends BaseMatcher<T> {
         if (Objects.equals(expected, actual)) {
             return true;
         }
-        if (hasEqualsMethod(actual.getClass())) {
+        if (hasEqualsMethod(actual.getClass()) && (!(filter instanceof IgnoreField))) {
             // Expected does not equal actual, and equals is implemented. Hence, we should not perform field equality.
             noneMatchingEquals = true;
             return false;

--- a/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/DeepEqualsMatcher.java
@@ -83,7 +83,7 @@ public class DeepEqualsMatcher<T> extends BaseMatcher<T> {
         if (Objects.equals(expected, actual)) {
             return true;
         }
-        if (hasEqualsMethod(actual.getClass()) && (!(filter instanceof IgnoreField))) {
+        if (hasEqualsMethod(actual.getClass()) && (!containsIgnoreFieldFilter())) {
             // Expected does not equal actual, and equals is implemented. Hence, we should not perform field equality.
             noneMatchingEquals = true;
             return false;
@@ -95,6 +95,9 @@ public class DeepEqualsMatcher<T> extends BaseMatcher<T> {
         return expected.getClass().isInstance(actual) && expected.getClass().equals(actual.getClass());
     }
 
+    private boolean containsIgnoreFieldFilter(){
+        return filter instanceof MatchAllFieldFilter && ((MatchAllFieldFilter) filter).containsIgnoreFieldFilter();
+    }
     private boolean matchingFields(Class<?> aClass, Object expectedValue, Object actual) {
         boolean match = true;
         for (Field field : aClass.getDeclaredFields()) {

--- a/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
+++ b/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
@@ -52,4 +52,8 @@ public class MatchAllFieldFilter implements FieldFilter {
         }
         return true;
     }
+
+    public boolean containsIgnoreFieldFilter(){
+        return filters.stream().anyMatch(fieldFilter -> fieldFilter instanceof IgnoreField);
+    }
 }

--- a/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
+++ b/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
@@ -54,6 +54,6 @@ public class MatchAllFieldFilter implements FieldFilter {
     }
 
     public boolean containsIgnoreFieldFilter(){
-        return filters.stream().anyMatch(fieldFilter -> fieldFilter instanceof IgnoreField);
+        return filters.stream().anyMatch(IgnoreField.class::isInstance);
     }
 }

--- a/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
+++ b/test/src/main/java/org/axonframework/test/matchers/MatchAllFieldFilter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2015. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -51,9 +51,5 @@ public class MatchAllFieldFilter implements FieldFilter {
             }
         }
         return true;
-    }
-
-    public boolean containsIgnoreFieldFilter(){
-        return filters.stream().anyMatch(IgnoreField.class::isInstance);
     }
 }

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -16,10 +16,13 @@
 
 package org.axonframework.test.matchers;
 
+import com.sun.tools.javac.util.List;
 import org.axonframework.common.AxonConfigurationException;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.junit.jupiter.api.*;
+
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -83,7 +86,8 @@ class DeepEqualsMatcherTest {
 
     @Test
     void testIgnoredFieldOnEvent(){
-        DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(new SomeEvent("someField"), new IgnoreField(SomeEvent.class, "someField"));
+        DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(new SomeEvent("someField"), new MatchAllFieldFilter(
+                List.of(new IgnoreField(SomeEvent.class, "someField"))));
         boolean result = testSubject.matches(new SomeEvent("otherField"));
         assertTrue(result);
     }
@@ -103,6 +107,18 @@ class DeepEqualsMatcherTest {
 
         private SomeEvent(String someField) {
             this.someField = someField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SomeEvent someEvent = (SomeEvent) o;
+            return Objects.equals(someField, someEvent.someField);
         }
     }
 }

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -21,7 +21,7 @@ import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.junit.jupiter.api.*;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -85,9 +85,11 @@ class DeepEqualsMatcherTest {
     }
 
     @Test
-    void testIgnoredFieldOnEvent(){
-        DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(new SomeEvent("someField"), new MatchAllFieldFilter(
-                Arrays.asList((new IgnoreField(SomeEvent.class, "someField")))));
+    void testIgnoredFieldOnEvent() {
+        DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(
+                new SomeEvent("someField"),
+                new MatchAllFieldFilter(Collections.singletonList((new IgnoreField(SomeEvent.class, "someField"))))
+        );
         boolean result = testSubject.matches(new SomeEvent("otherField"));
         assertTrue(result);
     }
@@ -101,7 +103,9 @@ class DeepEqualsMatcherTest {
             this.someField = someField;
         }
     }
+
     private static class SomeEvent {
+
         @SuppressWarnings({"unused"})
         private final String someField;
 

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -22,6 +22,8 @@ import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.junit.jupiter.api.*;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,7 +89,7 @@ class DeepEqualsMatcherTest {
     @Test
     void testIgnoredFieldOnEvent(){
         DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(new SomeEvent("someField"), new MatchAllFieldFilter(
-                List.of(new IgnoreField(SomeEvent.class, "someField"))));
+                Arrays.asList((new IgnoreField(SomeEvent.class, "someField")))));
         boolean result = testSubject.matches(new SomeEvent("otherField"));
         assertTrue(result);
     }

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -81,12 +81,27 @@ class DeepEqualsMatcherTest {
         assertThrows(AxonConfigurationException.class, () -> new DeepEqualsMatcher<>(null).matches("foo"));
     }
 
+    @Test
+    void testIgnoredFieldOnEvent(){
+        DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(new SomeEvent("someField"), new IgnoreField(SomeEvent.class, "someField"));
+        boolean result = testSubject.matches(new SomeEvent("otherField"));
+        assertTrue(result);
+    }
+
     private static class ObjectNotOverridingEquals {
 
         @SuppressWarnings({"FieldCanBeLocal", "unused"})
         private final String someField;
 
         private ObjectNotOverridingEquals(String someField) {
+            this.someField = someField;
+        }
+    }
+    private static class SomeEvent {
+        @SuppressWarnings({"unused"})
+        private final String someField;
+
+        private SomeEvent(String someField) {
             this.someField = someField;
         }
     }

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -16,14 +16,12 @@
 
 package org.axonframework.test.matchers;
 
-import com.sun.tools.javac.util.List;
 import org.axonframework.common.AxonConfigurationException;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.junit.jupiter.api.*;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
Since 4.5.10 when I register a field to be ignored in a fixture test, the field is not ignored. In the DeepEqualsMatcher a check is missing when before calling the equals method of the object.