### PR TITLE
Create a protected method to fetch tracking events on JpaEventStorageEngine

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -152,6 +152,36 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
                : new GenericDomainEventMessage<>(null, event.getIdentifier(), 0L, event, event::getTimestamp);
     }
 
+    /**
+     * Returns a batch of event data as object entries in the event storage with a
+     * greater than the given {@code token}.
+     *
+     * @param token     Object describing the global index of the last processed event.
+     * @param batchSize The maximum number of events that should be returned
+     * @return A batch of event messages as object stored since the given tracking token
+     */
+    protected List<Object[]> fetchEvents(GapAwareTrackingToken token, int batchSize) {
+        TypedQuery<Object[]> query;
+        if (token == null || token.getGaps().isEmpty()) {
+            query = entityManager().createQuery(
+                    "SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, "
+                            + "e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData " +
+                            "FROM " + domainEventEntryEntityName() + " e " +
+                            "WHERE e.globalIndex > :token ORDER BY e.globalIndex ASC", Object[].class);
+        } else {
+            query = entityManager().createQuery(
+                    "SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, "
+                            + "e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData " +
+                            "FROM " + domainEventEntryEntityName() + " e " +
+                            "WHERE e.globalIndex > :token OR e.globalIndex IN :gaps ORDER BY e.globalIndex ASC",
+                    Object[].class
+            ).setParameter("gaps", token.getGaps());
+        }
+        return query.setParameter("token", token == null ? -1L : token.getIndex())
+                .setMaxResults(batchSize)
+                .getResultList();
+    }
+
     @Override
     protected List<? extends TrackedEventData<?>> fetchTrackedEvents(TrackingToken lastToken, int batchSize) {
         Assert.isTrue(
@@ -162,28 +192,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
         GapAwareTrackingToken previousToken = cleanedToken((GapAwareTrackingToken) lastToken);
 
-        List<Object[]> entries = transactionManager.fetchInTransaction(() -> {
-            // if there are many gaps, it's worth checking if it is possible to clean them up
-            TypedQuery<Object[]> query;
-            if (previousToken == null || previousToken.getGaps().isEmpty()) {
-                query = entityManager().createQuery(
-                        "SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, "
-                                + "e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData " +
-                                "FROM " + domainEventEntryEntityName() + " e " +
-                                "WHERE e.globalIndex > :token ORDER BY e.globalIndex ASC", Object[].class);
-            } else {
-                query = entityManager().createQuery(
-                        "SELECT e.globalIndex, e.type, e.aggregateIdentifier, e.sequenceNumber, e.eventIdentifier, "
-                                + "e.timeStamp, e.payloadType, e.payloadRevision, e.payload, e.metaData " +
-                                "FROM " + domainEventEntryEntityName() + " e " +
-                                "WHERE e.globalIndex > :token OR e.globalIndex IN :gaps ORDER BY e.globalIndex ASC",
-                        Object[].class
-                ).setParameter("gaps", previousToken.getGaps());
-            }
-            return query.setParameter("token", previousToken == null ? -1L : previousToken.getIndex())
-                        .setMaxResults(batchSize)
-                        .getResultList();
-        });
+        List<Object[]> entries = transactionManager.fetchInTransaction(() -> fetchEvents(previousToken, batchSize));
         List<TrackedEventData<?>> result = new ArrayList<>();
         GapAwareTrackingToken token = previousToken;
         for (Object[] entry : entries) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -154,13 +154,12 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
     /**
      * Returns a batch of event data as object entries in the event storage with a
-     * greater than the given {@code token}.
+     * greater than the given {@code token}.Size of event is decided by batchSize()
      *
      * @param token     Object describing the global index of the last processed event.
-     * @param batchSize The maximum number of events that should be returned
-     * @return A batch of event messages as object stored since the given tracking token
+     * @return A batch of event messages as object stored since the given tracking token.It
      */
-    protected List<Object[]> fetchEvents(GapAwareTrackingToken token, int batchSize) {
+    protected List<Object[]> fetchEvents(GapAwareTrackingToken token) {
         TypedQuery<Object[]> query;
         if (token == null || token.getGaps().isEmpty()) {
             query = entityManager().createQuery(
@@ -178,7 +177,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
             ).setParameter("gaps", token.getGaps());
         }
         return query.setParameter("token", token == null ? -1L : token.getIndex())
-                .setMaxResults(batchSize)
+                .setMaxResults(batchSize())
                 .getResultList();
     }
 
@@ -192,7 +191,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
         GapAwareTrackingToken previousToken = cleanedToken((GapAwareTrackingToken) lastToken);
 
-        List<Object[]> entries = transactionManager.fetchInTransaction(() -> fetchEvents(previousToken, batchSize));
+        List<Object[]> entries = transactionManager.fetchInTransaction(() -> fetchEvents(previousToken));
         List<TrackedEventData<?>> result = new ArrayList<>();
         GapAwareTrackingToken token = previousToken;
         for (Object[] entry : entries) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -154,10 +154,10 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
     /**
      * Returns a batch of event data as object entries in the event storage with a
-     * greater than the given {@code token}.Size of event is decided by batchSize()
+     * greater than the given {@code token}. Size of event is decided by {@link #batchSize()}.
      *
-     * @param token     Object describing the global index of the last processed event.
-     * @return A batch of event messages as object stored since the given tracking token.It
+     * @param token Object describing the global index of the last processed event.
+     * @return A batch of event messages as object stored since the given tracking token.
      */
     protected List<Object[]> fetchEvents(GapAwareTrackingToken token) {
         TypedQuery<Object[]> query;
@@ -177,8 +177,8 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
             ).setParameter("gaps", token.getGaps());
         }
         return query.setParameter("token", token == null ? -1L : token.getIndex())
-                .setMaxResults(batchSize())
-                .getResultList();
+                    .setMaxResults(batchSize())
+                    .getResultList();
     }
 
     @Override


### PR DESCRIPTION
Hi :) This PR is an enhancement to override fetchTrackedEvents queries.

**Event**
We faced a problem using Tracking Event Processes and wrote a [medium story](https://medium.com/trendyol-tech/axon-tracking-event-processor-optimization-8baba7946a96) about it. Then We decided to change the queries on the fetchTrackedEvents method on JpaEventStorageEngine class because sometimes they run very slowly, especially when there is at least one gap. (details are in the story)

**Problem**
While overriding these queries, we had to duplicate other methods and some fields. ([a sample implementation](https://github.com/altuntasfatih/axon-tracking-event-processor-optimization/blob/main/src/main/java/com/tep/config/CustomJpaEventStorageEngine.java) ).

**Solution**
If there is a protected method like the one proposed in this PR, anyone can easily extend and change those queries without duplicating irrelevant methods and fields.

**Extra**
We can also consider changing those queries if you are okay with that improvement. I did not include this PR because it is a breaking change.