### PR TITLE
Purge `CLOSED` Unit of Work instances on `CurrentUnitOfWork#isStarted()` and `CurrentUnitOfWork#get()`

### DIFF
--- a/core/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
+++ b/core/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
@@ -94,7 +94,7 @@ public abstract class CurrentUnitOfWork {
 
     private static boolean isEmpty() {
         Deque<UnitOfWork<?>> unitsOfWork = CURRENT.get();
-//        purgeClosed(unitsOfWork);
+        purgeClosed(unitsOfWork);
         return unitsOfWork == null || unitsOfWork.isEmpty();
     }
 
@@ -143,10 +143,7 @@ public abstract class CurrentUnitOfWork {
      *                               indicates a potentially wrong nesting of Units Of Work.
      */
     public static void clear(UnitOfWork<?> unitOfWork) {
-        if (!isStarted()) {
-            throw new IllegalStateException("Could not clear this UnitOfWork. There is no UnitOfWork active.");
-        }
-        if (CURRENT.get().peek() == unitOfWork) {
+        if (CURRENT.get() != null && CURRENT.get().peek() == unitOfWork) {
             CURRENT.get().pop();
             if (CURRENT.get().isEmpty()) {
                 CURRENT.remove();

--- a/core/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
+++ b/core/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2016. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,9 @@ public abstract class CurrentUnitOfWork {
      * @return whether a UnitOfWork has already been started.
      */
     public static boolean isStarted() {
-        return CURRENT.get() != null && !CURRENT.get().isEmpty();
+        Deque<UnitOfWork<?>> current = CURRENT.get();
+        purgeClosed(current);
+        return current != null && !current.isEmpty();
     }
 
     /**
@@ -92,7 +94,21 @@ public abstract class CurrentUnitOfWork {
 
     private static boolean isEmpty() {
         Deque<UnitOfWork<?>> unitsOfWork = CURRENT.get();
+//        purgeClosed(unitsOfWork);
         return unitsOfWork == null || unitsOfWork.isEmpty();
+    }
+
+    /**
+     * Purges any closed {@link UnitOfWork} instances left on the stack. Invoking this method prior validating whether
+     * there's a started or empty set of units of work ensures we do not accidentally try to register callbacks while
+     * the top unit of work is already closed.
+     *
+     * @param current The current stack of {@link UnitOfWork Units of Work}.
+     */
+    private static void purgeClosed(Deque<UnitOfWork<?>> current) {
+        while (current != null && !current.isEmpty() && current.peek().phase() == UnitOfWork.Phase.CLOSED) {
+            current.pop();
+        }
     }
 
     /**

--- a/core/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
+++ b/core/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
@@ -73,26 +73,18 @@ public class CurrentUnitOfWorkTest {
 
     @Test
     public void testIsStartedPurgesClosedUnitsOfWork() {
-        UnitOfWork<GenericMessage<String>> thisUoW = new DefaultUnitOfWork<>(new GenericMessage<>("this"));
-        thisUoW.commit(); // Committing the unit of work will close it.
-        CurrentUnitOfWork.set(thisUoW);
-
-        UnitOfWork<GenericMessage<String>> thatUoW = new DefaultUnitOfWork<>(new GenericMessage<>("that"));
-        thatUoW.commit(); // Committing the unit of work will close it.
-        CurrentUnitOfWork.set(thatUoW);
+        UnitOfWork<GenericMessage<String>> uow = DefaultUnitOfWork.startAndGet(new GenericMessage<>("this"));
+        uow.commit();
+        CurrentUnitOfWork.set(uow);
 
         assertFalse(CurrentUnitOfWork.isStarted());
     }
 
     @Test
     public void testGetPurgesClosedUnitsOfWorkAndThrowsIllegalStateException() {
-        UnitOfWork<GenericMessage<String>> thisUoW = new DefaultUnitOfWork<>(new GenericMessage<>("this"));
-        thisUoW.commit(); // Committing the unit of work will close it.
-        CurrentUnitOfWork.set(thisUoW);
-
-        UnitOfWork<GenericMessage<String>> thatUoW = new DefaultUnitOfWork<>(new GenericMessage<>("that"));
-        thatUoW.commit(); // Committing the unit of work will close it.
-        CurrentUnitOfWork.set(thatUoW);
+        UnitOfWork<GenericMessage<String>> uow = DefaultUnitOfWork.startAndGet(new GenericMessage<>("this"));
+        uow.commit();
+        CurrentUnitOfWork.set(uow);
 
         IllegalStateException result = null;
         try {

--- a/core/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
+++ b/core/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2012. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@
 
 package org.axonframework.messaging.unitofwork;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.axonframework.messaging.GenericMessage;
+import org.junit.*;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
+ * Test class validating the {@link CurrentUnitOfWork}.
+ *
  * @author Allard Buijze
  */
 public class CurrentUnitOfWorkTest {
@@ -71,4 +71,35 @@ public class CurrentUnitOfWorkTest {
         throw new AssertionError("The unit of work is not the current");
     }
 
+    @Test
+    public void testIsStartedPurgesClosedUnitsOfWork() {
+        UnitOfWork<GenericMessage<String>> thisUoW = new DefaultUnitOfWork<>(new GenericMessage<>("this"));
+        thisUoW.commit(); // Committing the unit of work will close it.
+        CurrentUnitOfWork.set(thisUoW);
+
+        UnitOfWork<GenericMessage<String>> thatUoW = new DefaultUnitOfWork<>(new GenericMessage<>("that"));
+        thatUoW.commit(); // Committing the unit of work will close it.
+        CurrentUnitOfWork.set(thatUoW);
+
+        assertFalse(CurrentUnitOfWork.isStarted());
+    }
+
+    @Test
+    public void testGetPurgesClosedUnitsOfWorkAndThrowsIllegalStateException() {
+        UnitOfWork<GenericMessage<String>> thisUoW = new DefaultUnitOfWork<>(new GenericMessage<>("this"));
+        thisUoW.commit(); // Committing the unit of work will close it.
+        CurrentUnitOfWork.set(thisUoW);
+
+        UnitOfWork<GenericMessage<String>> thatUoW = new DefaultUnitOfWork<>(new GenericMessage<>("that"));
+        thatUoW.commit(); // Committing the unit of work will close it.
+        CurrentUnitOfWork.set(thatUoW);
+
+        IllegalStateException result = null;
+        try {
+            CurrentUnitOfWork.get();
+        } catch (IllegalStateException e) {
+            result = e;
+        }
+        assertNotNull(result);
+    }
 }


### PR DESCRIPTION
This pull request changes the behavior of the `CurrentUnitOfWork#isStarted()` and `CurrentUnitOfWork#get()` methods (strictly speaking the private `isEmpty` method for the latter).
It purges any `UnitOfWork` instances on the stack that are in the `Phase#CLOSED`.

Note that this required a change in the `CurrentUnitOfWork#clear(UnitOfWork)` static method too.
Said operation performed an `CurrentUnitOfWork#isStarted()` check before clearing the `UnitOfWork`.
But as `CurrentUnitOfWork#isStarted()` now clears closed entries, as is the intention of `CurrentUnitOfWork#clear(UnitOfWork)`, we ended up in an undesired state.

Doing so eliminates the possibility that life cycle handlers are attached on a `CLOSED` unit of work when nesting is involved.
Although this is an off chance, it does cause unexpected scenarios for users.

We've based this fix on the following stack trace that we received from a user:

```text
java.lang.IllegalStateException: Cannot register a listener for phase: CLEANUP because the Unit of Work is already in a later phase: CLOSED
at org.axonframework.common.Assert.state(Assert.java:42)
at org.axonframework.messaging.unitofwork.DefaultUnitOfWork.addHandler(DefaultUnitOfWork.java:96)
at org.axonframework.messaging.unitofwork.AbstractUnitOfWork.onCleanup(AbstractUnitOfWork.java:193)
at org.axonframework.messaging.unitofwork.AbstractUnitOfWork.lambda$start$3(AbstractUnitOfWork.java:55)
at org.axonframework.messaging.unitofwork.AbstractUnitOfWork$$Lambda$312/485814789.accept(Unknown Source)
at org.axonframework.messaging.unitofwork.CurrentUnitOfWork.ifStarted(CurrentUnitOfWork.java:57)
at org.axonframework.messaging.unitofwork.AbstractUnitOfWork.start(AbstractUnitOfWork.java:52)
at org.axonframework.messaging.unitofwork.DefaultUnitOfWork.startAndGet(DefaultUnitOfWork.java:48)
at org.axonframework.commandhandling.SimpleCommandBus.handle(SimpleCommandBus.java:144)
at org.axonframework.commandhandling.SimpleCommandBus.doDispatch(SimpleCommandBus.java:121)
at org.axonframework.commandhandling.SimpleCommandBus.dispatch(SimpleCommandBus.java:85)
at org.axonframework.commandhandling.gateway.AbstractCommandGateway.send(AbstractCommandGateway.java:79)
at org.axonframework.commandhandling.gateway.DefaultCommandGateway.send(DefaultCommandGateway.java:95)
at org.axonframework.commandhandling.gateway.DefaultCommandGateway.sendAndWait(DefaultCommandGateway.java:113)
...
```