### PR TITLE
Ensure commands and queries are processed in FIFO order

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -48,12 +48,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Comparator;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
@@ -68,8 +69,6 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
 public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus> {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-    private static final long DEFAULT_PRIORITY = 0;
 
     private final AxonServerConnectionManager axonServerConnectionManager;
     private final CommandBus localSegment;
@@ -120,11 +119,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
 
         this.executorService = builder.executorServiceBuilder.apply(
                 builder.configuration,
-                new PriorityBlockingQueue<>(1000, Comparator.comparingLong(
-                        r -> r instanceof CommandProcessingTask
-                                ? ((CommandProcessingTask) r).getPriority()
-                                : DEFAULT_PRIORITY).reversed()
-                )
+                new PriorityBlockingQueue<>(1000)
         );
 
         dispatchInterceptors = new DispatchInterceptors<>();
@@ -153,6 +148,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     private <C, R> void doDispatch(CommandMessage<C> commandMessage,
                                    CommandCallback<? super C, ? super R> commandCallback) {
         shutdownLatch.ifShuttingDown("Cannot dispatch new commands as this bus is being shutdown");
+        //noinspection resource
         ShutdownLatch.ActivityHandle commandInTransit = shutdownLatch.registerActivity();
         try {
             String context = targetContextResolver.resolveContext(commandMessage);
@@ -192,7 +188,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
                                                    c -> {
                                                        CompletableFuture<CommandResponse> result =
                                                                new CompletableFuture<>();
-                                                       executorService.submit(new CommandProcessingTask(
+                                                       executorService.execute(new CommandProcessingTask(
                                                                c, serializer, result, localSegment
                                                        ));
                                                        return result;
@@ -245,13 +241,16 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         return shutdownLatch.initiateShutdown();
     }
 
-    private static class CommandProcessingTask implements Runnable {
+    private static class CommandProcessingTask implements Runnable, Comparable<CommandProcessingTask> {
+
+        private static final AtomicLong COUNTER = new AtomicLong(Long.MIN_VALUE);
 
         private final long priority;
         private final CompletableFuture<CommandResponse> result;
         private final CommandBus localSegment;
         private final Command command;
         private final CommandSerializer serializer;
+        private final long index;
 
         public CommandProcessingTask(Command command,
                                      CommandSerializer serializer,
@@ -262,6 +261,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
             this.priority = ProcessingInstructionHelper.priority(command.getProcessingInstructionsList());
             this.result = result;
             this.localSegment = localSegment;
+            this.index = COUNTER.incrementAndGet();
         }
 
         public long getPriority() {
@@ -280,6 +280,32 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
             } catch (Exception e) {
                 result.completeExceptionally(e);
             }
+        }
+
+        @Override
+        public int compareTo(CommandProcessingTask o) {
+            int c = Long.compare(this.priority, o.priority);
+            if (c != 0) {
+                return -c;
+            }
+            return Long.compare(this.index, o.index);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CommandProcessingTask that = (CommandProcessingTask) o;
+            return priority == that.priority && index == that.index;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(priority, index);
         }
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
-import java.util.Comparator;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -80,6 +80,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -156,24 +157,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
 
         dispatchInterceptors = new DispatchInterceptors<>();
 
-        PriorityBlockingQueue<Runnable> queryProcessQueue = new PriorityBlockingQueue<>(
-                QUERY_QUEUE_CAPACITY,
-                Comparator.comparingLong(this::queryProcessingTaskPriority).reversed()
-        );
+        PriorityBlockingQueue<Runnable> queryProcessQueue = new PriorityBlockingQueue<>(QUERY_QUEUE_CAPACITY);
         queryExecutor = builder.executorServiceBuilder.apply(configuration, queryProcessQueue);
         localSegmentAdapter = new LocalSegmentAdapter();
-    }
-
-    private long queryProcessingTaskPriority(Object r) {
-        return r instanceof QueryProcessingTask
-                ? ((QueryProcessingTask) r).getPriority() :
-                responseProcessingTaskPriority(r);
-    }
-
-    private int responseProcessingTaskPriority(Object r) {
-        return r instanceof ResponseProcessingTask
-                ? ((ResponseProcessingTask<?>) r).getPriority()
-                : DEFAULT_PRIORITY;
     }
 
     /**
@@ -351,6 +337,48 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
         return shutdownLatch.initiateShutdown();
     }
 
+    private static class PriorityTask implements Comparable<PriorityTask> {
+        private static final AtomicLong COUNTER = new AtomicLong(Long.MIN_VALUE);
+        private final long priority;
+        private final long index;
+
+        public PriorityTask(long priority) {
+            this.priority = priority;
+            this.index = COUNTER.incrementAndGet();
+        }
+
+        @Override
+        public int compareTo(PriorityTask o) {
+            int c = Long.compare(this.priority, o.priority);
+            if (c != 0) {
+                return -c;
+            }
+            return Long.compare(this.index, o.index);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PriorityTask that = (PriorityTask) o;
+            return priority == that.priority && index == that.index;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(priority, index);
+        }
+
+        public long getPriority() {
+            return priority;
+        }
+
+    }
+
     /**
      * A {@link QueryHandler} implementation serving as a wrapper around the local {@link QueryBus} to push through the
      * message handling and subscription query registration.
@@ -362,7 +390,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
             QueryProcessingTask processingTask = new QueryProcessingTask(
                     localSegment, query, responseHandler, serializer, configuration.getClientId()
             );
-            queryExecutor.submit(processingTask);
+            queryExecutor.execute(processingTask);
         }
 
         @Override
@@ -398,10 +426,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
      * {@link ExecutorService}, in order. The {@code priority} is retrieved from the provided {@link QueryRequest} and
      * used to priorities this {@link QueryProcessingTask} among others of it's kind.
      */
-    private static class QueryProcessingTask implements Runnable {
+    private static class QueryProcessingTask extends PriorityTask implements Runnable {
 
         private final QueryBus localSegment;
-        private final long priority;
         private final QueryRequest queryRequest;
         private final ReplyChannel<QueryResponse> responseHandler;
         private final QuerySerializer serializer;
@@ -411,16 +438,12 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                                     QueryRequest queryRequest,
                                     ReplyChannel<QueryResponse> responseHandler,
                                     QuerySerializer serializer, String clientId) {
+            super(priority(queryRequest.getProcessingInstructionsList()));
             this.localSegment = localSegment;
-            this.priority = priority(queryRequest.getProcessingInstructionsList());
             this.queryRequest = queryRequest;
             this.responseHandler = responseHandler;
             this.serializer = serializer;
             this.clientId = clientId;
-        }
-
-        public long getPriority() {
-            return priority;
         }
 
         @Override
@@ -703,13 +726,12 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
         }
     }
 
-    private static class ResponseProcessingTask<R> implements Runnable {
+    private static class ResponseProcessingTask<R> extends PriorityTask implements Runnable {
 
         private final AtomicBoolean singleExecutionCheck = new AtomicBoolean();
         private final ResultStream<QueryResponse> result;
         private final QuerySerializer serializer;
         private final CompletableFuture<QueryResponseMessage<R>> queryTransaction;
-        private final int priority;
         private final ResponseType<R> expectedResponseType;
 
         public ResponseProcessingTask(ResultStream<QueryResponse> result,
@@ -717,10 +739,10 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                                       CompletableFuture<QueryResponseMessage<R>> queryTransaction,
                                       int priority,
                                       ResponseType<R> expectedResponseType) {
+            super(priority);
             this.result = result;
             this.serializer = serializer;
             this.queryTransaction = queryTransaction;
-            this.priority = priority;
             this.expectedResponseType = expectedResponseType;
         }
 
@@ -740,10 +762,6 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                     queryTransaction.completeExceptionally(exception);
                 }
             }
-        }
-
-        public int getPriority() {
-            return priority;
         }
     }
 


### PR DESCRIPTION
This PR addresses an issue where commands and queries with equal priority were not guaranteed to be processed in FIFO (First In, First Out) order. Under sustained load, it was possible for some commands to be continuously superseded by newly incoming commands. 