### PR TITLE
Pooled Streaming Event Processor configuration enhancement

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -259,6 +259,25 @@ public interface EventProcessingConfigurer {
      * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
      */
     EventProcessingConfigurer usingPooledStreamingEventProcessors();
+
+    /**
+     * Defaults Event Processors builders to construct a {@link PooledStreamingEventProcessor} using the
+     * {@code configuration} to configure them.
+     * <p>
+     * The default behavior depends on the {@link EventBus} available in the {@link Configuration}. If the
+     * {@code EventBus} is a {@link StreamableMessageSource}, processors are Tracking by default. This method must be
+     * used to force the use of Pooled Streaming Processors, unless specifically overridden for individual processors.
+     *
+     * @param pooledStreamingProcessorConfiguration configuration used when constructing every
+     *                                              {@link PooledStreamingEventProcessor}
+     * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
+     */
+    default EventProcessingConfigurer usingPooledStreamingEventProcessors(
+            PooledStreamingProcessorConfiguration pooledStreamingProcessorConfiguration
+    ) {
+        return usingPooledStreamingEventProcessors()
+                .registerPooledStreamingEventProcessorConfiguration(pooledStreamingProcessorConfiguration);
+    }
 
     /**
      * Registers a {@link org.axonframework.eventhandling.SubscribingEventProcessor} with given {@code name} within this

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -814,13 +814,13 @@ public class EventProcessingModule
                                              .transactionManager(transactionManager(name))
                                              .coordinatorExecutor(processorName -> {
                                                  ScheduledExecutorService coordinatorExecutor =
-                                                         defaultExecutor("Coordinator[" + processorName + "]");
+                                                         defaultExecutor(1, "Coordinator[" + processorName + "]");
                                                  config.onShutdown(coordinatorExecutor::shutdown);
                                                  return coordinatorExecutor;
                                              })
                                              .workerExecutor(processorName -> {
                                                  ScheduledExecutorService workerExecutor =
-                                                         defaultExecutor("WorkPackage[" + processorName + "]");
+                                                         defaultExecutor(4, "WorkPackage[" + processorName + "]");
                                                  config.onShutdown(workerExecutor::shutdown);
                                                  return workerExecutor;
                                              });
@@ -830,8 +830,8 @@ public class EventProcessingModule
                                                            .build();
     }
 
-    private ScheduledExecutorService defaultExecutor(String factoryName) {
-        return Executors.newScheduledThreadPool(1, new AxonThreadFactory(factoryName));
+    private ScheduledExecutorService defaultExecutor(int poolSize, String factoryName) {
+        return Executors.newScheduledThreadPool(poolSize, new AxonThreadFactory(factoryName));
     }
 
     /**


### PR DESCRIPTION
This pull request contains two adjustments around `PooledStreamingEventProcessor` configuration:

1. We introduced a `usingPooledStreamingEventProcessors` method to the `EventProcessingConfigurer` that takes in the `PooledStreamingProcessorConfiguration`. With this users can define their default `PooledStreamingEventProcessor` in one go.
2. The thread pool size for the Worker Executor is changed to four in the `EventProcessingModule`. This is inline with the Spring Boot auto configuration, which also defaults to four.

Point one is most definitely a simplification.
Point two is arguably a bug fix, as there's an unintended difference between Java configuration and Spring Boot auto configuration.
Due to point two, this pull request targets the `axon-4.5.x` instead of `master`.