### PR TITLE
[#2290] `TrackingEventProcessor` does not wait for his worker threads to shut down

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -351,11 +351,12 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
             transactionManager.executeInTransaction(() -> tokenStore.releaseClaim(getName(), segment.getSegmentId()));
             logger.info("Released claim");
         } catch (Exception e) {  
-        	if (logger.isDebugEnabled()) {
-        		logger.debug("Release claim failed", e);
-        	} else if (logger.isInfoEnabled()) {
-        		logger.info("Release claim failed");
-        	}
+            // Ignore exception
+            if (logger.isDebugEnabled()) {
+                logger.debug("Release claim failed", e);
+            } else if (logger.isInfoEnabled()) {
+                logger.info("Release claim failed");
+            }
             // Ignore exception
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -350,9 +350,12 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
         try {
             transactionManager.executeInTransaction(() -> tokenStore.releaseClaim(getName(), segment.getSegmentId()));
             logger.info("Released claim");
-        } catch (Exception e) { 
-            logger.info("Release claim failed");
-            logger.debug("Release claim failed", e);
+        } catch (Exception e) {  
+        	if (logger.isDebugEnabled()) {
+        		logger.debug("Release claim failed", e);
+        	} else if (logger.isInfoEnabled()) {
+        		logger.info("Release claim failed");
+        	}
             // Ignore exception
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -702,7 +702,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                                         workerThread.join(workerTerminationTimeout);
                                         if (workerThread.isAlive( )) {
                                         	logger.warn(
-                                        			"Forced shutdown of TrackingProcessor Worker '{}' was not successful. Consider increasing workerTerminationTimeout.",
+                                        			"Forced shutdown of Tracking Processor Worker '{}' was unsuccessful. Consider increasing workerTerminationTimeout.",
                                         			worker.getKey()
                                         	);
                                         }

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -701,11 +701,12 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                                     if (workerThread.isAlive()) {
                                         workerThread.interrupt();
                                         workerThread.join(workerTerminationTimeout);
-                                        if (workerThread.isAlive( )) {
-                                        	logger.warn(
-                                        			"Forced shutdown of Tracking Processor Worker '{}' was unsuccessful. Consider increasing workerTerminationTimeout.",
-                                        			worker.getKey()
-                                        	);
+                                        if (workerThread.isAlive()) {
+                                            logger.warn(
+                                                    "Forced shutdown of Tracking Processor Worker '{}' was unsuccessful. " 
+                                                            + "Consider increasing workerTerminationTimeout.",
+                                                    worker.getKey()
+                                            );
                                         }
                                     }
                                 } catch (InterruptedException e) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -350,8 +350,9 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
         try {
             transactionManager.executeInTransaction(() -> tokenStore.releaseClaim(getName(), segment.getSegmentId()));
             logger.info("Released claim");
-        } catch (Exception e) {
-            logger.info("Release claim failed", e);
+        } catch (Exception e) { 
+            logger.info("Release claim failed");
+            logger.debug("Release claim failed", e);
             // Ignore exception
         }
     }
@@ -696,6 +697,12 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                                     if (workerThread.isAlive()) {
                                         workerThread.interrupt();
                                         workerThread.join(workerTerminationTimeout);
+                                        if (workerThread.isAlive( )) {
+                                        	logger.warn(
+                                        			"Forced shutdown of TrackingProcessor Worker '{}' was not successful. Consider increasing workerTerminationTimeout.",
+                                        			worker.getKey()
+                                        	);
+                                        }
                                     }
                                 } catch (InterruptedException e) {
                                     logger.info(

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
@@ -186,14 +186,32 @@ public class TrackingEventProcessorConfiguration {
     }
 
     /**
-     * Sets the shutdown timeout to terminate active workers. Defaults to 5000ms.
+     * Sets the shutdown timeout to terminate active workers. This is used for both the graceful termination and the 
+     * potential forced termination of active workers. It is thus possible that it is used twice during the shutdown 
+     * phase. Defaults to 5000ms.
      *
-     * @param workerTerminationTimeout the timeout for workers to terminate on a shutdown
+     * @param workerTerminationTimeout the timeout for workers to terminate on a shutdown in milliseconds
+     * @return {@code this} for method chaining
+     * 
+     * @deprecated Use {@link #andWorkerTerminationTimeout(long, TimeUnit)} instead.
+     */
+    @Deprecated
+    public TrackingEventProcessorConfiguration andWorkerTerminationTimeout(long workerTerminationTimeoutInMilliseconds) {
+    	return andWorkerTerminationTimeout(workerTerminationTimeoutInMilliseconds, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * Sets the shutdown timeout to terminate active workers. This is used for both the graceful termination and the 
+     * potential forced termination of active workers. It is thus possible that it is used twice during the shutdown 
+     * phase. Defaults to 5000ms.
+     *
+     * @param workerTerminationTimeout the timeout for workers to terminate on a shutdown.
+     * @param timeUnit           The unit of time
      * @return {@code this} for method chaining
      */
-    public TrackingEventProcessorConfiguration andWorkerTerminationTimeout(long workerTerminationTimeout) {
+    public TrackingEventProcessorConfiguration andWorkerTerminationTimeout(long workerTerminationTimeout, TimeUnit timeUnit) {
         assertStrictPositive(workerTerminationTimeout, "The worker termination timeout should be strictly positive");
-        this.workerTerminationTimeout = workerTerminationTimeout;
+        this.workerTerminationTimeout = timeUnit.toMillis(workerTerminationTimeout);
         return this;
     }
 


### PR DESCRIPTION
TrackingEventProcessor does not wait for his worker threads to shut down

Signed-off-by: Nils Christian Ehmke <nils-christian.ehmke@bmiag.de>

This pull request resolves #2290. 