### PR TITLE
Fix duplicate command handler detection.

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
@@ -494,6 +495,21 @@ public abstract class ReflectionUtils {
         throw new IllegalStateException(
                 String.format(UNSUPPORTED_MEMBER_TYPE_EXCEPTION_MESSAGE, member.getClass().getName())
         );
+    }
+
+
+    /**
+     * Returns a discernible signature without including the classname. This will contain the method name and the parameter
+     * types, such as: thisIfMyMethod(java.lang.String myString, com.acme.MyGreatObject)
+     *
+     * @param executable The executable to make a signature of
+     * @return The discernible signature
+     */
+    public static String toDiscernibleSignature(Executable executable) {
+        return String.format("%s(%s)",
+                             executable.getName(),
+                             Arrays.stream(executable.getParameterTypes()).map(Class::getName)
+                                   .collect(Collectors.joining(",")));
     }
 
     private ReflectionUtils() {

--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -500,10 +500,10 @@ public abstract class ReflectionUtils {
 
     /**
      * Returns a discernible signature without including the classname. This will contain the method name and the parameter
-     * types, such as: thisIfMyMethod(java.lang.String myString, com.acme.MyGreatObject)
+     * types, such as: {@code thisIfMyMethod(java.lang.String myString, com.acme.MyGreatObject)}.
      *
-     * @param executable The executable to make a signature of
-     * @return The discernible signature
+     * @param executable The executable to make a signature of.
+     * @return The discernible signature.
      */
     public static String toDiscernibleSignature(Executable executable) {
         return String.format("%s(%s)",

--- a/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -294,6 +294,21 @@ class ReflectionUtilsTest {
         assertEquals(constructor.toGenericString(), memberGenericString);
     }
 
+
+    @Test
+    void testToDiscernableSignatureOfConstructor() throws NoSuchMethodException {
+        Constructor<SomeTypeWithMethods> constructor = SomeTypeWithMethods.class.getDeclaredConstructor();
+        String memberGenericString = toDiscernibleSignature(constructor);
+        assertEquals("org.axonframework.common.ReflectionUtilsTest$SomeTypeWithMethods()", memberGenericString);
+    }
+
+    @Test
+    void testToDiscernableSignatureOfMethod() throws NoSuchMethodException {
+        Method method = SomeTypeWithMethods.class.getMethod("someMethodWithParameters", String.class, Integer.class, Object.class);
+        String memberGenericString = toDiscernibleSignature(method);
+        assertEquals("someMethodWithParameters(java.lang.String,java.lang.Integer,java.lang.Object)", memberGenericString);
+    }
+
     @SuppressWarnings("FieldCanBeLocal")
     private static class SomeType implements SomeInterface {
 
@@ -346,6 +361,10 @@ class ReflectionUtilsTest {
 
         public void someVoidMethod() {
             voidMethodInvocations.incrementAndGet();
+        }
+
+        public String someMethodWithParameters(String parameterOne, Integer parameterTwo, Object parameter3) {
+            return "someMethodWithParametersResult";
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -152,11 +152,12 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
     }
 
     private String getHandlerSignature(MessageHandlingMember<? super T> handler) {
-        Executable executable = handler.unwrap(Executable.class).orElseThrow(() -> new IllegalStateException(
-                "A handler is missing an Executable. Please provide an "
-                        + "Executable in your MessageHandlingMembers"
-        ));
-        return toDiscernibleSignature(executable);
+        return = handler.unwrap(Executable.class)
+                        .map(ReflectionUtils::toDiscernibleSignature)
+                        .orElseThrow(() -> new IllegalStateException(
+                            "A handler is missing an Executable. Please provide an "
+                                + "Executable in your MessageHandlingMembers"
+                        ));
     }
 
     private void initializeHandler(AggregateModel<T> aggregateModel,

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -24,6 +24,7 @@ import org.axonframework.commandhandling.CommandMessageHandler;
 import org.axonframework.commandhandling.CommandMessageHandlingMember;
 import org.axonframework.commandhandling.NoHandlerForCommandException;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
@@ -50,7 +51,6 @@ import java.util.stream.Collectors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
-import static org.axonframework.common.ReflectionUtils.toDiscernibleSignature;
 import static org.axonframework.modelling.command.AggregateCreationPolicy.NEVER;
 
 /**
@@ -152,12 +152,12 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
     }
 
     private String getHandlerSignature(MessageHandlingMember<? super T> handler) {
-        return = handler.unwrap(Executable.class)
-                        .map(ReflectionUtils::toDiscernibleSignature)
-                        .orElseThrow(() -> new IllegalStateException(
-                            "A handler is missing an Executable. Please provide an "
-                                + "Executable in your MessageHandlingMembers"
-                        ));
+        return handler.unwrap(Executable.class)
+                      .map(ReflectionUtils::toDiscernibleSignature)
+                      .orElseThrow(() -> new IllegalStateException(
+                              "A handler is missing an Executable. Please provide an "
+                                      + "Executable in your MessageHandlingMembers"
+                      ));
     }
 
     private void initializeHandler(AggregateModel<T> aggregateModel,

--- a/modelling/src/test/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandlerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandlerTest.java
@@ -608,8 +608,7 @@ class AggregateAnnotationCommandHandlerTest {
         Repository<RootAggregate> repository = mock(Repository.class);
 
         Set<Class<? extends RootAggregate>> subtypes = new HashSet<>();
-        subtypes.add(ChildOneAggregate.class);
-        subtypes.add(ChildTwoAggregate.class);
+        subtypes.add(ChildAggregate.class);
         AggregateModel<RootAggregate> polymorphicAggregateModel =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(RootAggregate.class, subtypes);
 
@@ -1119,19 +1118,20 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @SuppressWarnings("unused")
-    private abstract static class RootAggregate {
+    abstract class RootAggregate {
 
         @CommandHandler
-        public void handle(String command) {
-
+        public String handle(String command) {
+            return "ROOT";
         }
     }
 
-    private static class ChildOneAggregate extends RootAggregate {
+    class ChildAggregate extends RootAggregate {
 
-    }
-
-    private static class ChildTwoAggregate extends RootAggregate {
-
+        @CommandHandler
+        @Override
+        public String handle(String command) {
+            return "CHILD";
+        }
     }
 }


### PR DESCRIPTION
This fix is achieved by registering for each signature instead of each Executable. The signature is a combination of the method's name and its parameters. Different Executables can have the same signature, for example in polymorphic aggregates. When the signature is the same, we only want to register once, since this is not a true duplicate handler. At runtime, the AnnotatedHandlerInspector will resolve the right Executable based on the aggregate type and the command.

Fixes #2243