### PR TITLE
Support `Cache` and `LockFactory` configuration on `@Aggregate` stereotype

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot.autoconfig;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.common.Registration;
+import org.axonframework.common.caching.Cache;
+import org.axonframework.common.lock.Lock;
+import org.axonframework.common.lock.LockFactory;
+import org.axonframework.eventsourcing.EventCountSnapshotTriggerDefinition;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.eventsourcing.EventSourcingRepository;
+import org.axonframework.eventsourcing.SnapshotTriggerDefinition;
+import org.axonframework.eventsourcing.Snapshotter;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.CommandTargetResolver;
+import org.axonframework.modelling.command.Repository;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+import org.axonframework.modelling.command.VersionedAggregateIdentifier;
+import org.axonframework.spring.stereotype.Aggregate;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating whether the {@link org.axonframework.spring.stereotype.Aggregate} stereotype annotation with
+ * the configurable bean names sets an Aggregate correctly.
+ *
+ * @author Steven van Beelen
+ */
+class AggregateStereotypeAutoConfigurationTest {
+
+    private static final String AGGREGATE_IDENTIFIER = "aggregateIdentifier";
+
+    private static AtomicBoolean snapshotFilterInvoked;
+    private static AtomicBoolean commandTargetResolverInvoked;
+    private static AtomicBoolean cacheInvoked;
+    private static AtomicBoolean lockFactoryInvoked;
+
+    private ApplicationContextRunner testApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        snapshotFilterInvoked = new AtomicBoolean(false);
+        commandTargetResolverInvoked = new AtomicBoolean(false);
+        cacheInvoked = new AtomicBoolean(false);
+        lockFactoryInvoked = new AtomicBoolean(false);
+
+        testApplicationContext = new ApplicationContextRunner().withUserConfiguration(TestContext.class)
+                                                               .withPropertyValues("axon.axonserver.enabled:false");
+    }
+
+    @Test
+    void testAggregateStereotypeConfiguration() {
+        testApplicationContext.run(context -> {
+            // Publish the first command to create the TestAggregate
+            CommandGateway commandGateway = context.getBean(DefaultCommandGateway.class);
+            String aggregateId = commandGateway.sendAndWait(new CreateTestAggregate());
+
+            SnapshotTriggerDefinition snapshotTriggerDefinition =
+                    context.getBean("testSnapshotTriggerDefinition", SnapshotTriggerDefinition.class);
+            verify(snapshotTriggerDefinition).prepareTrigger(TestContext.TestAggregate.class);
+            assertTrue(cacheInvoked.get());
+            assertTrue(lockFactoryInvoked.get());
+
+            // Publish the second command to trigger the SnapshotFilter and CommandTargetResolver
+            commandGateway.sendAndWait(new UpdateTestAggregate(aggregateId));
+
+            assertTrue(snapshotFilterInvoked.get());
+            assertTrue(commandTargetResolverInvoked.get());
+
+            EventStore eventStore = context.getBean("eventBus", EventStore.class);
+            assertTrue(eventStore.readEvents(aggregateId)
+                                 .asStream()
+                                 .allMatch(event -> Objects.equals(event.getType(), "testType")));
+        });
+    }
+
+    /**
+     * By configuring a custom {@link Repository} through the {@link Aggregate} stereotype, you remove the bean
+     * definitions of the {@link SnapshotTriggerDefinition}, {@link Cache}, and the {@link LockFactory}. This holds as
+     * the framework directly configures these components on the {@code Repository}. This test also asserts that the
+     * {@link SnapshotFilter} is <b>not</b> invoked, since the {@code SnapshotTriggerDefinition} is no longer defined on
+     * the {@code Repository}.
+     */
+    @Test
+    void testAggregateStereotypeWithCustomizedRepository() {
+        testApplicationContext.run(context -> {
+            // Publish the first command to create the TestAggregate
+            CommandGateway commandGateway = context.getBean(DefaultCommandGateway.class);
+            String aggregateId = commandGateway.sendAndWait(new CreateCustomRepoTestAggregate());
+
+            //noinspection unchecked
+            Repository<TestContext.CustomRepoTestAggregate> testRepository =
+                    context.getBean("testRepository", Repository.class);
+            verify(testRepository).newInstance(any());
+
+            SnapshotTriggerDefinition snapshotTriggerDefinition =
+                    context.getBean("testSnapshotTriggerDefinition", SnapshotTriggerDefinition.class);
+            verifyNoInteractions(snapshotTriggerDefinition);
+            assertFalse(cacheInvoked.get());
+            assertFalse(lockFactoryInvoked.get());
+
+            // Publish the second command to trigger the SnapshotFilter and CommandTargetResolver
+            commandGateway.sendAndWait(new UpdateCustomRepoTestAggregate(aggregateId));
+
+            verify(testRepository).load(eq(aggregateId), eq(null));
+            assertTrue(commandTargetResolverInvoked.get());
+
+            verifyNoInteractions(snapshotTriggerDefinition);
+            assertFalse(snapshotFilterInvoked.get());
+            assertFalse(cacheInvoked.get());
+            assertFalse(lockFactoryInvoked.get());
+
+            EventStore eventStore = context.getBean("eventBus", EventStore.class);
+            assertTrue(eventStore.readEvents(aggregateId)
+                                 .asStream()
+                                 .allMatch(event -> Objects.equals(event.getType(), "testTypeWithCustomRepository")));
+        });
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class TestContext {
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        @Aggregate(
+                snapshotTriggerDefinition = "testSnapshotTriggerDefinition",
+                snapshotFilter = "testSnapshotFilter",
+                type = "testType",
+                commandTargetResolver = "testCommandTargetResolver",
+                cache = "testCache",
+                lockFactory = "testLockFactory"
+        )
+        public static class TestAggregate {
+
+            @AggregateIdentifier
+            private String aggregateId;
+
+            @CommandHandler
+            public TestAggregate(CreateTestAggregate cmd) {
+                apply(new TestAggregateCreated(cmd.getAggregateId()));
+                // Publish multiple events to hit the snapshot event count when configured.
+                apply(new TestAggregateUpdated(cmd.getAggregateId()));
+                apply(new TestAggregateUpdated(cmd.getAggregateId()));
+                apply(new TestAggregateUpdated(cmd.getAggregateId()));
+            }
+
+            @CommandHandler
+            public void handle(UpdateTestAggregate command) {
+                // Do nothing
+            }
+
+            @EventSourcingHandler
+            public void on(TestAggregateCreated event) {
+                aggregateId = event.getAggregateId();
+            }
+
+            private TestAggregate() {
+                // Required by AggregateFactory
+            }
+        }
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        @Aggregate(
+                repository = "testRepository",
+                snapshotTriggerDefinition = "testSnapshotTriggerDefinition",
+                snapshotFilter = "testSnapshotFilter",
+                type = "testTypeWithCustomRepository",
+                commandTargetResolver = "testCommandTargetResolver",
+                cache = "testCache",
+                lockFactory = "testLockFactory"
+        )
+        private static class CustomRepoTestAggregate {
+
+            @AggregateIdentifier
+            private String aggregateId;
+
+            @CommandHandler
+            public CustomRepoTestAggregate(CreateCustomRepoTestAggregate cmd) {
+                apply(new CustomRepoTestAggregateCreated(cmd.getAggregateId()));
+                // Publish multiple events to hit the snapshot event count when configured.
+                apply(new CustomRepoTestAggregateUpdated(cmd.getAggregateId()));
+                apply(new CustomRepoTestAggregateUpdated(cmd.getAggregateId()));
+                apply(new CustomRepoTestAggregateUpdated(cmd.getAggregateId()));
+            }
+
+            @CommandHandler
+            public void handle(UpdateCustomRepoTestAggregate command) {
+                // Do nothing
+            }
+
+            @EventSourcingHandler
+            public void on(CustomRepoTestAggregateCreated event) {
+                aggregateId = event.getAggregateId();
+            }
+
+            private CustomRepoTestAggregate() {
+                // Required by AggregateFactory
+            }
+        }
+
+        @Bean
+        public SnapshotTriggerDefinition testSnapshotTriggerDefinition(Snapshotter snapshotter) {
+            return spy(new EventCountSnapshotTriggerDefinition(snapshotter, 3));
+        }
+
+        @Bean
+        public SnapshotFilter testSnapshotFilter() {
+            return domainEventData -> {
+                snapshotFilterInvoked.set(true);
+                return false;
+            };
+        }
+
+        @Bean
+        public CommandTargetResolver testCommandTargetResolver() {
+            return command -> {
+                commandTargetResolverInvoked.set(true);
+                return new VersionedAggregateIdentifier(AGGREGATE_IDENTIFIER, null);
+            };
+        }
+
+        @Bean
+        public Cache testCache() {
+            return new Cache() {
+                @Override
+                public <K, V> V get(K key) {
+                    return null;
+                }
+
+                @Override
+                public void put(Object key, Object value) {
+                    cacheInvoked.set(true);
+                }
+
+                @Override
+                public boolean putIfAbsent(Object key, Object value) {
+                    return false;
+                }
+
+                @Override
+                public boolean remove(Object key) {
+                    return false;
+                }
+
+                @Override
+                public boolean containsKey(Object key) {
+                    return false;
+                }
+
+                @Override
+                public Registration registerCacheEntryListener(EntryListener cacheEntryListener) {
+                    return null;
+                }
+            };
+        }
+
+        @Bean
+        public LockFactory testLockFactory() {
+            return identifier -> {
+                lockFactoryInvoked.set(true);
+                return new Lock() {
+                    @Override
+                    public void release() {
+                        // Do nothing
+                    }
+
+                    @Override
+                    public boolean isHeld() {
+                        return true;
+                    }
+                };
+            };
+        }
+
+        @Bean
+        public Repository<CustomRepoTestAggregate> testRepository(EventStore eventStore) {
+            EventSourcingRepository<CustomRepoTestAggregate> testRepository = EventSourcingRepository.builder(
+                    CustomRepoTestAggregate.class).eventStore(eventStore).build();
+            return spy(testRepository);
+        }
+    }
+
+    static class CreateTestAggregate {
+
+        private final String aggregateId;
+
+        CreateTestAggregate() {
+            this(AGGREGATE_IDENTIFIER);
+        }
+
+        CreateTestAggregate(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    static class TestAggregateCreated {
+
+        private final String aggregateId;
+
+        TestAggregateCreated(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class UpdateTestAggregate {
+
+        @TargetAggregateIdentifier private final String aggregateId;
+
+        UpdateTestAggregate() {
+            this(AGGREGATE_IDENTIFIER);
+        }
+
+        UpdateTestAggregate(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class TestAggregateUpdated {
+
+        private final String aggregateId;
+
+        TestAggregateUpdated(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    static class CreateCustomRepoTestAggregate {
+
+        private final String aggregateId;
+
+        CreateCustomRepoTestAggregate() {
+            this(AGGREGATE_IDENTIFIER);
+        }
+
+        CreateCustomRepoTestAggregate(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    static class CustomRepoTestAggregateCreated {
+
+        private final String aggregateId;
+
+        CustomRepoTestAggregateCreated(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class UpdateCustomRepoTestAggregate {
+
+        @TargetAggregateIdentifier private final String aggregateId;
+
+        UpdateCustomRepoTestAggregate() {
+            this(AGGREGATE_IDENTIFIER);
+        }
+
+        UpdateCustomRepoTestAggregate(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class CustomRepoTestAggregateUpdated {
+
+        private final String aggregateId;
+
+        CustomRepoTestAggregateUpdated(String aggregateId) {
+            this.aggregateId = aggregateId;
+        }
+
+        public String getAggregateId() {
+            return aggregateId;
+        }
+    }
+}

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
@@ -131,7 +131,7 @@ class AggregateStereotypeAutoConfigurationTest {
             // Publish the second command to trigger the SnapshotFilter and CommandTargetResolver
             commandGateway.sendAndWait(new UpdateCustomRepoTestAggregate(aggregateId));
 
-            verify(testRepository).load(eq(aggregateId), eq(null));
+            verify(testRepository).load(aggregateId, null);
             assertTrue(commandTargetResolverInvoked.get());
 
             verifyNoInteractions(snapshotTriggerDefinition);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
@@ -303,9 +303,9 @@ class AggregateStereotypeAutoConfigurationTest {
 
         @Bean
         public Repository<CustomRepoTestAggregate> testRepository(EventStore eventStore) {
-            EventSourcingRepository<CustomRepoTestAggregate> testRepository = EventSourcingRepository.builder(
-                    CustomRepoTestAggregate.class).eventStore(eventStore).build();
-            return spy(testRepository);
+            return spy(EventSourcingRepository.builder(CustomRepoTestAggregate.class)
+                                              .eventStore(eventStore)
+                                              .build());
         }
     }
 

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -51,11 +51,13 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
 
     private static final Logger logger = LoggerFactory.getLogger(SpringAggregateLookup.class);
 
+    private static final String REPOSITORY = "repository";
+    private static final String REPOSITORY_BEAN = "Repository";
     private static final String SNAPSHOT_FILTER = "snapshotFilter";
     private static final String SNAPSHOT_TRIGGER_DEFINITION = "snapshotTriggerDefinition";
     private static final String COMMAND_TARGET_RESOLVER = "commandTargetResolver";
-    private static final String REPOSITORY = "repository";
-    private static final String REPOSITORY_BEAN = "Repository";
+    private static final String CACHE = "cache";
+    private static final String LOCK_FACTORY = "lockFactory";
 
     /**
      * Builds a hierarchy model from the given {@code aggregatePrototypes} found in the given {@code beanFactory}.
@@ -175,6 +177,12 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
         }
         if (nonEmptyOrNull((String) props.get(COMMAND_TARGET_RESOLVER))) {
             beanDefinitionBuilder.addPropertyValue(COMMAND_TARGET_RESOLVER, props.get(COMMAND_TARGET_RESOLVER));
+        }
+        if (nonEmptyOrNull((String) props.get(CACHE))) {
+            beanDefinitionBuilder.addPropertyValue(CACHE, props.get(CACHE));
+        }
+        if (nonEmptyOrNull((String) props.get(LOCK_FACTORY))) {
+            beanDefinitionBuilder.addPropertyValue(LOCK_FACTORY, props.get(LOCK_FACTORY));
         }
         if (nonEmptyOrNull((String) props.get(REPOSITORY))) {
             beanDefinitionBuilder.addPropertyValue(REPOSITORY, props.get(REPOSITORY));

--- a/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
+++ b/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,8 +86,13 @@ public @interface Aggregate {
     boolean filterEventsByType() default false;
 
     /**
-     * Sets the name of the bean providing the caching. If none is provided, no cache is
-     * created, unless explicitly configured on the referenced repository.
+     * Sets the name of the bean providing the {@link org.axonframework.common.caching.Cache caching}. If none is
+     * provided, no cache is created, unless explicitly configured on the referenced repository.
+     * <p>
+     * Note that the use of {@link #repository()}, or adding a {@link org.axonframework.modelling.command.Repository}
+     * bean to the Spring context with the default naming scheme overrides this setting, as a Repository may explicitly
+     * define the cache. The default name corresponds to {@code "[aggregate-name]Repository"}, thus a {@code Trade}
+     * Aggregate would by default create/look for a bean named {@code "tradeRepository"}.
      */
     String cache() default "";
 
@@ -98,7 +103,7 @@ public @interface Aggregate {
      * <p>
      * Note that the use of {@link #repository()}, or adding a {@link org.axonframework.modelling.command.Repository}
      * bean to the Spring context with the default naming scheme overrides this setting, as a Repository explicitly defines
-     * the snapshot trigger definition. The default name corresponds to {@code "[aggregate-name]Repository"}, thus a
+     * the lock factory. The default name corresponds to {@code "[aggregate-name]Repository"}, thus a
      * {@code Trade} Aggregate would by default create/look for a bean named {@code "tradeRepository"}.
      */
     String lockFactory() default "";


### PR DESCRIPTION
When we introduced the [new Spring configuration](https://github.com/AxonFramework/AxonFramework/pull/2105), we unintentionally broke Aggregate stereotype configuration.
More specifically, a `Cache` and `LockFactory` bean name weren't taken into account when constructing the `AggregateConfigurer`.

This pull request resolves this predicament, by checking whether `cache` and `lockFactory` have a non-null and non-empty bean name on the `@Aggregate` annotation.
When this is the case, they are provided to the `AggregateConfigurer`.

We've introduced a dedicated test case for all Aggregate stereotype configurable components within this pull request.
Lastly, the JavaDoc of the stereotype has been improved slightly.