### PR TITLE
Ensure all dispatchable messages are serialiable by Jackson and Xstream.

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -218,6 +218,12 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -17,13 +17,13 @@
 package org.axonframework.commandhandling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
 import org.axonframework.messaging.MetaData;
 
+import java.beans.ConstructorProperties;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
@@ -34,7 +34,6 @@ import javax.annotation.Nonnull;
  * @author Allard Buijze
  * @since 2.0
  */
-@JsonIgnoreProperties("payloadType")
 public class GenericCommandMessage<T> extends MessageDecorator<T> implements CommandMessage<T> {
 
     private static final long serialVersionUID = 3282528436414939876L;
@@ -83,8 +82,18 @@ public class GenericCommandMessage<T> extends MessageDecorator<T> implements Com
         this(new GenericMessage<>(payload, metaData), payload.getClass().getName());
     }
 
+    /**
+     * Create a CommandMessage from existing data.
+     *
+     * @param payload    the payload for the Message
+     * @param metaData   The metadata for this message
+     * @param identifier The message identifier
+     */
     @JsonCreator
-    public GenericCommandMessage(@JsonProperty("payload") @Nonnull T payload, @JsonProperty("metaData") @Nonnull Map<String, ?> metaData, @JsonProperty("identifier") String identifier) {
+    @ConstructorProperties({"payload", "metaData", "identifier"})
+    public GenericCommandMessage(@JsonProperty("payload") @Nonnull T payload,
+                                 @JsonProperty("metaData") @Nonnull Map<String, ?> metaData,
+                                 @JsonProperty("identifier") String identifier) {
         this(new GenericMessage<>(identifier, payload, metaData), payload.getClass().getName());
     }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.commandhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
@@ -31,6 +34,7 @@ import javax.annotation.Nonnull;
  * @author Allard Buijze
  * @since 2.0
  */
+@JsonIgnoreProperties("payloadType")
 public class GenericCommandMessage<T> extends MessageDecorator<T> implements CommandMessage<T> {
 
     private static final long serialVersionUID = 3282528436414939876L;
@@ -77,6 +81,11 @@ public class GenericCommandMessage<T> extends MessageDecorator<T> implements Com
      */
     public GenericCommandMessage(@Nonnull T payload, @Nonnull Map<String, ?> metaData) {
         this(new GenericMessage<>(payload, metaData), payload.getClass().getName());
+    }
+
+    @JsonCreator
+    public GenericCommandMessage(@JsonProperty("payload") @Nonnull T payload, @JsonProperty("metaData") @Nonnull Map<String, ?> metaData, @JsonProperty("identifier") String identifier) {
+        this(new GenericMessage<>(identifier, payload, metaData), payload.getClass().getName());
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 
+import java.beans.ConstructorProperties;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -130,6 +131,7 @@ public class GenericDeadlineMessage<T> extends GenericEventMessage<T> implements
      * @param timestamp    An {@link Instant} timestamp of the Message creation
      */
     @JsonCreator
+    @ConstructorProperties({"deadlineName", "identifier", "payload", "metaData", "timestamp"})
     public GenericDeadlineMessage(@JsonProperty("deadlineName")  @Nonnull String deadlineName,
                                   @JsonProperty("identifier") @Nonnull String identifier,
                                   @JsonProperty("payload") @Nullable T payload,

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.deadline;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
@@ -127,11 +129,12 @@ public class GenericDeadlineMessage<T> extends GenericEventMessage<T> implements
      * @param metaData     The {@link MetaData} of the Message
      * @param timestamp    An {@link Instant} timestamp of the Message creation
      */
-    public GenericDeadlineMessage(@Nonnull String deadlineName,
-                                  @Nonnull String identifier,
-                                  @Nullable T payload,
-                                  Map<String, ?> metaData,
-                                  Instant timestamp) {
+    @JsonCreator
+    public GenericDeadlineMessage(@JsonProperty("deadlineName")  @Nonnull String deadlineName,
+                                  @JsonProperty("identifier") @Nonnull String identifier,
+                                  @JsonProperty("payload") @Nullable T payload,
+                                  @JsonProperty("metaData")  Map<String, ?> metaData,
+                                  @JsonProperty("timestamp")  Instant timestamp) {
         super(identifier, payload, metaData, timestamp);
         this.deadlineName = deadlineName;
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
@@ -76,8 +78,14 @@ public class GenericDomainEventMessage<T> extends GenericEventMessage<T> impleme
      * @param messageIdentifier   The message identifier
      * @param timestamp           The event's timestamp
      */
-    public GenericDomainEventMessage(String type, String aggregateIdentifier, long sequenceNumber, T payload,
-                                     Map<String, ?> metaData, String messageIdentifier, Instant timestamp) {
+    @JsonCreator
+    public GenericDomainEventMessage(@JsonProperty("type") String type,
+                                     @JsonProperty("aggregateIdentifier") String aggregateIdentifier,
+                                     @JsonProperty("sequenceNumber") long sequenceNumber,
+                                     @JsonProperty("payload") T payload,
+                                     @JsonProperty("metaData") Map<String, ?> metaData,
+                                     @JsonProperty("identifier") String messageIdentifier,
+                                     @JsonProperty("timestamp") Instant timestamp) {
         this(type, aggregateIdentifier, sequenceNumber, new GenericMessage<>(messageIdentifier, payload, metaData),
              timestamp);
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 
+import java.beans.ConstructorProperties;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -79,6 +80,13 @@ public class GenericDomainEventMessage<T> extends GenericEventMessage<T> impleme
      * @param timestamp           The event's timestamp
      */
     @JsonCreator
+    @ConstructorProperties({"type",
+            "aggregateIdentifier",
+            "sequenceNumber",
+            "payload",
+            "metaData",
+            "identifier",
+            "timestamp"})
     public GenericDomainEventMessage(@JsonProperty("type") String type,
                                      @JsonProperty("aggregateIdentifier") String aggregateIdentifier,
                                      @JsonProperty("sequenceNumber") long sequenceNumber,

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -17,7 +17,6 @@
 package org.axonframework.eventhandling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
@@ -25,6 +24,7 @@ import org.axonframework.messaging.MessageDecorator;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.CachingSupplier;
 
+import java.beans.ConstructorProperties;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
@@ -36,7 +36,6 @@ import javax.annotation.Nonnull;
  *
  * @param <T> The type of payload contained in this Message
  */
-@JsonIgnoreProperties("payloadType")
 public class GenericEventMessage<T> extends MessageDecorator<T> implements EventMessage<T> {
     private static final long serialVersionUID = -8296350547944518544L;
     private final Supplier<Instant> timestampSupplier;
@@ -97,7 +96,8 @@ public class GenericEventMessage<T> extends MessageDecorator<T> implements Event
      * @param payload    The payload of the message
      * @param metaData   The metadata of the message
      */
-    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    @JsonCreator
+    @ConstructorProperties({"identifier", "payload", "metaData", "timestamp"})
     public GenericEventMessage(@Nonnull @JsonProperty("identifier") String identifier,
                                @JsonProperty("payload") T payload,
                                @JsonProperty("metaData") @Nonnull Map<String, ?> metaData,

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.eventhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
@@ -33,6 +36,7 @@ import javax.annotation.Nonnull;
  *
  * @param <T> The type of payload contained in this Message
  */
+@JsonIgnoreProperties("payloadType")
 public class GenericEventMessage<T> extends MessageDecorator<T> implements EventMessage<T> {
     private static final long serialVersionUID = -8296350547944518544L;
     private final Supplier<Instant> timestampSupplier;
@@ -93,8 +97,11 @@ public class GenericEventMessage<T> extends MessageDecorator<T> implements Event
      * @param payload    The payload of the message
      * @param metaData   The metadata of the message
      */
-    public GenericEventMessage(@Nonnull String identifier, T payload, @Nonnull Map<String, ?> metaData,
-                               @Nonnull Instant timestamp) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public GenericEventMessage(@Nonnull @JsonProperty("identifier") String identifier,
+                               @JsonProperty("payload") T payload,
+                               @JsonProperty("metaData") @Nonnull Map<String, ?> metaData,
+                               @Nonnull @JsonProperty("timestamp") Instant timestamp) {
         this(new GenericMessage<>(identifier, payload, metaData), timestamp);
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 
+import java.beans.ConstructorProperties;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -89,7 +90,27 @@ public class GenericTrackedDomainEventMessage<T> extends GenericDomainEventMessa
         this.trackingToken = trackingToken;
     }
 
+    /**
+     * Initialize a DomainEventMessage originating from existing data.,
+     *
+     * @param trackingToken       Tracking token of the event
+     * @param type                The domain type
+     * @param aggregateIdentifier The identifier of the aggregate generating this message
+     * @param sequenceNumber      The message's sequence number
+     * @param payload             The application-specific payload of the message
+     * @param metaData            The MetaData to attach to the message
+     * @param timestamp           The event's timestamp
+     * @param identifier          The message identifier
+     */
     @JsonCreator
+    @ConstructorProperties({"trackingToken",
+            "type",
+            "aggregateIdentifier",
+            "sequenceNumber",
+            "payload",
+            "metaData",
+            "timestamp",
+            "identifier"})
     protected GenericTrackedDomainEventMessage(@JsonProperty("trackingToken") TrackingToken trackingToken,
                                                @JsonProperty("type") String type,
                                                @JsonProperty("aggregateIdentifier") String aggregateIdentifier,

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
@@ -16,7 +16,11 @@
 
 package org.axonframework.eventhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MetaData;
 
 import java.time.Instant;
 import java.util.Map;
@@ -28,6 +32,14 @@ import javax.annotation.Nonnull;
  *
  * @param <T> The type of payload contained in this Message
  */
+@JsonIncludeProperties({"trackingToken",
+        "type",
+        "aggregateIdentifier",
+        "sequenceNumber",
+        "payload",
+        "metaData",
+        "timestamp",
+        "identifier"})
 public class GenericTrackedDomainEventMessage<T> extends GenericDomainEventMessage<T> implements
                                                                                       TrackedEventMessage<T> {
     private static final long serialVersionUID = 6211645167637822558L;
@@ -74,6 +86,19 @@ public class GenericTrackedDomainEventMessage<T> extends GenericDomainEventMessa
     protected GenericTrackedDomainEventMessage(TrackingToken trackingToken, String type, String aggregateIdentifier,
                                                long sequenceNumber, Message<T> delegate, Instant timestamp) {
         super(type, aggregateIdentifier, sequenceNumber, delegate, timestamp);
+        this.trackingToken = trackingToken;
+    }
+
+    @JsonCreator
+    protected GenericTrackedDomainEventMessage(@JsonProperty("trackingToken") TrackingToken trackingToken,
+                                               @JsonProperty("type") String type,
+                                               @JsonProperty("aggregateIdentifier") String aggregateIdentifier,
+                                               @JsonProperty("sequenceNumber") long sequenceNumber,
+                                               @JsonProperty("payload") T payload,
+                                               @JsonProperty("metaData") MetaData metaData,
+                                               @JsonProperty("timestamp") Instant timestamp,
+                                               @JsonProperty("identifier") String identifier) {
+        super(type, aggregateIdentifier, sequenceNumber, payload, metaData, identifier, timestamp);
         this.trackingToken = trackingToken;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
@@ -75,7 +75,7 @@ public class GenericTrackedDomainEventMessage<T> extends GenericDomainEventMessa
     }
 
     /**
-     * Initialize a DomainEventMessage originating from an aggregate.
+     * Initialize a {@link GenericTrackedDomainEventMessage} originating from an aggregate.
      *
      * @param trackingToken       Tracking token of the event
      * @param type                The domain type
@@ -91,7 +91,7 @@ public class GenericTrackedDomainEventMessage<T> extends GenericDomainEventMessa
     }
 
     /**
-     * Initialize a DomainEventMessage originating from existing data.,
+     * Initialize a {@link GenericTrackedDomainEventMessage} originating from existing data.
      *
      * @param trackingToken       Tracking token of the event
      * @param type                The domain type

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
@@ -16,8 +16,12 @@
 
 package org.axonframework.eventhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MetaData;
 
+import java.beans.ConstructorProperties;
 import java.time.Instant;
 import java.util.function.Supplier;
 
@@ -67,6 +71,26 @@ public class GenericTrackedEventMessage<T> extends GenericEventMessage<T> implem
         super(delegate, timestamp);
         this.trackingToken = trackingToken;
     }
+
+    /**
+     * Creates a GenericTrackedEventMessage with all properties that would be present in the serialized form of it.
+     *
+     * @param trackingToken the tracking token of the resulting message
+     * @param payload       The payload of the message
+     * @param identifier    The identifier of the Message
+     * @param metaData      The metadata of the message
+     * @param timestamp     The timestamp of the Message creation
+     */
+    @JsonCreator
+    @ConstructorProperties({"trackingToken", "payload", "identifier", "metaData", "timestamp"})
+    public GenericTrackedEventMessage(@JsonProperty("trackingToken") TrackingToken trackingToken,
+                                      @JsonProperty("payload") T payload, @JsonProperty("identifier") String identifier,
+                                      @JsonProperty("metaData") MetaData metaData,
+                                      @JsonProperty("timestamp") Instant timestamp) {
+        super(identifier, payload, metaData, timestamp);
+        this.trackingToken = trackingToken;
+    }
+
 
     @Override
     public TrackingToken trackingToken() {

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
@@ -84,9 +84,11 @@ public class GenericTrackedEventMessage<T> extends GenericEventMessage<T> implem
     @JsonCreator
     @ConstructorProperties({"trackingToken", "payload", "identifier", "metaData", "timestamp"})
     public GenericTrackedEventMessage(@JsonProperty("trackingToken") TrackingToken trackingToken,
-                                      @JsonProperty("payload") T payload, @JsonProperty("identifier") String identifier,
+                                      @JsonProperty("payload") T payload,
+                                      @JsonProperty("identifier") String identifier,
                                       @JsonProperty("metaData") MetaData metaData,
-                                      @JsonProperty("timestamp") Instant timestamp) {
+                                      @JsonProperty("timestamp") Instant timestamp
+    ) {
         super(identifier, payload, metaData, timestamp);
         this.trackingToken = trackingToken;
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedEventMessage.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
  *
  * @param <T> The type of payload contained in this Message
  */
+
 public class GenericTrackedEventMessage<T> extends GenericEventMessage<T> implements TrackedEventMessage<T> {
     private static final long serialVersionUID = -8955035317050776846L;
     private final TrackingToken trackingToken;

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackedEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackedEventMessage.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 /**
  * Represents an {@link EventMessage} containing a {@link TrackingToken}. The tracking token can be used be {@link
  * EventProcessor event processors} to keep track of which events it has processed.
@@ -30,6 +32,7 @@ public interface TrackedEventMessage<T> extends EventMessage<T> {
      *
      * @return the tracking token of the event
      */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
     TrackingToken trackingToken();
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -107,8 +107,10 @@ public class GenericMessage<T> extends AbstractMessage<T> {
      */
     @JsonCreator
     @ConstructorProperties({"identifier", "payload", "metaData"})
-    public GenericMessage(@JsonProperty("identifier") String identifier, @JsonProperty("payload") T payload,
-                          @JsonProperty("metaData") Map<String, ?> metaData) {
+    public GenericMessage(@JsonProperty("identifier") String identifier,
+                          @JsonProperty("payload") T payload,
+                          @JsonProperty("metaData") Map<String, ?> metaData
+    ) {
         this(identifier, getDeclaredPayloadType(payload), payload, metaData);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -16,12 +16,15 @@
 
 package org.axonframework.messaging;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedObjectHolder;
 import org.axonframework.serialization.Serializer;
 
+import java.beans.ConstructorProperties;
 import java.util.Map;
 
 /**
@@ -94,15 +97,18 @@ public class GenericMessage<T> extends AbstractMessage<T> {
 
     /**
      * Constructor to reconstruct a Message using existing data. Note that no correlation data from a UnitOfWork is
-     * attached when using this constructor. If you're constructing a new Message, use {@link #GenericMessage(Object,
-     * Map)} instead.
+     * attached when using this constructor. If you're constructing a new Message, use
+     * {@link #GenericMessage(Object, Map)} instead.
      *
      * @param identifier The identifier of the Message
      * @param payload    The payload of the message
      * @param metaData   The meta data of the message
      * @throws NullPointerException when the given {@code payload} is {@code null}.
      */
-    public GenericMessage(String identifier, T payload, Map<String, ?> metaData) {
+    @JsonCreator
+    @ConstructorProperties({"identifier", "payload", "metaData"})
+    public GenericMessage(@JsonProperty("identifier") String identifier, @JsonProperty("payload") T payload,
+                          @JsonProperty("metaData") Map<String, ?> metaData) {
         this(identifier, getDeclaredPayloadType(payload), payload, metaData);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
@@ -61,6 +62,7 @@ public interface Message<T> extends Serializable {
      *
      * @return the payload of this message
      */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
     T getPayload();
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.serialization.SerializedObject;
@@ -73,6 +74,8 @@ public interface Message<T> extends Serializable {
      *
      * @return the type of payload.
      */
+    @JsonIgnore
+    // Type information is included in the payload property in a way Jackson understands
     Class<T> getPayloadType();
 
     /**

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -15,6 +15,10 @@
  */
 package org.axonframework.queryhandling;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
@@ -33,11 +37,13 @@ import javax.annotation.Nonnull;
  * @author Marc Gathier
  * @since 3.1
  */
+@JsonIgnoreProperties("payloadType")
 public class GenericQueryMessage<T, R> extends MessageDecorator<T> implements QueryMessage<T, R> {
 
     private static final long serialVersionUID = -3908412412867063631L;
 
     private final String queryName;
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
     private final ResponseType<R> responseType;
 
     /**
@@ -60,6 +66,11 @@ public class GenericQueryMessage<T, R> extends MessageDecorator<T> implements Qu
      */
     public GenericQueryMessage(T payload, String queryName, ResponseType<R> responseType) {
         this(new GenericMessage<>(payload, MetaData.emptyInstance()), queryName, responseType);
+    }
+
+    @JsonCreator
+    public GenericQueryMessage(@JsonProperty("payload") T payload, @JsonProperty("queryName") String queryName, @JsonProperty("responseType") ResponseType<R> responseType, @JsonProperty("identifier") String identifier) {
+        this(new GenericMessage<>(identifier, payload, MetaData.emptyInstance()), queryName, responseType);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -16,7 +16,6 @@
 package org.axonframework.queryhandling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.messaging.GenericMessage;
@@ -25,6 +24,7 @@ import org.axonframework.messaging.MessageDecorator;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
 
+import java.beans.ConstructorProperties;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
@@ -37,7 +37,6 @@ import javax.annotation.Nonnull;
  * @author Marc Gathier
  * @since 3.1
  */
-@JsonIgnoreProperties("payloadType")
 public class GenericQueryMessage<T, R> extends MessageDecorator<T> implements QueryMessage<T, R> {
 
     private static final long serialVersionUID = -3908412412867063631L;
@@ -68,9 +67,23 @@ public class GenericQueryMessage<T, R> extends MessageDecorator<T> implements Qu
         this(new GenericMessage<>(payload, MetaData.emptyInstance()), queryName, responseType);
     }
 
+
+    /**
+     * Creates a GenericQueryMessage with all properties that would be present in the serialized form of it.
+     *
+     * @param payload      The payload of the message
+     * @param identifier   The identifier of the Message
+     * @param queryName    The name identifying the query to execute
+     * @param responseType The expected response type of type {@link ResponseType}
+     * @param metaData     The metadata of the message
+     */
     @JsonCreator
-    public GenericQueryMessage(@JsonProperty("payload") T payload, @JsonProperty("queryName") String queryName, @JsonProperty("responseType") ResponseType<R> responseType, @JsonProperty("identifier") String identifier) {
-        this(new GenericMessage<>(identifier, payload, MetaData.emptyInstance()), queryName, responseType);
+    @ConstructorProperties({"payload", "queryName", "responseType", "identifier", "metaData"})
+    public GenericQueryMessage(@JsonProperty("payload") T payload, @JsonProperty("queryName") String queryName,
+                               @JsonProperty("responseType") ResponseType<R> responseType,
+                               @JsonProperty("identifier") String identifier,
+                               @JsonProperty("metaData") MetaData metaData) {
+        this(new GenericMessage<>(identifier, payload, metaData), queryName, responseType);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -79,10 +79,12 @@ public class GenericQueryMessage<T, R> extends MessageDecorator<T> implements Qu
      */
     @JsonCreator
     @ConstructorProperties({"payload", "queryName", "responseType", "identifier", "metaData"})
-    public GenericQueryMessage(@JsonProperty("payload") T payload, @JsonProperty("queryName") String queryName,
+    public GenericQueryMessage(@JsonProperty("payload") T payload,
+                               @JsonProperty("queryName") String queryName,
                                @JsonProperty("responseType") ResponseType<R> responseType,
                                @JsonProperty("identifier") String identifier,
-                               @JsonProperty("metaData") MetaData metaData) {
+                               @JsonProperty("metaData") MetaData metaData
+    ) {
         this(new GenericMessage<>(identifier, payload, metaData), queryName, responseType);
     }
 

--- a/messaging/src/test/java/org/axonframework/serialization/MessageSerializationPayload.java
+++ b/messaging/src/test/java/org/axonframework/serialization/MessageSerializationPayload.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization;
+
+public class MessageSerializationPayload {
+    private String myProperty1;
+    private String getMyProperty2;
+
+    public MessageSerializationPayload() {}
+
+    public MessageSerializationPayload(String myProperty1, String getMyProperty2) {
+        this.myProperty1 = myProperty1;
+        this.getMyProperty2 = getMyProperty2;
+    }
+
+    public String getMyProperty1() {
+        return myProperty1;
+    }
+
+    public void setMyProperty1(String myProperty1) {
+        this.myProperty1 = myProperty1;
+    }
+
+    public String getGetMyProperty2() {
+        return getMyProperty2;
+    }
+
+    public void setGetMyProperty2(String getMyProperty2) {
+        this.getMyProperty2 = getMyProperty2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MessageSerializationPayload that = (MessageSerializationPayload) o;
+
+        if (myProperty1 != null ? !myProperty1.equals(that.myProperty1) : that.myProperty1 != null) {
+            return false;
+        }
+        return getMyProperty2 != null ? getMyProperty2.equals(that.getMyProperty2) : that.getMyProperty2 == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = myProperty1 != null ? myProperty1.hashCode() : 0;
+        result = 31 * result + (getMyProperty2 != null ? getMyProperty2.hashCode() : 0);
+        return result;
+    }
+}

--- a/messaging/src/test/java/org/axonframework/serialization/MessageSerializationPayload.java
+++ b/messaging/src/test/java/org/axonframework/serialization/MessageSerializationPayload.java
@@ -16,11 +16,13 @@
 
 package org.axonframework.serialization;
 
-public class MessageSerializationPayload {
+class MessageSerializationPayload {
+
     private String myProperty1;
     private String getMyProperty2;
 
-    public MessageSerializationPayload() {}
+    public MessageSerializationPayload() {
+    }
 
     public MessageSerializationPayload(String myProperty1, String getMyProperty2) {
         this.myProperty1 = myProperty1;

--- a/messaging/src/test/java/org/axonframework/serialization/MessageSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/MessageSerializationTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization;
+
+import com.thoughtworks.xstream.XStream;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.deadline.DeadlineMessage;
+import org.axonframework.deadline.GenericDeadlineMessage;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.GenericQueryMessage;
+import org.axonframework.queryhandling.QueryMessage;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * Testcase that checks whether every message can be serialized using the Jackson and Xstream serializer. That is, every
+ * messages that can be dispatched using Axon Framework by default.
+ */
+class MessageSerializationTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_GenericEventMessage(Serializer serializer) {
+        EventMessage<Object> message = GenericEventMessage
+                .asEventMessage(new MessageSerializationPayload("one", "Two"))
+                .andMetaData(createAdditionalMetadata());
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        EventMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_GenericDomainEventMessage(Serializer serializer) {
+        EventMessage<Object> message = new GenericDomainEventMessage<>("Room",
+                                                                       UUID.randomUUID().toString(),
+                                                                       5L,
+                                                                       new MessageSerializationPayload("one", "Two"),
+                                                                       createAdditionalMetadata());
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        EventMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_GenericTrackedDomainEventMessage(Serializer serializer) {
+        GapAwareTrackingToken gapAwareTrackingToken = new GapAwareTrackingToken(231972091,
+                                                                                Arrays.asList(5L, 6L, 7L, 8L));
+        EventMessage<Object> message = new GenericTrackedDomainEventMessage(
+                gapAwareTrackingToken,
+                "Room",
+                UUID.randomUUID().toString(),
+                231972091,
+                GenericTrackedDomainEventMessage.asEventMessage(
+                        new MessageSerializationPayload(
+                                "one",
+                                "Two")),
+                () -> Instant.now())
+                .andMetaData(createAdditionalMetadata());
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        EventMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(deserialize, message);
+    }
+
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_DeadlineMessage_Full(Serializer serializer) {
+        DeadlineMessage<Object> message = new GenericDeadlineMessage<>(
+                "myDeadline",
+                "identifier",
+                new MessageSerializationPayload("one", "Two"),
+                createAdditionalMetadata(),
+                Instant.now());
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        DeadlineMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_DeadlineMessage_Small(Serializer serializer) {
+        DeadlineMessage<Object> message = new GenericDeadlineMessage<>("myDeadline");
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        EventMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_CommandMessage(Serializer serializer) {
+        CommandMessage<Object> message = new GenericCommandMessage<>(new MessageSerializationPayload("one", "Two"),
+                                                                     createAdditionalMetadata());
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        CommandMessage<Object> deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider.class)
+    void shouldSerialize_QueryMessage(Serializer serializer) {
+        GenericQueryMessage message = new GenericQueryMessage<>(
+                new MessageSerializationPayload("one", "Two"),
+                ResponseTypes.multipleInstancesOf(
+                        String.class));
+
+        SerializedObject<String> serialize = serializer.serialize(message, String.class);
+        QueryMessage deserialize = serializer.deserialize(serialize);
+        assertEquals(message, deserialize);
+    }
+
+    private void assertEquals(DeadlineMessage<Object> deserialized, DeadlineMessage<Object> original) {
+        Assertions.assertEquals(original.getTimestamp(), deserialized.getTimestamp());
+        Assertions.assertEquals(original.getIdentifier(), deserialized.getIdentifier());
+        Assertions.assertEquals(original.getMetaData(), deserialized.getMetaData());
+        Assertions.assertEquals(original.getPayload(), deserialized.getPayload());
+        Assertions.assertEquals(original.getPayloadType(), deserialized.getPayloadType());
+        Assertions.assertEquals(original.getClass(), deserialized.getClass());
+        Assertions.assertEquals(original.getDeadlineName(), deserialized.getDeadlineName());
+    }
+
+    private void assertEquals(EventMessage<Object> deserialized, EventMessage<Object> original) {
+        Assertions.assertEquals(original.getTimestamp(), deserialized.getTimestamp());
+        Assertions.assertEquals(original.getIdentifier(), deserialized.getIdentifier());
+        Assertions.assertEquals(original.getMetaData(), deserialized.getMetaData());
+        Assertions.assertEquals(original.getPayload(), deserialized.getPayload());
+        Assertions.assertEquals(original.getPayloadType(), deserialized.getPayloadType());
+        Assertions.assertEquals(original.getClass(), deserialized.getClass());
+        if (deserialized instanceof DomainEventMessage && original instanceof DomainEventMessage) {
+            Assertions.assertEquals(((DomainEventMessage<Object>) original).getSequenceNumber(),
+                                    ((DomainEventMessage<Object>) deserialized).getSequenceNumber());
+            Assertions.assertEquals(((DomainEventMessage<Object>) original).getType(),
+                                    ((DomainEventMessage<Object>) deserialized).getType());
+        }
+        if (deserialized instanceof TrackedEventMessage && original instanceof TrackedEventMessage) {
+            Assertions.assertEquals(((TrackedEventMessage<Object>) original).trackingToken(),
+                                    ((TrackedEventMessage<Object>) deserialized).trackingToken());
+        }
+    }
+
+    private void assertEquals(CommandMessage<Object> deserialized, CommandMessage<Object> original) {
+        Assertions.assertEquals(original.getIdentifier(), deserialized.getIdentifier());
+        Assertions.assertEquals(original.getMetaData(), deserialized.getMetaData());
+        Assertions.assertEquals(original.getPayload(), deserialized.getPayload());
+        Assertions.assertEquals(original.getPayloadType(), deserialized.getPayloadType());
+        Assertions.assertEquals(original.getClass(), deserialized.getClass());
+    }
+
+    private void assertEquals(QueryMessage deserialized, QueryMessage original) {
+        Assertions.assertEquals(original.getIdentifier(), deserialized.getIdentifier());
+        Assertions.assertEquals(original.getQueryName(), deserialized.getQueryName());
+        Assertions.assertEquals(original.getMetaData(), deserialized.getMetaData());
+        Assertions.assertEquals(original.getPayload(), deserialized.getPayload());
+        Assertions.assertEquals(original.getPayloadType(), deserialized.getPayloadType());
+        Assertions.assertEquals(original.getClass(), deserialized.getClass());
+    }
+
+    private static class ArgumentsProvider implements org.junit.jupiter.params.provider.ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            Serializer jackson = JacksonSerializer.defaultSerializer();
+            Serializer xStream = XStreamSerializer.builder().xStream(new XStream()).build();
+
+            return Stream.of(
+                    Arguments.of(jackson),
+                    Arguments.of(xStream)
+            );
+        }
+    }
+
+    private MetaData createAdditionalMetadata() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("Marco", "Polo");
+        map.put("Steven", "Programmer");
+        return MetaData.from(map);
+    }
+}


### PR DESCRIPTION
Adds a testcase for each message type that checks whether it can be serialized, and whether the contents are still the same after serializing and then deserializing it.

Useful for occurrences when you want to serialize entire messages instead of only the payload. For example, this will be very useful in the upcoming DLQ feature of Axon 4.6.0