### PR TITLE
Fix a problem where when a shutdown takes places while the worklaunch…

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
@@ -422,6 +422,21 @@ class TrackingEventProcessorTest_MultiThreaded {
         assertNotNull(tokenStore.fetchToken(testSubject.getName(), 1));
     }
 
+    @Test
+    void testProcessorIncrementAndDecrementCorrectly() throws InterruptedException {
+        configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
+                                                              .andInitialSegmentsCount(4));
+        testSubject.start();
+        // It's an edge case, but locally this successfully fails with the previous implementation.
+        // It would before prevent to increase available threads because the launcher was running.
+        testSubject.shutDown();
+        testSubject.start();
+        testSubject.shutDown();
+        testSubject.start();
+        Thread.sleep(200);
+        assertEquals(2, testSubject.activeProcessorThreads());
+    }
+
     // Utility to add up acknowledged messages by Thread (worker) name and assertions facilities.
     class AcknowledgeByThread {
 


### PR DESCRIPTION
Fix a problem where when a shutdown takes places while the worklauncher is running, the available threads becomes lower than the initial value. This in turn may lead to some segments not being processed.
The change makes sure the available thread count is always increased on cleanup.

Fixes https://github.com/AxonFramework/AxonFramework/issues/2293