### PR TITLE
Process events with identical `TrackingToken` together in the `PooledStreamingEventProcessor`

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -152,24 +152,17 @@ class WorkPackage {
     }
 
     /**
-     * The given {@code event} should not be scheduled if:
-     * <ol>
-     *     <li>The {@link TrackedEventMessage#trackingToken()} {@link TrackingToken#covers(TrackingToken)} the last delivered token, and</li>
-     *     <li>if the last delivered token does not equal the given {@code event's} token.</li>
-     * </ol>
+     * The given {@code event} should not be scheduled if the {@link TrackedEventMessage#trackingToken()}
+     * {@link TrackingToken#covers(TrackingToken)} the last delivered token.
      * <p>
-     * The first validation ensures events that this work package already covered are ignored. The second validation
-     * ensures that subsequent events with the exact same token <b>are</b> included. The last step is necessary to
-     * include events that are the result of a one-to-many upcaster.
+     * This validation ensures events that this work package already covered are ignored.
      *
      * @param event The event to validate whether it should be scheduled yes or no.
      * @return {@code true} if the given {@code event} should not be scheduled, {@code false} otherwise.
      */
     private boolean shouldNotSchedule(TrackedEventMessage<?> event) {
         // Null check is done to solve potential NullPointerException.
-        return lastDeliveredToken != null
-                && lastDeliveredToken.covers(event.trackingToken())
-                && !lastDeliveredToken.equals(event.trackingToken());
+        return lastDeliveredToken != null && lastDeliveredToken.covers(event.trackingToken());
     }
 
     private boolean canHandle(TrackedEventMessage<?> event) {

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -1,21 +1,50 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventhandling.pooled;
 
+import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.messaging.StreamableMessageSource;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.stubbing.Answer;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import org.mockito.stubbing.*;
 
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.axonframework.eventhandling.Segment.computeSegment;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.axonframework.utils.AssertUtils.assertWithin;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.*;
 
 /**
@@ -30,24 +59,27 @@ class CoordinatorTest {
     private Coordinator testSubject;
 
     private final Segment SEGMENT_ZERO = computeSegment(0);
-    private final int[] SEGMENT_IDS = {0};
+    private final int SEGMENT_ID = 0;
+    private final int[] SEGMENT_IDS = {SEGMENT_ID};
 
     private final TokenStore tokenStore = mock(TokenStore.class);
-    private final WorkPackage workPackage = mock(WorkPackage.class);
     private final ScheduledThreadPoolExecutor executorService = mock(ScheduledThreadPoolExecutor.class);
     @SuppressWarnings("unchecked")
     private final StreamableMessageSource<TrackedEventMessage<?>> messageSource = mock(StreamableMessageSource.class);
+
+    private final WorkPackage workPackage = mock(WorkPackage.class);
 
     @BeforeEach
     void setUp() {
         testSubject = Coordinator.builder()
                                  .name(PROCESSOR_NAME)
+                                 .messageSource(messageSource)
                                  .tokenStore(tokenStore)
-                                 .workPackageFactory((segment, trackingToken) -> workPackage)
-                                 .maxClaimedSegments(SEGMENT_IDS.length)
                                  .transactionManager(NoTransactionManager.instance())
                                  .executorService(executorService)
-                                 .messageSource(messageSource)
+                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                 .eventFilter(eventMessage -> true)
+                                 .maxClaimedSegments(SEGMENT_IDS.length)
                                  .build();
     }
 
@@ -73,11 +105,67 @@ class CoordinatorTest {
         verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
 
+    @SuppressWarnings("rawtypes") // Mockito cannot deal with the wildcard generics of the TrackedEventMessage
+    @Test
+    void testIfCoordinationTaskSchedulesEventsWithTheSameTokenTogether() throws InterruptedException {
+        TrackingToken testToken = new GlobalSequenceTrackingToken(0);
+        TrackedEventMessage testEventOne =
+                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));
+        TrackedEventMessage testEventTwo =
+                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("that-event"));
+        List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
+        testEvents.add(testEventOne);
+        testEvents.add(testEventTwo);
+
+        when(workPackage.hasRemainingCapacity()).thenReturn(true)
+                                                .thenReturn(false);
+        when(workPackage.isAbortTriggered()).thenReturn(false);
+        when(workPackage.scheduleEvents(testEvents)).thenReturn(true);
+
+        //noinspection unchecked
+        BlockingStream<TrackedEventMessage<?>> testStream = mock(BlockingStream.class);
+        when(testStream.setOnAvailableCallback(any())).thenReturn(false);
+        when(testStream.hasNextAvailable()).thenReturn(true)
+                                           .thenReturn(false);
+        //noinspection unchecked
+        when(testStream.nextAvailable()).thenReturn(testEventOne)
+                                        .thenReturn(testEventTwo);
+        //noinspection unchecked
+        when(testStream.peek()).thenReturn(Optional.of(testEventTwo))
+                               .thenReturn(Optional.of(testEventTwo))
+                               .thenReturn(Optional.empty());
+
+        when(executorService.submit(any(Runnable.class))).thenAnswer(runTaskAsync());
+        when(tokenStore.fetchSegments(PROCESSOR_NAME)).thenReturn(SEGMENT_IDS);
+        when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_ID)).thenReturn(testToken);
+        when(messageSource.openStream(testToken)).thenReturn(testStream);
+
+        testSubject.start();
+
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> verify(tokenStore).fetchToken(PROCESSOR_NAME, SEGMENT_ID));
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> verify(messageSource).openStream(testToken));
+
+        //noinspection unchecked
+        ArgumentCaptor<List<TrackedEventMessage<?>>> eventsCaptor = ArgumentCaptor.forClass(List.class);
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> verify(workPackage).scheduleEvents(eventsCaptor.capture()));
+
+        List<TrackedEventMessage<?>> resultEvents = eventsCaptor.getValue();
+        assertEquals(2, resultEvents.size());
+        assertTrue(resultEvents.contains(testEventOne));
+        assertTrue(resultEvents.contains(testEventTwo));
+
+        verify(workPackage, times(0)).scheduleEvent(any());
+    }
+
     private Answer<Future<Void>> runTaskSync() {
         return invocationOnMock -> {
             final Runnable runnable = invocationOnMock.getArgument(0);
             runnable.run();
             return completedFuture(null);
         };
+    }
+
+    private Answer<Future<Void>> runTaskAsync() {
+        return invocationOnMock -> CompletableFuture.runAsync(invocationOnMock.getArgument(0));
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
@@ -35,6 +35,7 @@ import org.mockito.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
@@ -117,7 +118,7 @@ class WorkPackageTest {
      * The "last delivered token" is configured as the initialToken for a fresh WorkPackage.
      */
     @Test
-    void testScheduleEventDoesNotScheduleIfTheLastDeliveredTokenCoversAndDoesNotEqualTheEventsToken() {
+    void testScheduleEventDoesNotScheduleIfTheLastDeliveredTokenCoversTheEventsToken() {
         TrackedEventMessage<String> testEvent = new GenericTrackedEventMessage<>(
                 new GlobalSequenceTrackingToken(1L), GenericEventMessage.asEventMessage("some-event")
         );
@@ -262,35 +263,6 @@ class WorkPackageTest {
         assertEquals(expectedAdvancedToken, ((TrackedEventMessage<?>) processedEvents.get(0)).trackingToken());
     }
 
-    /**
-     * The "last delivered token" is configured as the initialToken for a fresh WorkPackage.
-     */
-    @Test
-    void testScheduleEventIsScheduledIfTheLastDeliveredTokenEqualsTheEventsToken() {
-        TrackedEventMessage<String> expectedEvent = new GenericTrackedEventMessage<>(
-                initialTrackingToken, GenericEventMessage.asEventMessage("some-event")
-        );
-
-        testSubject.scheduleEvent(expectedEvent);
-
-        List<EventMessage<?>> validatedEvents = eventFilter.getValidatedEvents();
-        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(1, validatedEvents.size()));
-        assertEquals(expectedEvent, validatedEvents.get(0));
-
-        List<EventMessage<?>> processedEvents = batchProcessor.getProcessedEvents();
-        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(1, processedEvents.size()));
-        assertEquals(expectedEvent.trackingToken(), ((TrackedEventMessage<?>) processedEvents.get(0)).trackingToken());
-
-        ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
-        verify(tokenStore).storeToken(tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()));
-        assertEquals(initialTrackingToken, tokenCaptor.getValue());
-
-        assertEquals(1, trackerStatusUpdates.size());
-        OptionalLong resultPosition = trackerStatusUpdates.get(0).getCurrentPosition();
-        assertTrue(resultPosition.isPresent());
-        assertEquals(0L, resultPosition.getAsLong());
-    }
-
     @Test
     void testScheduleEventExtendsTokenClaimAfterClaimThresholdExtension() {
         // The short threshold ensures the packages assume the token should be reclaimed.
@@ -420,6 +392,121 @@ class WorkPackageTest {
 
         assertWithin(500, TimeUnit.MILLISECONDS, () -> assertTrue(result.isDone()));
         assertEquals(originalAbortReason, result.get());
+    }
+
+    @Test
+    void testScheduleEventsReturnsFalseForEmptyList() {
+        assertFalse(testSubject.scheduleEvents(Collections.emptyList()));
+    }
+
+    @Test
+    void testScheduleEventsThrowsIllegalArgumentExceptionForNoneMatchingTokens() {
+        TrackingToken testTokenOne = new GlobalSequenceTrackingToken(1L);
+        TrackedEventMessage<String> testEventOne =
+                new GenericTrackedEventMessage<>(testTokenOne, GenericEventMessage.asEventMessage("this-event"));
+        TrackingToken testTokenTwo = new GlobalSequenceTrackingToken(2L);
+        TrackedEventMessage<String> testEventTwo =
+                new GenericTrackedEventMessage<>(testTokenTwo, GenericEventMessage.asEventMessage("that-event"));
+        List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
+        testEvents.add(testEventOne);
+        testEvents.add(testEventTwo);
+
+        assertThrows(IllegalArgumentException.class, () -> testSubject.scheduleEvents(testEvents));
+    }
+
+    /**
+     * The "last delivered token" is configured as the initialToken for a fresh WorkPackage.
+     */
+    @Test
+    void testScheduleEventsDoesNotScheduleIfTheLastDeliveredTokensCoversTheEventsToken() {
+        TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
+        TrackedEventMessage<String> testEventOne =
+                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));
+        TrackedEventMessage<String> testEventTwo =
+                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("that-event"));
+        List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
+        testEvents.add(testEventOne);
+        testEvents.add(testEventTwo);
+
+        WorkPackage testSubjectWithCustomInitialToken =
+                testSubjectBuilder.initialToken(new GlobalSequenceTrackingToken(2L))
+                                  .build();
+
+        boolean result = testSubjectWithCustomInitialToken.scheduleEvents(testEvents);
+
+        assertFalse(result);
+        verifyNoInteractions(executorService);
+    }
+
+    @Test
+    void testScheduleEventsReturnsTrueIfOnlyOneEventIsAcceptedByTheEventValidator() {
+        TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
+        TrackedEventMessage<String> filteredEvent =
+                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));
+        TrackedEventMessage<String> expectedEvent =
+                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("that-event"));
+        List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
+        testEvents.add(filteredEvent);
+        testEvents.add(expectedEvent);
+
+        eventFilterPredicate = event -> !event.equals(filteredEvent);
+
+        boolean result = testSubject.scheduleEvents(testEvents);
+
+        assertTrue(result);
+
+        List<EventMessage<?>> validatedEvents = eventFilter.getValidatedEvents();
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(2, validatedEvents.size()));
+        assertTrue(validatedEvents.containsAll(testEvents));
+
+        List<EventMessage<?>> processedEvents = batchProcessor.getProcessedEvents();
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(1, processedEvents.size()));
+        assertEquals(expectedEvent.trackingToken(), ((TrackedEventMessage<?>) processedEvents.get(0)).trackingToken());
+
+        ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+        verify(tokenStore).storeToken(tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()));
+        assertEquals(expectedToken, tokenCaptor.getValue());
+
+        assertEquals(1, trackerStatusUpdates.size());
+        OptionalLong resultPosition = trackerStatusUpdates.get(0).getCurrentPosition();
+        assertTrue(resultPosition.isPresent());
+        assertEquals(1L, resultPosition.getAsLong());
+    }
+
+    @Test
+    void testScheduleEventsHandlesAllEventsInOneTransactionWhenAllEventsCanBeHandled() {
+        TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
+        TrackedEventMessage<String> expectedEventOne =
+                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));
+        TrackedEventMessage<String> expectedEventTwo =
+                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("that-event"));
+        List<TrackedEventMessage<?>> expectedEvents = new ArrayList<>();
+        expectedEvents.add(expectedEventOne);
+        expectedEvents.add(expectedEventTwo);
+
+        boolean result = testSubject.scheduleEvents(expectedEvents);
+
+        assertTrue(result);
+
+        List<EventMessage<?>> validatedEvents = eventFilter.getValidatedEvents();
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(2, validatedEvents.size()));
+        assertTrue(validatedEvents.containsAll(expectedEvents));
+
+        List<EventMessage<?>> processedEvents = batchProcessor.getProcessedEvents();
+        assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(2, processedEvents.size()));
+        assertEquals(expectedEventOne.trackingToken(),
+                     ((TrackedEventMessage<?>) processedEvents.get(0)).trackingToken());
+        assertEquals(expectedEventTwo.trackingToken(),
+                     ((TrackedEventMessage<?>) processedEvents.get(1)).trackingToken());
+
+        ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+        verify(tokenStore).storeToken(tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()));
+        assertEquals(expectedToken, tokenCaptor.getValue());
+
+        assertEquals(1, trackerStatusUpdates.size());
+        OptionalLong resultPosition = trackerStatusUpdates.get(0).getCurrentPosition();
+        assertTrue(resultPosition.isPresent());
+        assertEquals(1L, resultPosition.getAsLong());
     }
 
     private class TestEventFilter implements WorkPackage.EventFilter {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
@@ -21,8 +21,12 @@ import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventTrackerStatus;
+import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.annotation.MessageIdentifier;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedType;
 import org.axonframework.serialization.json.JacksonSerializer;
@@ -30,7 +34,9 @@ import org.axonframework.serialization.upcasting.event.ContextAwareEventMultiUpc
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
@@ -39,8 +45,14 @@ import org.springframework.test.context.ContextConfiguration;
 
 import java.beans.ConstructorProperties;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -49,8 +61,8 @@ import static org.axonframework.springboot.utils.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration test for the {@link PooledStreamingEventProcessor}. Tests, for example, that all events from an {@link
- * org.axonframework.serialization.upcasting.event.EventMultiUpcaster} are read.
+ * Integration test for the {@link PooledStreamingEventProcessor}. Tests, for example, that all events from an
+ * {@link org.axonframework.serialization.upcasting.event.EventMultiUpcaster} are read.
  *
  * @author Steven van Beelen
  */
@@ -66,7 +78,7 @@ class PooledStreamingEventProcessorIntegrationTest {
 
     @Test
     void testAllEventsFromMultiUpcasterAreHandled() {
-        testApplicationContext.run(context -> {
+        testApplicationContext.withPropertyValues("upcaster-test=true").run(context -> {
             EventProcessingConfiguration processingConfig = context.getBean(EventProcessingConfiguration.class);
             Optional<PooledStreamingEventProcessor> optionalProcessor =
                     processingConfig.eventProcessor("upcaster-test", PooledStreamingEventProcessor.class);
@@ -80,14 +92,59 @@ class PooledStreamingEventProcessorIntegrationTest {
             processor.start();
             assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(1, processor.processingStatus().size()));
 
-            EventHandlingComponent eventHandlingComponent =
-                    context.getBean(EventHandlingComponent.class);
+            UpcasterTestEventHandlingComponent eventHandlingComponent =
+                    context.getBean(UpcasterTestEventHandlingComponent.class);
 
             assertNotNull(eventHandlingComponent);
             assertWithin(500, TimeUnit.MILLISECONDS,
                          () -> assertEquals(0, eventHandlingComponent.getOriginalEventCounter().get()));
             assertWithin(500, TimeUnit.MILLISECONDS,
                          () -> assertEquals(2, eventHandlingComponent.getUpcastedEventCounter().get()));
+        });
+    }
+
+    @Test
+    void testLastEventIsNotHandledTwice() {
+        int numberOfEvents = 100;
+
+        testApplicationContext.withPropertyValues("once-test=true", "errorCount=2").run(context -> {
+            EventProcessingConfiguration processingConfig = context.getBean(EventProcessingConfiguration.class);
+            Optional<PooledStreamingEventProcessor> optionalProcessor =
+                    processingConfig.eventProcessor("once-test", PooledStreamingEventProcessor.class);
+
+            assertTrue(optionalProcessor.isPresent());
+            PooledStreamingEventProcessor processor = optionalProcessor.get();
+            processor.shutDown();
+
+            EventGateway eventGateway = context.getBean(EventGateway.class);
+
+            for (int i = 0; i < numberOfEvents; i++) {
+                eventGateway.publish(new OriginalEvent("Event[" + i + "]"));
+            }
+            processor.start();
+            assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(16, processor.processingStatus().size()));
+            assertWithin(500, TimeUnit.MILLISECONDS,
+                         () -> assertTrue(processor.processingStatus()
+                                                   .values()
+                                                   .stream()
+                                                   .map(EventTrackerStatus::getTrackingToken)
+                                                   .filter(Objects::nonNull)
+                                                   .map(TrackingToken::position)
+                                                   .filter(OptionalLong::isPresent)
+                                                   .map(OptionalLong::getAsLong)
+                                                   .anyMatch(position -> position >= numberOfEvents)));
+
+            HandlingOnceEventHandlingComponent eventHandlingComponent =
+                    context.getBean(HandlingOnceEventHandlingComponent.class);
+            assertNotNull(eventHandlingComponent);
+
+            CountDownLatch errorLatch = context.getBean(CountDownLatch.class);
+            assertNotNull(errorLatch);
+
+            assertTrue(errorLatch.await(10, TimeUnit.SECONDS));
+            processor.shutDown();
+
+            assertFalse(eventHandlingComponent.hasHandledEventsMoreThanOnce());
         });
     }
 
@@ -103,22 +160,50 @@ class PooledStreamingEventProcessorIntegrationTest {
         }
 
         @Bean
-        public ConfigurerModule defaultToPooledStreaming() {
+        public ConfigurerModule configureEventProcessors(ListenerInvocationErrorHandler latchedErrorHandler) {
             return configurer -> configurer.eventProcessing()
                                            .usingPooledStreamingEventProcessors()
                                            .registerPooledStreamingEventProcessorConfiguration(
-                                                   (config, builder) -> builder.initialSegmentCount(1)
+                                                   "upcaster-test", (config, builder) -> builder.initialSegmentCount(1)
+                                           )
+                                           .registerListenerInvocationErrorHandler(
+                                                   "once-test", c -> latchedErrorHandler
+                                           )
+                                           .registerPooledStreamingEventProcessorConfiguration(
+                                                   "once-test", (config, builder) -> builder.initialSegmentCount(16)
                                            );
         }
 
         @Bean
+        @ConditionalOnProperty("upcaster-test")
         public MultiUpcaster multiUpcaster() {
             return new MultiUpcaster();
         }
 
         @Bean
-        public EventHandlingComponent eventHandlingComponent() {
-            return new EventHandlingComponent();
+        @ConditionalOnProperty("upcaster-test")
+        public UpcasterTestEventHandlingComponent upcasterTestEventHandlingComponent() {
+            return new UpcasterTestEventHandlingComponent();
+        }
+
+        @Bean
+        @ConditionalOnProperty("once-test")
+        public HandlingOnceEventHandlingComponent onceTestEventHandlingComponent() {
+            return new HandlingOnceEventHandlingComponent();
+        }
+
+        @Bean
+        public CountDownLatch errorCountLatch(@Value("${errorCount:2}") int errorCount) {
+            return new CountDownLatch(errorCount);
+        }
+
+        @Bean
+        public ListenerInvocationErrorHandler latchedErrorHandler(CountDownLatch errorCountLatch) {
+            return (exception, event, eventHandler) -> {
+                System.out.println("REACHEDREACHEDREACHEDREACHEDREACHEDREACHEDREACHED");
+                errorCountLatch.countDown();
+                throw exception;
+            };
         }
     }
 
@@ -158,7 +243,7 @@ class PooledStreamingEventProcessorIntegrationTest {
     }
 
     @ProcessingGroup("upcaster-test")
-    private static class EventHandlingComponent {
+    private static class UpcasterTestEventHandlingComponent {
 
         private final AtomicInteger originalEventCounter = new AtomicInteger(0);
         private final AtomicInteger upcastedEventCounter = new AtomicInteger(0);
@@ -179,6 +264,29 @@ class PooledStreamingEventProcessorIntegrationTest {
 
         public AtomicInteger getUpcastedEventCounter() {
             return upcastedEventCounter;
+        }
+    }
+
+    @ProcessingGroup("once-test")
+    private static class HandlingOnceEventHandlingComponent {
+
+        private final CopyOnWriteArraySet<String> eventIdentifiers = new CopyOnWriteArraySet<>();
+        private final List<String> duplicateHandles = new CopyOnWriteArrayList<>();
+
+        @EventHandler
+        public void on(OriginalEvent event, @MessageIdentifier String eventId) {
+            if (event.getTextField().equals("Event[13]")) {
+                throw new RuntimeException();
+            }
+
+            boolean didNotExistYet = eventIdentifiers.add(eventId);
+            if (!didNotExistYet) {
+                duplicateHandles.add(eventId);
+            }
+        }
+
+        public boolean hasHandledEventsMoreThanOnce() {
+            return !duplicateHandles.isEmpty();
         }
     }
 


### PR DESCRIPTION
This pull request can be regarded as a follow up for #2067, doing it right this time.
Pull request #2067 introduced an issue where one failing segment (read: `WorkPackage`) somewhere in the middle of the stream would cause the other segments to pick up the last event again.
This was in essence the issue of the `Coordinator`, as it would reset the event stream to the failing segment once it got picked up again.
Due to this, the stream was traversed again, causing the last handled event by all other segments to be scheduled again.
This scenario, followed by the `WorkPackage` accepting an event with an identical token (as introduced in PR #2067) caused duplicate handling of the last event.

This pull request resolves this predicament by very consciously moving into a different processing branch for event scheduling if subsequent events are present with the same token.
The `Coordinator` ensure they're grouped into a collection and provided together.
The `WorkPackage` will in turn group them to process them within the same batch.

The changes are accompanied by unit tests and an integration test to validate the correct process.