### PR TITLE
Allow subtype definition on the `Repository` builders for Polymorphic Aggregates

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -34,6 +34,7 @@ import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.modelling.command.inspection.AggregateModel;
 
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
@@ -256,6 +257,18 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         @Override
         public Builder<T> lockFactory(LockFactory lockFactory) {
             super.lockFactory(lockFactory);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtypes(@Nonnull Set<Class<? extends T>> subtypes) {
+            super.subtypes(subtypes);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtype(@Nonnull Class<? extends T> subtype) {
+            super.subtype(subtype);
             return this;
         }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
@@ -43,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
+ * Test class validating the {@link EventSourcingRepository}.
+ *
  * @author Allard Buijze
  */
 class EventSourcingRepositoryTest {
@@ -188,6 +191,24 @@ class EventSourcingRepositoryTest {
         inOrder.verify(snapshotTrigger, times(3)).eventHandled(any());
         inOrder.verify(snapshotTrigger).initializationFinished();
         inOrder.verify(snapshotTrigger, times(2)).eventHandled(any());
+    }
+
+    @Test
+    void testBuildWithNullSubtypesThrowsAxonConfigurationException() {
+        EventSourcingRepository.Builder<TestAggregate> builderTestSubject =
+                EventSourcingRepository.builder(TestAggregate.class)
+                                       .eventStore(mockEventStore);
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.subtypes(null));
+    }
+
+    @Test
+    void testBuildWithNullSubtypeThrowsAxonConfigurationException() {
+        EventSourcingRepository.Builder<TestAggregate> builderTestSubject =
+                EventSourcingRepository.builder(TestAggregate.class)
+                                       .eventStore(mockEventStore);
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.subtype(null));
     }
 
     private static class StubAggregateFactory extends AbstractAggregateFactory<TestAggregate> {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicESAggregateAnnotationCommandHandlerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicESAggregateAnnotationCommandHandlerTest.java
@@ -21,10 +21,10 @@ import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.command.RepositoryProvider;
-import org.axonframework.modelling.command.inspection.AggregateModel;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 
@@ -40,20 +40,21 @@ public class PolymorphicESAggregateAnnotationCommandHandlerTest
 
     @Override
     public <T> Repository<T> repository(Class<T> aggregateType,
-                                        AggregateModel<T> model,
+                                        Set<Class<? extends T>> subTypes,
                                         EntityManager entityManager) {
         EventSourcingRepository<T> repository = EventSourcingRepository
                 .builder(aggregateType)
+                .subtypes(subTypes)
                 .eventStore(EmbeddedEventStore.builder()
                                               .storageEngine(new InMemoryEventStorageEngine())
                                               .build())
                 .repositoryProvider(new RepositoryProvider() {
                     @Override
                     public <R> Repository<R> repositoryFor(@Nonnull Class<R> aggregateType) {
+                        //noinspection unchecked
                         return (Repository<R>) repositories.get(aggregateType);
                     }
                 })
-                .aggregateModel(model)
                 .build();
         repositories.put(aggregateType, repository);
         return repository;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicJpaAggregateAnnotationCommandHandlerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicJpaAggregateAnnotationCommandHandlerTest.java
@@ -20,10 +20,10 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.modelling.command.GenericJpaRepository;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.command.RepositoryProvider;
-import org.axonframework.modelling.command.inspection.AggregateModel;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 
@@ -41,19 +41,20 @@ public class PolymorphicJpaAggregateAnnotationCommandHandlerTest
 
     @Override
     public <T> Repository<T> repository(Class<T> aggregateType,
-                                        AggregateModel<T> model,
+                                        Set<Class<? extends T>> subTypes,
                                         EntityManager entityManager) {
         GenericJpaRepository<T> repository = GenericJpaRepository
                 .builder(aggregateType)
+                .subtypes(subTypes)
                 .entityManagerProvider(() -> entityManager)
                 .repositoryProvider(new RepositoryProvider() {
                     @Override
                     public <R> Repository<R> repositoryFor(@Nonnull Class<R> aggregateType) {
+                        //noinspection unchecked
                         return (Repository<R>) repositories.get(aggregateType);
                     }
                 })
                 .eventBus(mock(EventBus.class))
-                .aggregateModel(model)
                 .build();
         repositories.put(aggregateType, repository);
         return repository;

--- a/modelling/src/main/java/org/axonframework/modelling/command/GenericJpaRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/GenericJpaRepository.java
@@ -27,6 +27,7 @@ import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.modelling.command.inspection.AnnotatedAggregate;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -225,6 +226,18 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
         @Override
         public Builder<T> lockFactory(LockFactory lockFactory) {
             super.lockFactory(lockFactory);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtypes(@Nonnull Set<Class<? extends T>> subtypes) {
+            super.subtypes(subtypes);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtype(@Nonnull Class<? extends T> subtype) {
+            super.subtype(subtype);
             return this;
         }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
@@ -262,6 +263,18 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends
         @Override
         public Builder<T> aggregateModel(@Nonnull AggregateModel<T> aggregateModel) {
             super.aggregateModel(aggregateModel);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtypes(@Nonnull Set<Class<? extends T>> subtypes) {
+            super.subtypes(subtypes);
+            return this;
+        }
+
+        @Override
+        public Builder<T> subtype(@Nonnull Class<? extends T> subtype) {
+            super.subtype(subtype);
             return this;
         }
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.command;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.DomainEventSequenceAware;
@@ -47,6 +48,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
+ * Test class validating the {@link GenericJpaRepository}.
+ *
  * @author Allard Buijze
  */
 class GenericJpaRepositoryTest {
@@ -228,6 +231,26 @@ class GenericJpaRepositoryTest {
         testSubject.doSave(testSubject.load(aggregateId));
         verify(mockEntityManager).persist(aggregate);
         verify(mockEntityManager, never()).flush();
+    }
+
+    @Test
+    void testBuildWithNullSubtypesThrowsAxonConfigurationException() {
+        GenericJpaRepository.Builder<StubJpaAggregate> builderTestSubject =
+                GenericJpaRepository.builder(StubJpaAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mockEntityManager))
+                                    .eventBus(eventBus);
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.subtypes(null));
+    }
+
+    @Test
+    void testBuildWithNullSubtypeThrowsAxonConfigurationException() {
+        GenericJpaRepository.Builder<StubJpaAggregate> builderTestSubject =
+                GenericJpaRepository.builder(StubJpaAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mockEntityManager))
+                                    .eventBus(eventBus);
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.subtype(null));
     }
 
     private class StubJpaAggregate {


### PR DESCRIPTION
When a user needs to construct a custom `Repository` for a polymorphic aggregate, they're currently required to manually construct the `AggregateModel` since this is where subtypes may be defined. 

Although this works, this is not in line with the fact the `AggregateModel` **is not** a hard requirement during the construction of the `Repository`.
As such, chances are high that the user forgets to mention the subtypes, assuming they're picked up through annotations, for example.

By allowing configuration of the subtypes of the `aggregateType` on the `Repository.Builders` directly, we ease the configuration of a custom `Repository` for polymorphic aggregates.