### PR TITLE
Remove update handler registration on `UpdateHandlerRegistration#complete`

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
@@ -133,14 +133,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         Flux<SubscriptionQueryUpdateMessage<U>> updateMessageFlux = sink.asFlux()
                                                                         .doOnCancel(removeHandler)
                                                                         .doOnTerminate(removeHandler);
-        Runnable completeHandler = () -> {
-            sinksManyWrapper.complete();
-            // In case a user didn't subscribe to the flux, the remove handler is never invoked.
-            // Hence, invoke removeHandler potentially twice to ensure the registration is removed from the emitter.
-            removeHandler.run();
-        };
-
-        return new UpdateHandlerRegistration<>(registration, updateMessageFlux, completeHandler);
+        return new UpdateHandlerRegistration<>(registration, updateMessageFlux, sinksManyWrapper::complete);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/UpdateHandlerRegistration.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/UpdateHandlerRegistration.java
@@ -73,6 +73,6 @@ public class UpdateHandlerRegistration<U> {
         completeHandler.run();
         // In case a user didn't subscribe to the flux, the remove handler is never invoked.
         // Hence, invoke removeHandler potentially twice to ensure the registration is removed from the emitter.
-        registration.close();
+        getRegistration().close();
     }
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/UpdateHandlerRegistration.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/UpdateHandlerRegistration.java
@@ -67,9 +67,12 @@ public class UpdateHandlerRegistration<U> {
 
     /**
      * Completes the {@link #getUpdates()} {@link Flux}. The consumer can use this method to indicate it is no longer
-     * interested in updates.
+     * interested in updates. This operation automatically closes the {@link #getRegistration() registration} too.
      */
     public void complete() {
         completeHandler.run();
+        // In case a user didn't subscribe to the flux, the remove handler is never invoked.
+        // Hence, invoke removeHandler potentially twice to ensure the registration is removed from the emitter.
+        registration.close();
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -651,6 +651,23 @@ class SimpleQueryBusTest {
         assertEquals("hello1234", result.get().getPayload());
     }
 
+    @Test
+    void testOnSubscriptionQueryCancelTheActiveSubscriptionIsRemovedFromTheEmitterIfFluxIsNotSubscribed() {
+        //noinspection resource
+        testSubject.subscribe(String.class.getName(), String.class, q -> q.getPayload() + "1234");
+
+        SubscriptionQueryMessage<String, String, String> testQuery = new GenericSubscriptionQueryMessage<>(
+                "test", ResponseTypes.instanceOf(String.class), ResponseTypes.instanceOf(String.class)
+        );
+
+        //noinspection resource
+        SubscriptionQueryResult<QueryResponseMessage<String>, SubscriptionQueryUpdateMessage<String>> result =
+                testSubject.subscriptionQuery(testQuery);
+
+        result.cancel();
+        assertEquals(0, testSubject.queryUpdateEmitter().activeSubscriptions().size());
+    }
+
     @SuppressWarnings("unused")
     public Future<String> futureMethod() {
         return null;

--- a/messaging/src/test/java/org/axonframework/queryhandling/UpdateHandlerRegistrationTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/UpdateHandlerRegistrationTest.java
@@ -1,0 +1,36 @@
+package org.axonframework.queryhandling;
+
+import org.junit.jupiter.api.*;
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link UpdateHandlerRegistration}.
+ *
+ * @author Steven van Beelen
+ */
+class UpdateHandlerRegistrationTest {
+
+    @Test
+    void testCompleteClosesTheRegistration() {
+        AtomicBoolean registrationInvocation = new AtomicBoolean(false);
+        AtomicBoolean completeInvocation = new AtomicBoolean(false);
+
+        UpdateHandlerRegistration<Object> testSubject = new UpdateHandlerRegistration<>(
+                () -> {
+                    registrationInvocation.set(true);
+                    return true;
+                },
+                Flux.empty(),
+                () -> completeInvocation.set(true)
+        );
+
+        testSubject.complete();
+
+        assertTrue(registrationInvocation.get());
+        assertTrue(completeInvocation.get());
+    }
+}


### PR DESCRIPTION
Users are not inclined to subscribe to the `Flux` returned by the `QueryBus`.
If they don't subscribe, the `QueryUpdateEmitter` does not remove the update handler registration since it's only removed through closing the `Flux`. 

This pull request adjusts the `UpdateHandlerRegistration` to remove the registered handler from the `SimpleQueryUpdateEmitter` whenever `UpdateHandlerRegistration#complete` is invoked.

Doing so, this pull request resolves #2299.