### PR TITLE
Strip test prefix once required in JUnit 3 from test method names

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
@@ -14,7 +14,7 @@ class AxonServerConfigurationTest {
 
 
     @Test
-    void testEventsFlowControl() {
+    void eventsFlowControl() {
 
         AxonServerConfiguration axonServerConfiguration = builder().eventFlowControl(10, 20, 30).build();
 
@@ -28,7 +28,7 @@ class AxonServerConfigurationTest {
     }
 
     @Test
-    void testCommandFlowControl() {
+    void commandFlowControl() {
 
         AxonServerConfiguration axonServerConfiguration = builder().commandFlowControl(10, 20, 30).build();
 
@@ -42,7 +42,7 @@ class AxonServerConfigurationTest {
     }
 
     @Test
-    void testQueryFlowControl() {
+    void queryFlowControl() {
 
         AxonServerConfiguration axonServerConfiguration = builder().queryFlowControl(10, 20, 30).build();
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -75,7 +75,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testWhetherConnectionPreferenceIsSent() {
+    void whetherConnectionPreferenceIsSent() {
         TagsConfiguration testTags = new TagsConfiguration(Collections.singletonMap("key", "value"));
 
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
@@ -106,7 +106,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testConnectionTimeout() throws IOException, InterruptedException {
+    void connectionTimeout() throws IOException, InterruptedException {
         stubServer.shutdown();
         stubServer = new StubServer(TcpUtil.findFreePort(), new PlatformService(TcpUtil.findFreePort()) {
             @Override
@@ -138,7 +138,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testEnablingHeartbeatsEnsuresHeartbeatMessagesAreSent() {
+    void enablingHeartbeatsEnsuresHeartbeatMessagesAreSent() {
         testConfig.getHeartbeat().setEnabled(true);
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
@@ -155,7 +155,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testEnablingHeartbeatsEnsuresHeartbeatMessagesAreSentOnOtherContexts() {
+    void enablingHeartbeatsEnsuresHeartbeatMessagesAreSentOnOtherContexts() {
         testConfig.getHeartbeat().setEnabled(true);
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
@@ -176,7 +176,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testDisablingHeartbeatsEnsuresNoHeartbeatMessagesAreSent() {
+    void disablingHeartbeatsEnsuresNoHeartbeatMessagesAreSent() {
         testConfig.getHeartbeat().setEnabled(false);
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
@@ -193,7 +193,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testChannelCustomization() {
+    void channelCustomization() {
         AtomicBoolean interceptorCalled = new AtomicBoolean();
         AxonServerConnectionManager testSubject =
                 AxonServerConnectionManager.builder()
@@ -218,7 +218,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testIsConnected() {
+    void isConnected() {
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
@@ -232,7 +232,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testShutdownClosesAllConnections() {
+    void shutdownClosesAllConnections() {
         AxonServerConnectionManager testSubject =
                 AxonServerConnectionManager.builder()
                                            .axonServerConfiguration(testConfig)
@@ -258,7 +258,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testDisconnectClosesAllConnections() {
+    void disconnectClosesAllConnections() {
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
@@ -283,7 +283,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testDisconnectSingleConnection() {
+    void disconnectSingleConnection() {
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
@@ -308,7 +308,7 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testConnectionsReturnsConnectionStatus() {
+    void connectionsReturnsConnectionStatus() {
         AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
@@ -333,19 +333,19 @@ class AxonServerConnectionManagerTest {
     }
 
     @Test
-    void testBuildWithNullAxonServerConfigurationThrowsAxonConfigurationException() {
+    void buildWithNullAxonServerConfigurationThrowsAxonConfigurationException() {
         AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.axonServerConfiguration(null));
     }
 
     @Test
-    void testBuildWithNullTagsConfigurationThrowsAxonConfigurationException() {
+    void buildWithNullTagsConfigurationThrowsAxonConfigurationException() {
         AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.tagsConfiguration(null));
     }
 
     @Test
-    void testBuildWithoutAxonServerConfigurationThrowsAxonConfigurationException() {
+    void buildWithoutAxonServerConfigurationThrowsAxonConfigurationException() {
         AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
         assertThrows(AxonConfigurationException.class, builderTestSubject::build);
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ServerConnectorConfigurerModuleTest {
 
     @Test
-    void testAxonServerConfiguredInDefaultConfiguration() {
+    void axonServerConfiguredInDefaultConfiguration() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration()
                                                      .configureSerializer(c -> TestSerializer.xStreamSerializer())
                                                      .buildConfiguration();
@@ -70,7 +70,7 @@ class ServerConnectorConfigurerModuleTest {
     }
 
     @Test
-    void testQueryUpdateEmitterIsTakenFromConfiguration() {
+    void queryUpdateEmitterIsTakenFromConfiguration() {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .configureSerializer(c -> TestSerializer.xStreamSerializer())
                                                        .buildConfiguration();
@@ -82,7 +82,7 @@ class ServerConnectorConfigurerModuleTest {
     }
 
     @Test
-    void testCustomCommandLoadFactorProvider() throws NoSuchFieldException {
+    void customCommandLoadFactorProvider() throws NoSuchFieldException {
         CommandLoadFactorProvider expected = command -> 5000;
         Configuration config =
                 DefaultConfigurer.defaultConfiguration()

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -392,12 +392,12 @@ class AxonServerCommandBusTest {
     }
 
     @Test
-    void testLocalSegmentReturnsLocalCommandBus() {
+    void localSegmentReturnsLocalCommandBus() {
         assertEquals(localSegment, testSubject.localSegment());
     }
 
     @Test
-    void testDisconnectUnsubscribesAllRegisteredCommands() {
+    void disconnectUnsubscribesAllRegisteredCommands() {
         String testCommandOne = "testCommandOne";
         String testCommandTwo = "testCommandTwo";
         testSubject.subscribe(testCommandOne, command -> "Done");
@@ -410,7 +410,7 @@ class AxonServerCommandBusTest {
     }
 
     @Test
-    void testAfterShutdownDispatchingAnShutdownInProgressExceptionIsThrownOnDispatchInvocation() {
+    void afterShutdownDispatchingAnShutdownInProgressExceptionIsThrownOnDispatchInvocation() {
         testSubject.shutdownDispatching();
 
         GenericCommandMessage<String> command = new GenericCommandMessage<>("some-command");
@@ -421,7 +421,7 @@ class AxonServerCommandBusTest {
     }
 
     @Test
-    void testShutdownDispatchingWaitsForCommandsInTransitToComplete() {
+    void shutdownDispatchingWaitsForCommandsInTransitToComplete() {
         AtomicBoolean commandHandled = new AtomicBoolean(false);
         // Commands containing "blocking" will sleep for 500 millis
         GenericCommandMessage<String> testCommand = new GenericCommandMessage<>("some-blocking-command");

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/CommandSerializerTest.java
@@ -59,7 +59,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeRequest(CommandSerializer testSubject) {
+    void serializeRequest(CommandSerializer testSubject) {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");
@@ -77,7 +77,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeResponse(CommandSerializer testSubject) {
+    void serializeResponse(CommandSerializer testSubject) {
         CommandResultMessage response = new GenericCommandResultMessage<>("response",
                                                                           MetaData.with("test", "testValue"));
         CommandResponse outbound = testSubject.serialize(response, "requestIdentifier");
@@ -92,7 +92,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeExceptionalResponse(CommandSerializer testSubject) {
+    void serializeExceptionalResponse(CommandSerializer testSubject) {
         RuntimeException exception = new RuntimeException("oops");
         CommandResultMessage response = new GenericCommandResultMessage<>(exception,
                                                                           MetaData.with("test", "testValue"));
@@ -108,7 +108,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeExceptionalResponseWithDetails(CommandSerializer testSubject) {
+    void serializeExceptionalResponseWithDetails(CommandSerializer testSubject) {
         Exception exception = new CommandExecutionException("oops", null, "Details");
         CommandResultMessage<?> response = new GenericCommandResultMessage<>(exception,
                                                                              MetaData.with("test", "testValue"));
@@ -128,7 +128,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeNonTransientExceptionalResponse(CommandSerializer testSubject) {
+    void serializeNonTransientExceptionalResponse(CommandSerializer testSubject) {
         SerializationException nonTransientExceptionCause = new SerializationException(
                 "Serialization non recoverable problem");
         Exception exception = new CommandExecutionException("oops", nonTransientExceptionCause, null);
@@ -142,7 +142,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testSerializeDeserializeNonTransientExceptionalResponseWithDetails(CommandSerializer testSubject) {
+    void serializeDeserializeNonTransientExceptionalResponseWithDetails(CommandSerializer testSubject) {
         SerializationException nonTransientExceptionCause = new SerializationException(
                 "Serialization non recoverable problem");
         Exception exception = new CommandExecutionException("oops", nonTransientExceptionCause, "Details");
@@ -165,7 +165,7 @@ class CommandSerializerTest {
 
     @MethodSource("data")
     @ParameterizedTest
-    void testDeserializeResponseWithoutPayload(CommandSerializer testSubject) {
+    void deserializeResponseWithoutPayload(CommandSerializer testSubject) {
         CommandResponse response = CommandResponse.newBuilder()
                                                   .setRequestIdentifier("requestId")
                                                   .putAllMetaData(Collections.singletonMap("meta-key",

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/GrpcBackedCommandMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/GrpcBackedCommandMessageTest.java
@@ -46,7 +46,7 @@ class GrpcBackedCommandMessageTest {
             new CommandSerializer(serializer, new AxonServerConfiguration());
 
     @Test
-    void testGetCommandNameReturnsTheNameOfTheCommandAsSpecifiedInTheGrpcCommand() {
+    void getCommandNameReturnsTheNameOfTheCommandAsSpecifiedInTheGrpcCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -55,7 +55,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheGrpcCommand() {
+    void getIdentifierReturnsTheSameIdentifierAsSpecifiedInTheGrpcCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -64,7 +64,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheGrpcCommand() {
+    void getMetaDataReturnsTheSameMapAsWasInsertedInTheGrpcCommand() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(expectedMetaData);
@@ -75,7 +75,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheGrpcCommand() {
+    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheGrpcCommand() {
         TestCommand expectedCommand = TEST_COMMAND;
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(expectedCommand);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
@@ -85,7 +85,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsTheTypeOfTheInsertedCommand() {
+    void getPayloadTypeReturnsTheTypeOfTheInsertedCommand() {
         CommandMessage<TestCommand> testCommandMessage = GenericCommandMessage.asCommandMessage(TEST_COMMAND);
         Command testCommand = commandSerializer.serialize(testCommandMessage, ROUTING_KEY, PRIORITY);
         GrpcBackedCommandMessage<TestCommand> testSubject = new GrpcBackedCommandMessage<>(testCommand, serializer);
@@ -94,7 +94,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void withMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(testMetaData);
@@ -110,7 +110,7 @@ class GrpcBackedCommandMessageTest {
     }
 
     @Test
-    void testAndMetaDataAppendsToTheExistingMetaData() {
+    void andMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         CommandMessage<TestCommand> testCommandMessage =
                 GenericCommandMessage.<TestCommand>asCommandMessage(TEST_COMMAND).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -115,7 +115,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testPublishAndConsumeEvents() throws Exception {
+    void publishAndConsumeEvents() throws Exception {
         UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         testSubject.publish(GenericEventMessage.asEventMessage("Test1"),
                             GenericEventMessage.asEventMessage("Test2"),
@@ -134,7 +134,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testQueryEvents() throws Exception {
+    void queryEvents() throws Exception {
         String queryAll = "";
         boolean noLiveUpdates = false;
 
@@ -151,7 +151,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testLoadEventsWithMultiUpcaster() {
+    void loadEventsWithMultiUpcaster() {
         reset(upcasterChain);
         when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
             Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
@@ -173,7 +173,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testLoadSnapshotAndEventsWithMultiUpcaster() {
+    void loadSnapshotAndEventsWithMultiUpcaster() {
         reset(upcasterChain);
         when(upcasterChain.upcast(any())).thenAnswer(invocation -> {
             Stream<IntermediateEventRepresentation> si = invocation.getArgument(0);
@@ -200,7 +200,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testLoadEventsWithContextAwareUpcaster() {
+    void loadEventsWithContextAwareUpcaster() {
         reset(upcasterChain);
         ContextAwareSingleEventUpcaster<AtomicInteger> upcaster = new ContextAwareSingleEventUpcaster<AtomicInteger>() {
             @Override
@@ -232,17 +232,17 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testLastSequenceNumberFor() {
+    void lastSequenceNumberFor() {
         assertThrows(EventStoreException.class, () -> testSubject.lastSequenceNumberFor("Agg1"));
     }
 
     @Test
-    void testCreateStreamableMessageSourceForContext() {
+    void createStreamableMessageSourceForContext() {
         assertNotNull(testSubject.createStreamableMessageSourceForContext("some-context"));
     }
 
     @Test
-    void testUsingLocalEventStoreOnOpeningStream() {
+    void usingLocalEventStoreOnOpeningStream() {
         testSubject.publish(new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 0, "Test1"));
         testSubject.openStream(null);
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(1, eventStore.getEventsRequests().size()));
@@ -251,7 +251,7 @@ class AxonServerEventStoreTest {
 
     @Disabled("No supported in new connector, yet.")
     @Test
-    void testUsingLocalEventStoreOnQueryingEvents() {
+    void usingLocalEventStoreOnQueryingEvents() {
         testSubject.publish(new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 0, "Test1"));
         testSubject.query("", true);
         assertWithin(1, TimeUnit.SECONDS,
@@ -260,7 +260,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testReadEventsReturnsSnapshotsAndEventsWithMetaData() {
+    void readEventsReturnsSnapshotsAndEventsWithMetaData() {
         Map<String, String> testMetaData = Collections.singletonMap("key", "value");
         testSubject.storeSnapshot(
                 new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 1, "Snapshot1", testMetaData)
@@ -294,7 +294,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testReadEventsWithSequenceNumberIgnoresSnapshots() {
+    void readEventsWithSequenceNumberIgnoresSnapshots() {
         Map<String, String> testMetaData = Collections.singletonMap("key", "value");
         testSubject.storeSnapshot(
                 new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 1, "Snapshot1", testMetaData)
@@ -334,7 +334,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testReadEventsWithMagicSequenceNumberAndNoSnapshotFilterIncludesSnapshots() {
+    void readEventsWithMagicSequenceNumberAndNoSnapshotFilterIncludesSnapshots() {
         JacksonSerializer eventSerializer = JacksonSerializer.defaultSerializer();
         AxonServerEventStore testSubjectWithoutSnapshotFilter =
                 AxonServerEventStore.builder()
@@ -380,7 +380,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testReadEventsWithMagicSequenceNumberAndSnapshotFilterSetIgnoresSnapshots() {
+    void readEventsWithMagicSequenceNumberAndSnapshotFilterSetIgnoresSnapshots() {
         Map<String, String> testMetaData = Collections.singletonMap("key", "value");
         testSubject.storeSnapshot(
                 new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 1, "Snapshot1", testMetaData)
@@ -420,7 +420,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testReadEventsWithSnapshotFilterAndSameSerializerSetReadsSnapshot() {
+    void readEventsWithSnapshotFilterAndSameSerializerSetReadsSnapshot() {
         XStreamSerializer serializer = TestSerializer.xStreamSerializer();
         testSubject = AxonServerEventStore.builder()
                                           .configuration(config)
@@ -463,7 +463,7 @@ class AxonServerEventStoreTest {
         assertFalse(resultStream.hasNext());
     }
     @Test
-    void testRethrowStatusRuntimeExceptionAsEventStoreExceptionIfNotOfTypeUnknown() {
+    void rethrowStatusRuntimeExceptionAsEventStoreExceptionIfNotOfTypeUnknown() {
         String testAggregateId = AGGREGATE_ID;
         Status expectedCode = Status.ABORTED;
 
@@ -478,7 +478,7 @@ class AxonServerEventStoreTest {
     }
 
     @Test
-    void testSnapReadingExceptionProceedsWithReadingEvents() {
+    void snapReadingExceptionProceedsWithReadingEvents() {
         String testPayloadOne = "Test1";
         String testPayloadTwo = "Test2";
         String testPayloadThree = "Test3";

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/ErrorCodeTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/ErrorCodeTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ErrorCodeTest {
 
     @Test
-    void testConvert4002FromCodeAndMessage() {
+    void convert4002FromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("AXONIQ-4002");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build(), () -> "myCustomObject");
         assertTrue(exception instanceof CommandExecutionException);
@@ -45,7 +45,7 @@ class ErrorCodeTest {
     }
 
     @Test
-    void testConvertUnknownFromCodeAndMessage() {
+    void convertUnknownFromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("????????");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build());
         assertTrue(exception instanceof AxonServerException);
@@ -53,14 +53,14 @@ class ErrorCodeTest {
     }
 
     @Test
-    void testConvertWithoutSource() {
+    void convertWithoutSource() {
         RuntimeException exception = new RuntimeException("oops");
         AxonException axonException = ErrorCode.getFromCode("AXONIQ-4002").convert(exception);
         assertEquals(exception.getMessage(), axonException.getMessage());
     }
 
     @Test
-    void testConvert4005FromCodeAndMessage() {
+    void convert4005FromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("AXONIQ-4005");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build(), () -> "myCustomObject");
         assertTrue(exception instanceof CommandExecutionException);
@@ -70,7 +70,7 @@ class ErrorCodeTest {
     }
 
     @Test
-    void testConvert5003FromCodeAndMessage() {
+    void convert5003FromCodeAndMessage() {
         ErrorCode errorCode = ErrorCode.getFromCode("AXONIQ-5003");
         AxonException exception = errorCode.convert(ErrorMessage.newBuilder().setMessage("myMessage").build(), () -> "myCustomObject");
         assertTrue(exception instanceof QueryExecutionException);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
@@ -101,7 +101,7 @@ class EventBufferTest {
 
     @Test
     @Timeout(value = 450, unit = TimeUnit.MILLISECONDS)
-    void testDataUpcastAndDeserialized() {
+    void dataUpcastAndDeserialized() {
         assertFalse(testSubject.hasNextAvailable());
         eventStream.onNext(TEST_EVENT_WITH_TOKEN);
         assertTrue(testSubject.hasNextAvailable());
@@ -122,7 +122,7 @@ class EventBufferTest {
     }
 
     @Test
-    void testHasNextAvailableThrowsAxonServerExceptionWhenStreamFailed() {
+    void hasNextAvailableThrowsAxonServerExceptionWhenStreamFailed() {
         TestException testException = new TestException();
         eventStream.onError(testException);
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/QueryResultStreamAdapterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/QueryResultStreamAdapterTest.java
@@ -46,7 +46,7 @@ class QueryResultStreamAdapterTest {
     }
 
     @Test
-    void testHasNextBuffersNextEntry() throws InterruptedException {
+    void hasNextBuffersNextEntry() throws InterruptedException {
         EventQueryResultEntry mockResult1 = mock(EventQueryResultEntry.class);
         EventQueryResultEntry mockResult2 = mock(EventQueryResultEntry.class);
         doReturn(mockResult1, mockResult2, null)
@@ -61,7 +61,7 @@ class QueryResultStreamAdapterTest {
     }
 
     @Test
-    void testNextClearsBufferedEntry() throws InterruptedException {
+    void nextClearsBufferedEntry() throws InterruptedException {
         EventQueryResultEntry mockResult1 = mock(EventQueryResultEntry.class);
         EventQueryResultEntry mockResult2 = mock(EventQueryResultEntry.class);
         doReturn(mockResult1, mockResult2, null)
@@ -81,7 +81,7 @@ class QueryResultStreamAdapterTest {
     }
 
     @Test
-    void testHasNextReturnsFalseAtEnd() throws InterruptedException {
+    void hasNextReturnsFalseAtEnd() throws InterruptedException {
         EventQueryResultEntry mockResult1 = mock(EventQueryResultEntry.class);
         EventQueryResultEntry mockResult2 = mock(EventQueryResultEntry.class);
         doReturn(mockResult1, mockResult2, null)
@@ -100,7 +100,7 @@ class QueryResultStreamAdapterTest {
     }
 
     @Test
-    void testNextReturnsNullAtEnd() throws InterruptedException {
+    void nextReturnsNullAtEnd() throws InterruptedException {
         EventQueryResultEntry mockResult1 = mock(EventQueryResultEntry.class);
         EventQueryResultEntry mockResult2 = mock(EventQueryResultEntry.class);
         doReturn(mockResult1, mockResult2, null)
@@ -121,7 +121,7 @@ class QueryResultStreamAdapterTest {
 
 
     @Test
-    void testHasNextBlocksWithGivenTimeout() throws InterruptedException {
+    void hasNextBlocksWithGivenTimeout() throws InterruptedException {
         EventQueryResultEntry mockResult1 = mock(EventQueryResultEntry.class);
         EventQueryResultEntry mockResult2 = mock(EventQueryResultEntry.class);
         doReturn(mockResult1, mockResult2, null)

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatConnectionCheckerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatConnectionCheckerTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class HeartbeatConnectionCheckerTest {
 
     @Test
-    void testHeartbeatNeverReceived() {
+    void heartbeatNeverReceived() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
                                                                       r -> {
@@ -31,7 +31,7 @@ class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    void testHeartbeatProperlyReceived() {
+    void heartbeatProperlyReceived() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
@@ -44,7 +44,7 @@ class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    void testHeartbeatReceivedLate() {
+    void heartbeatReceivedLate() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,
@@ -57,7 +57,7 @@ class HeartbeatConnectionCheckerTest {
     }
 
     @Test
-    void testDelegateDetectsBrokenConnection() {
+    void delegateDetectsBrokenConnection() {
         AtomicReference<Instant> instant = new AtomicReference<>(Instant.now());
         AtomicReference<Runnable> heartbeatCallback = new AtomicReference<>();
         HeartbeatConnectionChecker check = new HeartbeatConnectionChecker(1_000,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitorTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/heartbeat/HeartbeatMonitorTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class HeartbeatMonitorTest {
 
     @Test
-    void testConnectionAlive() {
+    void connectionAlive() {
         FakeScheduler fakeScheduler = new FakeScheduler();
         AtomicBoolean reconnect = new AtomicBoolean(false);
         HeartbeatMonitor monitor = new HeartbeatMonitor(() -> reconnect.set(true),
@@ -32,7 +32,7 @@ class HeartbeatMonitorTest {
     }
 
     @Test
-    void testDisconnection() {
+    void disconnection() {
         FakeScheduler fakeScheduler = new FakeScheduler();
         AtomicBoolean reconnect = new AtomicBoolean(false);
         HeartbeatMonitor monitor = new HeartbeatMonitor(() -> reconnect.set(true),

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -157,7 +157,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testSeveralSubscribeInvocationsUseSameQueryHandlerInstance() {
+    void severalSubscribeInvocationsUseSameQueryHandlerInstance() {
         QueryDefinition firstExpectedQueryDefinition = new QueryDefinition(TEST_QUERY, String.class);
         QueryDefinition secondExpectedQueryDefinition = new QueryDefinition("testIntegerQuery", Integer.class);
 
@@ -207,7 +207,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testQueryReportsCorrectException() throws ExecutionException, InterruptedException {
+    void queryReportsCorrectException() throws ExecutionException, InterruptedException {
         when(mockQueryChannel.query(any())).thenReturn(new StubResultStream<>(
                 stubErrorResponse(ErrorCode.QUERY_EXECUTION_ERROR.errorCode(), "Faking exception result")
         ));
@@ -229,7 +229,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testQueryReportsCorrectNonTransientException() throws ExecutionException, InterruptedException {
+    void queryReportsCorrectNonTransientException() throws ExecutionException, InterruptedException {
         when(mockQueryChannel.query(any())).thenReturn(new StubResultStream<>(
                 stubErrorResponse(ErrorCode.QUERY_EXECUTION_NON_TRANSIENT_ERROR.errorCode(),
                                   "Faking non transient exception result")
@@ -395,12 +395,12 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testLocalSegmentReturnsLocalQueryBus() {
+    void localSegmentReturnsLocalQueryBus() {
         assertEquals(localSegment, testSubject.localSegment());
     }
 
     @Test
-    void testAfterShutdownDispatchingAnShutdownInProgressExceptionOnQueryInvocation() {
+    void afterShutdownDispatchingAnShutdownInProgressExceptionOnQueryInvocation() {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("some-query", instanceOf(String.class));
 
         assertDoesNotThrow(() -> testSubject.shutdownDispatching().get(5, TimeUnit.SECONDS));
@@ -412,7 +412,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testShutdownTakesFinishedQueriesIntoAccount() {
+    void shutdownTakesFinishedQueriesIntoAccount() {
         when(mockQueryChannel.query(any())).thenReturn(new StubResultStream<>(QueryResponse.newBuilder().build()));
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("some-query", instanceOf(String.class));
 
@@ -423,7 +423,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testAfterShutdownDispatchingAnShutdownInProgressExceptionOnScatterGatherInvocation() {
+    void afterShutdownDispatchingAnShutdownInProgressExceptionOnScatterGatherInvocation() {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>("some-query", instanceOf(String.class));
 
         assertDoesNotThrow(() -> testSubject.shutdownDispatching().get(5, TimeUnit.SECONDS));
@@ -438,7 +438,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testSubscriptionQueryCompletesWithExceptionOnUpdateDeserializationError() {
+    void subscriptionQueryCompletesWithExceptionOnUpdateDeserializationError() {
         when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt()))
                 .thenReturn(new SimpleSubscriptionQueryResult(
                         "<string>Hello world</string>", stubUpdate("Not a valid XML object")
@@ -460,7 +460,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testSubscriptionQueryCompletesWithExceptionOnInitialResultDeserializationError() {
+    void subscriptionQueryCompletesWithExceptionOnInitialResultDeserializationError() {
         when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt()))
                 .thenReturn(new SimpleSubscriptionQueryResult(
                         "Not a valid XML object", stubUpdate("<string>Hello world</string>")
@@ -482,7 +482,7 @@ class AxonServerQueryBusTest {
     }
 
     @Test
-    void testAfterShutdownDispatchingAnShutdownInProgressExceptionOnSubscriptionQueryInvocation() {
+    void afterShutdownDispatchingAnShutdownInProgressExceptionOnSubscriptionQueryInvocation() {
         SubscriptionQueryMessage<String, String, String> testSubscriptionQuery =
                 new GenericSubscriptionQueryMessage<>("some-query", instanceOf(String.class), instanceOf(String.class));
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
@@ -50,7 +50,7 @@ class GrpcBackedQueryMessageTest {
             new QuerySerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheQueryRequest() {
+    void getQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -61,7 +61,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheQueryRequest() {
+    void getResponseTypeReturnsTheTypeAsSpecifiedInTheQueryRequest() {
         ResponseType<String> expectedResponseType = RESPONSE_TYPE;
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, expectedResponseType);
         QueryRequest testQueryRequest =
@@ -75,7 +75,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryRequest() {
+    void getIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -86,7 +86,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryRequest() {
+    void getMetaDataReturnsTheSameMapAsWasInsertedInTheQueryRequest() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(expectedMetaData);
@@ -99,7 +99,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
+    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
         TestQuery expectedQuery = TEST_QUERY;
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(expectedQuery, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
@@ -111,7 +111,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryRequest() {
+    void getPayloadTypeReturnsTheTypeOfTheInsertedQueryRequest() {
         QueryMessage<TestQuery, String> testQueryMessage = new GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE);
         QueryRequest testQueryRequest =
                 querySerializer.serializeRequest(testQueryMessage, NUMBER_OF_RESULTS, TIMEOUT, PRIORITY);
@@ -122,7 +122,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void withMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(testMetaData);
@@ -140,7 +140,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void testAndMetaDataAppendsToTheExistingMetaData() {
+    void andMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryMessage<TestQuery, String> testQueryMessage = new
                 GenericQueryMessage<>(TEST_QUERY, RESPONSE_TYPE).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
@@ -41,7 +41,7 @@ class GrpcBackedResponseMessageTest {
             new QuerySerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryResponseMessage() {
+    void getIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TEST_QUERY_RESPONSE);
         QueryResponse testQueryResponse =
@@ -53,7 +53,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryResponseMessage() {
+    void getMetaDataReturnsTheSameMapAsWasInsertedInTheQueryResponseMessage() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)
@@ -67,7 +67,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
+    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
         TestQueryResponse expectedQuery = TEST_QUERY_RESPONSE;
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(expectedQuery);
@@ -80,7 +80,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testGetPayloadThrowIllegalPayloadExceptionIfTheQueryResponseMessageDidNotContainAnyPayload() {
+    void getPayloadThrowIllegalPayloadExceptionIfTheQueryResponseMessageDidNotContainAnyPayload() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -94,7 +94,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryResponseMessage() {
+    void getPayloadTypeReturnsTheTypeOfTheInsertedQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TEST_QUERY_RESPONSE);
         QueryResponse testQueryResponse =
@@ -106,7 +106,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
+    void getPayloadTypeReturnsNullIfTheQueryResponseMessageDidNotContainAnyPayload() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -120,7 +120,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testIsExceptionalReturnsTrueForAnExceptionalQueryResponseMessage() {
+    void isExceptionalReturnsTrueForAnExceptionalQueryResponseMessage() {
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(
                         TestQueryResponse.class, new IllegalArgumentException("some-exception")
@@ -134,7 +134,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testOptionalExceptionResultReturnsTheExceptionAsAsInsertedThroughTheQueryResponseMessage() {
+    void optionalExceptionResultReturnsTheExceptionAsAsInsertedThroughTheQueryResponseMessage() {
         IllegalArgumentException expectedException = new IllegalArgumentException("some-exception");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.asResponseMessage(TestQueryResponse.class, expectedException);
@@ -149,7 +149,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void withMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)
@@ -168,7 +168,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void testAndMetaDataAppendsToTheExistingMetaData() {
+    void andMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage =
                 GenericQueryResponseMessage.<TestQueryResponse>asResponseMessage(TEST_QUERY_RESPONSE)

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -87,7 +87,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testDirectQueryWhenRequesterDoesntSupportStreaming() {
+    void directQueryWhenRequesterDoesntSupportStreaming() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
                                                                                             ResponseTypes.publisherOf(String.class));
 
@@ -107,7 +107,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testDirectQueryWhenRequesterDoesntSupportStreamingAndFlowControlMessagesComesBeforeQueryExecution() {
+    void directQueryWhenRequesterDoesntSupportStreamingAndFlowControlMessagesComesBeforeQueryExecution() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
                                                                                             ResponseTypes.publisherOf(String.class));
 
@@ -127,7 +127,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testDirectQueryWhenRequesterDoesntSupportStreamingAndCancelMessagesComesBeforeQueryExecution() {
+    void directQueryWhenRequesterDoesntSupportStreamingAndCancelMessagesComesBeforeQueryExecution() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
                                                                                             ResponseTypes.publisherOf(String.class));
 
@@ -146,7 +146,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingQuery() {
+    void streamingQuery() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage = new GenericQueryMessage<>(new FluxQuery(1000),
                                                                                             ResponseTypes.publisherOf(String.class));
 
@@ -177,7 +177,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingAList() {
+    void streamingAList() {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000),
                                           ResponseTypes.multipleInstancesOf(String.class));
@@ -209,7 +209,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingAListWhenReactorIsNotOnClasspath() {
+    void streamingAListWhenReactorIsNotOnClasspath() {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000),
                                           ResponseTypes.multipleInstancesOf(String.class));
@@ -242,7 +242,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingAListWhenReactorIsNotOnClasspathWithConcurrentRequests()
+    void streamingAListWhenReactorIsNotOnClasspathWithConcurrentRequests()
             throws InterruptedException {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000),
@@ -293,7 +293,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingQueryWithConcurrentRequests() throws InterruptedException {
+    void streamingQueryWithConcurrentRequests() throws InterruptedException {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000),
                                           ResponseTypes.publisherOf(String.class));
@@ -342,7 +342,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingStringViaDirectQuery() {
+    void streamingStringViaDirectQuery() {
         QueryMessage<InstanceQuery, String> queryMessage =
                 new GenericQueryMessage<>(new InstanceQuery(), ResponseTypes.instanceOf(String.class));
 
@@ -368,7 +368,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testMultipleInstanceQueryShouldInvokeFlux() {
+    void multipleInstanceQueryShouldInvokeFlux() {
         QueryMessage<MultipleInstanceQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new MultipleInstanceQuery(1000), ResponseTypes.publisherOf(String.class));
 
@@ -396,7 +396,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testCancellationOfStreamingFluxQuery() {
+    void cancellationOfStreamingFluxQuery() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
@@ -424,7 +424,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingFluxQueryWhenCancelMessageComesFirst() {
+    void streamingFluxQueryWhenCancelMessageComesFirst() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
@@ -446,7 +446,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testCancellationOfStreamingListQuery() {
+    void cancellationOfStreamingListQuery() {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000), ResponseTypes.multipleInstancesOf(String.class));
 
@@ -474,7 +474,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testStreamingListQueryWhenCancelMessageComesFirst() {
+    void streamingListQueryWhenCancelMessageComesFirst() {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000), ResponseTypes.multipleInstancesOf(String.class));
 
@@ -497,7 +497,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testFluxEmittingErrorAfterAWhile() {
+    void fluxEmittingErrorAfterAWhile() {
         QueryMessage<ErroringAfterAWhileFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ErroringAfterAWhileFluxQuery(), ResponseTypes.publisherOf(String.class));
 
@@ -523,7 +523,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testFluxEmittingErrorRightAway() {
+    void fluxEmittingErrorRightAway() {
         QueryMessage<ErroringFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ErroringFluxQuery(), ResponseTypes.publisherOf(String.class));
 
@@ -548,7 +548,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testFluxHandlerThrowingAnException() {
+    void fluxHandlerThrowingAnException() {
         QueryMessage<ThrowingExceptionFluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new ThrowingExceptionFluxQuery(), ResponseTypes.publisherOf(String.class));
 
@@ -573,7 +573,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testListHandlerThrowingAnException() {
+    void listHandlerThrowingAnException() {
         QueryMessage<ThrowingExceptionListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ThrowingExceptionListQuery(),
                                           ResponseTypes.multipleInstancesOf(String.class));
@@ -599,7 +599,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testFluxStreamingQueryWhenRequestingTooMany() {
+    void fluxStreamingQueryWhenRequestingTooMany() {
         QueryMessage<FluxQuery, Publisher<String>> queryMessage =
                 new GenericQueryMessage<>(new FluxQuery(1000), ResponseTypes.publisherOf(String.class));
 
@@ -624,7 +624,7 @@ class QueryProcessingTaskIntegrationTest {
     }
 
     @Test
-    void testListStreamingQueryWhenRequestingTooMany() {
+    void listStreamingQueryWhenRequestingTooMany() {
         QueryMessage<ListQuery, List<String>> queryMessage =
                 new GenericQueryMessage<>(new ListQuery(1000), ResponseTypes.multipleInstancesOf(String.class));
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
@@ -58,7 +58,7 @@ class QuerySerializerTest {
             new QuerySerializer(jacksonSerializer, xStreamSerializer, configuration);
 
     @Test
-    void testSerializeRequest() {
+    void serializeRequest() {
         QueryMessage<String, Integer> message = new GenericQueryMessage<>("Test", "MyQueryName", instanceOf(int.class));
         QueryRequest queryRequest = testSubject.serializeRequest(message, 5, 10, 1);
         QueryMessage<Object, Object> deserialized = testSubject.deserializeRequest(queryRequest);
@@ -72,7 +72,7 @@ class QuerySerializerTest {
     }
 
     @Test
-    void testSerializeResponse() {
+    void serializeResponse() {
         Map<String, ?> metadata = new HashMap<String, Object>() {{
             this.put("firstKey", "firstValue");
             this.put("secondKey", "secondValue");
@@ -90,7 +90,7 @@ class QuerySerializerTest {
     }
 
     @Test
-    void testSerializeExceptionalResponse() {
+    void serializeExceptionalResponse() {
         RuntimeException exception = new RuntimeException("oops");
         GenericQueryResponseMessage<String> responseMessage =
                 new GenericQueryResponseMessage<>(String.class, exception, MetaData.with("test", "testValue"));
@@ -108,7 +108,7 @@ class QuerySerializerTest {
     }
 
     @Test
-    void testSerializeDeserializeNonTransientExceptionalResponse() {
+    void serializeDeserializeNonTransientExceptionalResponse() {
         SerializationException exception = new SerializationException("oops");
         GenericQueryResponseMessage responseMessage = new GenericQueryResponseMessage<>(
                 String.class,
@@ -128,7 +128,7 @@ class QuerySerializerTest {
     }
 
     @Test
-    void testSerializeExceptionalResponseWithDetails() {
+    void serializeExceptionalResponseWithDetails() {
         Exception exception = new QueryExecutionException("oops", null, "Details");
         GenericQueryResponseMessage<String> responseMessage = new GenericQueryResponseMessage<>(
                 String.class,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -159,7 +159,7 @@ class StreamingQueryEndToEndTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testStreamingFluxQuery(boolean supportsStreaming) {
+    void streamingFluxQuery(boolean supportsStreaming) {
         StreamingQueryMessage<FluxQuery, String> query =
                 new GenericStreamingQueryMessage<>(new FluxQuery(), String.class);
 
@@ -170,7 +170,7 @@ class StreamingQueryEndToEndTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testConcurrentStreamingQueries(boolean supportsStreaming) {
+    void concurrentStreamingQueries(boolean supportsStreaming) {
         int count = 100;
 
         StepVerifier.create(Flux.range(0, count)
@@ -181,7 +181,7 @@ class StreamingQueryEndToEndTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testStreamingErrorFluxQuery(boolean supportsStreaming) {
+    void streamingErrorFluxQuery(boolean supportsStreaming) {
         StreamingQueryMessage<ErrorFluxQuery, String> query =
                 new GenericStreamingQueryMessage<>(new ErrorFluxQuery(), String.class);
 
@@ -192,7 +192,7 @@ class StreamingQueryEndToEndTest {
     }
 
     @Test
-    void testStreamingHandlerErrorFluxQuery() {
+    void streamingHandlerErrorFluxQuery() {
         StreamingQueryMessage<HandlerErrorFluxQuery, String> query =
                 new GenericStreamingQueryMessage<>(new HandlerErrorFluxQuery(), String.class);
 
@@ -204,7 +204,7 @@ class StreamingQueryEndToEndTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testStreamingListQuery(boolean supportsStreaming) {
+    void streamingListQuery(boolean supportsStreaming) {
         StreamingQueryMessage<ListQuery, String> query =
                 new GenericStreamingQueryMessage<>(new ListQuery(), String.class);
 
@@ -215,7 +215,7 @@ class StreamingQueryEndToEndTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testListQuery(boolean supportsStreaming) throws ExecutionException, InterruptedException {
+    void listQuery(boolean supportsStreaming) throws ExecutionException, InterruptedException {
         QueryMessage<ListQuery, List<String>> query = new GenericQueryMessage<>(new ListQuery(),
                                                                                 multipleInstancesOf(String.class));
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResultTest.java
@@ -78,7 +78,7 @@ class AxonServerSubscriptionQueryResultTest {
     }
 
     @Test
-    void testSubscriptionQueryClosesUpdateFluxWithErrorOnErrorInResultStream() {
+    void subscriptionQueryClosesUpdateFluxWithErrorOnErrorInResultStream() {
         executorService.schedule(() -> {
             subscriptionQueryUpdateBuffer.onError(new RuntimeException("Test"));
         }, 10, TimeUnit.MILLISECONDS);
@@ -89,7 +89,7 @@ class AxonServerSubscriptionQueryResultTest {
     }
 
     @Test
-    void testSubscriptionQueryCompletesUpdateFluxOnCompletedResultStream() {
+    void subscriptionQueryCompletesUpdateFluxOnCompletedResultStream() {
         executorService.schedule(() -> {
             subscriptionQueryUpdateBuffer.onCompleted();
         }, 10, TimeUnit.MILLISECONDS);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
@@ -45,7 +45,7 @@ class GrpcBackedQueryUpdateMessageTest {
             new SubscriptionMessageSerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryUpdate() {
+    void getIdentifierReturnsTheSameIdentifierAsSpecifiedInTheQueryUpdate() {
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE);
         QueryUpdate testQueryUpdate =
@@ -57,7 +57,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheQueryUpdate() {
+    void getMetaDataReturnsTheSameMapAsWasInsertedInTheQueryUpdate() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(expectedMetaData);
@@ -70,7 +70,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
+    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
         TestQueryUpdate expectedQueryUpdate = TEST_QUERY_UPDATE;
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(expectedQueryUpdate);
@@ -83,7 +83,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsTheTypeOfTheInsertedQueryUpdate() {
+    void getPayloadTypeReturnsTheTypeOfTheInsertedQueryUpdate() {
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE);
         QueryUpdate testQueryUpdate =
@@ -95,7 +95,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testGetPayloadThrowsIllegalPayloadExceptionWhenUpdateIsExceptional() {
+    void getPayloadThrowsIllegalPayloadExceptionWhenUpdateIsExceptional() {
         SubscriptionQueryUpdateMessage<TestQueryUpdate> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TestQueryUpdate.class, new RuntimeException());
         QueryUpdate testQueryUpdate =
@@ -107,7 +107,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void withMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(testMetaData);
@@ -125,7 +125,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void testAndMetaDataAppendsToTheExistingMetaData() {
+    void andMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 GenericSubscriptionQueryUpdateMessage.asUpdateMessage(TEST_QUERY_UPDATE).withMetaData(testMetaData);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
@@ -47,7 +47,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
             new SubscriptionMessageSerializer(serializer, serializer, new AxonServerConfiguration());
 
     @Test
-    void testGetUpdateResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
+    void getUpdateResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
         ResponseType<String> expectedUpdateResponseType = RESPONSE_TYPE;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, expectedUpdateResponseType);
@@ -62,7 +62,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheSubscriptionQuery() {
+    void getQueryNameReturnsTheNameOfTheQueryAsSpecifiedInTheSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -73,7 +73,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
+    void getResponseTypeReturnsTheTypeAsSpecifiedInTheSubscriptionQuery() {
         ResponseType<String> expectedResponseType = RESPONSE_TYPE;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, expectedResponseType, RESPONSE_TYPE);
@@ -87,7 +87,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetIdentifierReturnsTheSameIdentifierAsSpecifiedInTheSubscriptionQuery() {
+    void getIdentifierReturnsTheSameIdentifierAsSpecifiedInTheSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -98,7 +98,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetMetaDataReturnsTheSameMapAsWasInsertedInTheSubscriptionQuery() {
+    void getMetaDataReturnsTheSameMapAsWasInsertedInTheSubscriptionQuery() {
         MetaData expectedMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)
@@ -111,7 +111,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetPayloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
+    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
         TestQuery expectedQuery = TEST_QUERY;
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(expectedQuery, RESPONSE_TYPE, RESPONSE_TYPE);
@@ -123,7 +123,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testGetPayloadTypeReturnsTheTypeOfTheInsertedSubscriptionQuery() {
+    void getPayloadTypeReturnsTheTypeOfTheInsertedSubscriptionQuery() {
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE);
         SubscriptionQuery testSubscriptionQuery = subscriptionMessageSerializer.serialize(testSubscriptionQueryMessage);
@@ -134,7 +134,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testWithMetaDataCompletelyReplacesTheInitialMetaDataMap() {
+    void withMetaDataCompletelyReplacesTheInitialMetaDataMap() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)
@@ -152,7 +152,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void testAndMetaDataAppendsToTheExistingMetaData() {
+    void andMetaDataAppendsToTheExistingMetaData() {
         MetaData testMetaData = MetaData.with("some-key", "some-value");
         SubscriptionQueryMessage testSubscriptionQueryMessage =
                 new GenericSubscriptionQueryMessage<>(TEST_QUERY, RESPONSE_TYPE, RESPONSE_TYPE)

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
@@ -64,7 +64,7 @@ class SubscriptionMessageSerializerTest {
             new SubscriptionMessageSerializer(jacksonSerializer, xStreamSerializer, configuration);
 
     @Test
-    void testInitialResponse() {
+    void initialResponse() {
         MetaData metadata = MetaData.with("firstKey", "firstValue")
                                     .mergedWith(MetaData.with("secondKey", "secondValue"));
         QueryResponseMessage<String> message = new GenericQueryResponseMessage<>(String.class, "Result", metadata);
@@ -79,7 +79,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testExceptionalInitialResponse() {
+    void exceptionalInitialResponse() {
         MetaData metadata = MetaData.with("firstKey", "firstValue")
                                     .mergedWith(MetaData.with("secondKey", "secondValue"));
         QueryResponseMessage<String> message = new GenericQueryResponseMessage<>(String.class,
@@ -98,7 +98,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testNonTransientExceptionalInitialResponse() {
+    void nonTransientExceptionalInitialResponse() {
         MetaData metadata = MetaData.with("firstKey", "firstValue")
                                     .mergedWith(MetaData.with("secondKey", "secondValue"));
         QueryResponseMessage<String> message = new GenericQueryResponseMessage<>(String.class,
@@ -117,7 +117,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testUpdate() {
+    void update() {
         List<String> payload = new ArrayList<>();
         payload.add("A");
         payload.add("B");
@@ -131,7 +131,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testExceptionalUpdate() {
+    void exceptionalUpdate() {
         MetaData metaData = MetaData.with("k1", "v1");
         SubscriptionQueryUpdateMessage<String> message =
                 new GenericSubscriptionQueryUpdateMessage<>(String.class, new RuntimeException("oops"), metaData);
@@ -146,7 +146,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testNonTransientExceptionalUpdate() {
+    void nonTransientExceptionalUpdate() {
         MetaData metaData = MetaData.with("k1", "v1");
         SubscriptionQueryUpdateMessage<String> message =
                 new GenericSubscriptionQueryUpdateMessage<>(String.class, new SerializationException("oops"), metaData);
@@ -161,7 +161,7 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testSubscriptionQueryMessage() {
+    void subscriptionQueryMessage() {
         GenericSubscriptionQueryMessage<String, Integer, Integer> message = new GenericSubscriptionQueryMessage<>(
                 "query",
                 "MyQueryName",
@@ -180,13 +180,13 @@ class SubscriptionMessageSerializerTest {
     }
 
     @Test
-    void testComplete() {
+    void complete() {
         QueryProviderOutbound grpcMessage = testSubject.serializeComplete("subscriptionId");
         assertEquals("subscriptionId", grpcMessage.getSubscriptionQueryResponse().getSubscriptionIdentifier());
     }
 
     @Test
-    void testCompleteExceptionally() {
+    void completeExceptionally() {
         QueryProviderOutbound grpcMessage = testSubject.serializeCompleteExceptionally("subscriptionId",
                                                                                        new RuntimeException("Error"));
         SubscriptionQueryResponse subscriptionQueryResponse = grpcMessage.getSubscriptionQueryResponse();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcBufferingInterceptorTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcBufferingInterceptorTest.java
@@ -46,7 +46,7 @@ class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    void testInterceptClientCall_BiDiStreaming() {
+    void interceptClientCall_BiDiStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -60,7 +60,7 @@ class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    void testInterceptClientCall_ServerStreaming() {
+    void interceptClientCall_ServerStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.SERVER_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -74,7 +74,7 @@ class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    void testInterceptClientCall_ClientStreaming() {
+    void interceptClientCall_ClientStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.CLIENT_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -88,7 +88,7 @@ class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    void testInterceptClientCall_NoStreaming() {
+    void interceptClientCall_NoStreaming() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.UNARY);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(1000);
@@ -102,7 +102,7 @@ class GrpcBufferingInterceptorTest {
     }
 
     @Test
-    void testInterceptClientCall_ZeroBuffer() {
+    void interceptClientCall_ZeroBuffer() {
         MethodDescriptor<Object, Object> method = buildMethod(MethodDescriptor.MethodType.BIDI_STREAMING);
 
         GrpcBufferingInterceptor testSubject = new GrpcBufferingInterceptor(0);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/GrpcMetaDataConverterTest.java
@@ -41,7 +41,7 @@ class GrpcMetaDataConverterTest {
     private final GrpcMetaDataConverter testSubject = new GrpcMetaDataConverter(serializer);
 
     @Test
-    void testConvertStringToMetaDataValue() {
+    void convertStringToMetaDataValue() {
         String testValue = "some-text";
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -50,7 +50,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertDoubleToMetaDataValue() {
+    void convertDoubleToMetaDataValue() {
         double testValue = 10d;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -59,7 +59,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFloatToMetaDataValue() {
+    void convertFloatToMetaDataValue() {
         float testValue = 10f;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -68,7 +68,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertIntegerToMetaDataValue() {
+    void convertIntegerToMetaDataValue() {
         int testValue = 10;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -77,7 +77,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertLongToMetaDataValue() {
+    void convertLongToMetaDataValue() {
         long testValue = 10L;
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testValue);
@@ -86,14 +86,14 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertBooleanToMetaDataValue() {
+    void convertBooleanToMetaDataValue() {
         MetaDataValue result = testSubject.convertToMetaDataValue(true);
 
         assertTrue(result.getBooleanValue());
     }
 
     @Test
-    void testConvertObjectToMetaDataValueUsesSerializer() {
+    void convertObjectToMetaDataValueUsesSerializer() {
         TestObject testObject = new TestObject("some-text");
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
@@ -107,7 +107,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertObjectWithRevisionToMetaDataValue() {
+    void convertObjectWithRevisionToMetaDataValue() {
         RevisionTestObject testObject = new RevisionTestObject("some-text");
 
         MetaDataValue result = testSubject.convertToMetaDataValue(testObject);
@@ -121,7 +121,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertNullToMetaDataValue() {
+    void convertNullToMetaDataValue() {
         MetaDataValue result = testSubject.convertToMetaDataValue(null);
 
         verify(serializer).serialize(null, byte[].class);
@@ -130,7 +130,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromTextMetaDataValue() {
+    void convertFromTextMetaDataValue() {
         String expected = "some-text";
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setTextValue(expected)
@@ -144,7 +144,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromBytesMetaDataValue() {
+    void convertFromBytesMetaDataValue() {
         TestObject testObject = new TestObject("some-text");
         MetaDataValue testMetaData = testSubject.convertToMetaDataValue(testObject);
 
@@ -156,14 +156,14 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromBytesMetaDataValueOfTypeEmptyReturnsNull() {
+    void convertFromBytesMetaDataValueOfTypeEmptyReturnsNull() {
         MetaDataValue testMetaData = testSubject.convertToMetaDataValue(null);
 
         assertNull(testSubject.convertFromMetaDataValue(testMetaData));
     }
 
     @Test
-    void testConvertFromDoubleMetaDataValue() {
+    void convertFromDoubleMetaDataValue() {
         Double expected = 10d;
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setDoubleValue(expected)
@@ -177,7 +177,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromNumberMetaDataValue() {
+    void convertFromNumberMetaDataValue() {
         Long expected = 10L;
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setNumberValue(expected)
@@ -191,7 +191,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromBooleanMetaDataValue() {
+    void convertFromBooleanMetaDataValue() {
         MetaDataValue testMetaData = MetaDataValue.newBuilder()
                                                   .setBooleanValue(true)
                                                   .build();
@@ -204,7 +204,7 @@ class GrpcMetaDataConverterTest {
     }
 
     @Test
-    void testConvertFromDataNotSetMetaDataValue() {
+    void convertFromDataNotSetMetaDataValue() {
         MetaDataValue testMetaData = MetaDataValue.getDefaultInstance();
 
         assertNull(testSubject.convertFromMetaDataValue(testMetaData));

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ProcessingInstructionHelperTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ProcessingInstructionHelperTest.java
@@ -22,12 +22,12 @@ class ProcessingInstructionHelperTest {
                                                                            .build();
 
     @Test
-    void testPriorityDefaultsToZero() {
+    void priorityDefaultsToZero() {
         assertEquals(0L, ProcessingInstructionHelper.priority(Collections.emptyList()));
     }
 
     @Test
-    void testPriority() {
+    void priority() {
         ProcessingInstruction testProcessingInstruction =
                 ProcessingInstruction.newBuilder()
                                      .setKey(ProcessingKey.PRIORITY)
@@ -38,12 +38,12 @@ class ProcessingInstructionHelperTest {
     }
 
     @Test
-    void testNumberOfResultsDefaultsToZero() {
+    void numberOfResultsDefaultsToZero() {
         assertEquals(1L, ProcessingInstructionHelper.numberOfResults(Collections.emptyList()));
     }
 
     @Test
-    void testNumberOfResults() {
+    void numberOfResults() {
         ProcessingInstruction testProcessingInstruction =
                 ProcessingInstruction.newBuilder()
                                      .setKey(ProcessingKey.NR_OF_RESULTS)
@@ -54,12 +54,12 @@ class ProcessingInstructionHelperTest {
     }
 
     @Test
-    void testTimeoutDefaultsToZero() {
+    void timeoutDefaultsToZero() {
         assertEquals(0L, ProcessingInstructionHelper.timeout(Collections.emptyList()));
     }
 
     @Test
-    void testTimeoutDefaults() {
+    void timeoutDefaults() {
         ProcessingInstruction testProcessingInstruction =
                 ProcessingInstruction.newBuilder()
                                      .setKey(ProcessingKey.TIMEOUT)

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -97,7 +97,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testConfiguredDisruptorCommandBusCreatesTheRepository() {
+    void configuredDisruptorCommandBusCreatesTheRepository() {
         //noinspection unchecked
         Repository<Object> expectedRepository = mock(Repository.class);
 
@@ -119,7 +119,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testConfiguredDisruptorCommandBusAsLocalSegmentCreatesTheRepository() {
+    void configuredDisruptorCommandBusAsLocalSegmentCreatesTheRepository() {
         //noinspection unchecked
         Repository<Object> expectedRepository = mock(Repository.class);
 
@@ -143,7 +143,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testPolymorphicConfig() {
+    void polymorphicConfig() {
         AggregateConfigurer<A> aggregateConfigurer = AggregateConfigurer.defaultConfiguration(A.class)
                                                                         .withSubtypes(B.class);
 
@@ -167,7 +167,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testAggregateFactoryConfiguration() {
+    void aggregateFactoryConfiguration() {
         AggregateFactory<TestAggregate> expectedAggregateFactory = new GenericAggregateFactory<>(TestAggregate.class);
 
         testSubject.configureAggregateFactory(configuration -> expectedAggregateFactory);
@@ -176,7 +176,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testSnapshotFilterConfiguration() {
+    void snapshotFilterConfiguration() {
         SnapshotFilter testFilter = snapshotData -> true;
 
         testSubject.configureSnapshotFilter(configuration -> testFilter);
@@ -185,7 +185,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testAggregateConfigurationCreatesRevisionSnapshotFilterForAggregateWithRevision() {
+    void aggregateConfigurationCreatesRevisionSnapshotFilterForAggregateWithRevision() {
         DomainEventMessage<TestAggregateWithRevision> snapshotEvent = new GenericDomainEventMessage<>(
                 TestAggregateWithRevision.class.getName(), "some-aggregate-id", 0, new TestAggregateWithRevision()
         );
@@ -203,7 +203,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testAggregateConfigurationThrowsAxonConfigExceptionWhenCreatingRevisionSnapshotFilterForUndefinedDeclaredType() {
+    void aggregateConfigurationThrowsAxonConfigExceptionWhenCreatingRevisionSnapshotFilterForUndefinedDeclaredType() {
         //noinspection unchecked
         AggregateModel<TestAggregateWithRevision> mockModel = mock(AggregateModel.class);
         when(mockModel.declaredType(TestAggregateWithRevision.class)).thenReturn(Optional.empty());
@@ -220,7 +220,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testConfigureLockFactoryForEventSourcedAggregate() {
+    void configureLockFactoryForEventSourcedAggregate() {
         PessimisticLockFactory lockFactory = spy(PessimisticLockFactory.usingDefaults());
         AggregateConfigurer<A> aggregateConfigurer = AggregateConfigurer.defaultConfiguration(A.class)
                                                                         .configureLockFactory(config -> lockFactory);
@@ -240,7 +240,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testConfigureLockFactoryForStateStoredAggregateWithConfiguredEntityManagerProviderComponent() {
+    void configureLockFactoryForStateStoredAggregateWithConfiguredEntityManagerProviderComponent() {
         PessimisticLockFactory lockFactory = spy(PessimisticLockFactory.usingDefaults());
         AggregateConfigurer<A> aggregateConfigurer = AggregateConfigurer.jpaMappedConfiguration(A.class)
                                                                         .configureLockFactory(config -> lockFactory);
@@ -264,7 +264,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testConfigureLockFactoryForStateStoredAggregate() {
+    void configureLockFactoryForStateStoredAggregate() {
         PessimisticLockFactory lockFactory = spy(PessimisticLockFactory.usingDefaults());
         AggregateConfigurer<A> aggregateConfigurer =
                 AggregateConfigurer.jpaMappedConfiguration(
@@ -286,7 +286,7 @@ public class AggregateConfigurerTest {
         config.shutdown();
     }
     @Test
-    void testNullRevisionEventAndNullRevisionAggregateAllowed() {
+    void nullRevisionEventAndNullRevisionAggregateAllowed() {
         DomainEventMessage<TestAggregate> snapshotEvent = new GenericDomainEventMessage<>(
                 TestAggregate.class.getSimpleName(), "some-aggregate-id", 0, new TestAggregate());
 
@@ -304,7 +304,7 @@ public class AggregateConfigurerTest {
     }
 
     @Test
-    void testNonNullEventRevisionAndNullAggregateRevisionNotAllowed(){
+    void nonNullEventRevisionAndNullAggregateRevisionNotAllowed(){
         DomainEventMessage<TestAggregate> snapshotEvent = new GenericDomainEventMessage<>(
                 TestAggregate.class.getSimpleName(), "some-aggregate-id", 0, new TestAggregate()
         );

--- a/config/src/test/java/org/axonframework/config/ConfigurationParameterResolverFactoryTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationParameterResolverFactoryTest.java
@@ -48,14 +48,14 @@ class ConfigurationParameterResolverFactoryTest {
     }
 
     @Test
-    void testReturnsNullOnUnavailableParameter() {
+    void returnsNullOnUnavailableParameter() {
         assertNull(testSubject.createInstance(method, parameters, 0));
 
         verify(configuration).getComponent(String.class);
     }
 
     @Test
-    void testConfigurationContainsRequestedParameter() {
+    void configurationContainsRequestedParameter() {
         ParameterResolver<?> actual = testSubject.createInstance(method, parameters, 1);
         assertNotNull(actual);
         assertSame(commandBus, actual.resolveParameterValue(new GenericMessage<>("test")));

--- a/config/src/test/java/org/axonframework/config/ConfigurationResourceInjectorTest.java
+++ b/config/src/test/java/org/axonframework/config/ConfigurationResourceInjectorTest.java
@@ -42,7 +42,7 @@ public class ConfigurationResourceInjectorTest {
     }
 
     @Test
-    void testInjectorHasResource() {
+    void injectorHasResource() {
         Saga saga = new Saga();
         testSubject.injectResources(saga);
 

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerHandlerRegistrationTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerHandlerRegistrationTest.java
@@ -52,7 +52,7 @@ class DefaultConfigurerHandlerRegistrationTest {
     }
 
     @Test
-    void testRegisterCommandHandler() {
+    void registerCommandHandler() {
         AtomicBoolean handled = new AtomicBoolean(false);
 
         Configuration config = baseConfigurer.registerCommandHandler(c -> new CommandHandlingComponent(handled))
@@ -65,7 +65,7 @@ class DefaultConfigurerHandlerRegistrationTest {
     }
 
     @Test
-    void testRegisterQueryHandler() {
+    void registerQueryHandler() {
         AtomicBoolean handled = new AtomicBoolean(false);
 
         Configuration config = baseConfigurer.registerQueryHandler(c -> new QueryHandlingComponent(handled))
@@ -78,7 +78,7 @@ class DefaultConfigurerHandlerRegistrationTest {
     }
 
     @Test
-    void testRegisterMessageHandler() {
+    void registerMessageHandler() {
         AtomicReference<MessageHandlingComponent> commandHandled = new AtomicReference<>();
         AtomicReference<MessageHandlingComponent> eventHandled = new AtomicReference<>();
         AtomicReference<MessageHandlingComponent> queryHandled = new AtomicReference<>();

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
@@ -42,7 +42,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     private static final String START_FAILURE_EXCEPTION_MESSAGE = "some start failure";
 
     @Test
-    void testStartLifecycleHandlersAreInvokedInAscendingPhaseOrder() {
+    void startLifecycleHandlersAreInvokedInAscendingPhaseOrder() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -66,7 +66,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testStartLifecycleHandlerConfiguredThroughConfigurerAreInvokedInAscendingPhaseOrder() {
+    void startLifecycleHandlerConfiguredThroughConfigurerAreInvokedInAscendingPhaseOrder() {
         Configurer testSubject = DefaultConfigurer.defaultConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -90,7 +90,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testStartLifecycleHandlersWillOnlyProceedToFollowingPhaseAfterCurrentPhaseIsFinalized()
+    void startLifecycleHandlersWillOnlyProceedToFollowingPhaseAfterCurrentPhaseIsFinalized()
             throws InterruptedException {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
         // Create a lock for the slow handler and lock it immediately, to spoof the handler's slow/long process
@@ -132,7 +132,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testOutOfOrderAddedStartHandlerHasPrecedenceOverSubsequentHandlers() {
+    void outOfOrderAddedStartHandlerHasPrecedenceOverSubsequentHandlers() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -161,7 +161,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testOutOfOrderAddedShutdownHandlerDuringStartUpIsNotCalledImmediately() {
+    void outOfOrderAddedShutdownHandlerDuringStartUpIsNotCalledImmediately() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -189,7 +189,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testShutdownLifecycleHandlersAreInvokedInDescendingPhaseOrder() {
+    void shutdownLifecycleHandlersAreInvokedInDescendingPhaseOrder() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -214,7 +214,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testShutdownLifecycleHandlersConfiguredThroughConfigurerAreInvokedInDescendingPhaseOrder() {
+    void shutdownLifecycleHandlersConfiguredThroughConfigurerAreInvokedInDescendingPhaseOrder() {
         Configurer testSubject = DefaultConfigurer.defaultConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -239,7 +239,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testShutdownLifecycleHandlersWillOnlyProceedToFollowingPhaseAfterCurrentPhaseIsFinalized()
+    void shutdownLifecycleHandlersWillOnlyProceedToFollowingPhaseAfterCurrentPhaseIsFinalized()
             throws InterruptedException {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
         // Create a lock for the slow handler and lock it immediately, to spoof the handler's slow/long process
@@ -282,7 +282,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testOutOfOrderAddedShutdownHandlerHasPrecedenceOverSubsequentHandlers() {
+    void outOfOrderAddedShutdownHandlerHasPrecedenceOverSubsequentHandlers() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseTwoHandler = spy(new LifecycleManagedInstance());
@@ -316,7 +316,7 @@ class DefaultConfigurerLifecycleOperationsTest {
      * there through the lifecycle state I wanted to test it regardless.
      */
     @Test
-    void testOutOfOrderAddedStartHandlerDuringShutdownIsNotCalledImmediately() {
+    void outOfOrderAddedStartHandlerDuringShutdownIsNotCalledImmediately() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseTwoHandler = spy(new LifecycleManagedInstance());
@@ -345,7 +345,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testFailingStartLifecycleProceedsIntoShutdownOrderAtFailingPhase() {
+    void failingStartLifecycleProceedsIntoShutdownOrderAtFailingPhase() {
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
         LifecycleManagedInstance phaseZeroHandler = spy(new LifecycleManagedInstance());
@@ -387,7 +387,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testLifecycleHandlersProceedToFollowingPhaseWhenTheThreadIsInterrupted() throws InterruptedException {
+    void lifecycleHandlersProceedToFollowingPhaseWhenTheThreadIsInterrupted() throws InterruptedException {
         AtomicBoolean invoked = new AtomicBoolean(false);
         Configuration testSubject = DefaultConfigurer.defaultConfiguration().buildConfiguration();
 
@@ -415,7 +415,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testLifecycleHandlersProceedToFollowingPhaseForNeverEndingPhases() {
+    void lifecycleHandlersProceedToFollowingPhaseForNeverEndingPhases() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         Configuration testSubject = DefaultConfigurer.defaultConfiguration()
                                                      .configureLifecyclePhaseTimeout(100, TimeUnit.MILLISECONDS)
@@ -439,7 +439,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testConfigureLifecyclePhaseTimeoutWithZeroTimeoutThrowsAxonConfigurationException() {
+    void configureLifecyclePhaseTimeoutWithZeroTimeoutThrowsAxonConfigurationException() {
         Configurer configurerTestSubject = DefaultConfigurer.defaultConfiguration();
 
         assertThrows(
@@ -449,7 +449,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testConfigureLifecyclePhaseTimeoutWithNegativeTimeoutThrowsAxonConfigurationException() {
+    void configureLifecyclePhaseTimeoutWithNegativeTimeoutThrowsAxonConfigurationException() {
         Configurer configurerTestSubject = DefaultConfigurer.defaultConfiguration();
 
         assertThrows(
@@ -459,7 +459,7 @@ class DefaultConfigurerLifecycleOperationsTest {
     }
 
     @Test
-    void testConfigureLifecyclePhaseTimeoutWithNullTimeUnitThrowsAxonConfigurationException() {
+    void configureLifecyclePhaseTimeoutWithNullTimeUnitThrowsAxonConfigurationException() {
         Configurer configurerTestSubject = DefaultConfigurer.defaultConfiguration();
 
         assertThrows(

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -292,7 +292,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testJpaConfigurationWithInitialTransactionManagerJpaRepository() throws Exception {
+    void jpaConfigurationWithInitialTransactionManagerJpaRepository() throws Exception {
         EntityManagerTransactionManager transactionManager = spy(new EntityManagerTransactionManager(em));
         Configuration config = DefaultConfigurer.jpaConfiguration(
                 () -> em, transactionManager).configureCommandBus(c -> {
@@ -324,7 +324,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testJpaConfigurationWithInitialTransactionManagerJpaRepositoryFromConfiguration() throws Exception {
+    void jpaConfigurationWithInitialTransactionManagerJpaRepositoryFromConfiguration() throws Exception {
         EntityManagerTransactionManager transactionManager = spy(new EntityManagerTransactionManager(em));
         Configuration config =
                 DefaultConfigurer.jpaConfiguration(() -> em, transactionManager)
@@ -350,7 +350,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testMissingEntityManagerProviderIsReported() {
+    void missingEntityManagerProviderIsReported() {
         Configuration config =
                 DefaultConfigurer.defaultConfiguration()
                                  .configureCommandBus(c -> {
@@ -373,7 +373,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testJpaConfigurationWithJpaRepository() throws Exception {
+    void jpaConfigurationWithJpaRepository() throws Exception {
         EntityManagerTransactionManager transactionManager = spy(new EntityManagerTransactionManager(em));
         Configuration config = DefaultConfigurer.jpaConfiguration(() -> em).registerComponent(
                 TransactionManager.class, c -> transactionManager
@@ -429,7 +429,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testRegisterSeveralModules() {
+    void registerSeveralModules() {
         Configuration config = DefaultConfigurer.defaultConfiguration()
                                                 .configureAggregate(StubAggregate.class)
                                                 .configureAggregate(Object.class)
@@ -443,7 +443,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testQueryUpdateEmitterConfigurationPropagatedToTheQueryBus() {
+    void queryUpdateEmitterConfigurationPropagatedToTheQueryBus() {
         QueryUpdateEmitter queryUpdateEmitter = SimpleQueryUpdateEmitter.builder().build();
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .configureQueryUpdateEmitter(c -> queryUpdateEmitter)
@@ -472,7 +472,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testConfiguredSnapshotterDefaultsToAggregateSnapshotter() {
+    void configuredSnapshotterDefaultsToAggregateSnapshotter() {
         Snapshotter defaultSnapshotter =
                 DefaultConfigurer.jpaConfiguration(() -> em)
                                  .configureSerializer(configuration -> TestSerializer.xStreamSerializer())
@@ -483,7 +483,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testConfigureSnapshotterSetsCustomSnapshotter() {
+    void configureSnapshotterSetsCustomSnapshotter() {
         Snapshotter expectedSnapshotter = mock(Snapshotter.class);
 
         AggregateConfigurer<StubAggregate> aggregateConfigurer = defaultConfiguration(StubAggregate.class)
@@ -505,7 +505,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testConfigurationSnapshotFilterContainsConfiguredSnapshotFilters() {
+    void configurationSnapshotFilterContainsConfiguredSnapshotFilters() {
         AtomicBoolean filteredFirst = new AtomicBoolean(false);
         SnapshotFilter testFilterOne = snapshotData -> {
             filteredFirst.set(true);
@@ -537,7 +537,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testAggregateSnapshotFilterIsAddedToTheEventStore() {
+    void aggregateSnapshotFilterIsAddedToTheEventStore() {
         AtomicBoolean filteredFirst = new AtomicBoolean(false);
         SnapshotFilter testFilterOne = snapshotData -> {
             filteredFirst.set(true);
@@ -586,7 +586,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testDefaultConfiguredDeadlineManager() {
+    void defaultConfiguredDeadlineManager() {
         DeadlineManager result = DefaultConfigurer.defaultConfiguration()
                                                   .buildConfiguration()
                                                   .deadlineManager();
@@ -595,7 +595,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testCustomConfiguredDeadlineManager() throws SchedulerException {
+    void customConfiguredDeadlineManager() throws SchedulerException {
         Scheduler mockScheduler = mock(Scheduler.class);
         when(mockScheduler.getContext()).thenReturn(mock(SchedulerContext.class));
 
@@ -614,7 +614,7 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void testDefaultConfiguredScopeAwareProvider() {
+    void defaultConfiguredScopeAwareProvider() {
         ScopeAwareProvider result = DefaultConfigurer.defaultConfiguration()
                                                      .buildConfiguration()
                                                      .scopeAwareProvider();

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -92,7 +92,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testAssignmentRules() {
+    void assignmentRules() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
         AnnotatedBean annotatedBean = new AnnotatedBean();
@@ -123,7 +123,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testByTypeAssignmentRules() {
+    void byTypeAssignmentRules() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
         AnnotatedBean annotatedBean = new AnnotatedBean();
@@ -154,7 +154,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testProcessorsDefaultToSubscribingWhenUsingSimpleEventBus() {
+    void processorsDefaultToSubscribingWhenUsingSimpleEventBus() {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
                                                        .configureEventBus(c -> SimpleEventBus.builder().build())
                                                        .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
@@ -174,7 +174,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testAssigningATrackingProcessorFailsWhenUsingSimpleEventBus() {
+    void assigningATrackingProcessorFailsWhenUsingSimpleEventBus() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration()
                                                  .configureEventBus(c -> SimpleEventBus.builder().build())
                                                  .eventProcessing(ep -> ep.registerEventHandler(c -> new SubscribingEventHandler())
@@ -185,7 +185,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testAssignmentRulesOverrideThoseWithLowerPriority() {
+    void assignmentRulesOverrideThoseWithLowerPriority() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
         configurer.eventProcessing()
@@ -217,7 +217,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testDefaultAssignToKeepsAnnotationScanning() {
+    void defaultAssignToKeepsAnnotationScanning() {
         Map<String, StubEventProcessor> processors = new HashMap<>();
         AnnotatedBean annotatedBean = new AnnotatedBean();
         Object object = new Object();
@@ -241,7 +241,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testTypeAssignmentWithCustomDefault() {
+    void typeAssignmentWithCustomDefault() {
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("myGroup", String.class::equals)
                   .byDefaultAssignHandlerTypesTo(
@@ -266,7 +266,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testTypeAssignment() {
+    void typeAssignment() {
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("myGroup", c -> "java.lang".equals(c.getPackage().getName()))
                   .registerSaga(Object.class)
@@ -287,7 +287,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testAssignSequencingPolicy() throws NoSuchFieldException {
+    void assignSequencingPolicy() throws NoSuchFieldException {
         Object mockHandler = new Object();
         Object specialHandler = new Object();
         SequentialPolicy sequentialPolicy = new SequentialPolicy();
@@ -323,7 +323,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testAssignInterceptors() {
+    void assignInterceptors() {
         StubInterceptor interceptor1 = new StubInterceptor();
         StubInterceptor interceptor2 = new StubInterceptor();
         configurer.eventProcessing()
@@ -344,7 +344,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigureMonitor() throws Exception {
+    void configureMonitor() throws Exception {
         MessageCollectingMonitor subscribingMonitor = new MessageCollectingMonitor();
         MessageCollectingMonitor trackingMonitor = new MessageCollectingMonitor(1);
         CountDownLatch tokenStoreInvocation = new CountDownLatch(1);
@@ -367,7 +367,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigureDefaultListenerInvocationErrorHandler() throws Exception {
+    void configureDefaultListenerInvocationErrorHandler() throws Exception {
         GenericEventMessage<Boolean> errorThrowingEventMessage = new GenericEventMessage<>(true);
 
         int expectedListenerInvocationErrorHandlerCalls = 2;
@@ -393,7 +393,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigureListenerInvocationErrorHandlerPerEventProcessor() throws Exception {
+    void configureListenerInvocationErrorHandlerPerEventProcessor() throws Exception {
         GenericEventMessage<Boolean> errorThrowingEventMessage = new GenericEventMessage<>(true);
 
         int expectedErrorHandlerCalls = 1;
@@ -423,7 +423,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigureDefaultErrorHandler() throws Exception {
+    void configureDefaultErrorHandler() throws Exception {
         GenericEventMessage<Integer> failingEventMessage = new GenericEventMessage<>(1000);
 
         int expectedErrorHandlerCalls = 2;
@@ -450,7 +450,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testTrackingProcessorsUsesConfiguredDefaultStreamableMessageSource(
+    void trackingProcessorsUsesConfiguredDefaultStreamableMessageSource(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mock) {
         configurer.eventProcessing().configureDefaultStreamableMessageSource(c -> mock);
         configurer.eventProcessing().usingTrackingEventProcessors();
@@ -464,7 +464,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testTrackingProcessorsUsesSpecificSource(
+    void trackingProcessorsUsesSpecificSource(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mock,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mock2) {
         configurer.eventProcessing()
@@ -480,7 +480,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSubscribingProcessorsUsesConfiguredDefaultSubscribableMessageSource(
+    void subscribingProcessorsUsesConfiguredDefaultSubscribableMessageSource(
             @Mock SubscribableMessageSource<EventMessage<?>> mock) {
         configurer.eventProcessing().configureDefaultSubscribableMessageSource(c -> mock);
         configurer.eventProcessing().usingSubscribingEventProcessors();
@@ -494,7 +494,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSubscribingProcessorsUsesSpecificSource(
+    void subscribingProcessorsUsesSpecificSource(
             @Mock SubscribableMessageSource<EventMessage<?>> mock,
             @Mock SubscribableMessageSource<EventMessage<?>> mock2) {
         configurer.eventProcessing()
@@ -511,7 +511,7 @@ class EventProcessingModuleTest {
 
 
     @Test
-    void testConfigureErrorHandlerPerEventProcessor() throws Exception {
+    void configureErrorHandlerPerEventProcessor() throws Exception {
         GenericEventMessage<Integer> failingEventMessage = new GenericEventMessage<>(1000);
 
         int expectedErrorHandlerCalls = 1;
@@ -542,13 +542,13 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testPackageOfObject() {
+    void packageOfObject() {
         String expectedPackageName = EventProcessingModule.class.getPackage().getName();
         assertEquals(expectedPackageName, EventProcessingModule.packageOfObject(this));
     }
 
     @Test
-    void testDefaultTrackingEventProcessingConfiguration(
+    void defaultTrackingEventProcessingConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException {
         Object someHandler = new Object();
@@ -582,7 +582,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testCustomTrackingEventProcessingConfiguration(
+    void customTrackingEventProcessingConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException {
         Object someHandler = new Object();
@@ -615,7 +615,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSagaTrackingProcessorsDefaultsToSagaTrackingEventProcessorConfigIfNoCustomizationIsPresent(
+    void sagaTrackingProcessorsDefaultsToSagaTrackingEventProcessorConfigIfNoCustomizationIsPresent(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
     ) throws NoSuchFieldException {
@@ -642,7 +642,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomProcessingGroup(
+    void sagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomProcessingGroup(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
     ) throws NoSuchFieldException {
@@ -670,7 +670,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomProcessor(
+    void sagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomProcessor(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
     ) throws NoSuchFieldException {
@@ -698,7 +698,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomTrackingProcessorBuilder(
+    void sagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomTrackingProcessorBuilder(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
     ) throws NoSuchFieldException {
@@ -726,7 +726,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testSagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomConfigInstance(
+    void sagaTrackingProcessorsDoesNotPickDefaultsSagaTrackingEventProcessorConfigForCustomConfigInstance(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
     ) throws NoSuchFieldException {
@@ -756,7 +756,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testDefaultPooledStreamingEventProcessingConfiguration(
+    void defaultPooledStreamingEventProcessingConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) {
         Object someHandler = new Object();
@@ -779,7 +779,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigurePooledStreamingEventProcessorFailsInAbsenceOfStreamableMessageSource() {
+    void configurePooledStreamingEventProcessorFailsInAbsenceOfStreamableMessageSource() {
         String testName = "pooled-streaming";
         // This configurer does not contain an EventStore or other StreamableMessageSource.
         configurer.eventProcessing()
@@ -789,7 +789,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigurePooledStreamingEventProcessor() throws NoSuchFieldException, IllegalAccessException {
+    void configurePooledStreamingEventProcessor() throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
         TokenStore testTokenStore = new InMemoryTokenStore();
 
@@ -820,7 +820,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigurePooledStreamingEventProcessorWithSource(
+    void configurePooledStreamingEventProcessorWithSource(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -853,7 +853,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testConfigurePooledStreamingEventProcessorWithConfiguration(
+    void configurePooledStreamingEventProcessorWithConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -879,7 +879,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testRegisterPooledStreamingEventProcessorConfigurationIsUsedDuringAllPsepConstructions(
+    void registerPooledStreamingEventProcessorConfigurationIsUsedDuringAllPsepConstructions(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -916,7 +916,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testUsingPooledStreamingEventProcessorWithConfigurationIsUsedDuringAllPsepConstructions(
+    void usingPooledStreamingEventProcessorWithConfigurationIsUsedDuringAllPsepConstructions(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -950,7 +950,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testRegisterPooledStreamingEventProcessorConfigurationForNameIsUsedDuringSpecificPsepConstruction(
+    void registerPooledStreamingEventProcessorConfigurationForNameIsUsedDuringSpecificPsepConstruction(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -987,7 +987,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testRegisterPooledStreamingEventProcessorWithConfigurationOverridesDefaultPsepConfiguration(
+    void registerPooledStreamingEventProcessorWithConfigurationOverridesDefaultPsepConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -1017,7 +1017,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testRegisterPooledStreamingEventProcessorWithConfigurationOverridesCustomPsepConfiguration(
+    void registerPooledStreamingEventProcessorWithConfigurationOverridesCustomPsepConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) throws NoSuchFieldException, IllegalAccessException {
         String testName = "pooled-streaming";
@@ -1052,7 +1052,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testDefaultTransactionManagerIsUsedUponEventProcessorConstruction() throws InterruptedException {
+    void defaultTransactionManagerIsUsedUponEventProcessorConstruction() throws InterruptedException {
         String testName = "pooled-streaming";
         GenericEventMessage<Integer> testEvent = new GenericEventMessage<>(1000);
 
@@ -1075,7 +1075,7 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void testDefaultTransactionManagerIsOverriddenByProcessorSpecificInstance() throws InterruptedException {
+    void defaultTransactionManagerIsOverriddenByProcessorSpecificInstance() throws InterruptedException {
         String testName = "pooled-streaming";
         GenericEventMessage<Integer> testEvent = new GenericEventMessage<>(1000);
 

--- a/config/src/test/java/org/axonframework/config/LifecycleHandlerInspectorTest.java
+++ b/config/src/test/java/org/axonframework/config/LifecycleHandlerInspectorTest.java
@@ -46,14 +46,14 @@ class LifecycleHandlerInspectorTest {
     public static final int TEST_PHASE = 1;
 
     @Test
-    void testNothingIsRegisteredForNullComponent(@Mock Configuration configuration) {
+    void nothingIsRegisteredForNullComponent(@Mock Configuration configuration) {
         LifecycleHandlerInspector.registerLifecycleHandlers(configuration, null);
 
         verifyNoInteractions(configuration);
     }
 
     @Test
-    void testAxonConfigurationExceptionIsThrownForLifecycleHandlerMethodWithParameters(
+    void axonConfigurationExceptionIsThrownForLifecycleHandlerMethodWithParameters(
             @Mock Configuration configuration) {
         assertThrows(
                 AxonConfigurationException.class,
@@ -64,7 +64,7 @@ class LifecycleHandlerInspectorTest {
     }
 
     @Test
-    void testLifecycleHandlerWithReturnTypeCompletableFutureIsRegistered(@Mock Configuration config)
+    void lifecycleHandlerWithReturnTypeCompletableFutureIsRegistered(@Mock Configuration config)
             throws ExecutionException, InterruptedException {
         String asyncShutdownResult = "some result";
         ComponentWithLifecycleHandlers testComponent = new ComponentWithLifecycleHandlers(asyncShutdownResult);
@@ -93,7 +93,7 @@ class LifecycleHandlerInspectorTest {
     }
 
     @Test
-    void testLifecycleHandlerWithoutReturnTypeCompletableFutureIsRegistered(@Mock Configuration config) {
+    void lifecycleHandlerWithoutReturnTypeCompletableFutureIsRegistered(@Mock Configuration config) {
         AtomicBoolean started = new AtomicBoolean(false);
         ComponentWithLifecycleHandlers testComponent = new ComponentWithLifecycleHandlers(started);
         ArgumentCaptor<LifecycleHandler> lifecycleHandlerCaptor = ArgumentCaptor.forClass(LifecycleHandler.class);
@@ -107,7 +107,7 @@ class LifecycleHandlerInspectorTest {
     }
 
     @Test
-    void testLifecycleHandlerThrownExceptionIsWrappedInLifecycleHandlerInvocationException(@Mock Configuration config)
+    void lifecycleHandlerThrownExceptionIsWrappedInLifecycleHandlerInvocationException(@Mock Configuration config)
             throws InterruptedException {
         ComponentWithFailingLifecycleHandler testComponent = new ComponentWithFailingLifecycleHandler();
         ArgumentCaptor<LifecycleHandler> lifecycleHandlerCaptor = ArgumentCaptor.forClass(LifecycleHandler.class);

--- a/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
+++ b/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
@@ -38,7 +38,7 @@ class MessageHandlerRegistrarTest {
     private static final Registration TEST_REGISTRATION_IMPLEMENTATION = () -> false;
 
     @Test
-    void testStartThrowsAxonConfigurationExceptionForCreatingNullMessageHandler(@Mock Configuration config) {
+    void startThrowsAxonConfigurationExceptionForCreatingNullMessageHandler(@Mock Configuration config) {
         MessageHandlerRegistrar testSubject = new MessageHandlerRegistrar(
                 () -> config, c -> null, (c, msgHandler) -> TEST_REGISTRATION_IMPLEMENTATION
         );
@@ -47,7 +47,7 @@ class MessageHandlerRegistrarTest {
     }
 
     @Test
-    void testStartRegistersCreatedMessageHandler(@Mock Configuration config) {
+    void startRegistersCreatedMessageHandler(@Mock Configuration config) {
         AtomicBoolean isCreated = new AtomicBoolean(false);
         AtomicBoolean isRegistered = new AtomicBoolean(false);
 
@@ -70,7 +70,7 @@ class MessageHandlerRegistrarTest {
      * since the {@link MessageHandlerRegistrar#shutdown()} will be wrapped in a {@link LifecycleHandler}.
      */
     @Test
-    void testShutdownThrowsNullPointerExceptionIfRegistrationDidNotHappen(@Mock Configuration config) {
+    void shutdownThrowsNullPointerExceptionIfRegistrationDidNotHappen(@Mock Configuration config) {
         MessageHandlerRegistrar testSubject = new MessageHandlerRegistrar(
                 () -> config, c -> new SomeMessageHandler(),
                 (c, msgHandler) -> TEST_REGISTRATION_IMPLEMENTATION
@@ -80,7 +80,7 @@ class MessageHandlerRegistrarTest {
     }
 
     @Test
-    void testShutdownCancelsMessageHandlerRegistration(@Mock Configuration config) {
+    void shutdownCancelsMessageHandlerRegistration(@Mock Configuration config) {
         AtomicBoolean isCanceled = new AtomicBoolean(false);
 
         MessageHandlerRegistrar testSubject = new MessageHandlerRegistrar(

--- a/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class SagaConfigurerTest {
 
     @Test
-    void testNullChecksOnSagaConfigurer() {
+    void nullChecksOnSagaConfigurer() {
         SagaConfigurer<Object> configurer = SagaConfigurer.forType(Object.class);
         assertConfigurerNullCheck(() -> SagaConfigurer.forType(null), "Saga type should be checked for null");
         assertConfigurerNullCheck(() -> configurer.configureSagaStore(null), "Saga store builder should be checked for null");
@@ -44,7 +44,7 @@ class SagaConfigurerTest {
     }
 
     @Test
-    void testDefaultConfiguration(
+    void defaultConfiguration(
             @Mock ListenerInvocationErrorHandler listenerInvocationErrorHandler,
             @Mock SagaStore store) {
         Configuration configuration = DefaultConfigurer.defaultConfiguration()
@@ -63,7 +63,7 @@ class SagaConfigurerTest {
     }
 
     @Test
-    void testCustomConfiguration(
+    void customConfiguration(
             @Mock SagaRepository<Object> repository,
             @Mock AnnotatedSagaManager<Object> manager) {
         SagaStore<Object> sagaStore = new InMemorySagaStore();

--- a/config/src/test/java/org/axonframework/config/SingleEventProcessorAssigningToMultipleInvokersTest.java
+++ b/config/src/test/java/org/axonframework/config/SingleEventProcessorAssigningToMultipleInvokersTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SingleEventProcessorAssigningToMultipleInvokersTest {
 
     @Test
-    void testMultipleAssignmentsToTrackingProcessor() {
+    void multipleAssignmentsToTrackingProcessor() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .registerEventHandler(config -> new EventHandler1())
@@ -57,7 +57,7 @@ class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    void testMultipleAssignmentsToSubscribingProcessor() {
+    void multipleAssignmentsToSubscribingProcessor() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .usingSubscribingEventProcessors()
@@ -85,7 +85,7 @@ class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    void testMultipleAssignmentsWithProvidedProcessorName() {
+    void multipleAssignmentsWithProvidedProcessorName() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("processor1", clazz -> clazz.equals(Saga3.class))
@@ -120,7 +120,7 @@ class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    void testProcessorGroupAssignment() {
+    void processorGroupAssignment() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .registerEventProcessor("myProcessor", (name, conf, eventHandlerInvoker) ->
@@ -145,7 +145,7 @@ class SingleEventProcessorAssigningToMultipleInvokersTest {
     }
 
     @Test
-    void testProcessorGroupAssignmentByRule() {
+    void processorGroupAssignmentByRule() {
         Configurer configurer = DefaultConfigurer.defaultConfiguration();
         configurer.eventProcessing()
                   .assignHandlerTypesMatching("myProcessor", clazz -> clazz.equals(Saga3.class))

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvokerTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/CommandHandlerInvokerTest.java
@@ -113,7 +113,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testLoadFromRepositoryStoresLoadedAggregateInCache() throws Exception {
+    void loadFromRepositoryStoresLoadedAggregateInCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -132,7 +132,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testLoadFromRepositoryLoadsFromCache() throws Exception {
+    void loadFromRepositoryLoadsFromCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -151,7 +151,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testAddToRepositoryAddsInCache() throws Exception {
+    void addToRepositoryAddsInCache() throws Exception {
         final Repository<StubAggregate> repository = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -170,7 +170,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testCacheEntryInvalidatedOnRecoveryEntry() {
+    void cacheEntryInvalidatedOnRecoveryEntry() {
         commandHandlingEntry.resetAsRecoverEntry(aggregateIdentifier);
         testSubject.onEvent(commandHandlingEntry, 0, true);
 
@@ -179,7 +179,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testCreateRepositoryReturnsSameInstanceOnSecondInvocation() {
+    void createRepositoryReturnsSameInstanceOnSecondInvocation() {
         final Repository<StubAggregate> repository1 = testSubject
                 .createRepository(mockEventStore, new GenericAggregateFactory<>(StubAggregate.class),
                                   snapshotTriggerDefinition,
@@ -193,7 +193,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
+    void canResolveReturnsTrueForMatchingAggregateDescriptor() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -206,7 +206,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
+    void canResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -217,7 +217,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testCanResolveReturnsFalseForNonMatchingAggregateType() {
+    void canResolveReturnsFalseForNonMatchingAggregateType() {
         Repository<StubAggregate> testRepository =
                 testSubject.createRepository(mockEventStore,
                                              new GenericAggregateFactory<>(StubAggregate.class),
@@ -230,7 +230,7 @@ class CommandHandlerInvokerTest {
     }
 
     @Test
-    void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
+    void sendDeliversMessageAtDescribedAggregateInstance() throws Exception {
         String testAggregateId = "some-identifier";
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload(), Instant.now());

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBuilderTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusBuilderTest.java
@@ -29,12 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class DisruptorCommandBusBuilderTest {
 
     @Test
-    void testSetIllegalPublisherThreadCount() {
+    void setIllegalPublisherThreadCount() {
         assertThrows(AxonConfigurationException.class, () -> DisruptorCommandBus.builder().publisherThreadCount(0));
     }
 
     @Test
-    void testSetIllegalInvokerThreadCount() {
+    void setIllegalInvokerThreadCount() {
         assertThrows(AxonConfigurationException.class, () -> DisruptorCommandBus.builder().invokerThreadCount(0));
     }
 }

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusMultiThreadedTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusMultiThreadedTest.java
@@ -100,7 +100,7 @@ class DisruptorCommandBusMultiThreadedTest {
     }
 
     @Test
-    void testDispatchLargeNumberCommandForDifferentAggregates() throws Exception {
+    void dispatchLargeNumberCommandForDifferentAggregates() throws Exception {
         final Map<Object, Object> garbageCollectionPrevention = new ConcurrentHashMap<>();
         doAnswer(trackCreateAndLoad(garbageCollectionPrevention)).when(spiedRepository).newInstance(any());
         doAnswer(trackCreateAndLoad(garbageCollectionPrevention)).when(spiedRepository).load(isA(String.class));

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorCommandBusTest.java
@@ -137,7 +137,7 @@ class DisruptorCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testCallbackInvokedBeforeUnitOfWorkCleanup() throws Exception {
+    void callbackInvokedBeforeUnitOfWorkCleanup() throws Exception {
         MessageHandlerInterceptor<CommandMessage<?>> mockHandlerInterceptor = mock(MessageHandlerInterceptor.class);
         MessageDispatchInterceptor<CommandMessage<?>> mockDispatchInterceptor = mock(MessageDispatchInterceptor.class);
         when(mockDispatchInterceptor.handle(isA(CommandMessage.class))).thenAnswer(new Parameter(0));
@@ -188,7 +188,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testPublishUnsupportedCommand() {
+    void publishUnsupportedCommand() {
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         //noinspection unchecked
         CommandCallback<Object, Object> callback = mock(CommandCallback.class);
@@ -214,7 +214,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testEventStreamsDecoratedOnReadAndWrite() throws InterruptedException {
+    void eventStreamsDecoratedOnReadAndWrite() throws InterruptedException {
         ExecutorService customExecutor = Executors.newCachedThreadPool();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -266,7 +266,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testEventPublicationExecutedWithinTransaction() throws Exception {
+    void eventPublicationExecutedWithinTransaction() throws Exception {
         //noinspection unchecked
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
@@ -287,7 +287,7 @@ class DisruptorCommandBusTest {
 
     @Test
     @Timeout(value = 10)
-    void testAggregatesBlacklistedAndRecoveredOnError_WithAutoReschedule() throws Exception {
+    void aggregatesBlacklistedAndRecoveredOnError_WithAutoReschedule() throws Exception {
         //noinspection unchecked
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
@@ -309,7 +309,7 @@ class DisruptorCommandBusTest {
 
     @Test
     @Timeout(value = 10)
-    void testAggregatesBlacklistedAndRecoveredOnError_WithoutReschedule() throws Exception {
+    void aggregatesBlacklistedAndRecoveredOnError_WithoutReschedule() throws Exception {
         //noinspection unchecked
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor = mock(MessageHandlerInterceptor.class);
         ExecutorService customExecutor = Executors.newCachedThreadPool();
@@ -378,7 +378,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCreateAggregate() {
+    void createAggregate() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -406,7 +406,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCreateOrUpdateAggregateWithPreviousAggregate() {
+    void createOrUpdateAggregateWithPreviousAggregate() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -436,7 +436,7 @@ class DisruptorCommandBusTest {
 
 
     @Test
-    void testCreateOrUpdateAggregateWithoutPreviousAggregate() {
+    void createOrUpdateAggregateWithoutPreviousAggregate() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -463,7 +463,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCommandReturnsAValue() {
+    void commandReturnsAValue() {
         eventStore.storedEvents.clear();
         testSubject = DisruptorCommandBus.builder()
                                          .bufferSize(8)
@@ -486,7 +486,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testMessageMonitoring() {
+    void messageMonitoring() {
         eventStore.storedEvents.clear();
         final AtomicLong successCounter = new AtomicLong();
         final AtomicLong failureCounter = new AtomicLong();
@@ -550,7 +550,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCommandRejectedAfterShutdown() {
+    void commandRejectedAfterShutdown() {
         testSubject = DisruptorCommandBus.builder().build();
         testSubject.subscribe(StubCommand.class.getName(), stubHandler);
         stubHandler.setRepository(
@@ -563,7 +563,7 @@ class DisruptorCommandBusTest {
 
     @Test
     @Timeout(value = 10)
-    void testCommandProcessedAndEventsStored() throws InterruptedException {
+    void commandProcessedAndEventsStored() throws InterruptedException {
         testSubject = DisruptorCommandBus.builder().build();
         testSubject.subscribe(StubCommand.class.getName(), stubHandler);
         stubHandler.setRepository(
@@ -582,7 +582,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
+    void canResolveReturnsTrueForMatchingAggregateDescriptor() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -594,7 +594,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
+    void canResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -604,7 +604,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCanResolveReturnsFalseForNonMatchingAggregateType() {
+    void canResolveReturnsFalseForNonMatchingAggregateType() {
         testSubject = DisruptorCommandBus.builder().build();
         Repository<StubAggregate> testRepository = testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), parameterResolverFactory
@@ -616,7 +616,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testSendDeliversMessageAtDescribedAggregateInstance() throws Exception {
+    void sendDeliversMessageAtDescribedAggregateInstance() throws Exception {
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload(), Instant.now());
         AggregateScopeDescriptor testDescriptor =
@@ -633,7 +633,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testSendThrowsMessageHandlerInvocationExceptionIfHandleFails() {
+    void sendThrowsMessageHandlerInvocationExceptionIfHandleFails() {
         DeadlineMessage<FailingEvent> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new FailingEvent(), Instant.now());
         AggregateScopeDescriptor testDescriptor =
@@ -648,7 +648,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testSendFailsSilentlyOnAggregateNotFoundException() throws Exception {
+    void sendFailsSilentlyOnAggregateNotFoundException() throws Exception {
         DeadlineMessage<DeadlinePayload> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", new DeadlinePayload(), Instant.now());
         AggregateScopeDescriptor testDescriptor =
@@ -665,7 +665,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testDuplicateCommandHandlerResolverSetsTheExpectedHandler() throws Exception {
+    void duplicateCommandHandlerResolverSetsTheExpectedHandler() throws Exception {
         DuplicateCommandHandlerResolver testDuplicateCommandHandlerResolver =
                 DuplicateCommandHandlerResolution.silentOverride();
 
@@ -692,7 +692,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCreateRepository() {
+    void createRepository() {
         assertDoesNotThrow(() -> testSubject.createRepository(
                 eventStore, new GenericAggregateFactory<>(StubAggregate.class), (RepositoryProvider) null
         ));
@@ -705,7 +705,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCommandIsRescheduledForCorruptAggregateState() throws Exception {
+    void commandIsRescheduledForCorruptAggregateState() throws Exception {
         int expectedNumberOfInvocations = 1;
         AtomicInteger invocationCounter = new AtomicInteger(0);
 
@@ -731,7 +731,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testCommandIsNotRescheduledForCorruptAggregateState() throws Exception {
+    void commandIsNotRescheduledForCorruptAggregateState() throws Exception {
         int expectedNumberOfInvocations = 1;
         AtomicInteger invocationCounter = new AtomicInteger(0);
 
@@ -757,7 +757,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testPublisherInterceptors() throws Exception {
+    void publisherInterceptors() throws Exception {
         int expectedNumberOfInvocations = 1;
         AtomicInteger invocationCounter = new AtomicInteger(0);
 
@@ -783,7 +783,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testBuildWithZeroOrNegativeCoolingDownPeriodThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeCoolingDownPeriodThrowsAxonConfigurationException() {
         DisruptorCommandBus.Builder builderTestSubject = DisruptorCommandBus.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.coolingDownPeriod(0));
@@ -792,7 +792,7 @@ class DisruptorCommandBusTest {
     }
 
     @Test
-    void testBuildWithNullCommandTargetResolverThrowsAxonConfigurationException() {
+    void buildWithNullCommandTargetResolverThrowsAxonConfigurationException() {
         DisruptorCommandBus.Builder builderTestSubject = DisruptorCommandBus.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.commandTargetResolver(null));

--- a/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorRepositoryTest.java
+++ b/disruptor/src/test/java/org/axonframework/disruptor/commandhandling/DisruptorRepositoryTest.java
@@ -39,7 +39,7 @@ class DisruptorRepositoryTest {
     private final EventStore eventStore = mock(EventStore.class);
 
     @Test
-    void testDisruptorCommandBusRepositoryNotAvailableOutsideOfInvokerThread() {
+    void disruptorCommandBusRepositoryNotAvailableOutsideOfInvokerThread() {
         DisruptorCommandBus commandBus = DisruptorCommandBus.builder().build();
         Repository<TestAggregate> repository = commandBus
                 .createRepository(eventStore, new GenericAggregateFactory<>(TestAggregate.class));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractAggregateFactoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractAggregateFactoryTest.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 class AbstractAggregateFactoryTest {
 
     @Test
-    void testPolymorphicFactoryConstructorBuildsAnticipatedAggregateModel() {
+    void polymorphicFactoryConstructorBuildsAnticipatedAggregateModel() {
         //noinspection unchecked
         Set<Class<? extends RootAggregate>> subTypes = Sets.newSet(LeafOneAggregate.class, LeafTwoAggregate.class);
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
@@ -74,7 +74,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot() {
+    void scheduleSnapshot() {
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier))
                 .thenReturn(DomainEventStream.of(createEvents(2)));
@@ -83,7 +83,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshotIsPostponedUntilUnitOfWorkAfterCommit() {
+    void scheduleSnapshotIsPostponedUntilUnitOfWorkAfterCommit() {
         DefaultUnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier))
@@ -97,7 +97,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshotOnlyOnce() {
+    void scheduleSnapshotOnlyOnce() {
         DefaultUnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier))
@@ -115,7 +115,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot_ConcurrencyExceptionIsSilenced() {
+    void scheduleSnapshot_ConcurrencyExceptionIsSilenced() {
         final String aggregateIdentifier = "aggregateIdentifier";
         doNothing()
                 .doThrow(new ConcurrencyException("Mock"))
@@ -131,7 +131,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot_SnapshotIsNull() {
+    void scheduleSnapshot_SnapshotIsNull() {
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier)).thenReturn(DomainEventStream.of(createEvent()));
         testSubject.scheduleSnapshot(Object.class, aggregateIdentifier);
@@ -139,7 +139,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot_SnapshotReplacesOneEvent() {
+    void scheduleSnapshot_SnapshotReplacesOneEvent() {
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier)).thenReturn(DomainEventStream.of(createEvent(2)));
         testSubject.scheduleSnapshot(Object.class, aggregateIdentifier);
@@ -148,7 +148,7 @@ class AbstractSnapshotterTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testScheduleSnapshot_WithTransaction() {
+    void scheduleSnapshot_WithTransaction() {
         Transaction mockTransaction = mock(Transaction.class);
         TransactionManager txManager = spy(new StubTransactionManager(mockTransaction));
         when(txManager.startTransaction()).thenReturn(mockTransaction);
@@ -158,7 +158,7 @@ class AbstractSnapshotterTest {
                                      .transactionManager(txManager)
                                      .build();
 
-        testScheduleSnapshot();
+        scheduleSnapshot();
 
         InOrder inOrder = inOrder(mockEventStore, txManager, mockTransaction);
         inOrder.verify(txManager).startTransaction();
@@ -168,7 +168,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot_IgnoredWhenSnapshotAlreadyScheduled() {
+    void scheduleSnapshot_IgnoredWhenSnapshotAlreadyScheduled() {
         StubExecutor executor = new StubExecutor();
         testSubject = TestSnapshotter.builder().eventStore(mockEventStore).executor(executor).build();
 
@@ -185,7 +185,7 @@ class AbstractSnapshotterTest {
     }
 
     @Test
-    void testScheduleSnapshot_AcceptedWhenOtherSnapshotIsScheduled() {
+    void scheduleSnapshot_AcceptedWhenOtherSnapshotIsScheduled() {
         StubExecutor executor = new StubExecutor();
         testSubject = TestSnapshotter.builder().eventStore(mockEventStore).executor(executor).build();
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateLoadSnapshotTriggerDefinitionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateLoadSnapshotTriggerDefinitionTest.java
@@ -82,7 +82,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkCleanup() {
+    void snapshotterTriggeredOnUnitOfWorkCleanup() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -100,7 +100,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkCommit() {
+    void snapshotterTriggeredOnUnitOfWorkCommit() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
 
@@ -116,7 +116,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
+    void snapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
 
@@ -132,7 +132,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
+    void snapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
 
@@ -148,7 +148,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterNotTriggered() {
+    void snapshotterNotTriggered() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1000), ZoneId.of("UTC"));
 
@@ -163,7 +163,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testThresholdDoesNotResetWhenSerialized() throws IOException, ClassNotFoundException {
+    void thresholdDoesNotResetWhenSerialized() throws IOException, ClassNotFoundException {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
 
@@ -186,7 +186,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testScheduleANewSnapshotAfterCommitTrigger() {
+    void scheduleANewSnapshotAfterCommitTrigger() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateSnapshotterTest.java
@@ -55,7 +55,7 @@ public class AggregateSnapshotterTest {
 
     @Test
     @SuppressWarnings({"unchecked"})
-    void testCreateSnapshot() {
+    void createSnapshot() {
         String aggregateIdentifier = UUID.randomUUID().toString();
         DomainEventMessage firstEvent = new GenericDomainEventMessage<>("type", aggregateIdentifier, (long) 0,
                                                                         "Mock contents", MetaData.emptyInstance());
@@ -72,7 +72,7 @@ public class AggregateSnapshotterTest {
 
     @Test
     @SuppressWarnings({"unchecked"})
-    void testCreateSnapshot_FirstEventLoadedIsSnapshotEvent() {
+    void createSnapshot_FirstEventLoadedIsSnapshotEvent() {
         UUID aggregateIdentifier = UUID.randomUUID();
         StubAggregate aggregate = new StubAggregate(aggregateIdentifier);
 
@@ -94,7 +94,7 @@ public class AggregateSnapshotterTest {
 
     @Test
     @SuppressWarnings({"unchecked"})
-    void testCreateSnapshot_AggregateMarkedDeletedWillNotGenerateSnapshot() {
+    void createSnapshot_AggregateMarkedDeletedWillNotGenerateSnapshot() {
         String aggregateIdentifier = UUID.randomUUID().toString();
         DomainEventMessage firstEvent = new GenericDomainEventMessage<>("type", aggregateIdentifier, (long) 0,
                                                                         "Mock contents", MetaData.emptyInstance());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
@@ -88,7 +88,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testAggregatesRetrievedFromCache() throws Exception {
+    void aggregatesRetrievedFromCache() throws Exception {
         startAndGetUnitOfWork();
 
         LockAwareAggregate<StubAggregate, EventSourcedAggregate<StubAggregate>> aggregate1 =
@@ -121,7 +121,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadOrCreateNewAggregate() throws Exception {
+    void loadOrCreateNewAggregate() throws Exception {
         startAndGetUnitOfWork();
         Aggregate<StubAggregate> aggregate = testSubject.loadOrCreate("id1", StubAggregate::new);
         aggregate.execute(s -> s.setIdentifier("id1"));
@@ -133,7 +133,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadDeletedAggregate() throws Exception {
+    void loadDeletedAggregate() throws Exception {
         String identifier = "aggregateId";
 
         startAndGetUnitOfWork();
@@ -157,7 +157,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testCacheClearedAfterRollbackOfAddedAggregate() throws Exception {
+    void cacheClearedAfterRollbackOfAddedAggregate() throws Exception {
         UnitOfWork<?> uow = startAndGetUnitOfWork();
         uow.onCommit(c -> { throw new MockException();});
         try {
@@ -170,7 +170,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testCacheClearedAfterRollbackOfLoadedAggregate() throws Exception {
+    void cacheClearedAfterRollbackOfLoadedAggregate() throws Exception {
 
         startAndGetUnitOfWork().executeWithResult(() -> testSubject.newInstance(() -> new StubAggregate("id1")));
 
@@ -186,7 +186,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testCacheClearedAfterRollbackOfLoadedAggregateUsingLoadOrCreate() throws Exception {
+    void cacheClearedAfterRollbackOfLoadedAggregateUsingLoadOrCreate() throws Exception {
 
         startAndGetUnitOfWork().executeWithResult(() -> testSubject.newInstance(() -> new StubAggregate("id1")));
 
@@ -202,7 +202,7 @@ class CachingEventSourcingRepositoryTest {
     }
 
     @Test
-    void testCacheClearedAfterRollbackOfCreatedAggregateUsingLoadOrCreate() throws Exception {
+    void cacheClearedAfterRollbackOfCreatedAggregateUsingLoadOrCreate() throws Exception {
 
         UnitOfWork<?> uow = startAndGetUnitOfWork();
         uow.onCommit(c -> { throw new MockException();});

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
@@ -123,7 +123,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
     }
 
     @Test
-    void testWithoutCache() throws Exception {
+    void withoutCache() throws Exception {
         repository = CachingEventSourcingRepository.builder(TestAggregate.class)
                 .aggregateFactory(aggregateFactory)
                 .eventStore(eventStore)
@@ -133,7 +133,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
     }
 
     @Test
-    void testWithCache() throws Exception {
+    void withCache() throws Exception {
         repository = CachingEventSourcingRepository.builder(TestAggregate.class)
                 .aggregateFactory(aggregateFactory)
                 .eventStore(eventStore)
@@ -143,7 +143,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
     }
 
     @Test
-    void testMinimalScenarioWithoutCache() throws Exception {
+    void minimalScenarioWithoutCache() throws Exception {
         repository = CachingEventSourcingRepository.builder(TestAggregate.class)
                 .aggregateFactory(aggregateFactory)
                 .eventStore(eventStore)
@@ -153,7 +153,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
     }
 
     @Test
-    void testMinimalScenarioWithCache() throws Exception {
+    void minimalScenarioWithCache() throws Exception {
         repository = CachingEventSourcingRepository.builder(TestAggregate.class)
                 .aggregateFactory(aggregateFactory)
                 .eventStore(eventStore)

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/DomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/DomainEventStreamTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DomainEventStreamTest {
 
     @Test
-    void testPeek() {
+    void peek() {
         DomainEventMessage event1 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
                                                                     "Mock contents", MetaData.emptyInstance());
         DomainEventMessage event2 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
@@ -44,7 +44,7 @@ class DomainEventStreamTest {
     }
 
     @Test
-    void testPeek_EmptyStream() {
+    void peek_EmptyStream() {
         DomainEventStream testSubject = DomainEventStream.of();
         assertFalse(testSubject.hasNext());
         try {
@@ -56,7 +56,7 @@ class DomainEventStreamTest {
     }
 
     @Test
-    void testNextAndHasNext() {
+    void nextAndHasNext() {
         DomainEventMessage event1 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
                                                                     "Mock contents", MetaData.emptyInstance());
         DomainEventMessage event2 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
@@ -70,7 +70,7 @@ class DomainEventStreamTest {
     }
 
     @Test
-    void testNext_ReadBeyondEnd() {
+    void next_ReadBeyondEnd() {
         DomainEventMessage event1 = new GenericDomainEventMessage<>("type", UUID.randomUUID().toString(), (long) 0,
                                                                     "Mock contents", MetaData.emptyInstance());
         DomainEventStream testSubject = DomainEventStream.of(event1);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinitionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinitionTest.java
@@ -71,7 +71,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkCleanup() {
+    void snapshotterTriggeredOnUnitOfWorkCleanup() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -90,7 +90,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkCommit() {
+    void snapshotterTriggeredOnUnitOfWorkCommit() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -107,7 +107,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
+    void snapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -124,7 +124,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
+    void snapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -141,7 +141,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testSnapshotterNotTriggered() {
+    void snapshotterNotTriggered() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()
@@ -156,7 +156,7 @@ class EventCountSnapshotTriggerDefinitionTest {
     }
 
     @Test
-    void testCounterDoesNotResetWhenSerialized() throws IOException, ClassNotFoundException {
+    void counterDoesNotResetWhenSerialized() throws IOException, ClassNotFoundException {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
         GenericDomainEventMessage<String> msg = new GenericDomainEventMessage<>(
                 "type", aggregateIdentifier, 0, "Mock contents", MetaData.emptyInstance()

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIntegrationTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIntegrationTest.java
@@ -59,7 +59,7 @@ public class EventSourcingRepositoryIntegrationTest implements Thread.UncaughtEx
 
     @Test
     @Timeout(value = 6)
-    void testPessimisticLocking() throws Throwable {
+    void pessimisticLocking() throws Throwable {
         initializeRepository();
         long lastSequenceNumber = executeConcurrentModifications(CONCURRENT_MODIFIERS);
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -81,7 +81,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadAndSaveAggregate() {
+    void loadAndSaveAggregate() {
         String identifier = UUID.randomUUID().toString();
         DomainEventMessage event1 =
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance());
@@ -110,7 +110,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testFilterEventsByType() {
+    void filterEventsByType() {
         String identifier = UUID.randomUUID().toString();
         DomainEventMessage event1 =
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance());
@@ -127,7 +127,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoad_FirstEventIsSnapshot() {
+    void load_FirstEventIsSnapshot() {
         String identifier = UUID.randomUUID().toString();
         TestAggregate aggregate = new TestAggregate(identifier);
         when(mockEventStore.readEvents(identifier)).thenReturn(
@@ -136,7 +136,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadWithConflictingChanges() {
+    void loadWithConflictingChanges() {
         String identifier = UUID.randomUUID().toString();
         when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance()),
@@ -156,7 +156,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadWithConflictingChanges_NoConflictResolverSet_UsingTooHighExpectedVersion() {
+    void loadWithConflictingChanges_NoConflictResolverSet_UsingTooHighExpectedVersion() {
         String identifier = UUID.randomUUID().toString();
         when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance()),
@@ -175,7 +175,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testLoadEventsWithSnapshotter() {
+    void loadEventsWithSnapshotter() {
         String identifier = UUID.randomUUID().toString();
         when(mockEventStore.readEvents(identifier)).thenReturn(DomainEventStream.of(
                 new GenericDomainEventMessage<>("type", identifier, (long) 1, "Mock contents", emptyInstance()),
@@ -194,7 +194,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testBuildWithNullSubtypesThrowsAxonConfigurationException() {
+    void buildWithNullSubtypesThrowsAxonConfigurationException() {
         EventSourcingRepository.Builder<TestAggregate> builderTestSubject =
                 EventSourcingRepository.builder(TestAggregate.class)
                                        .eventStore(mockEventStore);
@@ -203,7 +203,7 @@ class EventSourcingRepositoryTest {
     }
 
     @Test
-    void testBuildWithNullSubtypeThrowsAxonConfigurationException() {
+    void buildWithNullSubtypeThrowsAxonConfigurationException() {
         EventSourcingRepository.Builder<TestAggregate> builderTestSubject =
                 EventSourcingRepository.builder(TestAggregate.class)
                                        .eventStore(mockEventStore);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventStreamUtilsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventStreamUtilsTest.java
@@ -45,7 +45,7 @@ class EventStreamUtilsTest {
     }
 
     @Test
-    void testDomainEventStream_lastSequenceNumberEqualToLastProcessedEntry() {
+    void domainEventStream_lastSequenceNumberEqualToLastProcessedEntry() {
         DomainEventStream eventStream = EventStreamUtils
                 .upcastAndDeserializeDomainEvents(Stream.of(createEntry(1)), serializer,
                                                   NoOpEventUpcaster.INSTANCE);
@@ -55,7 +55,7 @@ class EventStreamUtilsTest {
     }
 
     @Test
-    void testDomainEventStream_lastSequenceNumberEqualToLastProcessedEntryAfterIgnoringLastEntry() {
+    void domainEventStream_lastSequenceNumberEqualToLastProcessedEntryAfterIgnoringLastEntry() {
         DomainEventStream eventStream = EventStreamUtils
                 .upcastAndDeserializeDomainEvents(Stream.of(createEntry(1), createEntry(2), createEntry(3)), serializer,
                                                   new EventUpcasterChain(e -> e
@@ -68,7 +68,7 @@ class EventStreamUtilsTest {
     }
 
     @Test
-    void testDomainEventStream_lastSequenceNumberEqualToLastProcessedEntryAfterUpcastingToEmptyStream() {
+    void domainEventStream_lastSequenceNumberEqualToLastProcessedEntryAfterUpcastingToEmptyStream() {
         DomainEventStream eventStream = EventStreamUtils
                 .upcastAndDeserializeDomainEvents(Stream.of(createEntry(1)), serializer,
                                                   new EventUpcasterChain(s -> s.filter(e -> false)));
@@ -79,7 +79,7 @@ class EventStreamUtilsTest {
     }
 
     @Test
-    void testDomainEventStream_nullPointerExceptionOnEmptyEventStream() {
+    void domainEventStream_nullPointerExceptionOnEmptyEventStream() {
         DomainEventStream eventStream = EventStreamUtils.upcastAndDeserializeDomainEvents(Stream.empty(),
             serializer, NoOpEventUpcaster.INSTANCE);
         assertNull(eventStream.getLastSequenceNumber());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
@@ -42,7 +42,7 @@ class FilteringEventStorageEngineTest {
     }
 
     @Test
-    void testEventsFromArrayMatchingAreForwarded() {
+    void eventsFromArrayMatchingAreForwarded() {
         EventMessage<String> event1 = GenericEventMessage.asEventMessage("accept");
         EventMessage<String> event2 = GenericEventMessage.asEventMessage("fail");
         EventMessage<String> event3 = GenericEventMessage.asEventMessage("accept");
@@ -53,7 +53,7 @@ class FilteringEventStorageEngineTest {
     }
 
     @Test
-    void testEventsFromListMatchingAreForwarded() {
+    void eventsFromListMatchingAreForwarded() {
         EventMessage<String> event1 = GenericEventMessage.asEventMessage("accept");
         EventMessage<String> event2 = GenericEventMessage.asEventMessage("fail");
         EventMessage<String> event3 = GenericEventMessage.asEventMessage("accept");
@@ -64,7 +64,7 @@ class FilteringEventStorageEngineTest {
     }
 
     @Test
-    void testStoreSnapshotDelegated() {
+    void storeSnapshotDelegated() {
         GenericDomainEventMessage<Object> snapshot = new GenericDomainEventMessage<>("type", "id", 0, "fail");
         testSubject.storeSnapshot(snapshot);
 
@@ -72,21 +72,21 @@ class FilteringEventStorageEngineTest {
     }
 
     @Test
-    void testCreateTailTokenDelegated() {
+    void createTailTokenDelegated() {
         testSubject.createTailToken();
 
         verify(mockStorage).createTailToken();
     }
 
     @Test
-    void testCreateHeadTokenDelegated() {
+    void createHeadTokenDelegated() {
         testSubject.createHeadToken();
 
         verify(mockStorage).createHeadToken();
     }
 
     @Test
-    void testCreateTokenAtDelegated() {
+    void createTokenAtDelegated() {
         Instant now = Instant.now();
         testSubject.createTokenAt(now);
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/GenericAggregateFactoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/GenericAggregateFactoryTest.java
@@ -32,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericAggregateFactoryTest {
 
     @Test
-    void testInitializeRepository_NoSuitableConstructor() {
+    void initializeRepository_NoSuitableConstructor() {
         assertThrows(IncompatibleAggregateException.class, () -> new GenericAggregateFactory<>(UnsuitableAggregate.class));
     }
 
     @Test
-    void testInitializeRepository_ConstructorNotCallable() {
+    void initializeRepository_ConstructorNotCallable() {
         GenericAggregateFactory<ExceptionThrowingAggregate> factory =
                 new GenericAggregateFactory<>(ExceptionThrowingAggregate.class);
         try {
@@ -49,7 +49,7 @@ class GenericAggregateFactoryTest {
     }
 
     @Test
-    void testInitializeFromAggregateSnapshot() {
+    void initializeFromAggregateSnapshot() {
         StubAggregate aggregate = new StubAggregate("stubId");
         DomainEventMessage<StubAggregate> snapshotMessage = new GenericDomainEventMessage<>("type", aggregate.getIdentifier(),
                                                                                             2, aggregate);
@@ -61,7 +61,7 @@ class GenericAggregateFactoryTest {
      * Verify that {@link GenericAggregateFactory#doCreateAggregate} is not called unnecessarily.
      */
     @Test
-    void testInitializeFromAggregateSnapshot_AvoidCallingDoCreateAggregate() {
+    void initializeFromAggregateSnapshot_AvoidCallingDoCreateAggregate() {
         StubAggregate aggregate = new StubAggregate("stubId");
         DomainEventMessage<StubAggregate> snapshotMessage = new GenericDomainEventMessage<>("type",
                 aggregate.getIdentifier(),

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/SpawningNewAggregateTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/SpawningNewAggregateTest.java
@@ -98,7 +98,7 @@ class SpawningNewAggregateTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testSpawningNewAggregate() throws Exception {
+    void spawningNewAggregate() throws Exception {
         initializeAggregate1Repository(repositoryProvider);
         commandBus.dispatch(asCommandMessage(new CreateAggregate1Command("id", "aggregate2Id")));
 
@@ -115,7 +115,7 @@ class SpawningNewAggregateTest {
 
     @MockitoSettings(strictness = Strictness.LENIENT)
     @Test
-    void testSpawningNewAggregateWhenThereIsNoRepositoryForIt() throws Exception {
+    void spawningNewAggregateWhenThereIsNoRepositoryForIt() throws Exception {
         initializeAggregate1Repository(repositoryProvider);
         when(repositoryProvider.repositoryFor(Aggregate2.class)).thenReturn(null);
         commandBus.dispatch(asCommandMessage(new CreateAggregate1Command("id", "aggregate2Id")),
@@ -134,7 +134,7 @@ class SpawningNewAggregateTest {
 
     @MockitoSettings(strictness = Strictness.LENIENT)
     @Test
-    void testSpawningNewAggregateWhenThereIsNoRepositoryProviderProvided() throws Exception {
+    void spawningNewAggregateWhenThereIsNoRepositoryProviderProvided() throws Exception {
         initializeAggregate1Repository(null);
         commandBus.dispatch(asCommandMessage(new CreateAggregate1Command("id", "aggregate2Id")),
                             (commandMessage, commandResultMessage) -> {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictResolutionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictResolutionTest.java
@@ -52,13 +52,13 @@ class ConflictResolutionTest {
     }
 
     @Test
-    void testFactoryMethod() {
+    void factoryMethod() {
         assertNotNull(subject.createInstance(method, method.getParameters(), 1));
         assertNull(subject.createInstance(method, method.getParameters(), 0));
     }
 
     @Test
-    void testResolve() {
+    void resolve() {
         ConflictResolution.initialize(conflictResolver);
         assertFalse(subject.matches(GenericEventMessage.asEventMessage("testEvent")));
         assertTrue(subject.matches(commandMessage));
@@ -67,7 +67,7 @@ class ConflictResolutionTest {
     }
 
     @Test
-    void testResolveWithoutInitializationReturnsNoConflictsResolver() {
+    void resolveWithoutInitializationReturnsNoConflictsResolver() {
         assertTrue(subject.matches(commandMessage));
         assertSame(NoConflictResolver.INSTANCE, subject.resolveParameterValue(commandMessage));
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictsTest.java
@@ -35,14 +35,14 @@ class ConflictsTest {
                                                                 .collect(toList());
 
     @Test
-    void testPayload() {
+    void payload() {
         assertTrue(Conflicts.payloadMatching(payload -> Objects.equals(payload, PAYLOAD + 2)).test(events));
         assertTrue(Conflicts.payloadMatching(String.class, payload -> Objects.equals(payload, PAYLOAD + 5)).test(events));
         assertFalse(Conflicts.payloadMatching(payload -> Objects.equals(payload, PAYLOAD + 11)).test(events));
     }
 
     @Test
-    void testPayloadType() {
+    void payloadType() {
         assertTrue(Conflicts.payloadTypeOf(String.class).test(events));
         assertTrue(Conflicts.payloadTypeOf(Object.class).test(events));
         assertFalse(Conflicts.payloadTypeOf(Long.class).test(events));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/DefaultConflictResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/DefaultConflictResolverTest.java
@@ -42,7 +42,7 @@ class DefaultConflictResolverTest {
     }
 
     @Test
-    void testDetectConflicts() {
+    void detectConflicts() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         assertThrows(
                 ConflictingModificationException.class,
@@ -50,32 +50,32 @@ class DefaultConflictResolverTest {
     }
 
     @Test
-    void testDetectNoConflictsWhenPredicateDoesNotMatch() {
+    void detectNoConflictsWhenPredicateDoesNotMatch() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         subject.detectConflicts(Conflicts.payloadTypeOf(Long.class));
     }
 
     @Test
-    void testDetectNoConflictsWithoutUnseenEvents() {
+    void detectNoConflictsWithoutUnseenEvents() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 5);
         subject.detectConflicts(Conflicts.payloadTypeOf(String.class));
     }
 
     @Test
-    void testEnsureConflictsResolvedThrowsExceptionWithoutRegisteredConflicts() {
+    void ensureConflictsResolvedThrowsExceptionWithoutRegisteredConflicts() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         assertThrows(ConflictingModificationException.class, subject::ensureConflictsResolved);
     }
 
     @Test
-    void testEnsureConflictsResolvedDoesNothingWithRegisteredConflicts() {
+    void ensureConflictsResolvedDoesNothingWithRegisteredConflicts() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         subject.detectConflicts(Conflicts.payloadMatching(Long.class::isInstance));
         subject.ensureConflictsResolved();
     }
 
     @Test
-    void testConflictingEventsAreAvailableInExceptionBuilder() {
+    void conflictingEventsAreAvailableInExceptionBuilder() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         try {
             subject.detectConflicts(Conflicts.payloadTypeOf(String.class),
@@ -87,7 +87,7 @@ class DefaultConflictResolverTest {
     }
 
     @Test
-    void testConflictResolverProvidingNullExceptionIgnoresConflict() {
+    void conflictResolverProvidingNullExceptionIgnoresConflict() {
         subject = new DefaultConflictResolver(eventStore, AGGREGATE, 5, 9);
         subject.detectConflicts(Conflicts.payloadTypeOf(String.class), c -> null);
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     private AbstractEventStorageEngine testSubject;
 
     @Test
-    public void testUniqueKeyConstraintOnFirstEventIdentifierThrowsAggregateIdentifierAlreadyExistsException() {
+    public void uniqueKeyConstraintOnFirstEventIdentifierThrowsAggregateIdentifierAlreadyExistsException() {
         assertThrows(
                 AggregateStreamCreationException.class,
                 () -> testSubject.appendEvents(createEvent("id", AGGREGATE, 0), createEvent("id", "otherAggregate", 0))
@@ -57,7 +57,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testUniqueKeyConstraintOnEventIdentifier() {
+    public void uniqueKeyConstraintOnEventIdentifier() {
         assertThrows(
                 ConcurrencyException.class,
                 () -> testSubject.appendEvents(createEvent("id", AGGREGATE, 1), createEvent("id", "otherAggregate", 1))
@@ -65,7 +65,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testStoreAndLoadEventsWithUpcaster() {
+    public void storeAndLoadEventsWithUpcaster() {
         EventUpcaster mockUpcasterChain = mock(EventUpcaster.class);
         //noinspection unchecked
         when(mockUpcasterChain.upcast(isA(Stream.class))).thenAnswer(invocation -> {
@@ -90,7 +90,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testStoreDuplicateFirstEventWithExceptionTranslatorThrowsAggregateIdentifierAlreadyExistsException() {
+    public void storeDuplicateFirstEventWithExceptionTranslatorThrowsAggregateIdentifierAlreadyExistsException() {
         assertThrows(
                 AggregateStreamCreationException.class,
                 () -> testSubject.appendEvents(createEvent(0), createEvent(0))
@@ -98,7 +98,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testStoreDuplicateEventWithExceptionTranslator() {
+    public void storeDuplicateEventWithExceptionTranslator() {
         assertThrows(
                 ConcurrencyException.class,
                 () -> testSubject.appendEvents(createEvent(1), createEvent(1))
@@ -106,7 +106,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testStoreDuplicateEventWithoutExceptionResolver() {
+    public void storeDuplicateEventWithoutExceptionResolver() {
         //noinspection unchecked
         testSubject = createEngine(engineBuilder -> (EB) engineBuilder.persistenceExceptionResolver(e -> false));
         assertThrows(
@@ -116,7 +116,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testSnapshotFilterAllowsSnapshots() {
+    public void snapshotFilterAllowsSnapshots() {
         SnapshotFilter allowAll = SnapshotFilter.allowAll();
 
         //noinspection unchecked
@@ -127,7 +127,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testSnapshotFilterRejectsSnapshots() {
+    public void snapshotFilterRejectsSnapshots() {
         SnapshotFilter rejectAll = SnapshotFilter.rejectAll();
 
         //noinspection unchecked
@@ -138,7 +138,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractEventStor
     }
 
     @Test
-    public void testSnapshotFilterRejectsSnapshotsOnCombinedFilter() {
+    public void snapshotFilterRejectsSnapshotsOnCombinedFilter() {
         SnapshotFilter combinedFilter = SnapshotFilter.allowAll().combine(SnapshotFilter.rejectAll());
 
         //noinspection unchecked

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/BatchingEventStorageEngineTest.java
@@ -41,7 +41,7 @@ public abstract class BatchingEventStorageEngineTest<E extends BatchingEventStor
     private BatchingEventStorageEngine testSubject;
 
     @Test
-    protected void testLoadLargeAmountOfEventsFromAggregateStream() {
+    protected void loadLargeAmountOfEventsFromAggregateStream() {
         int eventCount = testSubject.batchSize() + 10;
         testSubject.appendEvents(createEvents(eventCount));
         testSubject.appendEvents(new GenericEventMessage<>("test"));
@@ -53,7 +53,7 @@ public abstract class BatchingEventStorageEngineTest<E extends BatchingEventStor
     }
 
     @Test
-    void testLoadLargeAmountFromOpenStream() {
+    void loadLargeAmountFromOpenStream() {
         int eventCount = testSubject.batchSize() + 10;
         testSubject.appendEvents(createEvents(eventCount));
         GenericEventMessage<String> last = new GenericEventMessage<>("test");

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
@@ -52,7 +52,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testForEachRemaining() {
+    void forEachRemaining() {
         List<DomainEventMessage> expectedMessages = Arrays.asList(event1, event2, event3, event4, event5);
 
         DomainEventStream concat = new ConcatenatingDomainEventStream(
@@ -69,7 +69,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testForEachRemainingKeepsDuplicateSequenceIdEventsInSameStream() {
+    void forEachRemainingKeepsDuplicateSequenceIdEventsInSameStream() {
         List<DomainEventMessage> expectedMessages =
                 Arrays.asList(event1, event1, event2, event3, event4, event4, event5);
 
@@ -89,7 +89,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testConcatSkipsDuplicateEvents() {
+    void concatSkipsDuplicateEvents() {
         DomainEventStream concat = new ConcatenatingDomainEventStream(DomainEventStream.of(event1, event2),
                                                                       DomainEventStream.of(event2, event3),
                                                                       DomainEventStream.of(event3, event4));
@@ -108,7 +108,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    public void testConcatDoesNotSkipDuplicateSequencesInSameStream() {
+    public void concatDoesNotSkipDuplicateSequencesInSameStream() {
         DomainEventStream concat = new ConcatenatingDomainEventStream(DomainEventStream.of(event1, event1, event2),
                                                                       DomainEventStream.of(event2, event2, event3),
                                                                       DomainEventStream.of(event3, event4));
@@ -124,7 +124,7 @@ class ConcatenatingDomainEventStreamTest {
 
 
     @Test
-    void testLastKnownSequenceReturnsTheLastEventItsSequence() {
+    void lastKnownSequenceReturnsTheLastEventItsSequence() {
         DomainEventStream lastStream = DomainEventStream.of(event4, event5);
         DomainEventStream concat = new ConcatenatingDomainEventStream(DomainEventStream.of(event1),
                                                                       DomainEventStream.of(event2, event3),
@@ -144,7 +144,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testLastKnownSequenceReturnsTheLastEventItsSequenceEventIfEventsHaveGaps() {
+    void lastKnownSequenceReturnsTheLastEventItsSequenceEventIfEventsHaveGaps() {
         DomainEventStream lastStream = DomainEventStream.of(event4, event5);
         DomainEventStream concat = new ConcatenatingDomainEventStream(DomainEventStream.of(event1, event3),
                                                                       lastStream);
@@ -162,7 +162,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testLastSequenceNumberWhenLastEventIsFilteredOut() {
+    void lastSequenceNumberWhenLastEventIsFilteredOut() {
         // the last sequence number is the one from the event that is filtered out, e.g. when using upcasters
         DomainEventStream concat = new ConcatenatingDomainEventStream(
                 DomainEventStream.of(
@@ -175,7 +175,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testMaxLastSequenceNumberFromDelegates() {
+    void maxLastSequenceNumberFromDelegates() {
         DomainEventStream concat = new ConcatenatingDomainEventStream(
                 DomainEventStream.of(event1, event3),
                 DomainEventStream.of(event2));
@@ -188,7 +188,7 @@ class ConcatenatingDomainEventStreamTest {
     }
 
     @Test
-    void testNullSequenceNumberFromDelegates_NullPointer() {
+    void nullSequenceNumberFromDelegates_NullPointer() {
         DomainEventStream concat = new ConcatenatingDomainEventStream(
                 DomainEventStream.of(event1),
                 DomainEventStream.of(Stream.empty(), () -> null));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -93,7 +93,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testExistingEventIsPassedToReader() throws Exception {
+    void existingEventIsPassedToReader() throws Exception {
         DomainEventMessage<?> expected = createEvent();
         testSubject.publish(expected);
         TrackingEventStream stream = testSubject.openStream(null);
@@ -107,7 +107,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = FETCH_DELAY / 10, unit = MILLISECONDS)
-    void testEventPublishedAfterOpeningStreamIsPassedToReaderImmediately() throws Exception {
+    void eventPublishedAfterOpeningStreamIsPassedToReaderImmediately() throws Exception {
         TrackingEventStream stream = testSubject.openStream(null);
         assertFalse(stream.hasNextAvailable());
         DomainEventMessage<?> expected = createEvent();
@@ -125,7 +125,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testReadingIsBlockedWhenStoreIsEmpty() throws Exception {
+    void readingIsBlockedWhenStoreIsEmpty() throws Exception {
         CountDownLatch lock = new CountDownLatch(1);
         TrackingEventStream stream = testSubject.openStream(null);
         Thread t = new Thread(() -> stream.asStream().findFirst().ifPresent(event -> lock.countDown()));
@@ -138,7 +138,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testReadingIsBlockedWhenEndOfStreamIsReached() throws Exception {
+    void readingIsBlockedWhenEndOfStreamIsReached() throws Exception {
         testSubject.publish(createEvent());
         CountDownLatch lock = new CountDownLatch(2);
         TrackingEventStream stream = testSubject.openStream(null);
@@ -153,7 +153,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testReadingCanBeContinuedUsingLastToken() throws Exception {
+    void readingCanBeContinuedUsingLastToken() throws Exception {
         List<? extends EventMessage<?>> events = createEvents(2);
         testSubject.publish(events);
         TrackedEventMessage<?> first = testSubject.openStream(null).nextAvailable();
@@ -165,7 +165,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testEventIsFetchedFromCacheWhenFetchedASecondTime() throws Exception {
+    void eventIsFetchedFromCacheWhenFetchedASecondTime() throws Exception {
         CountDownLatch lock = new CountDownLatch(2);
         List<TrackedEventMessage<?>> events = new CopyOnWriteArrayList<>();
         Thread t = new Thread(() -> testSubject.openStream(null).asStream().limit(2).forEach(event -> {
@@ -183,7 +183,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testPeriodicPollingWhenEventStorageIsUpdatedIndependently() throws Exception {
+    void periodicPollingWhenEventStorageIsUpdatedIndependently() throws Exception {
         newTestSubject(CACHED_EVENTS, 20, CLEANUP_DELAY, OPTIMIZE_EVENT_CONSUMPTION);
         TrackingEventStream stream = testSubject.openStream(null);
         CountDownLatch lock = new CountDownLatch(1);
@@ -197,7 +197,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testConsumerStopsTailingWhenItFallsBehindTheCache() throws Exception {
+    void consumerStopsTailingWhenItFallsBehindTheCache() throws Exception {
         newTestSubject(CACHED_EVENTS, FETCH_DELAY, 20, OPTIMIZE_EVENT_CONSUMPTION);
         TrackingEventStream stream = testSubject.openStream(null);
         assertFalse(stream.hasNextAvailable()); //now we should be tailing
@@ -215,7 +215,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testLoadWithoutSnapshot() {
+    void loadWithoutSnapshot() {
         testSubject.publish(createEvents(110));
         List<DomainEventMessage<?>> eventMessages = testSubject.readEvents(AGGREGATE).asStream().collect(toList());
         assertEquals(110, eventMessages.size());
@@ -223,7 +223,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testLoadWithSnapshot() {
+    void loadWithSnapshot() {
         testSubject.publish(createEvents(110));
         storageEngine.storeSnapshot(createEvent(30));
         List<DomainEventMessage<?>> eventMessages = testSubject.readEvents(AGGREGATE).asStream().collect(toList());
@@ -234,7 +234,7 @@ class EmbeddedEventStoreTest {
 
     /* Reproduces issue reported in https://github.com/AxonFramework/AxonFramework/issues/485 */
     @Test
-    void testStreamEventsShouldNotReturnDuplicateTokens() throws InterruptedException {
+    void streamEventsShouldNotReturnDuplicateTokens() throws InterruptedException {
         newTestSubject(0, 1000, 1000, OPTIMIZE_EVENT_CONSUMPTION);
         //noinspection rawtypes
         Stream mockStream = mock(Stream.class);
@@ -257,7 +257,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testLoadWithFailingSnapshot() {
+    void loadWithFailingSnapshot() {
         testSubject.publish(createEvents(110));
         storageEngine.storeSnapshot(createEvent(30));
         when(storageEngine.readSnapshot(AGGREGATE)).thenThrow(new MockException());
@@ -268,7 +268,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testLoadEventsAfterPublishingInSameUnitOfWork() {
+    void loadEventsAfterPublishingInSameUnitOfWork() {
         List<DomainEventMessage<?>> events = createEvents(10);
         testSubject.publish(events.subList(0, 2));
         DefaultUnitOfWork.startAndGet(null)
@@ -281,7 +281,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testLoadEventsWithOffsetAfterPublishingInSameUnitOfWork() {
+    void loadEventsWithOffsetAfterPublishingInSameUnitOfWork() {
         List<DomainEventMessage<?>> events = createEvents(10);
         testSubject.publish(events.subList(0, 2));
         DefaultUnitOfWork.startAndGet(null)
@@ -294,7 +294,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testEventsAppendedInvisibleUntilUnitOfWorkIsCommitted() {
+    void eventsAppendedInvisibleUntilUnitOfWorkIsCommitted() {
         List<DomainEventMessage<?>> events = createEvents(10);
         testSubject.publish(events.subList(0, 2));
         DefaultUnitOfWork<Message<?>> unitOfWork = DefaultUnitOfWork.startAndGet(null);
@@ -313,7 +313,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testStagedEventsNotDuplicatedAfterCommit() {
+    void stagedEventsNotDuplicatedAfterCommit() {
         List<DomainEventMessage<?>> events = createEvents(10);
         testSubject.publish(events.subList(0, 2));
         DefaultUnitOfWork<Message<?>> outerUoW = DefaultUnitOfWork.startAndGet(null);
@@ -337,7 +337,7 @@ class EmbeddedEventStoreTest {
 
     @Test
     @Timeout(value = 5)
-    void testCustomThreadFactoryIsUsed() throws Exception {
+    void customThreadFactoryIsUsed() throws Exception {
         CountDownLatch lock = new CountDownLatch(1);
         TrackingEventStream stream = testSubject.openStream(null);
         Thread t = new Thread(() -> stream.asStream().findFirst().ifPresent(event -> lock.countDown()));
@@ -351,7 +351,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testOpenStreamReadsEventsFromAnEventProducedByVerifyThreadFactoryOperation()
+    void openStreamReadsEventsFromAnEventProducedByVerifyThreadFactoryOperation()
             throws InterruptedException {
         TrackingEventStream eventStream = testSubject.openStream(null);
 
@@ -372,7 +372,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testTailingConsumptionThreadIsNeverCreatedIfEventConsumptionOptimizationIsSwitchedOff()
+    void tailingConsumptionThreadIsNeverCreatedIfEventConsumptionOptimizationIsSwitchedOff()
             throws InterruptedException {
         boolean doNotOptimizeEventConsumption = false;
         //noinspection ConstantConditions
@@ -391,7 +391,7 @@ class EmbeddedEventStoreTest {
     }
 
     @Test
-    void testEventStreamKeepsReturningEventsIfEventConsumptionOptimizationIsSwitchedOff()
+    void eventStreamKeepsReturningEventsIfEventConsumptionOptimizationIsSwitchedOff()
             throws InterruptedException {
         boolean doNotOptimizeEventConsumption = false;
         //noinspection ConstantConditions

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EqualRevisionPredicateTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EqualRevisionPredicateTest.java
@@ -39,27 +39,27 @@ class EqualRevisionPredicateTest {
     }
 
     @Test
-    void testSameRevisionForAggregateAndPayload() {
+    void sameRevisionForAggregateAndPayload() {
         assertTrue(testSubject.test(createEntry(WithAnnotationAggregate.class.getName(), "2.3-TEST")));
     }
 
     @Test
-    void testDifferentRevisionsForAggregateAndPayload() {
+    void differentRevisionsForAggregateAndPayload() {
         assertFalse(testSubject.test(createEntry(WithAnnotationAggregate.class.getName(), "2.3-TEST-DIFFERENT")));
     }
 
     @Test
-    void testNoRevisionForAggregateAndPayload() {
+    void noRevisionForAggregateAndPayload() {
         assertTrue(testSubject.test(createEntry(WithoutAnnotationAggregate.class.getName())));
     }
 
     @Test
-    void testNoRevisionForPayload() {
+    void noRevisionForPayload() {
         assertFalse(testSubject.test(createEntry(WithAnnotationAggregate.class.getName())));
     }
 
     @Test
-    void testNoRevisionForAggregate() {
+    void noRevisionForAggregate() {
         assertFalse(testSubject.test(createEntry(WithoutAnnotationAggregate.class.getName(), "2.3-TEST")));
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -56,7 +56,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testStoreAndLoadEvents() {
+    public void storeAndLoadEvents() {
         testSubject.appendEvents(createEvents(4));
         assertEquals(4, testSubject.readEvents(AGGREGATE).asStream().count());
 
@@ -66,7 +66,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testAppendAndReadNonDomainEvent() {
+    public void appendAndReadNonDomainEvent() {
         testSubject.appendEvents(new GenericEventMessage<>("Hello world"));
 
         List<? extends TrackedEventMessage<?>> actual = testSubject.readEvents(null, false)
@@ -76,13 +76,13 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testStoreAndLoadEventsArray() {
+    public void storeAndLoadEventsArray() {
         testSubject.appendEvents(createEvent(0), createEvent(1));
         assertEquals(2, testSubject.readEvents(AGGREGATE).asStream().count());
     }
 
     @Test
-    public void testStoreAndLoadApplicationEvent() {
+    public void storeAndLoadApplicationEvent() {
         testSubject.appendEvents(new GenericEventMessage<>("application event", MetaData.with("key", "value")));
         assertEquals(1, testSubject.readEvents(null, false).count());
         Optional<? extends TrackedEventMessage<?>> optionalFirst = testSubject.readEvents(null, false).findFirst();
@@ -93,7 +93,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testReturnedEventMessageBehavior() {
+    public void returnedEventMessageBehavior() {
         testSubject.appendEvents(createEvent().withMetaData(singletonMap("key", "value")));
         DomainEventMessage<?> messageWithMetaData = testSubject.readEvents(AGGREGATE).next();
 
@@ -112,13 +112,13 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testLoadNonExistent() {
+    public void loadNonExistent() {
         assertEquals(0L, testSubject.readEvents(randomUUID().toString()).asStream().count());
     }
 
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    public void testReadPartialStream() {
+    public void readPartialStream() {
         testSubject.appendEvents(createEvents(5));
         assertEquals(2L, testSubject.readEvents(AGGREGATE, 2).asStream().findFirst().get().getSequenceNumber());
         assertEquals(4L, testSubject.readEvents(AGGREGATE, 2).asStream().reduce((a, b) -> b).get().getSequenceNumber());
@@ -126,7 +126,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testStoreAndLoadSnapshot() {
+    public void storeAndLoadSnapshot() {
         testSubject.storeSnapshot(createEvent(0));
         testSubject.storeSnapshot(createEvent(1));
         testSubject.storeSnapshot(createEvent(3));
@@ -137,7 +137,7 @@ public abstract class EventStorageEngineTest {
 
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    public void testLoadTrackedEvents() throws InterruptedException {
+    public void loadTrackedEvents() throws InterruptedException {
         testSubject.appendEvents(createEvents(4));
         assertEquals(4, testSubject.readEvents(null, false).count());
 
@@ -153,7 +153,7 @@ public abstract class EventStorageEngineTest {
 
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    public void testLoadPartialStreamOfTrackedEvents() {
+    public void loadPartialStreamOfTrackedEvents() {
         List<DomainEventMessage<?>> events = createEvents(4);
         testSubject.appendEvents(events);
         TrackingToken token = testSubject.readEvents(null, false).findFirst().get().trackingToken();
@@ -163,7 +163,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testCreateTailToken() {
+    public void createTailToken() {
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:00.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
@@ -179,7 +179,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testCreateHeadToken() {
+    public void createHeadToken() {
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:00.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
@@ -195,7 +195,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testCreateTokenAt() {
+    public void createTokenAt() {
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:00.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
@@ -211,7 +211,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testCreateTokenAtExactTime() {
+    public void createTokenAtExactTime() {
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:35.00Z"));
@@ -227,7 +227,7 @@ public abstract class EventStorageEngineTest {
     }
 
     @Test
-    public void testCreateTokenWithUnorderedEvents() {
+    public void createTokenWithUnorderedEvents() {
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
         DomainEventMessage<String> event2 = createEvent(1, Instant.parse("2007-12-03T10:15:40.00Z"));
         DomainEventMessage<String> event3 = createEvent(2, Instant.parse("2007-12-03T10:15:50.00Z"));
@@ -249,7 +249,7 @@ public abstract class EventStorageEngineTest {
      * event.
      */
     @Test
-    public void testCreateTokenAtTimeAfterLastEvent() {
+    public void createTokenAtTimeAfterLastEvent() {
         Instant dateTimeAfterLastEvent = Instant.parse("2008-12-03T10:15:30.00Z");
 
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));
@@ -269,7 +269,7 @@ public abstract class EventStorageEngineTest {
      * event.
      */
     @Test
-    public void testCreateTokenAtTimeBeforeFirstEvent() {
+    public void createTokenAtTimeBeforeFirstEvent() {
         Instant dateTimeBeforeFirstEvent = Instant.parse("2006-12-03T10:15:30.00Z");
 
         DomainEventMessage<String> event1 = createEvent(0, Instant.parse("2007-12-03T10:15:30.00Z"));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/FilteringDomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/FilteringDomainEventStreamTest.java
@@ -44,7 +44,7 @@ class FilteringDomainEventStreamTest {
     }
 
     @Test
-    void testForEachRemainingType1() {
+    void forEachRemainingType1() {
         List<DomainEventMessage> expectedMessages = Arrays.asList(event1);
 
         DomainEventStream concat = new FilteringDomainEventStream(
@@ -59,7 +59,7 @@ class FilteringDomainEventStreamTest {
     }
     
     @Test
-    void testForEachRemainingType2() {
+    void forEachRemainingType2() {
         List<DomainEventMessage> expectedMessages = Arrays.asList(event2, event3);
 
         DomainEventStream concat = new FilteringDomainEventStream(

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
@@ -69,7 +69,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testPublishEventsSendsToActiveStorageOnly() {
+    void publishEventsSendsToActiveStorageOnly() {
         List<EventMessage<Object>> events = singletonList(GenericEventMessage.asEventMessage("test"));
         testSubject.appendEvents(events);
 
@@ -78,7 +78,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromHistoricThenActive() {
+    void aggregateEventsAreReadFromHistoricThenActive() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         when(historicStorage.readEvents(eq("aggregate"), anyLong())).thenReturn(DomainEventStream.of(event1));
@@ -105,7 +105,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromActiveWhenNoHistoricEventsAvailable() {
+    void aggregateEventsAreReadFromActiveWhenNoHistoricEventsAvailable() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         when(historicStorage.readEvents(eq("aggregate"), anyLong())).thenReturn(DomainEventStream.empty());
@@ -131,7 +131,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromHistoricWhenNoActiveEventsAvailable() {
+    void aggregateEventsAreReadFromHistoricWhenNoActiveEventsAvailable() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         when(historicStorage.readEvents(eq("aggregate"), anyLong())).thenReturn(DomainEventStream.of(event1, event2));
@@ -161,7 +161,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testSnapshotsStoredInActiveStorage() {
+    void snapshotsStoredInActiveStorage() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         testSubject.storeSnapshot(event1);
 
@@ -170,7 +170,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testEventStreamedFromHistoricThenActive() {
+    void eventStreamedFromHistoricThenActive() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         TrackingToken token1 = new GlobalSequenceTrackingToken(1);
@@ -194,7 +194,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testSnapshotReadFromActiveThenHistoric() {
+    void snapshotReadFromActiveThenHistoric() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
 
         when(historicStorage.readSnapshot("aggregate")).thenReturn(Optional.of(event1));
@@ -210,7 +210,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testSnapshotReadFromActive() {
+    void snapshotReadFromActive() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> event2 = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
 
@@ -227,21 +227,21 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testCreateTailToken() {
+    void createTailToken() {
         testSubject.createTailToken();
 
         verify(historicStorage).createTailToken();
     }
 
     @Test
-    void testCreateHeadToken() {
+    void createHeadToken() {
         testSubject.createHeadToken();
 
         verify(activeStorage).createHeadToken();
     }
 
     @Test
-    void testCreateTokenAtWhenIsPresentInActiveStorage() {
+    void createTokenAtWhenIsPresentInActiveStorage() {
         Instant now = Instant.now();
         TrackingToken mockTrackingToken = new GlobalSequenceTrackingToken(3);
         when(activeStorage.createTokenAt(now)).thenReturn(mockTrackingToken);
@@ -253,7 +253,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testCreateTokenAtWhenIsNotPresentInActiveStorage() {
+    void createTokenAtWhenIsNotPresentInActiveStorage() {
         Instant now = Instant.now();
         TrackingToken mockTrackingToken = new GlobalSequenceTrackingToken(3);
         when(activeStorage.createTokenAt(now)).thenReturn(null);
@@ -265,7 +265,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testStreamFromPositionInActiveStorage() {
+    void streamFromPositionInActiveStorage() {
         historicStorage = new InMemoryEventStorageEngine();
         activeStorage = new InMemoryEventStorageEngine(1);
 
@@ -300,7 +300,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromFirstSequenceNumber() {
+    void aggregateEventsAreReadFromFirstSequenceNumber() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> snapshotEvent = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         DomainEventMessage<String> event3 = new GenericDomainEventMessage<>("type", "aggregate", 2, "test3");
@@ -331,7 +331,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromFirstSequenceNumberHistoricOnly() {
+    void aggregateEventsAreReadFromFirstSequenceNumberHistoricOnly() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> snapshotEvent = new GenericDomainEventMessage<>("type", "aggregate", 1, "test2");
         DomainEventMessage<String> event3 = new GenericDomainEventMessage<>("type", "aggregate", 2, "test3");
@@ -363,7 +363,7 @@ class SequenceEventStorageEngineTest {
     }
 
     @Test
-    void testAggregateEventsAreReadFromFirstSequenceNumberActiveOnly() {
+    void aggregateEventsAreReadFromFirstSequenceNumberActiveOnly() {
         DomainEventMessage<String> event1 = new GenericDomainEventMessage<>("type", "aggregate", 0, "test1");
         DomainEventMessage<String> snapshotEvent = new GenericDomainEventMessage<>("type", "aggregate", 1, "test3");
         DomainEventMessage<String> event3 = new GenericDomainEventMessage<>("type", "aggregate", 2, "test4");

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
@@ -50,7 +50,7 @@ class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
     }
 
     @Test
-    void testPublishedEventsEmittedToExistingStreams() {
+    void publishedEventsEmittedToExistingStreams() {
         Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
         testSubject.appendEvents(TEST_EVENT);
 
@@ -58,7 +58,7 @@ class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
     }
 
     @Test
-    void testPublishedEventsEmittedToExistingStreams_WithOffset() {
+    void publishedEventsEmittedToExistingStreams_WithOffset() {
         testSubject = new InMemoryEventStorageEngine(1);
         Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
         testSubject.appendEvents(TEST_EVENT);
@@ -71,7 +71,7 @@ class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
     }
 
     @Test
-    void testEventsAreStoredOnCommitIfCurrentUnitOfWorkIsActive() {
+    void eventsAreStoredOnCommitIfCurrentUnitOfWorkIsActive() {
         UnitOfWork<EventMessage<Object>> unitOfWork = DefaultUnitOfWork.startAndGet(TEST_EVENT);
 
         // when _only_ publishing...
@@ -90,7 +90,7 @@ class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
     }
 
     @Test
-    void testEventsAreNotStoredWhenTheUnitOfWorkIsRolledBackIfCurrentUnitOfWorkIsActive() {
+    void eventsAreNotStoredWhenTheUnitOfWorkIsRolledBackIfCurrentUnitOfWorkIsActive() {
         UnitOfWork<EventMessage<Object>> unitOfWork = DefaultUnitOfWork.startAndGet(TEST_EVENT);
 
         // when _only_ publishing...

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
@@ -98,8 +98,8 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    protected void testLoadLargeAmountOfEventsFromAggregateStream() {
-        super.testLoadLargeAmountOfEventsFromAggregateStream();
+    void testLoadLargeAmountOfEventsFromAggregateStream() {
+        super.loadLargeAmountOfEventsFromAggregateStream();
 
         try {
             verify(readForAggregateStatementBuilder, times(6)).build(any(), any(), eq(AGGREGATE), anyLong(), anyInt());
@@ -109,23 +109,23 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testLoadLargeAmountOfEventsFromAggregateStream_WithCustomFinalBatchPredicate() throws SQLException {
+    void loadLargeAmountOfEventsFromAggregateStream_WithCustomFinalBatchPredicate() throws SQLException {
         setTestSubject(testSubject = createEngine(b -> b.finalAggregateBatchPredicate(l -> l.size() < 50)
                                                         .readEventDataForAggregate(readForAggregateStatementBuilder)));
 
-        super.testLoadLargeAmountOfEventsFromAggregateStream();
+        super.loadLargeAmountOfEventsFromAggregateStream();
 
         verify(readForAggregateStatementBuilder, times(4)).build(any(), any(), eq(AGGREGATE), anyLong(), anyInt());
     }
 
     @Test
-    void testStoreTwoExactSameSnapshots() {
+    void storeTwoExactSameSnapshots() {
         testSubject.storeSnapshot(createEvent(1));
         testSubject.storeSnapshot(createEvent(1));
     }
 
     @Test
-    void testLoadLastSequenceNumber() {
+    void loadLastSequenceNumber() {
         String aggregateId = UUID.randomUUID().toString();
         testSubject.appendEvents(createEvent(aggregateId, 0), createEvent(aggregateId, 1));
         assertEquals(1L, (long) testSubject.lastSequenceNumberFor(aggregateId).orElse(-1L));
@@ -134,7 +134,7 @@ class JdbcEventStorageEngineTest
 
     @Test
     @DirtiesContext
-    void testCustomSchemaConfig() {
+    void customSchemaConfig() {
         EventSchema testSchema = EventSchema.builder()
                                             .eventTable("CustomDomainEvent")
                                             .payloadColumn("eventData")
@@ -149,23 +149,23 @@ class JdbcEventStorageEngineTest
                 }
         ));
 
-        testStoreAndLoadEvents();
+        storeAndLoadEvents();
     }
 
     @Test
     @DirtiesContext
-    void testCustomSchemaConfigTimestampColumn() {
+    void customSchemaConfigTimestampColumn() {
         setTestSubject(testSubject = createTimestampEngine(new HsqlEventTableFactory() {
             @Override
             protected String timestampType() {
                 return "timestamp";
             }
         }));
-        testStoreAndLoadEvents();
+        storeAndLoadEvents();
     }
 
     @Test
-    void testGapsForVeryOldEventsAreNotIncluded() throws SQLException {
+    void gapsForVeryOldEventsAreNotIncluded() throws SQLException {
         GenericEventMessage.clock =
                 Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
         testSubject.appendEvents(createEvent(-1), createEvent(0));
@@ -192,7 +192,7 @@ class JdbcEventStorageEngineTest
 
     @DirtiesContext
     @Test
-    void testOldGapsAreRemovedFromProvidedTrackingToken() throws SQLException {
+    void oldGapsAreRemovedFromProvidedTrackingToken() throws SQLException {
         testSubject = createEngine(engineBuilder -> engineBuilder.gapTimeout(50001).gapCleaningThreshold(50));
 
         Instant now = Clock.systemUTC().instant();
@@ -220,7 +220,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testEventsWithUnknownPayloadTypeDoNotResultInError() throws SQLException, InterruptedException {
+    void eventsWithUnknownPayloadTypeDoNotResultInError() throws SQLException, InterruptedException {
         String expectedPayloadOne = "Payload3";
         String expectedPayloadTwo = "Payload4";
 
@@ -253,7 +253,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testStreamCrossesConsecutiveGapsOfMoreThanBatchSuccessfully() throws SQLException {
+    void streamCrossesConsecutiveGapsOfMoreThanBatchSuccessfully() throws SQLException {
         int testBatchSize = 10;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));
         testSubject.appendEvents(createEvents(100));
@@ -269,7 +269,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testStreamDoesNotCrossExtendedGapWhenDisabled() throws SQLException {
+    void streamDoesNotCrossExtendedGapWhenDisabled() throws SQLException {
         int testBatchSize = 10;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize)
                                                                  .extendedGapCheckEnabled(false));
@@ -296,7 +296,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testStreamCrossesInitialConsecutiveGapsOfMoreThanBatchSuccessfully() throws SQLException {
+    void streamCrossesInitialConsecutiveGapsOfMoreThanBatchSuccessfully() throws SQLException {
         int testBatchSize = 10;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));
 
@@ -313,7 +313,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testReadEventsForAggregateReturnsTheCompleteStream() {
+    void readEventsForAggregateReturnsTheCompleteStream() {
         int testBatchSize = 10;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));
 
@@ -337,7 +337,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testReadEventsForAggregateWithGapsReturnsTheCompleteStream() {
+    void readEventsForAggregateWithGapsReturnsTheCompleteStream() {
         int testBatchSize = 10;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));
 
@@ -360,7 +360,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testReadEventsForAggregateWithEventsExceedingOneBatchReturnsTheCompleteStream() {
+    void readEventsForAggregateWithEventsExceedingOneBatchReturnsTheCompleteStream() {
         // Set batch size to 5, so that the number of events exceeds at least one batch
         int testBatchSize = 5;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));
@@ -394,7 +394,7 @@ class JdbcEventStorageEngineTest
     }
 
     @Test
-    void testReadEventsForAggregateWithEventsExceedingOneBatchAndGapsReturnsTheCompleteStream() {
+    void readEventsForAggregateWithEventsExceedingOneBatchAndGapsReturnsTheCompleteStream() {
         // Set batch size to 5, so that the number of events exceeds at least one batch
         int testBatchSize = 5;
         testSubject = createEngine(engineBuilder -> engineBuilder.batchSize(testBatchSize));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
@@ -63,7 +63,7 @@ class MysqlJdbcEventStorageEngineTest {
      * aggregate that does not exist. This test replicates this problem.
      */
     @Test
-    void testLoadLastSequenceNumber() {
+    void loadLastSequenceNumber() {
         final String aggregateId = UUID.randomUUID().toString();
         testSubject.appendEvents(createEvent(aggregateId, 0), createEvent(aggregateId, 1));
         assertEquals(1L, (long) testSubject.lastSequenceNumberFor(aggregateId).orElse(-1L));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/DomainEventEntryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/DomainEventEntryTest.java
@@ -40,7 +40,7 @@ class DomainEventEntryTest {
     private final Serializer serializer = TestSerializer.xStreamSerializer();
 
     @Test
-    void testDomainEventEntryWrapEventsCorrectly() {
+    void domainEventEntryWrapEventsCorrectly() {
         Instant testTimestamp = Instant.now();
 
         String expectedType = "type";

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
@@ -97,14 +97,14 @@ class JpaEventStorageEngineTest
     }
 
     @Test
-    void testStoreAndLoadEventsFromDatastore() {
+    void storeAndLoadEventsFromDatastore() {
         testSubject.appendEvents(createEvents(2));
         entityManager.clear();
         assertEquals(2, testSubject.readEvents(AGGREGATE).asStream().count());
     }
 
     @Test
-    void testLoadLastSequenceNumber() {
+    void loadLastSequenceNumber() {
         testSubject.appendEvents(createEvents(2));
         entityManager.clear();
         assertEquals(1L, (long) testSubject.lastSequenceNumberFor(AGGREGATE).orElse(-1L));
@@ -112,7 +112,7 @@ class JpaEventStorageEngineTest
     }
 
     @Test
-    void testGapsForVeryOldEventsAreNotIncluded() {
+    void gapsForVeryOldEventsAreNotIncluded() {
         entityManager.createQuery("DELETE FROM DomainEventEntry dee").executeUpdate();
 
         GenericEventMessage.clock =
@@ -140,7 +140,7 @@ class JpaEventStorageEngineTest
 
     @DirtiesContext
     @Test
-    void testOldGapsAreRemovedFromProvidedTrackingToken() {
+    void oldGapsAreRemovedFromProvidedTrackingToken() {
         testSubject.setGapCleaningThreshold(50);
         testSubject.setGapTimeout(50001);
         Instant now = Clock.systemUTC().instant();
@@ -189,7 +189,7 @@ class JpaEventStorageEngineTest
     }
 
     @Test
-    void testUnknownSerializedTypeCausesException() {
+    void unknownSerializedTypeCausesException() {
         testSubject.appendEvents(createEvent());
         entityManager.createQuery("UPDATE DomainEventEntry e SET e.payloadType = :type").setParameter("type", "unknown")
                      .executeUpdate();
@@ -200,7 +200,7 @@ class JpaEventStorageEngineTest
     @Test
     @SuppressWarnings({"JpaQlInspection", "OptionalGetWithoutIsPresent"})
     @DirtiesContext
-    void testStoreEventsWithCustomEntity() {
+    void storeEventsWithCustomEntity() {
         XStreamSerializer serializer = xStreamSerializer();
         JpaEventStorageEngine.Builder jpaEventStorageEngineBuilder =
                 JpaEventStorageEngine.builder()
@@ -245,7 +245,7 @@ class JpaEventStorageEngineTest
     }
 
     @Test
-    void testEventsWithUnknownPayloadDoNotResultInError() throws InterruptedException {
+    void eventsWithUnknownPayloadDoNotResultInError() throws InterruptedException {
         String expectedPayloadOne = "Payload3";
         String expectedPayloadTwo = "Payload4";
 
@@ -277,7 +277,7 @@ class JpaEventStorageEngineTest
     }
 
     @Test
-    void testAppendEventsIsPerformedInATransaction() {
+    void appendEventsIsPerformedInATransaction() {
         testSubject.appendEvents(createEvents(2));
 
         verify(transactionManager).executeInTransaction(any());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLErrorCodesResolverTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SQLErrorCodesResolverTest {
 
     @Test
-    void testIsDuplicateKey() {
+    void isDuplicateKey() {
         SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesResolver(new ArrayList<>());
 
         boolean isDuplicateKey = sqlErrorCodesResolver.isDuplicateKeyViolation(new PersistenceException("error",
@@ -50,7 +50,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingSetDuplicateKeyCodes() {
+    void isDuplicateKey_isDuplicateKey_usingSetDuplicateKeyCodes() {
         List<Integer> errorCodes = new ArrayList<>();
         errorCodes.add(-104);
         SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesResolver(errorCodes);
@@ -65,7 +65,7 @@ class SQLErrorCodesResolverTest {
 
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingDataSource() throws Exception {
+    void isDuplicateKey_isDuplicateKey_usingDataSource() throws Exception {
         String databaseProductName = "HSQL Database Engine";
         DataSource dataSource = createMockDataSource(databaseProductName);
 
@@ -80,7 +80,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingAS400DataSource() throws Exception {
+    void isDuplicateKey_isDuplicateKey_usingAS400DataSource() throws Exception {
         String databaseProductName = "DB2 UDB for AS/400";
         DataSource dataSource = createMockDataSource(databaseProductName);
 
@@ -95,7 +95,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingDB2LinuxDataSource() throws Exception {
+    void isDuplicateKey_isDuplicateKey_usingDB2LinuxDataSource() throws Exception {
         String databaseProductName = "DB2/LINUXX8664";
         DataSource dataSource = createMockDataSource(databaseProductName);
 
@@ -110,7 +110,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingRandomDb2DataSource() throws Exception {
+    void isDuplicateKey_isDuplicateKey_usingRandomDb2DataSource() throws Exception {
         String databaseProductName = "DB2 Completely unexpected value";
         DataSource dataSource = createMockDataSource(databaseProductName);
 
@@ -125,7 +125,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingProductName() {
+    void isDuplicateKey_isDuplicateKey_usingProductName() {
         String databaseProductName = "HSQL Database Engine";
 
         SQLErrorCodesResolver sqlErrorCodesResolver = new SQLErrorCodesResolver(databaseProductName);
@@ -139,7 +139,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingCustomProperties() throws Exception {
+    void isDuplicateKey_isDuplicateKey_usingCustomProperties() throws Exception {
         Properties props = new Properties();
         props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
 
@@ -157,14 +157,14 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testInitialization_UnknownProductName() throws Exception {
+    void initialization_UnknownProductName() throws Exception {
         DataSource dataSource = createMockDataSource("Some weird unknown DB type");
         assertThrows(AxonConfigurationException.class, () -> new SQLErrorCodesResolver(dataSource))
         ;
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingSqlState() {
+    void isDuplicateKey_isDuplicateKey_usingSqlState() {
         Properties props = new Properties();
         props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
 
@@ -181,7 +181,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingNonIntSqlState() {
+    void isDuplicateKey_isDuplicateKey_usingNonIntSqlState() {
         Properties props = new Properties();
         props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
 
@@ -198,7 +198,7 @@ class SQLErrorCodesResolverTest {
     }
 
     @Test
-    void testIsDuplicateKey_isDuplicateKey_usingNonNullSqlState() {
+    void isDuplicateKey_isDuplicateKey_usingNonNullSqlState() {
         Properties props = new Properties();
         props.setProperty("MyCustom_Database_Engine.duplicateKeyCodes", "-104");
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLStateResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/SQLStateResolverTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SQLStateResolverTest {
 
     @Test
-    void testDefaultResolver_duplicateKeyException() {
+    void defaultResolver_duplicateKeyException() {
         SQLStateResolver resolver = new SQLStateResolver();
 
         boolean isDuplicateKey = resolver.isDuplicateKeyViolation(duplicateKeyException());
@@ -38,7 +38,7 @@ class SQLStateResolverTest {
     }
 
     @Test
-    void testDefaultResolver_integrityConstraintViolated() {
+    void defaultResolver_integrityConstraintViolated() {
         SQLStateResolver resolver = new SQLStateResolver();
 
         boolean isDuplicateKey = resolver.isDuplicateKeyViolation(integrityContraintViolation());
@@ -47,7 +47,7 @@ class SQLStateResolverTest {
     }
 
     @Test
-    void testExplicitResolver_duplicateKeyException() {
+    void explicitResolver_duplicateKeyException() {
         SQLStateResolver resolver = new SQLStateResolver("23505");
 
         boolean isDuplicateKey = resolver.isDuplicateKeyViolation(duplicateKeyException());
@@ -57,7 +57,7 @@ class SQLStateResolverTest {
 
 
     @Test
-    void testExplicitResolver_integrityConstraintViolated() {
+    void explicitResolver_integrityConstraintViolated() {
         SQLStateResolver resolver = new SQLStateResolver("23505");
 
         boolean isDuplicateKey = resolver.isDuplicateKeyViolation(integrityContraintViolation());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
@@ -40,7 +40,7 @@ class RevisionSnapshotFilterTest {
     private final Serializer serializer = TestSerializer.xStreamSerializer();
 
     @Test
-    void testAllowsDomainEventDataContainingTheAllowedAggregateTypeAndRevision() {
+    void allowsDomainEventDataContainingTheAllowedAggregateTypeAndRevision() {
         RevisionSnapshotFilter testSubject =
                 RevisionSnapshotFilter.builder()
                                       .type(RightAggregateTypeAndRevision.class.getSimpleName())
@@ -59,7 +59,7 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testAllowsDomainEventDataContainingTheWrongAggregateTypeAndAllowedRevision() {
+    void allowsDomainEventDataContainingTheWrongAggregateTypeAndAllowedRevision() {
         RevisionSnapshotFilter testSubject =
                 RevisionSnapshotFilter.builder()
                                       .type(RightAggregateTypeAndRevision.class.getSimpleName())
@@ -75,7 +75,7 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testDisallowsDomainEventDataContainingTheAllowedAggregateTypeAndWrongRevision() {
+    void disallowsDomainEventDataContainingTheAllowedAggregateTypeAndWrongRevision() {
         RevisionSnapshotFilter testSubject =
                 RevisionSnapshotFilter.builder()
                                       .type(RightAggregateTypeAndWrongRevision.class)
@@ -92,7 +92,7 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testBuildWithNullOrEmptyTypeThrowsAxonConfigurationException() {
+    void buildWithNullOrEmptyTypeThrowsAxonConfigurationException() {
         RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.type(""));
@@ -100,14 +100,14 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testBuildWithNullOrEmptyRevisionThrowsAxonConfigurationException() {
+    void buildWithNullOrEmptyRevisionThrowsAxonConfigurationException() {
         RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.revision(""));
     }
 
     @Test
-    void testBuildWithoutTypeThrowsAxonConfigurationException() {
+    void buildWithoutTypeThrowsAxonConfigurationException() {
         RevisionSnapshotFilter.Builder builderTestSubject = RevisionSnapshotFilter.builder()
                                                                                   .revision(EXPECTED_REVISION);
 
@@ -115,7 +115,7 @@ class RevisionSnapshotFilterTest {
     }
 
     @Test
-    void testBuildWithBlankRevisionThrowsAxonConfigurationException() {
+    void buildWithBlankRevisionThrowsAxonConfigurationException() {
         assertThrows(AxonConfigurationException.class, () -> RevisionSnapshotFilter.builder()
                                                                                    .type(RightAggregateTypeAndRevision.class)
                                                                                    .revision("")

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/SnapshotFilterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/SnapshotFilterTest.java
@@ -42,7 +42,7 @@ class SnapshotFilterTest {
     );
 
     @Test
-    void testAllowAllReturnsTrue() {
+    void allowAllReturnsTrue() {
         SnapshotFilter testSubject = SnapshotFilter.allowAll();
 
         assertTrue(testSubject.allow(NO_SNAPSHOT_DATA));
@@ -51,7 +51,7 @@ class SnapshotFilterTest {
     }
 
     @Test
-    void testRejectAllReturnsFalseOnAnyInput() {
+    void rejectAllReturnsFalseOnAnyInput() {
         SnapshotFilter testSubject = SnapshotFilter.rejectAll();
 
         assertFalse(testSubject.allow(NO_SNAPSHOT_DATA));
@@ -60,7 +60,7 @@ class SnapshotFilterTest {
     }
 
     @Test
-    void testFilterInvokesBothFiltersOnTrueForFirstFilter() {
+    void filterInvokesBothFiltersOnTrueForFirstFilter() {
         AtomicBoolean invokedFirst = new AtomicBoolean(false);
         SnapshotFilter first = snapshotData -> {
             invokedFirst.set(true);
@@ -81,7 +81,7 @@ class SnapshotFilterTest {
     }
 
     @Test
-    void testFilterInvokesFirstFilterOnlyOnFalseForFirstFilter() {
+    void filterInvokesFirstFilterOnlyOnFalseForFirstFilter() {
         AtomicBoolean invokedFirst = new AtomicBoolean(false);
         SnapshotFilter first = snapshotData -> {
             invokedFirst.set(true);

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/AbstractAggregateMemberTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/AbstractAggregateMemberTest.java
@@ -43,28 +43,28 @@ public class AbstractAggregateMemberTest {
     }
 
     @Test
-    public void testInitializingFactoryAggregate_ShouldBeAbleToInitialize(){
+    public void initializingFactoryAggregate_ShouldBeAbleToInitialize(){
         fixture.givenNoPriorActivity()
                 .when(new CreateFactoryCommand(factoryId))
                 .expectEvents(new FactoryCreatedEvent(factoryId));
     }
 
     @Test
-    public void testForwardingCommandToAggregateMemberWithTheSameGenericType_ShouldForwardCommandToEmployeeAggregate(){
+    public void forwardingCommandToAggregateMemberWithTheSameGenericType_ShouldForwardCommandToEmployeeAggregate(){
         fixture.givenCommands(new CreateFactoryCommand(factoryId))
                 .when(new CreateTaskCommand(factoryId, "employeeId"))
                 .expectEvents(new EmployeeTaskCreatedEvent(factoryId, "employeeId"));
     }
 
     @Test
-    public void testForwardingCommandToAggregateMemberWithTheSameGenericType_ShouldForwardCommandToManagerAggregate(){
+    public void forwardingCommandToAggregateMemberWithTheSameGenericType_ShouldForwardCommandToManagerAggregate(){
         fixture.givenCommands(new CreateFactoryCommand(factoryId))
                 .when(new CreateTaskCommand(factoryId, "managerId"))
                 .expectEvents(new ManagerTaskCreatedEvent(factoryId, "managerId"));
     }
 
     @Test
-    public void testSendCommandToNoneExistEntity_ShouldThrowAggregateEntityNotFoundException(){
+    public void sendCommandToNoneExistEntity_ShouldThrowAggregateEntityNotFoundException(){
         fixture.givenCommands(new CreateFactoryCommand(factoryId))
                 .when(new CreateTaskCommand(factoryId, "none-exist-id"))
                 .expectException(AggregateEntityNotFoundException.class);

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/CommandRetryAndDispatchInterceptorIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/CommandRetryAndDispatchInterceptorIntegrationTest.java
@@ -78,7 +78,7 @@ class CommandRetryAndDispatchInterceptorIntegrationTest {
      */
     @Test
     @Timeout(value = 10)// bug is that the caller waits forever for a CommandCallback.onFailure that never comes...
-    void testCommandDispatchInterceptorExceptionOnRetryThreadIsThrownToCaller() {
+    void commandDispatchInterceptorExceptionOnRetryThreadIsThrownToCaller() {
         commandGateway = DefaultCommandGateway.builder()
                                               .commandBus(commandBus)
                                               .retryScheduler(retryScheduler)
@@ -129,7 +129,7 @@ class CommandRetryAndDispatchInterceptorIntegrationTest {
     @SuppressWarnings("unchecked")
     @Test
     @Timeout(value = 10)
-    void testCommandGatewayDispatchInterceptorMetaDataIsPreservedOnRetry() {
+    void commandGatewayDispatchInterceptorMetaDataIsPreservedOnRetry() {
         final Thread testThread = Thread.currentThread();
         commandGateway =
                 DefaultCommandGateway.builder()
@@ -167,7 +167,7 @@ class CommandRetryAndDispatchInterceptorIntegrationTest {
      */
     @Test
     @Timeout(value = 10)
-    void testCommandBusDispatchInterceptorMetaDataIsNotPreservedOnRetry() {
+    void commandBusDispatchInterceptorMetaDataIsNotPreservedOnRetry() {
         final Thread testThread = Thread.currentThread();
         commandGateway = DefaultCommandGateway.builder()
                                               .commandBus(commandBus)

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/EventPublicationOrderTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/commandhandling/EventPublicationOrderTest.java
@@ -59,7 +59,7 @@ class EventPublicationOrderTest {
     }
 
     @Test
-    void testPublicationOrderIsMaintained_AggregateAdded() {
+    void publicationOrderIsMaintained_AggregateAdded() {
         String aggregateId = UUID.randomUUID().toString();
         GenericDomainEventMessage<StubAggregateCreatedEvent> event =
                 new GenericDomainEventMessage<>("test", aggregateId, 0, new StubAggregateCreatedEvent(aggregateId));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -113,7 +113,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     public abstract DeadlineManager buildDeadlineManager(Configuration configuration);
 
     @Test
-    void testDeadlineOnAggregate() {
+    void deadlineOnAggregate() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER, DEADLINE_TIMEOUT));
 
         assertPublishedEvents(new MyAggregateCreatedEvent(IDENTIFIER),
@@ -121,7 +121,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineCancellationWithinScopeOnAggregate() {
+    void deadlineCancellationWithinScopeOnAggregate() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER));
         configuration.commandGateway().sendAndWait(new ScheduleSpecificDeadline(IDENTIFIER, "some-payload"));
         configuration.commandGateway().sendAndWait(new ScheduleSpecificDeadline(IDENTIFIER, "some-payload"));
@@ -132,7 +132,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineCancellationOnAggregate() {
+    void deadlineCancellationOnAggregate() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER,
                                                                                 DEADLINE_TIMEOUT,
                                                                                 CANCEL_BEFORE_DEADLINE));
@@ -141,7 +141,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineOnChildEntity() {
+    void deadlineOnChildEntity() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER, DEADLINE_TIMEOUT));
         configuration.commandGateway().sendAndWait(new TriggerDeadlineInChildEntityCommand(IDENTIFIER));
 
@@ -151,7 +151,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineWithSpecifiedDeadlineName() {
+    void deadlineWithSpecifiedDeadlineName() {
         String expectedDeadlinePayload = "deadlinePayload";
 
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER,
@@ -164,7 +164,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineWithoutPayload() {
+    void deadlineWithoutPayload() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER,
                                                                                 DEADLINE_TIMEOUT,
                                                                                 CANCEL_BEFORE_DEADLINE));
@@ -175,7 +175,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testHandlerInterceptorOnAggregate() {
+    void handlerInterceptorOnAggregate() {
         configuration.deadlineManager().registerHandlerInterceptor((uow, chain) -> {
             uow.transformMessage(deadlineMessage -> GenericDeadlineMessage
                     .asDeadlineMessage(deadlineMessage.getDeadlineName(),
@@ -190,7 +190,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDispatchInterceptorOnAggregate() {
+    void dispatchInterceptorOnAggregate() {
         configuration.deadlineManager().registerDispatchInterceptor(messages -> (i, m) ->
                 GenericDeadlineMessage.asDeadlineMessage(m.getDeadlineName(),
                                                          new DeadlinePayload("fakeId"),
@@ -202,7 +202,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testScheduleInPastTriggersDeadline() {
+    void scheduleInPastTriggersDeadline() {
         configuration.commandGateway().sendAndWait(new CreateMyAggregateCommand(IDENTIFIER, -10000));
 
         assertPublishedEventsWithin(100,
@@ -211,7 +211,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testFailedExecution() throws InterruptedException {
+    void failedExecution() throws InterruptedException {
         configuration.deadlineManager().registerHandlerInterceptor((uow, interceptorChain) -> {
             interceptorChain.proceed();
             throw new AxonNonTransientException("Simulating handling error") {
@@ -224,7 +224,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineOnSaga() {
+    void deadlineOnSaga() {
         EventMessage<Object> testEventMessage =
                 asEventMessage(new SagaStartingEvent(IDENTIFIER, DO_NOT_CANCEL_BEFORE_DEADLINE));
         configuration.eventStore().publish(testEventMessage);
@@ -235,7 +235,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineCancellationWithinScopeOnSaga() {
+    void deadlineCancellationWithinScopeOnSaga() {
         SagaStartingEvent sagaStartingEvent = new SagaStartingEvent(IDENTIFIER, DO_NOT_CANCEL_BEFORE_DEADLINE);
         ScheduleSpecificDeadline firstSchedule = new ScheduleSpecificDeadline(IDENTIFIER, "some-payload");
         ScheduleSpecificDeadline secondSchedule = new ScheduleSpecificDeadline(IDENTIFIER, "some-payload");
@@ -254,7 +254,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineCancellationOnSaga() {
+    void deadlineCancellationOnSaga() {
         configuration.eventStore().publish(asEventMessage(new SagaStartingEvent(IDENTIFIER, CANCEL_BEFORE_DEADLINE)));
 
         assertPublishedEvents(new SagaStartingEvent(IDENTIFIER, CANCEL_BEFORE_DEADLINE));
@@ -262,7 +262,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineWithSpecifiedDeadlineNameOnSaga() {
+    void deadlineWithSpecifiedDeadlineNameOnSaga() {
         String expectedDeadlinePayload = "deadlinePayload";
 
         configuration.eventStore().publish(asEventMessage(new SagaStartingEvent(IDENTIFIER, CANCEL_BEFORE_DEADLINE)));
@@ -277,7 +277,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDeadlineWithoutPayloadOnSaga() {
+    void deadlineWithoutPayloadOnSaga() {
         configuration.eventStore().publish(asEventMessage(new SagaStartingEvent(IDENTIFIER, CANCEL_BEFORE_DEADLINE)));
         configuration.eventStore().publish(asEventMessage(new ScheduleSpecificDeadline(IDENTIFIER, null)));
 
@@ -288,7 +288,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testSagaEndingDeadlineEndsTheSaga() {
+    void sagaEndingDeadlineEndsTheSaga() {
         EventStore eventStore = configuration.eventStore();
         eventStore.publish(asEventMessage(new SagaStartingEvent(IDENTIFIER, CANCEL_BEFORE_DEADLINE)));
         eventStore.publish(asEventMessage(new ScheduleSpecificDeadline(IDENTIFIER, END_SAGA)));
@@ -300,7 +300,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testHandlerInterceptorOnSaga() {
+    void handlerInterceptorOnSaga() {
         EventMessage<Object> testEventMessage =
                 asEventMessage(new SagaStartingEvent(IDENTIFIER, DO_NOT_CANCEL_BEFORE_DEADLINE));
         configuration.deadlineManager().registerHandlerInterceptor((uow, chain) -> {
@@ -317,7 +317,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testDispatchInterceptorOnSaga() {
+    void dispatchInterceptorOnSaga() {
         EventMessage<Object> testEventMessage =
                 asEventMessage(new SagaStartingEvent(IDENTIFIER, DO_NOT_CANCEL_BEFORE_DEADLINE));
         configuration.deadlineManager().registerDispatchInterceptor(messages -> (i, m) ->

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/SimpleDeadlineManagerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/SimpleDeadlineManagerTest.java
@@ -41,7 +41,7 @@ class SimpleDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testShutdownInvokesExecutorServiceShutdown(@Mock ScopeAwareProvider scopeAwareProvider,
+    void shutdownInvokesExecutorServiceShutdown(@Mock ScopeAwareProvider scopeAwareProvider,
                                                     @Mock ScheduledExecutorService scheduledExecutorService) {
         SimpleDeadlineManager testSubject = SimpleDeadlineManager.builder()
                                                                  .scopeAwareProvider(scopeAwareProvider)

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/quartz/QuartzDeadlineManagerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/quartz/QuartzDeadlineManagerTest.java
@@ -57,7 +57,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testShutdownInvokesSchedulerShutdown(@Mock ScopeAwareProvider scopeAwareProvider) throws SchedulerException {
+    void shutdownInvokesSchedulerShutdown(@Mock ScopeAwareProvider scopeAwareProvider) throws SchedulerException {
         Scheduler scheduler = spy(new StdSchedulerFactory().getScheduler());
         QuartzDeadlineManager testSubject = QuartzDeadlineManager.builder()
                                                                  .scopeAwareProvider(scopeAwareProvider)
@@ -71,7 +71,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testShutdownFailureResultsInDeadlineException(@Mock ScopeAwareProvider scopeAwareProvider)
+    void shutdownFailureResultsInDeadlineException(@Mock ScopeAwareProvider scopeAwareProvider)
             throws SchedulerException {
         Scheduler scheduler = spy(new StdSchedulerFactory().getScheduler());
         doAnswer(invocation -> {
@@ -87,7 +87,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testBuildWithoutSchedulerThrowsAxonConfigurationException() {
+    void buildWithoutSchedulerThrowsAxonConfigurationException() {
         ScopeAwareProvider scopeAwareProvider = mock(ScopeAwareProvider.class);
         QuartzDeadlineManager.Builder builderTestSubject =
                 QuartzDeadlineManager.builder()
@@ -98,7 +98,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     }
 
     @Test
-    void testBuildWithoutScopeAwareProviderThrowsAxonConfigurationException() {
+    void buildWithoutScopeAwareProviderThrowsAxonConfigurationException() {
         Scheduler scheduler = mock(Scheduler.class);
         QuartzDeadlineManager.Builder builderTestSubject =
                 QuartzDeadlineManager.builder()

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
@@ -86,7 +86,7 @@ class MultiStreamableMessageSourceTest {
 
     @SuppressWarnings({"unchecked", "resource"})
     @Test
-    void testConnectionsAreClosedWhenOpeningFails() {
+    void connectionsAreClosedWhenOpeningFails() {
         StreamableMessageSource<TrackedEventMessage<?>> source1 = mock(StreamableMessageSource.class);
         StreamableMessageSource<TrackedEventMessage<?>> source2 = mock(StreamableMessageSource.class);
         testSubject = MultiStreamableMessageSource.builder()
@@ -123,7 +123,7 @@ class MultiStreamableMessageSourceTest {
 
     @SuppressWarnings("resource")
     @Test
-    void testPeekingLastMessageKeepsItAvailable() throws InterruptedException {
+    void peekingLastMessageKeepsItAvailable() throws InterruptedException {
         EventMessage<?> publishedEvent1 = GenericEventMessage.asEventMessage("Event1");
 
 
@@ -395,7 +395,7 @@ class MultiStreamableMessageSourceTest {
 
     @SuppressWarnings({"unchecked", "resource"})
     @Test
-    void testSkipMessagesWithPayloadTypeOfInvokesAllConfiguredStreams() {
+    void skipMessagesWithPayloadTypeOfInvokesAllConfiguredStreams() {
         TrackedEventMessage<String> testEvent = new GenericTrackedEventMessage<>(
                 new GlobalSequenceTrackingToken(1), GenericEventMessage.asEventMessage("some-payload")
         );
@@ -429,7 +429,7 @@ class MultiStreamableMessageSourceTest {
 
     @SuppressWarnings({"unchecked", "resource"})
     @Test
-    void testSetOnAvailableCallbackReturnsTrueIfAllStreamsReturnTrue() {
+    void setOnAvailableCallbackReturnsTrueIfAllStreamsReturnTrue() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         Runnable testCallback = () -> invoked.set(true);
 
@@ -467,7 +467,7 @@ class MultiStreamableMessageSourceTest {
 
     @SuppressWarnings({"unchecked", "resource"})
     @Test
-    void testSetOnAvailableCallbackReturnsFalseIfOneStreamsReturnsFalse() {
+    void setOnAvailableCallbackReturnsFalseIfOneStreamsReturnsFalse() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         Runnable testCallback = () -> invoked.set(true);
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/SubscribingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/SubscribingEventProcessorTest.java
@@ -64,7 +64,7 @@ class SubscribingEventProcessorTest {
     }
 
     @Test
-    void testRestartSubscribingEventProcessor() throws Exception {
+    void restartSubscribingEventProcessor() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             countDownLatch.countDown();
@@ -80,7 +80,7 @@ class SubscribingEventProcessorTest {
     }
 
     @Test
-    void testStartTransactionManager() throws Exception {
+    void startTransactionManager() throws Exception {
         testSubject.start();
         eventBus.publish(EventTestUtils.createEvents(1));
 
@@ -88,7 +88,7 @@ class SubscribingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullTransactionManagerThrowsAxonConfigurationException() {
+    void buildWithNullTransactionManagerThrowsAxonConfigurationException() {
         SubscribingEventProcessor.Builder builder = SubscribingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class,  () -> builder.transactionManager(null));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -232,7 +232,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testSequenceEventStorageReceivesEachEventOnlyOnce() throws Exception {
+    void sequenceEventStorageReceivesEachEventOnlyOnce() throws Exception {
         InMemoryEventStorageEngine historic = new InMemoryEventStorageEngine();
         InMemoryEventStorageEngine active = new InMemoryEventStorageEngine(2);
         SequenceEventStorageEngine sequenceEventStorageEngine = new SequenceEventStorageEngine(historic, active);
@@ -271,7 +271,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testSequenceMaxCapacity() {
+    void sequenceMaxCapacity() {
         testSubject.start();
         assertEquals(1, testSubject.maxCapacity());
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(0, testSubject.availableProcessorThreads()));
@@ -279,7 +279,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testPublishedEventsGetPassedToHandler() throws Exception {
+    void publishedEventsGetPassedToHandler() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             countDownLatch.countDown();
@@ -293,7 +293,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testBlacklist() {
+    void blacklist() {
         when(mockHandler.canHandle(any())).thenReturn(false);
         when(mockHandler.canHandleType(String.class)).thenReturn(false);
         Set<Class<?>> skipped = new HashSet<>();
@@ -318,7 +318,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testProcessorExposesErrorStateOnHandlerException() throws Exception {
+    void processorExposesErrorStateOnHandlerException() throws Exception {
         doReturn(Object.class).when(mockHandler).getTargetType();
         AtomicBoolean errorFlag = new AtomicBoolean(true);
         doAnswer(invocation -> {
@@ -350,7 +350,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testHandlerIsInvokedInTransactionScope() throws Exception {
+    void handlerIsInvokedInTransactionScope() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         AtomicInteger counter = new AtomicInteger();
         AtomicInteger counterAtHandle = new AtomicInteger();
@@ -374,7 +374,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testProcessorStopsOnNonTransientExceptionWhenLoadingToken() {
+    void processorStopsOnNonTransientExceptionWhenLoadingToken() {
         doThrow(new SerializationException("Faking a serialization issue")).when(tokenStore).fetchToken("test", 0);
 
         testSubject.start();
@@ -389,7 +389,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testProcessorRetriesOnTransientExceptionWhenLoadingToken() throws Exception {
+    void processorRetriesOnTransientExceptionWhenLoadingToken() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
             countDownLatch.countDown();
@@ -411,7 +411,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenIsStoredWhenEventIsRead() throws Exception {
+    void tokenIsStoredWhenEventIsRead() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         testSubject.registerHandlerInterceptor(((unitOfWork, interceptorChain) -> {
             unitOfWork.onCleanup(uow -> countDownLatch.countDown());
@@ -425,7 +425,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenIsExtendedAtStartAndStoredAtEndOfEventBatch_WithStoringTokensAfterProcessingSetting()
+    void tokenIsExtendedAtStartAndStoredAtEndOfEventBatch_WithStoringTokensAfterProcessingSetting()
             throws Exception {
         initProcessor(
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing().andBatchSize(100),
@@ -461,7 +461,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenStoredAtEndOfEventBatchAndNotExtendedWhenUsingANoTransactionManager() throws Exception {
+    void tokenStoredAtEndOfEventBatchAndNotExtendedWhenUsingANoTransactionManager() throws Exception {
         TrackingEventProcessorConfiguration tepConfig =
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing().andBatchSize(100);
         testSubject = TrackingEventProcessor.builder()
@@ -503,7 +503,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenStoredAtEndOfEventBatchAndNotExtendedWhenTransactionManagerIsConfigured() throws Exception {
+    void tokenStoredAtEndOfEventBatchAndNotExtendedWhenTransactionManagerIsConfigured() throws Exception {
         TrackingEventProcessorConfiguration tepConfig =
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing().andBatchSize(100);
         testSubject = TrackingEventProcessor.builder()
@@ -546,7 +546,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenStoredAtEndOfEventBatchAndExtendedWhenTokenClaimIntervalExceeded() throws Exception {
+    void tokenStoredAtEndOfEventBatchAndExtendedWhenTokenClaimIntervalExceeded() throws Exception {
         TrackingEventProcessorConfiguration tepConfig =
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
                                                    .andEventAvailabilityTimeout(10, TimeUnit.MILLISECONDS);
@@ -580,7 +580,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testTokenIsNotStoredWhenUnitOfWorkIsRolledBack() throws Exception {
+    void tokenIsNotStoredWhenUnitOfWorkIsRolledBack() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         testSubject.registerHandlerInterceptor(((unitOfWork, interceptorChain) -> {
             unitOfWork.onCommit(uow -> {
@@ -603,7 +603,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testContinueFromPreviousToken() throws Exception {
+    void continueFromPreviousToken() throws Exception {
         tokenStore = new InMemoryTokenStore();
         eventBus.publish(createEvents(10));
         TrackedEventMessage<?> firstEvent = eventBus.openStream(null).nextAvailable();
@@ -634,7 +634,7 @@ class TrackingEventProcessorTest {
     @Test
     @Timeout(value = 10)
     @DirtiesContext
-    void testContinueAfterPause() throws Exception {
+    void continueAfterPause() throws Exception {
         List<EventMessage<?>> acknowledgedEvents = new CopyOnWriteArrayList<>();
         CountDownLatch countDownLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
@@ -675,7 +675,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @DirtiesContext
-    void testProcessorGoesToRetryModeWhenOpenStreamFails() throws Exception {
+    void processorGoesToRetryModeWhenOpenStreamFails() throws Exception {
         eventBus = spy(eventBus);
 
         tokenStore = new InMemoryTokenStore();
@@ -707,7 +707,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @DirtiesContext
-    void testProcessorSetsAndUnsetsErrorState() throws Exception {
+    void processorSetsAndUnsetsErrorState() throws Exception {
         eventBus = spy(eventBus);
 
         tokenStore = new InMemoryTokenStore();
@@ -753,7 +753,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testFirstTokenIsStoredWhenUnitOfWorkIsRolledBackOnSecondEvent() throws Exception {
+    void firstTokenIsStoredWhenUnitOfWorkIsRolledBackOnSecondEvent() throws Exception {
         List<? extends EventMessage<?>> events = createEvents(2);
         CountDownLatch countDownLatch = new CountDownLatch(2);
         testSubject.registerHandlerInterceptor(((unitOfWork, interceptorChain) -> {
@@ -780,7 +780,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @DirtiesContext
-    void testEventsWithTheSameTokenAreProcessedInTheSameBatch() throws Exception {
+    void eventsWithTheSameTokenAreProcessedInTheSameBatch() throws Exception {
         eventBus.shutDown();
 
         eventBus = mock(EmbeddedEventStore.class);
@@ -823,7 +823,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetCausesEventsToBeReplayedWithCorrectContext() throws Exception {
+    void resetCausesEventsToBeReplayedWithCorrectContext() throws Exception {
         when(mockHandler.supportsReset()).thenReturn(true);
         final List<String> handled = new CopyOnWriteArrayList<>();
         final List<String> handledInRedelivery = new CopyOnWriteArrayList<>();
@@ -882,7 +882,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensPassesOnResetContextToResetHandlers() throws Exception {
+    void resetTokensPassesOnResetContextToResetHandlers() throws Exception {
         String resetContext = "reset-context";
         final List<String> handled = new CopyOnWriteArrayList<>();
 
@@ -907,7 +907,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetToPositionCausesCertainEventsToBeReplayed() throws Exception {
+    void resetToPositionCausesCertainEventsToBeReplayed() throws Exception {
         when(mockHandler.supportsReset()).thenReturn(true);
         final List<String> handled = new CopyOnWriteArrayList<>();
         final List<String> handledInRedelivery = new CopyOnWriteArrayList<>();
@@ -959,7 +959,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetOnInitializeWithTokenResetToThatToken() throws Exception {
+    void resetOnInitializeWithTokenResetToThatToken() throws Exception {
         TrackingEventProcessorConfiguration config =
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
                                                    .andInitialTrackingToken(ms -> new GlobalSequenceTrackingToken(1L));
@@ -1027,7 +1027,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetBeforeStartingPerformsANormalRun() throws Exception {
+    void resetBeforeStartingPerformsANormalRun() throws Exception {
         when(mockHandler.supportsReset()).thenReturn(true);
         final List<String> handled = new CopyOnWriteArrayList<>();
         final List<String> handledInRedelivery = new CopyOnWriteArrayList<>();
@@ -1058,7 +1058,7 @@ class TrackingEventProcessorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testReplayFlagAvailableWhenReplayInDifferentOrder() throws Exception {
+    void replayFlagAvailableWhenReplayInDifferentOrder() throws Exception {
         StreamableMessageSource<TrackedEventMessage<?>> stubSource = mock(StreamableMessageSource.class);
         testSubject = TrackingEventProcessor.builder()
                                             .name("test")
@@ -1103,27 +1103,27 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetRejectedWhileRunning() {
+    void resetRejectedWhileRunning() {
         testSubject.start();
 
         assertThrows(IllegalStateException.class, testSubject::resetTokens);
     }
 
     @Test
-    void testResetNotSupportedWhenInvokerDoesNotSupportReset() {
+    void resetNotSupportedWhenInvokerDoesNotSupportReset() {
         when(mockHandler.supportsReset()).thenReturn(false);
         assertFalse(testSubject.supportsReset());
     }
 
     @Test
-    void testResetRejectedWhenInvokerDoesNotSupportReset() {
+    void resetRejectedWhenInvokerDoesNotSupportReset() {
         when(mockHandler.supportsReset()).thenReturn(false);
 
         assertThrows(IllegalStateException.class, testSubject::resetTokens);
     }
 
     @Test
-    void testResetRejectedIfNotAllTokensCanBeClaimed() {
+    void resetRejectedIfNotAllTokensCanBeClaimed() {
         tokenStore.initializeTokenSegments("test", 4);
         when(tokenStore.fetchToken("test", 3)).thenThrow(new UnableToClaimTokenException("Mock"));
 
@@ -1132,7 +1132,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensPassesOnResetContextToTrackingToken() throws Exception {
+    void resetTokensPassesOnResetContextToTrackingToken() throws Exception {
         String resetContext = "reset-context";
         final AtomicInteger count = new AtomicInteger();
 
@@ -1192,7 +1192,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testWhenFailureDuringInit() throws InterruptedException {
+    void whenFailureDuringInit() throws InterruptedException {
         doThrow(new RuntimeException("Faking issue during fetchSegments"))
                 .doCallRealMethod()
                 .when(tokenStore).fetchSegments(anyString());
@@ -1212,7 +1212,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testUpdateActiveSegmentsWhenBatchIsEmpty() throws Exception {
+    void updateActiveSegmentsWhenBatchIsEmpty() throws Exception {
         int segmentId = 0;
         //noinspection unchecked
         StreamableMessageSource<TrackedEventMessage<?>> stubSource = mock(StreamableMessageSource.class);
@@ -1239,7 +1239,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testReleaseSegment() {
+    void releaseSegment() {
         testSubject.start();
         assertWithin(5, TimeUnit.SECONDS, () -> assertEquals(1, testSubject.activeProcessorThreads()));
         testSubject.releaseSegment(0, 2, TimeUnit.SECONDS);
@@ -1248,7 +1248,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testHasAvailableSegments() {
+    void hasAvailableSegments() {
         assertEquals(1, testSubject.availableProcessorThreads());
         testSubject.start();
         assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(0, testSubject.availableProcessorThreads()));
@@ -1258,7 +1258,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testSplitSegments() throws InterruptedException {
+    void splitSegments() throws InterruptedException {
         tokenStore.initializeTokenSegments(testSubject.getName(), 1);
         testSubject.start();
         waitForSegmentStart(0);
@@ -1269,7 +1269,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeSegments() throws InterruptedException {
+    void mergeSegments() throws InterruptedException {
         tokenStore.initializeTokenSegments(testSubject.getName(), 2);
         testSubject.start();
         while (testSubject.processingStatus().isEmpty()) {
@@ -1290,7 +1290,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeSegments_BothClaimedByProcessor() throws Exception {
+    void mergeSegments_BothClaimedByProcessor() throws Exception {
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
                                                          .andEventAvailabilityTimeout(10, TimeUnit.MILLISECONDS)
                                                          .andBatchSize(100));
@@ -1336,7 +1336,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeSegments_WithExplicitReleaseOther() throws Exception {
+    void mergeSegments_WithExplicitReleaseOther() throws Exception {
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2));
         tokenStore.initializeTokenSegments(testSubject.getName(), 2);
         List<EventMessage<?>> handledEvents = new CopyOnWriteArrayList<>();
@@ -1371,7 +1371,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testDoubleSplitAndMerge() throws Exception {
+    void doubleSplitAndMerge() throws Exception {
         tokenStore.initializeTokenSegments(testSubject.getName(), 1);
         List<EventMessage<?>> handledEvents = new CopyOnWriteArrayList<>();
         int segmentId = 0;
@@ -1418,7 +1418,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeSegmentWithDifferentProcessingGroupsAndSequencingPolicies() throws Exception {
+    void mergeSegmentWithDifferentProcessingGroupsAndSequencingPolicies() throws Exception {
         EventMessageHandler otherHandler = mock(EventMessageHandler.class);
         when(otherHandler.canHandle(any())).thenReturn(true);
         when(otherHandler.supportsReset()).thenReturn(true);
@@ -1472,7 +1472,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeSegmentsDuringReplay() throws Exception {
+    void mergeSegmentsDuringReplay() throws Exception {
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2));
         tokenStore.initializeTokenSegments(testSubject.getName(), 2);
         List<EventMessage<?>> handledEvents = new CopyOnWriteArrayList<>();
@@ -1524,7 +1524,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testReplayDuringIncompleteMerge() throws Exception {
+    void replayDuringIncompleteMerge() throws Exception {
         int segmentIdZero = 0;
         int segmentIdOne = 1;
         List<EventMessage<?>> handledEvents = new CopyOnWriteArrayList<>();
@@ -1583,7 +1583,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeWithIncompatibleSegmentRejected() throws InterruptedException {
+    void mergeWithIncompatibleSegmentRejected() throws InterruptedException {
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(3));
 
         testSubject.start();
@@ -1609,7 +1609,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 10)
-    void testMergeWithSingleSegmentRejected() throws InterruptedException {
+    void mergeWithSingleSegmentRejected() throws InterruptedException {
         int numberOfSegments = 1;
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(numberOfSegments));
         int segmentId = 0;
@@ -1628,7 +1628,7 @@ class TrackingEventProcessorTest {
      */
     @Test
     @Timeout(value = 10)
-    void testMergeInvertedSegmentOrder() throws InterruptedException {
+    void mergeInvertedSegmentOrder() throws InterruptedException {
         int numberOfSegments = 4;
         initProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(numberOfSegments));
         testSubject.start();
@@ -1644,7 +1644,7 @@ class TrackingEventProcessorTest {
      * This test is a follow-up from issue https://github.com/AxonFramework/AxonFramework/issues/1212
      */
     @Test
-    void testThrownErrorBubblesUp() {
+    void thrownErrorBubblesUp() {
         AtomicReference<Throwable> thrownException = new AtomicReference<>();
 
         EventHandlerInvoker eventHandlerInvoker = mock(EventHandlerInvoker.class);
@@ -1701,7 +1701,7 @@ class TrackingEventProcessorTest {
      * boolean} field updates are included as changes.
      */
     @Test
-    void testPublishedEventsUpdateStatusAndHitChangeListener() throws Exception {
+    void publishedEventsUpdateStatusAndHitChangeListener() throws Exception {
         CountDownLatch eventHandlingLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             eventHandlingLatch.countDown();
@@ -1756,7 +1756,7 @@ class TrackingEventProcessorTest {
      * </ol>
      */
     @Test
-    void testPublishedEventsUpdateStatusAndHitChangeListenerIncludingPositions() throws Exception {
+    void publishedEventsUpdateStatusAndHitChangeListenerIncludingPositions() throws Exception {
         CountDownLatch eventHandlingLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             eventHandlingLatch.countDown();
@@ -1807,7 +1807,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 15)
-    void testSplitAndMergeInfluenceOnChangeListenerInvocations() throws InterruptedException {
+    void splitAndMergeInfluenceOnChangeListenerInvocations() throws InterruptedException {
         int firstSegment = 0;
         int secondSegment = 1;
 
@@ -1857,7 +1857,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testCaughtUpSetToTrueAfterWaitingForEventAvailabilityTimeout() {
+    void caughtUpSetToTrueAfterWaitingForEventAvailabilityTimeout() {
         AtomicBoolean hasNextInvoked = new AtomicBoolean(false);
         AtomicBoolean hasNextAvailableTimedOut = new AtomicBoolean(true);
         // Set up two threads and one segment, to provide more "space" for assertions.
@@ -1916,7 +1916,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testRefuseStartDuringShutdown() throws Exception {
+    void refuseStartDuringShutdown() throws Exception {
         initProcessor(TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
                                                          .andEventAvailabilityTimeout(1000, TimeUnit.MILLISECONDS));
         CountDownLatch cdl = new CountDownLatch(1);
@@ -1938,7 +1938,7 @@ class TrackingEventProcessorTest {
 
     @Test
     @Timeout(value = 1000)
-    void testIsReplayingWhenNotCaughtUp() throws Exception {
+    void isReplayingWhenNotCaughtUp() throws Exception {
         when(mockHandler.supportsReset()).thenReturn(true);
 
         final List<String> handled = new CopyOnWriteArrayList<>();
@@ -1999,7 +1999,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testProcessorOnlyTriesToClaimAvailableSegments() {
+    void processorOnlyTriesToClaimAvailableSegments() {
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 2);
@@ -2018,7 +2018,7 @@ class TrackingEventProcessorTest {
     }
 
     @Test
-    void testShutdownTerminatesWorkersAfterConfiguredWorkerTerminationTimeout() throws Exception {
+    void shutdownTerminatesWorkersAfterConfiguredWorkerTerminationTimeout() throws Exception {
         int testWorkerTerminationTimeout = 50;
         List<Thread> createdThreads = new CopyOnWriteArrayList<>();
         // A higher event availability timeout will block a worker thread that should shut down

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest_MultiThreaded.java
@@ -94,7 +94,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorWorkerCount() {
+    void processorWorkerCount() {
         testSubject.start();
         // give it some time to split segments from the store and submit to executor service.
         assertWithin(1, SECONDS, () -> assertEquals(2, testSubject.activeProcessorThreads()));
@@ -106,7 +106,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorInitializesMoreTokensThanWorkerCount() throws InterruptedException {
+    void processorInitializesMoreTokensThanWorkerCount() throws InterruptedException {
         configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
                                                               .andInitialSegmentsCount(4));
         testSubject.start();
@@ -120,7 +120,7 @@ class TrackingEventProcessorTest_MultiThreaded {
 
     // Reproduce issue #508 (https://github.com/AxonFramework/AxonFramework/issues/508)
     @Test
-    void testProcessorInitializesAndUsesSameTokens() {
+    void processorInitializesAndUsesSameTokens() {
         configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(6)
                                                               .andInitialSegmentsCount(6));
         testSubject.start();
@@ -132,7 +132,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorWorkerCountWithMultipleSegments() {
+    void processorWorkerCountWithMultipleSegments() {
 
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
@@ -159,7 +159,7 @@ class TrackingEventProcessorTest_MultiThreaded {
      * This processor won't be able to handle any segments, as claiming a segment will fail.
      */
     @Test
-    void testProcessorWorkerCountWithMultipleSegmentsClaimFails() throws InterruptedException {
+    void processorWorkerCountWithMultipleSegmentsClaimFails() throws InterruptedException {
 
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
@@ -178,7 +178,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorClaimsSegment() {
+    void processorClaimsSegment() {
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
 
@@ -192,7 +192,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testBlacklistingSegmentWillHaveProcessorClaimAnotherOne() {
+    void blacklistingSegmentWillHaveProcessorClaimAnotherOne() {
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 2);
@@ -211,7 +211,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorWorkerCountWithMultipleSegmentsWithOneThread() throws InterruptedException {
+    void processorWorkerCountWithMultipleSegmentsWithOneThread() throws InterruptedException {
 
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
@@ -225,7 +225,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadSegmentsExceedsWorkerCount() throws Exception {
+    void multiThreadSegmentsExceedsWorkerCount() throws Exception {
         configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
                                                               .andInitialSegmentsCount(4));
 
@@ -247,7 +247,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadPublishedEventsGetPassedToHandler() throws Exception {
+    void multiThreadPublishedEventsGetPassedToHandler() throws Exception {
         CountDownLatch countDownLatch = new CountDownLatch(2);
         final AcknowledgeByThread acknowledgeByThread = new AcknowledgeByThread();
         doAnswer(invocation -> {
@@ -263,7 +263,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadTokenIsStoredWhenEventIsRead() throws Exception {
+    void multiThreadTokenIsStoredWhenEventIsRead() throws Exception {
 
         CountDownLatch countDownLatch = new CountDownLatch(2);
         testSubject.registerHandlerInterceptor(((unitOfWork, interceptorChain) -> {
@@ -279,7 +279,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadContinueFromPreviousToken() throws Exception {
+    void multiThreadContinueFromPreviousToken() throws Exception {
 
         tokenStore = spy(new InMemoryTokenStore());
         eventBus.publish(createEvents(10));
@@ -308,7 +308,7 @@ class TrackingEventProcessorTest_MultiThreaded {
 
     @Test
     @Timeout(value = 10)
-    void testMultiThreadContinueAfterPause() throws Exception {
+    void multiThreadContinueAfterPause() throws Exception {
 
         final AcknowledgeByThread acknowledgeByThread = new AcknowledgeByThread();
 
@@ -369,7 +369,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadProcessorGoesToRetryModeWhenOpenStreamFails() throws Exception {
+    void multiThreadProcessorGoesToRetryModeWhenOpenStreamFails() throws Exception {
         eventBus = spy(eventBus);
 
         tokenStore = new InMemoryTokenStore();
@@ -398,7 +398,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testMultiThreadTokensAreStoredWhenUnitOfWorkIsRolledBackOnSecondEvent() throws Exception {
+    void multiThreadTokensAreStoredWhenUnitOfWorkIsRolledBackOnSecondEvent() throws Exception {
         List<? extends EventMessage<?>> events = createEvents(2);
         CountDownLatch countDownLatch = new CountDownLatch(2);
         //noinspection Duplicates
@@ -423,7 +423,7 @@ class TrackingEventProcessorTest_MultiThreaded {
     }
 
     @Test
-    void testProcessorIncrementAndDecrementCorrectly() throws InterruptedException {
+    void processorIncrementAndDecrementCorrectly() throws InterruptedException {
         configureProcessor(TrackingEventProcessorConfiguration.forParallelProcessing(2)
                                                               .andInitialSegmentsCount(4));
         testSubject.start();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/NestedUnitOfWorkTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/NestedUnitOfWorkTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class NestedUnitOfWorkTest {
     @Test
-    void testStagedEventsLoadInCorrectOrder() {
+    void stagedEventsLoadInCorrectOrder() {
         Configuration config = DefaultConfigurer.defaultConfiguration()
                                                 .configureAggregate(TestAggregate.class)
                                                 .registerCommandHandler(x -> new Handler())

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/conflictresolution/ConflictResolutionIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/conflictresolution/ConflictResolutionIntegrationTest.java
@@ -51,14 +51,14 @@ public class ConflictResolutionIntegrationTest {
     }
 
     @Test
-    void testNonConflictingEventsAllowed() {
+    void nonConflictingEventsAllowed() {
         commandGateway.sendAndWait(new CreateCommand("1234"));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update1", 0L));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update2", 0L));
     }
 
     @Test
-    void testUnresolvedConflictCausesException() {
+    void unresolvedConflictCausesException() {
         commandGateway.sendAndWait(new CreateCommand("1234"));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update1", 0L));
         assertThrows(
@@ -68,7 +68,7 @@ public class ConflictResolutionIntegrationTest {
     }
 
     @Test
-    void testExpressedConflictCausesException() {
+    void expressedConflictCausesException() {
         commandGateway.sendAndWait(new CreateCommand("1234"));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update1", 0L));
         assertThrows(
@@ -78,7 +78,7 @@ public class ConflictResolutionIntegrationTest {
     }
 
     @Test
-    void testNoExpectedVersionIgnoresConflicts() {
+    void noExpectedVersionIgnoresConflicts() {
         commandGateway.sendAndWait(new CreateCommand("1234"));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update1", 0L));
         commandGateway.sendAndWait(new UpdateCommand("1234", "update1", null));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jdbc/Oracle11EventTableFactoryTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jdbc/Oracle11EventTableFactoryTest.java
@@ -67,7 +67,7 @@ class Oracle11EventTableFactoryTest {
     }
 
     @Test
-    void testCreateDomainEventTable() throws Exception {
+    void createDomainEventTable() throws Exception {
         // test passes if no exception is thrown
         testSubject.createDomainEventTable(connection, eventSchema)
                    .execute();
@@ -81,7 +81,7 @@ class Oracle11EventTableFactoryTest {
     }
 
     @Test
-    void testCreateSnapshotEventTable() throws Exception {
+    void createSnapshotEventTable() throws Exception {
         // test passes if no exception is thrown
         testSubject.createSnapshotEventTable(connection, eventSchema)
                    .execute();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/NestedUowRollbackTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/NestedUowRollbackTest.java
@@ -31,7 +31,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 class NestedUowRollbackTest {
 
     @Test
-    void testDispatchCommand() {
+    void dispatchCommand() {
         Configuration c = DefaultConfigurer.defaultConfiguration()
                                            .configureAggregate(TestAggregate.class)
                                            .registerCommandHandler(x -> new Handler())

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/SynchronousLoopbackTest.java
@@ -102,7 +102,7 @@ public class SynchronousLoopbackTest {
     }
 
     @Test
-    void testLoopBackKeepsProperEventOrder_PessimisticLocking() {
+    void loopBackKeepsProperEventOrder_PessimisticLocking() {
         initializeRepository(PessimisticLockFactory.usingDefaults());
         EventMessageHandler eventHandler = event -> {
             DomainEventMessage domainEvent = (DomainEventMessage) event;
@@ -146,7 +146,7 @@ public class SynchronousLoopbackTest {
     }
 
     @Test
-    void testLoopBackKeepsProperEventOrder_PessimisticLocking_ProcessingFails() {
+    void loopBackKeepsProperEventOrder_PessimisticLocking_ProcessingFails() {
         initializeRepository(PessimisticLockFactory.usingDefaults());
         EventMessageHandler eventHandler = event -> {
             DomainEventMessage domainEvent = (DomainEventMessage) event;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlerInterceptorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlerInterceptorTest.java
@@ -75,7 +75,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptor() {
+    void interceptor() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         String result = commandGateway
                 .sendAndWait(asCommandMessage(new UpdateMyAggregateStateCommand("id", "state")));
@@ -94,7 +94,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptorWithChainProceeding() {
+    void interceptorWithChainProceeding() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         commandGateway.sendAndWait(asCommandMessage(new ClearMyAggregateStateCommand("id", true)));
 
@@ -108,7 +108,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptorWithoutChainProceeding() {
+    void interceptorWithoutChainProceeding() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         commandGateway.sendAndWait(asCommandMessage(new ClearMyAggregateStateCommand("id", false)));
 
@@ -120,7 +120,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptorWithNestedEntity() {
+    void interceptorWithNestedEntity() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         commandGateway.sendAndWait(asCommandMessage(new MyNestedCommand("id", "state")));
 
@@ -136,7 +136,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptorWithNestedNestedEntity() {
+    void interceptorWithNestedNestedEntity() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         commandGateway.sendAndWait(asCommandMessage(new MyNestedNestedCommand("id", "state")));
 
@@ -156,7 +156,7 @@ class CommandHandlerInterceptorTest {
     }
 
     @Test
-    void testInterceptorWithNonVoidReturnType() {
+    void interceptorWithNonVoidReturnType() {
         EventSourcingRepository.Builder<MyAggregateWithInterceptorReturningNonVoid> builder =
                 EventSourcingRepository.builder(MyAggregateWithInterceptorReturningNonVoid.class)
                         .eventStore(eventStore);
@@ -165,7 +165,7 @@ class CommandHandlerInterceptorTest {
     }
 
     @Test
-    void testInterceptorWithDeclaredChainAllowedToDeclareNonVoidReturnType() {
+    void interceptorWithDeclaredChainAllowedToDeclareNonVoidReturnType() {
         EventSourcingRepository.builder(MyAggregateWithDeclaredInterceptorChainInterceptorReturningNonVoid.class)
                 .eventStore(eventStore)
                 .build();
@@ -173,7 +173,7 @@ class CommandHandlerInterceptorTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInterceptorThrowingAnException() {
+    void interceptorThrowingAnException() {
         commandGateway.sendAndWait(asCommandMessage(new CreateMyAggregateCommand("id")));
         assertThrows(
                 InterceptorException.class,

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
@@ -57,7 +57,7 @@ class CommandHandlingTest {
     }
 
     @Test
-    void testCommandHandlerLoadsSameAggregateTwice() throws Exception {
+    void commandHandlerLoadsSameAggregateTwice() throws Exception {
         DefaultUnitOfWork.startAndGet(null);
         repository.newInstance(() -> new StubAggregate(aggregateIdentifier)).execute(StubAggregate::doSomething);
         CurrentUnitOfWork.commit();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/ComplexAggregateStructureTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/ComplexAggregateStructureTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ComplexAggregateStructureTest {
 
     @Test
-    void testCommandsAreRoutedToCorrectEntity() throws Exception {
+    void commandsAreRoutedToCorrectEntity() throws Exception {
         AggregateModel<Book> bookAggregateModel = AnnotatedAggregateMetaModelFactory.inspectAggregate(Book.class);
         EventBus mockEventBus = SimpleEventBus.builder().build();
         AnnotatedAggregate<Book> bookAggregate = AnnotatedAggregate.initialize(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/saga/repository/jdbc/Oracle11SagaSqlSchemaTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/saga/repository/jdbc/Oracle11SagaSqlSchemaTest.java
@@ -67,7 +67,7 @@ class Oracle11SagaSqlSchemaTest {
     }
 
     @Test
-    void testSql_createTableAssocValueEntry() throws Exception {
+    void sql_createTableAssocValueEntry() throws Exception {
         // test passes if no exception is thrown
         testSubject.sql_createTableAssocValueEntry(connection)
                    .execute();
@@ -81,7 +81,7 @@ class Oracle11SagaSqlSchemaTest {
     }
 
     @Test
-    void testSql_createTableSagaEntry() throws Exception {
+    void sql_createTableSagaEntry() throws Exception {
         // test passes if no exception is thrown
         testSubject.sql_createTableSagaEntry(connection)
                    .execute();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
@@ -104,7 +104,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     public abstract QueryUpdateEmitter queryUpdateEmitter();
 
     @Test
-    void testEmittingAnUpdate() {
+    void emittingAnUpdate() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage1 = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -159,7 +159,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testEmittingNullUpdate() {
+    void emittingNullUpdate() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -184,7 +184,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testEmittingUpdateInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
+    void emittingUpdateInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
         String testQueryPayload = TEST_PAYLOAD;
         String testQueryName = "chatMessages";
         String testUpdate = "some-update";
@@ -219,7 +219,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testCompletingSubscriptionQueryExceptionally() {
+    void completingSubscriptionQueryExceptionally() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -251,7 +251,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
     @Deprecated
     @Test
-    void testCompletingSubscriptionQueryExceptionallyDeprecated() {
+    void completingSubscriptionQueryExceptionallyDeprecated() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -283,7 +283,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testCompletingSubscriptionQueryExceptionallyWhenOneOfSubscriptionFails() {
+    void completingSubscriptionQueryExceptionallyWhenOneOfSubscriptionFails() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage1 = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -322,7 +322,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testCompletingSubscriptionExceptionallyInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
+    void completingSubscriptionExceptionallyInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
         String testQueryPayload = TEST_PAYLOAD;
         String testQueryName = "chatMessages";
         String testUpdate = "some-update";
@@ -360,7 +360,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testCompletingSubscriptionQuery() {
+    void completingSubscriptionQuery() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -388,7 +388,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testCompletingSubscriptionInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
+    void completingSubscriptionInUnitOfWorkLifecycleRunsUpdatesOnAfterCommit() {
         String testQueryPayload = TEST_PAYLOAD;
         String testQueryName = "chatMessages";
         String testUpdate = "some-update";
@@ -425,7 +425,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testOrderingOfOperationOnUpdateHandler() {
+    void orderingOfOperationOnUpdateHandler() {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -450,7 +450,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscribingQueryHandlerFailing() {
+    void subscribingQueryHandlerFailing() {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -474,7 +474,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSeveralSubscriptions() {
+    void severalSubscriptions() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -543,7 +543,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
     @Deprecated
     @Test
-    void testSeveralSubscriptionsDeprecated() {
+    void severalSubscriptionsDeprecated() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -612,7 +612,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testDoubleSubscriptionMessage() {
+    void doubleSubscriptionMessage() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -628,7 +628,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testReplayBufferOverflow() {
+    void replayBufferOverflow() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
                 "chatMessages",
@@ -665,7 +665,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testOnBackpressureError() {
+    void onBackpressureError() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
                 "chatMessages",
@@ -696,7 +696,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionDisposal() {
+    void subscriptionDisposal() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
                 "chatMessages",
@@ -717,7 +717,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryWithInterceptors() {
+    void subscriptionQueryWithInterceptors() {
         // given
         List<String> interceptedResponse = Arrays.asList("fakeReply1", "fakeReply2");
         queryBus.registerDispatchInterceptor(
@@ -747,7 +747,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryUpdateWithInterceptors() {
+    void subscriptionQueryUpdateWithInterceptors() {
         // given
         Map<String, String> metaData = Collections.singletonMap("key", "value");
         queryUpdateEmitter.registerDispatchInterceptor(
@@ -774,7 +774,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testActiveSubscriptions() {
+    void activeSubscriptions() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage1 = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -801,7 +801,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandle() throws InterruptedException {
+    void subscriptionQueryResultHandle() throws InterruptedException {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -830,7 +830,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnInitialResult()
+    void subscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnInitialResult()
             throws InterruptedException {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
@@ -862,7 +862,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
     @Deprecated
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnUpdateDeprecated() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnUpdateDeprecated() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -892,7 +892,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
     @Deprecated
     @Test
-    void testBufferOverflowDeprecated() {
+    void bufferOverflowDeprecated() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
                 "chatMessages",
@@ -921,7 +921,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
     @Deprecated
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorConsumingABufferedUpdateDeprecated() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorConsumingABufferedUpdateDeprecated() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -953,7 +953,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnUpdate() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorConsumingAnUpdate() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -982,7 +982,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorConsumingABufferedUpdate() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorConsumingABufferedUpdate() {
         // given
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -1014,7 +1014,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorOnInitialResult() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorOnInitialResult() {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -1038,7 +1038,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testSubscriptionQueryResultHandleWhenThereIsAnErrorOnUpdate() {
+    void subscriptionQueryResultHandleWhenThereIsAnErrorOnUpdate() {
         // given
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 TEST_PAYLOAD,
@@ -1061,7 +1061,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testQueryGatewayCorrectlyReturnsNullOnSubscriptionQueryWithNullInitialResult()
+    void queryGatewayCorrectlyReturnsNullOnSubscriptionQueryWithNullInitialResult()
             throws ExecutionException, InterruptedException {
         QueryGateway queryGateway = DefaultQueryGateway.builder().queryBus(queryBus).build();
 
@@ -1071,7 +1071,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
     }
 
     @Test
-    void testQueryGatewayCorrectlyReturnsOnSubscriptionQuery() throws ExecutionException, InterruptedException {
+    void queryGatewayCorrectlyReturnsOnSubscriptionQuery() throws ExecutionException, InterruptedException {
         QueryGateway queryGateway = DefaultQueryGateway.builder().queryBus(queryBus).build();
         String result = queryGateway.subscriptionQuery(new SomeQuery(FOUND), String.class, String.class)
                                     .initialResult()

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryEventHandlingTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryEventHandlingTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 class QueryEventHandlingTest {
 
     @Test
-    void testQueryHandlerAndEventHandlerCleanlyShutdown() {
+    void queryHandlerAndEventHandlerCleanlyShutdown() {
         UserSummaryProjection userSummaryProjection = new UserSummaryProjection();
 
         Configurer configurer = DefaultConfigurer.defaultConfiguration();

--- a/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/commandhandling/model/AggregateScopeDescriptorTest.java
@@ -40,7 +40,7 @@ class AggregateScopeDescriptorTest {
     private static final String AGGREGATE_ID = "aggregate-id";
 
     @Test
-    void testXStreamSerializationOfOldAggregateScopeDescriptor() {
+    void xStreamSerializationOfOldAggregateScopeDescriptor() {
         XStreamSerializer serializer = TestSerializer.xStreamSerializer();
 
         String xmlSerializedScopeDescriptor =
@@ -63,7 +63,7 @@ class AggregateScopeDescriptorTest {
     }
 
     @Test
-    void testJacksonSerializationOfOldAggregateScopeDescriptor() {
+    void jacksonSerializationOfOldAggregateScopeDescriptor() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedScopeDescriptor =

--- a/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
+++ b/legacy/src/test/java/org/axonframework/eventhandling/saga/SagaScopeDescriptorTest.java
@@ -41,7 +41,7 @@ class SagaScopeDescriptorTest {
     private static final String SAGA_ID = "saga-id";
 
     @Test
-    void testXStreamSerializationOfOldSagaScopeDescriptor() {
+    void xStreamSerializationOfOldSagaScopeDescriptor() {
         XStreamSerializer serializer = TestSerializer.xStreamSerializer();
 
         String xmlSerializedScopeDescriptor =
@@ -59,7 +59,7 @@ class SagaScopeDescriptorTest {
     }
 
     @Test
-    void testJacksonSerializationOfOldSagaScopeDescriptor() {
+    void jacksonSerializationOfOldSagaScopeDescriptor() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedScopeDescriptor =

--- a/legacy/src/test/java/org/axonframework/eventhandling/scheduling/quartz/LegacyAwareJobDataBinderTest.java
+++ b/legacy/src/test/java/org/axonframework/eventhandling/scheduling/quartz/LegacyAwareJobDataBinderTest.java
@@ -36,7 +36,7 @@ class LegacyAwareJobDataBinderTest {
     }
 
     @Test
-    void testReadLegacyInstance() {
+    void readLegacyInstance() {
         JobDataMap legacyJobDataMap = mock(JobDataMap.class);
         when(legacyJobDataMap.get("org.axonframework.domain.EventMessage")).thenAnswer(
                 i -> {
@@ -56,7 +56,7 @@ class LegacyAwareJobDataBinderTest {
     }
 
     @Test
-    void testReadRecentInstance() {
+    void readRecentInstance() {
         JobDataMap legacyJobDataMap = mock(JobDataMap.class);
         when(legacyJobDataMap.get(EventMessage.class.getName())).thenReturn(new GenericEventMessage<>("new"));
 

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GapAwareTrackingTokenTest.java
@@ -46,7 +46,7 @@ class GapAwareTrackingTokenTest {
     private static final List<Long> TOKEN_GAPS = Stream.of(0L, 25L, 58L).collect(Collectors.toList());
 
     @Test
-    void testXStreamSerializationOfOldGapAwareTrackingToken() {
+    void xStreamSerializationOfOldGapAwareTrackingToken() {
         XStreamSerializer serializer = TestSerializer.xStreamSerializer();
 
         String xmlSerializedGapAwareTrackingToken =
@@ -79,7 +79,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testJacksonSerializationOfOldGapAwareTrackingToken() {
+    void jacksonSerializationOfOldGapAwareTrackingToken() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedGapAwareTrackingToken =

--- a/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
+++ b/legacy/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalSequenceTrackingTokenTest.java
@@ -40,7 +40,7 @@ class GlobalSequenceTrackingTokenTest {
     private static final int GLOBAL_INDEX = 10;
 
     @Test
-    void testXStreamSerializationOfOldGlobalSequenceTrackingToken() {
+    void xStreamSerializationOfOldGlobalSequenceTrackingToken() {
         XStreamSerializer serializer = TestSerializer.xStreamSerializer();
 
         String xmlSerializedGlobalSequenceTrackingToken =
@@ -57,7 +57,7 @@ class GlobalSequenceTrackingTokenTest {
     }
 
     @Test
-    void testJacksonSerializationOfOldGlobalSequenceTrackingToken() {
+    void jacksonSerializationOfOldGlobalSequenceTrackingToken() {
         JacksonSerializer serializer = JacksonSerializer.defaultSerializer();
 
         String jacksonSerializedGlobalSequenceTrackingToken =

--- a/messaging/src/test/java/org/axonframework/commandhandling/AnnotationCommandHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/AnnotationCommandHandlerAdapterTest.java
@@ -66,7 +66,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testHandlerDispatching_VoidReturnType() throws Exception {
+    void handlerDispatching_VoidReturnType() throws Exception {
         Object actualReturnValue = testSubject.handle(GenericCommandMessage.asCommandMessage(""));
         assertNull(actualReturnValue);
         assertEquals(1, mockTarget.voidHandlerInvoked);
@@ -74,7 +74,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testHandlerDispatching_WithReturnType() throws Exception {
+    void handlerDispatching_WithReturnType() throws Exception {
         Object actualReturnValue = testSubject.handle(GenericCommandMessage.asCommandMessage(1L));
         assertEquals(1L, actualReturnValue);
         assertEquals(0, mockTarget.voidHandlerInvoked);
@@ -82,7 +82,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testHandlerDispatching_WithCustomCommandName() throws Exception {
+    void handlerDispatching_WithCustomCommandName() throws Exception {
         Object actualReturnValue = testSubject.handle(new GenericCommandMessage<>(new GenericMessage<>(1L), "almostLong"));
         assertEquals(1L, actualReturnValue);
         assertEquals(0, mockTarget.voidHandlerInvoked);
@@ -91,7 +91,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testHandlerDispatching_ThrowingException() {
+    void handlerDispatching_ThrowingException() {
         try {
             testSubject.handle(GenericCommandMessage.asCommandMessage(new HashSet()));
             fail("Expected exception");
@@ -103,7 +103,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testSubscribe() {
+    void subscribe() {
         testSubject.subscribe(mockBus);
 
         verify(mockBus).subscribe(Long.class.getName(), testSubject);
@@ -115,7 +115,7 @@ class AnnotationCommandHandlerAdapterTest {
     }
 
     @Test
-    void testHandle_NoHandlerForCommand() throws Exception {
+    void handle_NoHandlerForCommand() throws Exception {
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage(new LinkedList<>());
 
         assertThrows(NoHandlerForCommandException.class, () -> testSubject.handle(command));

--- a/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
@@ -65,7 +65,7 @@ class AsynchronousCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testDispatchWithCallback() throws Exception {
+    void dispatchWithCallback() throws Exception {
         testSubject.subscribe(Object.class.getName(), commandHandler);
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         CommandMessage<Object> command = asCommandMessage(new Object());
@@ -90,7 +90,7 @@ class AsynchronousCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testDispatchWithoutCallback() throws Exception {
+    void dispatchWithoutCallback() throws Exception {
         MessageHandler<CommandMessage<?>> commandHandler = mock(MessageHandler.class);
         testSubject.subscribe(Object.class.getName(), commandHandler);
         testSubject.dispatch(asCommandMessage(new Object()), NoOpCallback.INSTANCE);
@@ -103,7 +103,7 @@ class AsynchronousCommandBusTest {
     }
 
     @Test
-    void testShutdown_ExecutorServiceUsed() {
+    void shutdown_ExecutorServiceUsed() {
         testSubject.shutdown();
 
         verify(executorService).shutdown();
@@ -111,7 +111,7 @@ class AsynchronousCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testExceptionIsThrownWhenNoHandlerIsRegistered() {
+    void exceptionIsThrownWhenNoHandlerIsRegistered() {
         CommandCallback<Object, Object> callback = mock(CommandCallback.class);
         CommandMessage<Object> command = asCommandMessage("test");
         testSubject.dispatch(command, callback);
@@ -125,7 +125,7 @@ class AsynchronousCommandBusTest {
     }
 
     @Test
-    void testShutdown_ExecutorUsed() {
+    void shutdown_ExecutorUsed() {
         Executor executor = mock(Executor.class);
         AsynchronousCommandBus.builder().executor(executor).build().shutdown();
 

--- a/messaging/src/test/java/org/axonframework/commandhandling/CurrentUnitOfWorkParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/CurrentUnitOfWorkParameterResolverFactoryTest.java
@@ -49,7 +49,7 @@ class CurrentUnitOfWorkParameterResolverFactoryTest {
     }
 
     @Test
-    void testCreateInstance() throws Exception {
+    void createInstance() throws Exception {
         Method someMethod = getClass().getMethod("someMethod", UnitOfWork.class);
 
         assertNull(testSubject.createInstance(method, method.getParameters(), 0));
@@ -57,7 +57,7 @@ class CurrentUnitOfWorkParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolveParameterValue() {
+    void resolveParameterValue() {
         DefaultUnitOfWork.startAndGet(null);
         try {
             assertSame(CurrentUnitOfWork.get(), testSubject.resolveParameterValue(mock(GenericCommandMessage.class)));
@@ -67,12 +67,12 @@ class CurrentUnitOfWorkParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolveParameterValueWithoutActiveUnitOfWork() {
+    void resolveParameterValueWithoutActiveUnitOfWork() {
         assertNull(testSubject.resolveParameterValue(mock(GenericCommandMessage.class)));
     }
 
     @Test
-    void testMatches() {
+    void matches() {
         assertTrue(testSubject.matches(mock(GenericCommandMessage.class)));
         DefaultUnitOfWork.startAndGet(null);
         try {

--- a/messaging/src/test/java/org/axonframework/commandhandling/DuplicateCommandHandlerResolutionTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/DuplicateCommandHandlerResolutionTest.java
@@ -44,7 +44,7 @@ class DuplicateCommandHandlerResolutionTest {
     }
 
     @Test
-    void testLogAndOverride() {
+    void logAndOverride() {
         DuplicateCommandHandlerResolver testSubject = DuplicateCommandHandlerResolution.logAndOverride();
 
         MessageHandler<? super CommandMessage<?>> result = testSubject.resolve("test", initialHandler, duplicateHandler);
@@ -53,7 +53,7 @@ class DuplicateCommandHandlerResolutionTest {
     }
 
     @Test
-    void testSilentlyOverride() {
+    void silentlyOverride() {
         DuplicateCommandHandlerResolver testSubject = DuplicateCommandHandlerResolution.silentOverride();
 
         MessageHandler<? super CommandMessage<?>> result = testSubject.resolve("test", initialHandler, duplicateHandler);
@@ -62,7 +62,7 @@ class DuplicateCommandHandlerResolutionTest {
     }
 
     @Test
-    void testDuplicateHandlersRejected() {
+    void duplicateHandlersRejected() {
         DuplicateCommandHandlerResolver testSubject =
                 DuplicateCommandHandlerResolution.rejectDuplicates();
 

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericCommandMessageTest {
 
     @Test
-    void testConstructor() {
+    void constructor() {
         Object payload = new Object();
         CommandMessage<Object> message1 = asCommandMessage(payload);
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
@@ -62,7 +62,7 @@ class GenericCommandMessageTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         Object payload = new Object();
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
@@ -76,7 +76,7 @@ class GenericCommandMessageTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         Object payload = new Object();
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
@@ -102,7 +102,7 @@ class GenericCommandMessageTest {
     }
 
     @Test
-    void testAsCommandMessageWrapsPayload() {
+    void asCommandMessageWrapsPayload() {
         String expectedPayload = "some-payload";
 
         CommandMessage<Object> result = asCommandMessage(expectedPayload);
@@ -115,7 +115,7 @@ class GenericCommandMessageTest {
     }
 
     @Test
-    void testAsCommandMessageReturnsCommandMessageAsIs() {
+    void asCommandMessageReturnsCommandMessageAsIs() {
         CommandMessage<String> expected = new GenericCommandMessage<>("some-payload", MetaData.with("key", "value"));
 
         CommandMessage<Object> result = asCommandMessage(expected);
@@ -124,7 +124,7 @@ class GenericCommandMessageTest {
     }
 
     @Test
-    void testAsCommandMessageRetrievesPayloadAndMetaDataFromMessageImplementations() {
+    void asCommandMessageRetrievesPayloadAndMetaDataFromMessageImplementations() {
         String expectedPayload = "some-payload";
         MetaData expectedMetaData = MetaData.with("key", "value");
 

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -58,7 +58,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testDispatchCommandHandlerSubscribed() {
+    void dispatchCommandHandlerSubscribed() {
         testSubject.subscribe(String.class.getName(), new MyStringCommandHandler());
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
@@ -72,7 +72,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testDispatchCommandImplicitUnitOfWorkIsCommittedOnReturnValue() {
+    void dispatchCommandImplicitUnitOfWorkIsCommittedOnReturnValue() {
         final AtomicReference<UnitOfWork<?>> unitOfWork = new AtomicReference<>();
         testSubject.subscribe(String.class.getName(), command -> {
             unitOfWork.set(CurrentUnitOfWork.get());
@@ -95,7 +95,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testFireAndForgetUsesDefaultCallback() {
+    void fireAndForgetUsesDefaultCallback() {
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         testSubject = SimpleCommandBus.builder()
                                       .defaultCommandCallback(mockCallback).build();
@@ -109,7 +109,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testDispatchCommandImplicitUnitOfWorkIsRolledBackOnException() {
+    void dispatchCommandImplicitUnitOfWorkIsRolledBackOnException() {
         final AtomicReference<UnitOfWork<?>> unitOfWork = new AtomicReference<>();
         testSubject.subscribe(String.class.getName(), command -> {
             unitOfWork.set(CurrentUnitOfWork.get());
@@ -130,7 +130,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testDispatchCommandUnitOfWorkIsCommittedOnCheckedException() {
+    void dispatchCommandUnitOfWorkIsCommittedOnCheckedException() {
         final AtomicReference<UnitOfWork<?>> unitOfWork = new AtomicReference<>();
         testSubject.subscribe(String.class.getName(), command -> {
             unitOfWork.set(CurrentUnitOfWork.get());
@@ -153,7 +153,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testDispatchCommandNoHandlerSubscribed() {
+    void dispatchCommandNoHandlerSubscribed() {
         CommandMessage<Object> command = asCommandMessage("test");
         CommandCallback callback = mock(CommandCallback.class);
         testSubject.dispatch(command, callback);
@@ -167,7 +167,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testDispatchCommandHandlerUnsubscribed() {
+    void dispatchCommandHandlerUnsubscribed() {
         MyStringCommandHandler commandHandler = new MyStringCommandHandler();
         Registration subscription = testSubject.subscribe(String.class.getName(), commandHandler);
         subscription.close();
@@ -184,7 +184,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testDispatchCommandNoHandlerSubscribedCallsMonitorCallbackIgnored() throws InterruptedException {
+    void dispatchCommandNoHandlerSubscribedCallsMonitorCallbackIgnored() throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         MessageMonitor<? super CommandMessage<?>> messageMonitor = (message) -> new MessageMonitor.MonitorCallback() {
             @Override
@@ -216,7 +216,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testInterceptorChainCommandHandledSuccessfully() throws Exception {
+    void interceptorChainCommandHandledSuccessfully() throws Exception {
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor1 = mock(MessageHandlerInterceptor.class);
         final MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor2 = mock(MessageHandlerInterceptor.class);
         final MessageHandler<CommandMessage<?>> commandHandler = mock(MessageHandler.class);
@@ -251,7 +251,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings({"unchecked", "ThrowableInstanceNeverThrown"})
     @Test
-    void testInterceptorChainCommandHandlerThrowsException() throws Exception {
+    void interceptorChainCommandHandlerThrowsException() throws Exception {
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor1 = mock(MessageHandlerInterceptor.class);
         final MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor2 = mock(MessageHandlerInterceptor.class);
         final MessageHandler<CommandMessage<?>> commandHandler = mock(MessageHandler.class);
@@ -289,7 +289,7 @@ class SimpleCommandBusTest {
 
     @SuppressWarnings({"ThrowableInstanceNeverThrown", "unchecked"})
     @Test
-    void testInterceptorChainInterceptorThrowsException() throws Exception {
+    void interceptorChainInterceptorThrowsException() throws Exception {
         MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor1 =
                 mock(MessageHandlerInterceptor.class, "stubName");
         final MessageHandlerInterceptor<CommandMessage<?>> mockInterceptor2 = mock(MessageHandlerInterceptor.class);
@@ -320,7 +320,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testCommandReplyMessageCorrelationData() {
+    void commandReplyMessageCorrelationData() {
         testSubject.subscribe(String.class.getName(), message -> message.getPayload().toString());
         testSubject.registerHandlerInterceptor(new CorrelationDataInterceptor<>(new MessageOriginProvider()));
         CommandMessage<String> command = asCommandMessage("Hi");
@@ -335,7 +335,7 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void testDuplicateCommandHandlerResolverSetsTheExpectedHandler() {
+    void duplicateCommandHandlerResolverSetsTheExpectedHandler() {
         DuplicateCommandHandlerResolver testDuplicateCommandHandlerResolver = DuplicateCommandHandlerResolution.silentOverride();
         SimpleCommandBus testSubject =
                 SimpleCommandBus.builder()

--- a/messaging/src/test/java/org/axonframework/commandhandling/callbacks/FutureCallbackTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/callbacks/FutureCallbackTest.java
@@ -49,7 +49,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testOnSuccess() throws InterruptedException {
+    void onSuccess() throws InterruptedException {
         Thread t = new Thread(() -> {
             try {
                 resultFromParallelThread = testSubject.get();
@@ -66,7 +66,7 @@ class FutureCallbackTest {
 
     @SuppressWarnings({"ThrowableInstanceNeverThrown"})
     @Test
-    void testOnFailure() throws InterruptedException {
+    void onFailure() throws InterruptedException {
         Thread t = new Thread(() -> {
             try {
                 resultFromParallelThread = testSubject.get();
@@ -84,7 +84,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testOnSuccessForLimitedTime_Timeout() throws InterruptedException {
+    void onSuccessForLimitedTime_Timeout() throws InterruptedException {
         Thread t = new Thread(() -> {
             try {
                 resultFromParallelThread = testSubject.get(1, TimeUnit.NANOSECONDS);
@@ -99,7 +99,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testOnResultReturnsMessageWithTimeoutExceptionOnTimeout() throws InterruptedException {
+    void onResultReturnsMessageWithTimeoutExceptionOnTimeout() throws InterruptedException {
         Thread t = new Thread(() -> {
             resultFromParallelThread = testSubject.getResult(1, TimeUnit.NANOSECONDS);
         });
@@ -111,7 +111,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testOnResultUnwrapsExecutionResult() throws InterruptedException {
+    void onResultUnwrapsExecutionResult() throws InterruptedException {
         Thread t = new Thread(() -> {
             resultFromParallelThread = testSubject.getResult();
         });
@@ -123,7 +123,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testGetThrowsExecutionException() throws InterruptedException {
+    void getThrowsExecutionException() throws InterruptedException {
         Thread t = new Thread(() -> {
             try {
                 testSubject.get();
@@ -138,7 +138,7 @@ class FutureCallbackTest {
     }
 
     @Test
-    void testOnSuccessForLimitedTime_InTime() throws InterruptedException {
+    void onSuccessForLimitedTime_InTime() throws InterruptedException {
         Thread t = new Thread(() -> {
             try {
                 resultFromParallelThread = testSubject.get(10, TimeUnit.SECONDS);

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategyTest.java
@@ -40,7 +40,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testGetRoutingKeyFromField() {
+    void getRoutingKeyFromField() {
         CommandMessage<SomeFieldAnnotatedCommand> testCommand = new GenericCommandMessage<>(new SomeFieldAnnotatedCommand());
         assertEquals("Target", testSubject.getRoutingKey(testCommand));
 
@@ -50,7 +50,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testGetRoutingKeyFromMethod() {
+    void getRoutingKeyFromMethod() {
         CommandMessage<SomeMethodAnnotatedCommand> testCommand =
                 new GenericCommandMessage<>(new SomeMethodAnnotatedCommand());
         assertEquals("Target", testSubject.getRoutingKey(testCommand));
@@ -61,7 +61,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testNullRoutingKeyOnFieldThrowsCommandDispatchException() {
+    void nullRoutingKeyOnFieldThrowsCommandDispatchException() {
         AnnotationRoutingStrategy errorFallbackRoutingStrategy =
                 AnnotationRoutingStrategy.builder()
                                          .fallbackRoutingStrategy(UnresolvedRoutingKeyPolicy.ERROR)
@@ -74,7 +74,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testNullRoutingKeyOnMethodThrowsCommandDispatchException() {
+    void nullRoutingKeyOnMethodThrowsCommandDispatchException() {
         AnnotationRoutingStrategy errorFallbackRoutingStrategy =
                 AnnotationRoutingStrategy.builder()
                                          .fallbackRoutingStrategy(UnresolvedRoutingKeyPolicy.ERROR)
@@ -87,7 +87,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testResolvesRoutingKeyFromAnnotationDoesNotInvokeFallbackStrategy() {
+    void resolvesRoutingKeyFromAnnotationDoesNotInvokeFallbackStrategy() {
         RoutingStrategy fallbackRoutingStrategy = mock(RoutingStrategy.class);
 
         AnnotationRoutingStrategy testSubjectWithMockedFallbackStrategy =
@@ -103,7 +103,7 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testResolvesRoutingKeyFromFallbackStrategy() {
+    void resolvesRoutingKeyFromFallbackStrategy() {
         String expectedRoutingKey = "some-routing-key";
         RoutingStrategy fallbackRoutingStrategy = mock(RoutingStrategy.class);
         when(fallbackRoutingStrategy.getRoutingKey(any())).thenReturn(expectedRoutingKey);
@@ -121,13 +121,13 @@ class AnnotationRoutingStrategyTest {
     }
 
     @Test
-    void testBuildAnnotationRoutingStrategyFailsForNullFallbackRoutingStrategy() {
+    void buildAnnotationRoutingStrategyFailsForNullFallbackRoutingStrategy() {
         AnnotationRoutingStrategy.Builder builderTestSubject = AnnotationRoutingStrategy.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.fallbackRoutingStrategy(null));
     }
 
     @Test
-    void testBuildAnnotationRoutingStrategyFailsForNullAnnotationType() {
+    void buildAnnotationRoutingStrategyFailsForNullAnnotationType() {
         AnnotationRoutingStrategy.Builder builderTestSubject = AnnotationRoutingStrategy.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.annotationType(null));
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/CommandCallbackRepositoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/CommandCallbackRepositoryTest.java
@@ -34,7 +34,7 @@ class CommandCallbackRepositoryTest {
     }
 
     @Test
-    void testCallback() {
+    void callback() {
         CommandCallbackRepository<Object> repository = new CommandCallbackRepository<>();
         CommandCallbackWrapper<Object, Object, Object> commandCallbackWrapper = createWrapper("A");
         repository.store("A", commandCallbackWrapper);
@@ -51,7 +51,7 @@ class CommandCallbackRepositoryTest {
 
 
     @Test
-    void testOverwriteCallback() {
+    void overwriteCallback() {
         CommandCallbackRepository<Object> repository = new CommandCallbackRepository<>();
         CommandCallbackWrapper<Object, Object, Object> commandCallbackWrapper = createWrapper("A");
         repository.store("A", commandCallbackWrapper);
@@ -67,7 +67,7 @@ class CommandCallbackRepositoryTest {
     }
 
     @Test
-    void testCancelCallbacks() {
+    void cancelCallbacks() {
         CommandCallbackRepository<Object> repository = new CommandCallbackRepository<>();
         repository.store("A", createWrapper("A"));
         repository.store("B", createWrapper("A"));

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/ConsistentHashTest.java
@@ -62,47 +62,47 @@ class ConsistentHashTest {
     }
 
     @Test
-    void testConsistentHashChangesVersionWhenModified() {
+    void consistentHashChangesVersionWhenModified() {
         assertEquals(3, testSubject.version());
         assertEquals(4, testSubject.without(member1).version());
         assertEquals(4, testSubject.without(member1).without(member1).version());
     }
 
     @Test
-    void testMessageRoutedToFirstEligibleMember() {
+    void messageRoutedToFirstEligibleMember() {
         Optional<Member> actual = testSubject.getMember("routingKey", new GenericCommandMessage<>(new GenericMessage<>("test"), "name1"));
         assertTrue(actual.isPresent());
         assertEquals("member1", actual.get().name());
     }
 
     @Test
-    void testMessageRoutedToNextEligibleMemberIfFirstChoiceIsRemoved() {
+    void messageRoutedToNextEligibleMemberIfFirstChoiceIsRemoved() {
         Optional<Member> actual = testSubject.without(member1).getMember("routingKey", new GenericCommandMessage<>(new GenericMessage<>("test"), "name1"));
         assertTrue(actual.isPresent());
         assertEquals("member2", actual.get().name());
     }
 
     @Test
-    void testNonEligibleMembersIgnored() {
+    void nonEligibleMembersIgnored() {
         Optional<Member> actual = testSubject.getMember("routingKey", new GenericCommandMessage<>(new GenericMessage<>("test"), "name3"));
         assertTrue(actual.isPresent());
         assertEquals("member3", actual.get().name());
     }
 
     @Test
-    void testNoMemberReturnedWhenNoEligibleMembers() {
+    void noMemberReturnedWhenNoEligibleMembers() {
         Optional<Member> actual = testSubject.getMember("routingKey", new GenericCommandMessage<>(new GenericMessage<>("test"), "unknown"));
         assertFalse(actual.isPresent());
     }
 
     @Test
-    void testEligibleMembersCorrectlyOrdered() {
+    void eligibleMembersCorrectlyOrdered() {
         Collection<ConsistentHash.ConsistentHashMember> actual = testSubject.getEligibleMembers("someOtherKey");
         assertEquals(asList("member2", "member1", "member3"), actual.stream().map(ConsistentHash.ConsistentHashMember::name).collect(Collectors.toList()));
     }
 
     @Test
-    void testConflictingHashesDoNotImpactMembership() {
+    void conflictingHashesDoNotImpactMembership() {
         ConsistentHash consistentHash = new ConsistentHash(s -> "fixed").with(member1, 1, AcceptAll.INSTANCE);
         ConsistentHash consistentHashModified = consistentHash
                                                             .with(member2, 1, AcceptAll.INSTANCE)
@@ -112,7 +112,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void testNotEqualsForModifiedInstanceWithDefaultInstance() throws Exception {
+    void notEqualsForModifiedInstanceWithDefaultInstance() throws Exception {
         ConsistentHash consistentHash = new ConsistentHash(s -> "fixed").with(member1, 1, AcceptAll.INSTANCE);
         assertNotEquals(consistentHash, new ConsistentHash());
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
@@ -74,7 +74,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDispatchWithoutCallbackWithMessageMonitor() throws Exception {
+    void dispatchWithoutCallbackWithMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
         when(mockMessageMonitor.onMessageIngested(any())).thenReturn(mockMonitorCallback);
@@ -88,7 +88,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDefaultCallbackIsUsedWhenFireAndForget() {
+    void defaultCallbackIsUsedWhenFireAndForget() {
         CommandMessage<Object> message = GenericCommandMessage.asCommandMessage("test");
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
@@ -106,7 +106,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDispatchFailingCommandWithoutCallbackWithMessageMonitor() throws Exception {
+    void dispatchFailingCommandWithoutCallbackWithMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("fail");
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
         when(mockMessageMonitor.onMessageIngested(any())).thenReturn(mockMonitorCallback);
@@ -120,7 +120,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDispatchWithoutCallbackAndWithoutMessageMonitor() throws Exception {
+    void dispatchWithoutCallbackAndWithoutMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
         testSubject = DistributedCommandBus.builder()
@@ -138,7 +138,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testUnknownCommandWithoutCallbackAndWithoutMessageMonitor() throws Exception {
+    void unknownCommandWithoutCallbackAndWithoutMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("unknown");
         CommandCallback<Object, Object> callback = mock(CommandCallback.class);
         when(mockCommandRouter.findDestination(testCommandMessage)).thenReturn(Optional.empty());
@@ -164,7 +164,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDispatchWithCallbackAndMessageMonitor() throws Exception {
+    void dispatchWithCallbackAndMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
@@ -184,7 +184,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testUnknownCommandWithCallbackAndMessageMonitor() throws Exception {
+    void unknownCommandWithCallbackAndMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("test");
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         when(mockCommandRouter.findDestination(testCommandMessage)).thenReturn(Optional.empty());
@@ -206,7 +206,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDispatchFailingCommandWithCallbackAndMessageMonitor() throws Exception {
+    void dispatchFailingCommandWithCallbackAndMessageMonitor() throws Exception {
         CommandMessage<Object> testCommandMessage = GenericCommandMessage.asCommandMessage("fail");
         CommandCallback<Object, Object> mockCallback = mock(CommandCallback.class);
         when(mockCommandRouter.findDestination(any())).thenReturn(Optional.of(mockMember));
@@ -225,7 +225,7 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testLocalSegmentReturnsTheCommandBusConnectorsLocalSegmentResult() {
+    void localSegmentReturnsTheCommandBusConnectorsLocalSegmentResult() {
         CommandBus expectedLocalSegment = mock(CommandBus.class);
         when(mockConnector.localSegment()).thenReturn(Optional.of(expectedLocalSegment));
 
@@ -235,24 +235,24 @@ class DistributedCommandBusTest {
     }
 
     @Test
-    void testDisconnectRemovesAllSubscribedCommandHandlers() {
+    void disconnectRemovesAllSubscribedCommandHandlers() {
         testSubject.disconnect();
         verify(mockCommandRouter).updateMembership(INITIAL_LOAD_FACTOR, DenyAll.INSTANCE);
     }
 
     @Test
-    void testShutdownDispatchingInitiatesShutdownOfCommandBusConnector() {
+    void shutdownDispatchingInitiatesShutdownOfCommandBusConnector() {
         testSubject.shutdownDispatching();
         verify(mockConnector).initiateShutdown();
     }
 
     @Test
-    void testLoadFactorDefault() {
+    void loadFactorDefault() {
         assertEquals(INITIAL_LOAD_FACTOR, testSubject.getLoadFactor());
     }
 
     @Test
-    void testUpdateLoadFactor() {
+    void updateLoadFactor() {
         int expectedLoadFactor = 42;
 
         testSubject.updateLoadFactor(expectedLoadFactor);

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategyTest.java
@@ -33,7 +33,7 @@ class MetaDataRoutingStrategyTest {
     }
 
     @Test
-    void testResolvesRoutingKeyFromMetaData() {
+    void resolvesRoutingKeyFromMetaData() {
         String expectedRoutingKey = "some-routing-key";
 
         MetaData testMetaData = MetaData.from(Collections.singletonMap(META_DATA_KEY, expectedRoutingKey));
@@ -44,7 +44,7 @@ class MetaDataRoutingStrategyTest {
     }
 
     @Test
-    void testResolvesRoutingKeyFromFallbackStrategy() {
+    void resolvesRoutingKeyFromFallbackStrategy() {
         String expectedRoutingKey = "some-routing-key";
         when(fallbackRoutingStrategy.getRoutingKey(any())).thenReturn(expectedRoutingKey);
 
@@ -55,19 +55,19 @@ class MetaDataRoutingStrategyTest {
     }
 
     @Test
-    void testBuildMetaDataRoutingStrategyFailsForNullFallbackRoutingStrategy() {
+    void buildMetaDataRoutingStrategyFailsForNullFallbackRoutingStrategy() {
         MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.fallbackRoutingStrategy(null));
     }
 
     @Test
-    void testBuildMetaDataRoutingStrategyFailsForNullMetaDataKey() {
+    void buildMetaDataRoutingStrategyFailsForNullMetaDataKey() {
         MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.metaDataKey(null));
     }
 
     @Test
-    void testBuildMetaDataRoutingStrategyFailsForEmptyMetaDataKey() {
+    void buildMetaDataRoutingStrategyFailsForEmptyMetaDataKey() {
         MetaDataRoutingStrategy.Builder builderTestSubject = MetaDataRoutingStrategy.builder();
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.metaDataKey(""));
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/ReplyMessageSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/ReplyMessageSerializationTest.java
@@ -45,7 +45,7 @@ class ReplyMessageSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testSerializationDeserializationOfSuccessfulMessage(TestSerializer serializer) {
+    void serializationDeserializationOfSuccessfulMessage(TestSerializer serializer) {
         String commandId = "commandId";
         CommandResultMessage<String> success = asCommandResultMessage("success");
         DummyReplyMessage message = new DummyReplyMessage(commandId, success, serializer.getSerializer());
@@ -55,7 +55,7 @@ class ReplyMessageSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testSerializationDeserializationOfUnsuccessfulMessage(TestSerializer serializer) {
+    void serializationDeserializationOfUnsuccessfulMessage(TestSerializer serializer) {
         String commandId = "commandId";
         CommandResultMessage<String> failure = asCommandResultMessage(new RuntimeException("oops"));
         DummyReplyMessage message = new DummyReplyMessage(commandId, failure, serializer.getSerializer());
@@ -65,7 +65,7 @@ class ReplyMessageSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testDeserializingOfPersistentExceptions(TestSerializer serializer) {
+    void deserializingOfPersistentExceptions(TestSerializer serializer) {
         String commandId = "commandId";
         CommandResultMessage<String> failure = asCommandResultMessage(new SerializationException("oops"));
         DummyReplyMessage message = new DummyReplyMessage(commandId, failure, serializer.getSerializer());
@@ -77,7 +77,7 @@ class ReplyMessageSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testDeserializingOfTransientExceptions(TestSerializer serializer) {
+    void deserializingOfTransientExceptions(TestSerializer serializer) {
         String commandId = "commandId";
         CommandResultMessage<String> failure = asCommandResultMessage(new RuntimeException("oops"));
         DummyReplyMessage message = new DummyReplyMessage(commandId, failure, serializer.getSerializer());

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicyTest.java
@@ -16,19 +16,19 @@ class UnresolvedRoutingKeyPolicyTest {
     private final CommandMessage<String> testCommand = new GenericCommandMessage<>("some-payload");
 
     @Test
-    void testErrorStrategy() {
+    void errorStrategy() {
         assertThrows(CommandDispatchException.class, () -> UnresolvedRoutingKeyPolicy.ERROR.getRoutingKey(testCommand));
     }
 
     @Test
-    void testRandomStrategy() {
+    void randomStrategy() {
         String firstResult = UnresolvedRoutingKeyPolicy.RANDOM_KEY.getRoutingKey(testCommand);
         String secondResult = UnresolvedRoutingKeyPolicy.RANDOM_KEY.getRoutingKey(testCommand);
         assertNotEquals(firstResult, secondResult);
     }
 
     @Test
-    void testStaticStrategy() {
+    void staticStrategy() {
         String firstResult = UnresolvedRoutingKeyPolicy.STATIC_KEY.getRoutingKey(testCommand);
         String secondResult = UnresolvedRoutingKeyPolicy.STATIC_KEY.getRoutingKey(testCommand);
         assertEquals(firstResult, secondResult);

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAllSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AcceptAllSerializationTest.java
@@ -24,7 +24,7 @@ class AcceptAllSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testAcceptAllShouldBeSerializable(TestSerializer serializer) {
+    void acceptAllShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/AndCommandMessageFilterSerializationTest.java
@@ -25,7 +25,7 @@ class AndCommandMessageFilterSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testAndCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+    void andCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandFilterTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandFilterTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CommandFilterTest {
 
     @Test
-    void testAcceptAll() {
+    void acceptAll() {
         CommandMessage<Object> testCommand = new GenericCommandMessage<>(new Object());
 
         assertTrue(AcceptAll.INSTANCE.matches(testCommand));
@@ -42,7 +42,7 @@ class CommandFilterTest {
     }
 
     @Test
-    void testDenyAll() {
+    void denyAll() {
         CommandMessage<Object> testCommand = new GenericCommandMessage<>(new Object());
 
         assertFalse(DenyAll.INSTANCE.matches(testCommand));
@@ -52,7 +52,7 @@ class CommandFilterTest {
     }
 
     @Test
-    void testCommandNameFilter() {
+    void commandNameFilter() {
         CommandMessage<Object> testCommand =
                 new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
 
@@ -82,7 +82,7 @@ class CommandFilterTest {
     }
 
     @Test
-    void testDenyCommandNameFilter() {
+    void denyCommandNameFilter() {
         CommandMessage<Object> testCommand =
                 new GenericCommandMessage<>(new GenericMessage<>(new Object()), "acceptable");
 

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/CommandNameFilterSerializationTest.java
@@ -25,7 +25,7 @@ class CommandNameFilterSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testCommandNameFilterShouldBeSerializable(TestSerializer serializer) {
+    void commandNameFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAllSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyAllSerializationTest.java
@@ -24,7 +24,7 @@ class DenyAllSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testDenyAllFilterShouldBeSerializable(TestSerializer serializer) {
+    void denyAllFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/DenyCommandNameFilterSerializationTest.java
@@ -25,7 +25,7 @@ class DenyCommandNameFilterSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testDenyCommandNameFilterShouldBeSerializable(TestSerializer serializer) {
+    void denyCommandNameFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/NegateCommandMessageFilterSerializationTest.java
@@ -24,7 +24,7 @@ class NegateCommandMessageFilterSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testNegateCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+    void negateCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilterSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/commandfilter/OrCommandMessageFilterSerializationTest.java
@@ -25,7 +25,7 @@ class OrCommandMessageFilterSerializationTest {
 
     @ParameterizedTest
     @MethodSource("testSerializers")
-    void testOrCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
+    void orCommandMessageFilterShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/CommandGatewayFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/CommandGatewayFactoryTest.java
@@ -86,7 +86,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayFireAndForget() {
+    void gatewayFireAndForget() {
         final Object metaTest = new Object();
 
         doAnswer(new Success(asCommandResultMessage(null)))
@@ -107,7 +107,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayFireAndForgetWithoutRetryScheduler() {
+    void gatewayFireAndForgetWithoutRetryScheduler() {
         final Object metaTest = new Object();
 
         CommandGatewayFactory testSubject = CommandGatewayFactory.builder().commandBus(mockCommandBus).build();
@@ -124,7 +124,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayTimeout() throws InterruptedException {
+    void gatewayTimeout() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         doAnswer(new CountDown(latch))
                 .when(mockCommandBus).dispatch(isA(CommandMessage.class), isA(CommandCallback.class));
@@ -138,7 +138,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayWithReturnValueReturns() throws InterruptedException {
+    void gatewayWithReturnValueReturns() throws InterruptedException {
         String expectedReturnValue = "ReturnValue";
         CommandResultMessage<String> returnValue = asCommandResultMessage(expectedReturnValue);
         final CountDownLatch latch = new CountDownLatch(1);
@@ -157,7 +157,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayWithReturnValueUndeclaredException() throws InterruptedException {
+    void gatewayWithReturnValueUndeclaredException() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -189,7 +189,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayWithReturnValueInterrupted() throws InterruptedException {
+    void gatewayWithReturnValueInterrupted() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -211,7 +211,7 @@ class CommandGatewayFactoryTest {
     }
 
     @Test
-    void testGatewayWithReturnValueRuntimeException() {
+    void gatewayWithReturnValueRuntimeException() {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         RuntimeException runtimeException = new RuntimeException();
@@ -235,7 +235,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayWaitForExceptionInterrupted() throws InterruptedException {
+    void gatewayWaitForExceptionInterrupted() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -257,7 +257,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testGatewayWaitForUndeclaredInterruptedException() throws InterruptedException {
+    void gatewayWaitForUndeclaredInterruptedException() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -279,7 +279,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndWaitWithTimeoutParameterReturns() throws InterruptedException {
+    void fireAndWaitWithTimeoutParameterReturns() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -306,7 +306,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndWaitWithTimeoutParameterTimeout() throws InterruptedException {
+    void fireAndWaitWithTimeoutParameterTimeout() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -328,7 +328,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndWaitWithTimeoutParameterTimeoutException() throws InterruptedException {
+    void fireAndWaitWithTimeoutParameterTimeoutException() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -349,7 +349,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndWaitWithTimeoutParameterInterrupted() throws InterruptedException {
+    void fireAndWaitWithTimeoutParameterInterrupted() throws InterruptedException {
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -372,7 +372,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndWaitForCheckedException() throws InterruptedException {
+    void fireAndWaitForCheckedException() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<String> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
@@ -403,7 +403,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndGetFuture() throws InterruptedException {
+    void fireAndGetFuture() throws InterruptedException {
         final AtomicReference<Future<Object>> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -424,7 +424,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndGetCompletableFuture() throws InterruptedException {
+    void fireAndGetCompletableFuture() throws InterruptedException {
         final AtomicReference<CompletableFuture<Object>> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -445,7 +445,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndGetFutureWithTimeout() throws Throwable {
+    void fireAndGetFutureWithTimeout() throws Throwable {
         final AtomicReference<Future<Object>> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -466,7 +466,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testFireAndGetCompletionStageWithTimeout() throws Throwable {
+    void fireAndGetCompletionStageWithTimeout() throws Throwable {
         final AtomicReference<CompletionStage<Object>> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -487,7 +487,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testRetrySchedulerInvokedOnFailure() throws Throwable {
+    void retrySchedulerInvokedOnFailure() throws Throwable {
         final AtomicReference<Object> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -515,7 +515,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testRetrySchedulerNotInvokedOnCheckedException() throws Throwable {
+    void retrySchedulerNotInvokedOnCheckedException() throws Throwable {
         final AtomicReference<Object> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -543,7 +543,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testRetrySchedulerInvokedOnExceptionCausedByDeadlock() {
+    void retrySchedulerInvokedOnExceptionCausedByDeadlock() {
         final AtomicReference<Object> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -566,7 +566,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayWaitForResultAndInvokeCallbacksSuccess() {
+    void createGatewayWaitForResultAndInvokeCallbacksSuccess() {
         CountDownLatch latch = new CountDownLatch(1);
         CommandResultMessage<String> resultMessage = asCommandResultMessage("OK");
         final CommandCallback<Object, String> callback1 = mock(CommandCallback.class);
@@ -585,7 +585,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayWaitForResultAndInvokeCallbacksFailure() {
+    void createGatewayWaitForResultAndInvokeCallbacksFailure() {
         final RuntimeException exception = new RuntimeException();
         final CommandCallback<Object, ?> callback1 = mock(CommandCallback.class);
         final CommandCallback<Object, ?> callback2 = mock(CommandCallback.class);
@@ -610,7 +610,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayAsyncWithCallbacksSuccess() {
+    void createGatewayAsyncWithCallbacksSuccess() {
         CountDownLatch latch = new CountDownLatch(1);
         CommandResultMessage<String> resultMessage = asCommandResultMessage("OK");
         final CommandCallback<Object, String> callback1 = mock(CommandCallback.class);
@@ -628,7 +628,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayAsyncWithCallbacksSuccessButReturnTypeDoesNotMatchCallback() {
+    void createGatewayAsyncWithCallbacksSuccessButReturnTypeDoesNotMatchCallback() {
         CountDownLatch latch = new CountDownLatch(1);
         CommandResultMessage<Object> resultMessage = asCommandResultMessage(42);
         final CommandCallback<Object, Object> callback1 = mock(CommandCallback.class);
@@ -647,7 +647,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayAsyncWithCallbacksFailure() {
+    void createGatewayAsyncWithCallbacksFailure() {
         final RuntimeException exception = new RuntimeException();
         final CommandCallback<Object, ?> callback1 = mock(CommandCallback.class);
         final CommandCallback<Object, ?> callback2 = mock(CommandCallback.class);
@@ -669,7 +669,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayCompletableFutureFailure() {
+    void createGatewayCompletableFutureFailure() {
         final RuntimeException exception = new RuntimeException();
 
         doAnswer(new Failure(exception))
@@ -683,7 +683,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayCompletableFutureSuccessfulResult() throws Throwable {
+    void createGatewayCompletableFutureSuccessfulResult() throws Throwable {
         String expectedReturnValue = "returnValue";
 
         doAnswer(new Success(asCommandResultMessage(expectedReturnValue)))
@@ -697,7 +697,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayFutureSuccessfulResult() throws Throwable {
+    void createGatewayFutureSuccessfulResult() throws Throwable {
         String expectedReturnValue = "returnValue";
 
         doAnswer(new Success(asCommandResultMessage(expectedReturnValue)))
@@ -711,7 +711,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testRetrySchedulerNotInvokedOnExceptionCausedByDeadlockAndActiveUnitOfWork() {
+    void retrySchedulerNotInvokedOnExceptionCausedByDeadlockAndActiveUnitOfWork() {
         final AtomicReference<Object> result = new AtomicReference<>();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         UnitOfWork<CommandMessage<?>> uow = DefaultUnitOfWork.startAndGet(null);
@@ -737,7 +737,7 @@ class CommandGatewayFactoryTest {
 
     @Test
     @Timeout(value = 2)
-    void testCreateGatewayEqualsAndHashCode() {
+    void createGatewayEqualsAndHashCode() {
         CompleteGateway gateway2 = testSubject.createGateway(CompleteGateway.class);
 
         assertNotSame(gateway, gateway2);
@@ -745,7 +745,7 @@ class CommandGatewayFactoryTest {
     }
 
     @Test
-    void testDifferentCommandCallbackResultTypesInvocationsAreAllInvoked() {
+    void differentCommandCallbackResultTypesInvocationsAreAllInvoked() {
         String expectedResult = "OK";
         AtomicBoolean stringCallbackInvocation = new AtomicBoolean(false);
         AtomicBoolean integerCallbackInvocation = new AtomicBoolean(false);

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
@@ -79,7 +79,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testSendWithCallbackCommandIsRetried() {
+    void sendWithCallbackCommandIsRetried() {
         doAnswer(invocation -> {
             ((CommandCallback<Object, Object>) invocation.getArguments()[1])
                     .onResult((CommandMessage<Object>) invocation.getArguments()[0],
@@ -110,7 +110,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testSendWithoutCallbackCommandIsRetried() {
+    void sendWithoutCallbackCommandIsRetried() {
         doAnswer(invocation -> {
             ((CommandCallback<Object, Object>) invocation.getArguments()[1]).onResult(
                     (CommandMessage<Object>) invocation.getArguments()[0],
@@ -140,7 +140,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testSendWithoutCallback() throws ExecutionException, InterruptedException {
+    void sendWithoutCallback() throws ExecutionException, InterruptedException {
         doAnswer(invocation -> {
             ((CommandCallback<Object, Object>) invocation.getArguments()[1]).onResult(
                     (CommandMessage<Object>) invocation.getArguments()[0],
@@ -156,7 +156,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testSendWithoutCallbackCustomizedCallbackIsCalled() throws ExecutionException, InterruptedException {
+    void sendWithoutCallbackCustomizedCallbackIsCalled() throws ExecutionException, InterruptedException {
         AtomicBoolean finalCallbackCalled = new AtomicBoolean(false);
         AtomicBoolean customizedCallbackCalled = new AtomicBoolean(false);
         testSubject = DefaultCommandGateway.builder()
@@ -190,7 +190,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testSendAndWaitCommandIsRetried() {
+    void sendAndWaitCommandIsRetried() {
         final RuntimeException failure = new RuntimeException(new RuntimeException());
         doAnswer(invocation -> {
             ((CommandCallback<Object, Object>) invocation.getArguments()[1]).onResult(
@@ -222,7 +222,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testSendAndWaitWithTimeoutCommandIsRetried() {
+    void sendAndWaitWithTimeoutCommandIsRetried() {
         final RuntimeException failure = new RuntimeException(new RuntimeException());
         doAnswer(invocation -> {
             ((CommandCallback<Object, Object>) invocation.getArguments()[1]).onResult(
@@ -254,7 +254,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testSendAndWaitNullOnInterrupt() {
+    void sendAndWaitNullOnInterrupt() {
         doAnswer(invocation -> {
             Thread.currentThread().interrupt();
             return null;
@@ -267,7 +267,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testSendAndWaitWithTimeoutNullOnInterrupt() {
+    void sendAndWaitWithTimeoutNullOnInterrupt() {
         doAnswer(invocation -> {
             Thread.currentThread().interrupt();
             return null;
@@ -286,7 +286,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testSendAndWaitWithTimeoutNullOnTimeout() {
+    void sendAndWaitWithTimeoutNullOnTimeout() {
         try {
             assertNull(testSubject.sendAndWait("Hello", 10, TimeUnit.MILLISECONDS));
             fail("Expected interrupted exception");
@@ -298,7 +298,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testCorrelationDataIsAttachedToCommandAsObject() {
+    void correlationDataIsAttachedToCommandAsObject() {
         UnitOfWork<CommandMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(null);
         unitOfWork.registerCorrelationDataProvider(message -> Collections.singletonMap("correlationId", "test"));
         testSubject.send("Hello");
@@ -311,7 +311,7 @@ class DefaultCommandGatewayTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testCorrelationDataIsAttachedToCommandAsMessage() {
+    void correlationDataIsAttachedToCommandAsMessage() {
         final Map<String, String> data = new HashMap<>();
         data.put("correlationId", "test");
         data.put("header", "someValue");
@@ -326,7 +326,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testPayloadExtractionProblemsReportedInException() throws ExecutionException, InterruptedException {
+    void payloadExtractionProblemsReportedInException() throws ExecutionException, InterruptedException {
         doAnswer(i -> {
             CommandCallback<String, String> callback = i.getArgument(1);
             callback.onResult(i.getArgument(0), new GenericCommandResultMessage<String>("result") {
@@ -347,7 +347,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testSendAndWaitAttachesMetaData() {
+    void sendAndWaitAttachesMetaData() {
         //noinspection unchecked
         doAnswer(invocation -> {
             //noinspection unchecked
@@ -374,7 +374,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testSendAndWaitWithTimeoutAttachesMetaData() {
+    void sendAndWaitWithTimeoutAttachesMetaData() {
         //noinspection unchecked
         doAnswer(invocation -> {
             //noinspection unchecked
@@ -401,7 +401,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testSendAttachesMetaData() {
+    void sendAttachesMetaData() {
         //noinspection unchecked
         doAnswer(invocation -> {
             //noinspection unchecked
@@ -428,7 +428,7 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
-    void testCommandCallbackIsCustomized() {
+    void commandCallbackIsCustomized() {
         AtomicBoolean customizedCallbackIsCalled = new AtomicBoolean();
 
         testSubject = DefaultCommandGateway.builder()

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/ExponentialBackOffIntervalRetrySchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/ExponentialBackOffIntervalRetrySchedulerTest.java
@@ -39,7 +39,7 @@ class ExponentialBackOffIntervalRetrySchedulerTest {
     }
 
     @Test
-    void testBuildingWhilstMissingScheduledExecutorServiceThrowsConfigurationException() {
+    void buildingWhilstMissingScheduledExecutorServiceThrowsConfigurationException() {
         ExponentialBackOffIntervalRetryScheduler.Builder builder = ExponentialBackOffIntervalRetryScheduler.builder();
         assertThrows(AxonConfigurationException.class, builder::build);
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/IntervalRetrySchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/IntervalRetrySchedulerTest.java
@@ -92,7 +92,7 @@ class IntervalRetrySchedulerTest {
     }
 
     @Test
-    void testBuildingWhilstMissingScheduledExecutorServiceThrowsConfigurationException() {
+    void buildingWhilstMissingScheduledExecutorServiceThrowsConfigurationException() {
         IntervalRetryScheduler.Builder builder = IntervalRetryScheduler.builder();
         assertThrows(AxonConfigurationException.class, builder::build);
     }

--- a/messaging/src/test/java/org/axonframework/common/AssertTest.java
+++ b/messaging/src/test/java/org/axonframework/common/AssertTest.java
@@ -26,22 +26,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AssertTest {
 
     @Test
-    void testState_Accept() {
+    void state_Accept() {
         Assert.state(true, () -> "Hello");
     }
 
     @Test
-    void testState_Fail() {
+    void state_Fail() {
         assertThrows(IllegalStateException.class, () -> Assert.state(false, () -> "Hello"));
     }
 
     @Test
-    void testIsTrue_Accept() {
+    void isTrue_Accept() {
         Assert.isTrue(true, () -> "Hello");
     }
 
     @Test
-    void testIsTrue_Fail() {
+    void isTrue_Fail() {
         assertThrows(IllegalArgumentException.class, () -> Assert.isTrue(false, () -> "Hello"));
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/AxonThreadFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/AxonThreadFactoryTest.java
@@ -30,7 +30,7 @@ class AxonThreadFactoryTest {
     private AxonThreadFactory testSubject;
 
     @Test
-    void testCreateWithThreadGroupByName() {
+    void createWithThreadGroupByName() {
         testSubject = new AxonThreadFactory("test");
         Thread t1 = testSubject.newThread(new NoOpRunnable());
         Thread t2 = testSubject.newThread(new NoOpRunnable());
@@ -42,7 +42,7 @@ class AxonThreadFactoryTest {
     }
 
     @Test
-    void testCreateWithThreadGroupByThreadGroupInstance() {
+    void createWithThreadGroupByThreadGroupInstance() {
         ThreadGroup threadGroup = new ThreadGroup("test");
         testSubject = new AxonThreadFactory(threadGroup);
         Thread t1 = testSubject.newThread(new NoOpRunnable());
@@ -55,7 +55,7 @@ class AxonThreadFactoryTest {
     }
 
     @Test
-    void testCreateWithPriority() {
+    void createWithPriority() {
         ThreadGroup threadGroup = new ThreadGroup("test");
         testSubject = new AxonThreadFactory(Thread.MAX_PRIORITY, threadGroup);
         Thread t1 = testSubject.newThread(new NoOpRunnable());
@@ -68,13 +68,13 @@ class AxonThreadFactoryTest {
     }
 
     @Test
-    void testRejectsTooHighPriority() {
+    void rejectsTooHighPriority() {
         assertThrows(IllegalArgumentException.class,
                 () -> new AxonThreadFactory(Thread.MAX_PRIORITY + 1, new ThreadGroup("")));
     }
 
     @Test
-    void testRejectsTooLowPriority() {
+    void rejectsTooLowPriority() {
         assertThrows(IllegalArgumentException.class,
                 () -> new AxonThreadFactory(Thread.MIN_PRIORITY - 1, new ThreadGroup("")));
     }

--- a/messaging/src/test/java/org/axonframework/common/BuilderUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/BuilderUtilsTest.java
@@ -42,7 +42,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertThat() {
+    void assertThatTest() {
         assertThat(0, n -> (n == 0), "Zero must be zero");
 
         testAssertFails(() -> assertThat(0, n -> n != 0, "Zero must be zero"),
@@ -50,7 +50,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertNonNull() {
+    void assertNonNullTest() {
         assertNonNull(this, "This is not null");
 
         testAssertFails(() -> assertNonNull(null, "Null should be null"),
@@ -58,7 +58,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertPositiveInteger() {
+    void assertPositiveInteger() {
         // Fixed tests
         assertPositive(0, "Zero is positive");
         assertPositive(1, "One is also positive");
@@ -78,7 +78,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertPositiveLong() {
+    void assertPositiveLong() {
         // Fixed tests
         assertPositive(0L, "Zero is positive");
         assertPositive(1L, "One is also positive");
@@ -98,7 +98,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertStrictPositiveInteger() {
+    void assertStrictPositiveInteger() {
         // Fixed tests
         assertStrictPositive(1, "One is positive");
         testAssertFails(() -> assertStrictPositive(0, "Zero is not strict positive"),
@@ -119,7 +119,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertStrictPositiveLong() {
+    void assertStrictPositiveLong() {
         // Fixed tests
         assertStrictPositive(1L, "One is also positive");
         testAssertFails(() -> assertStrictPositive(0L, "Zero is not strict positive"),
@@ -140,7 +140,7 @@ class BuilderUtilsTest {
     }
 
     @Test
-    void testAssertNonEmpty() {
+    void assertNonEmptyTest() {
         assertNonEmpty("some-text", "Reacts fine on some text");
         testAssertFails(() -> assertNonEmpty(null, "Should fail on null"),
                         "BuilderUtils.assertNonEmpty() should have failed on value null.");

--- a/messaging/src/test/java/org/axonframework/common/CollectionUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/CollectionUtilsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CollectionUtilsTest {
 
     @Test
-    void testCreateCollectionFromPotentialCollection() {
+    void createCollectionFromPotentialCollection() {
         Collection<String> collectionFromElement = CollectionUtils.asCollection("item");
         Collection<String> collectionFromNull = CollectionUtils.asCollection(null);
         Collection<String> collectionFromArray = CollectionUtils.asCollection(new String[]{"item1", "item2"});
@@ -45,7 +45,7 @@ class CollectionUtilsTest {
     }
 
     @Test
-    void testIntersect() {
+    void intersect() {
         TreeSet<Integer> result1 = CollectionUtils.intersect(asList(1, 2, 4, 5), asList(1, 3, 5, 7), TreeSet::new);
         TreeSet<Integer> result2 = CollectionUtils.intersect(emptyList(), asList(1, 3, 5, 7), TreeSet::new);
         List<Integer> result3 = CollectionUtils.intersect(singletonList(1), asList(1, 3, 5, 7), ArrayList::new);

--- a/messaging/src/test/java/org/axonframework/common/DateTimeUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/DateTimeUtilsTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DateTimeUtilsTest {
 
     @Test
-    void testFormattedDateAlwaysContainsMillis() {
+    void formattedDateAlwaysContainsMillis() {
         Instant now = Instant.now();
         Instant nowAtZeroMillis = now.minusNanos(now.get(ChronoField.NANO_OF_SECOND));
 
@@ -43,7 +43,7 @@ class DateTimeUtilsTest {
     }
 
     @Test
-    void testFormatInstantHasFixedPrecisionAtThree() {
+    void formatInstantHasFixedPrecisionAtThree() {
         String expectedDateTimeString = "2021-03-22T15:41:02.101Z";
 
         Instant testInstantWithTrailingZeroes = Instant.parse("2021-03-22T15:41:02.101900Z");

--- a/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ObjectUtilsTest.java
@@ -35,14 +35,14 @@ class ObjectUtilsTest {
     private static final String DEFAULT_VALUE = "default";
 
     @Test
-    void testGetOrDefaultUsingValueProvider() {
+    void getOrDefaultUsingValueProvider() {
         Function<String, String> valueProvider = o -> o;
         assertEquals(DEFAULT_VALUE, ObjectUtils.getOrDefault(NULL_INSTANCE, valueProvider, DEFAULT_VALUE));
         assertEquals(INSTANCE, ObjectUtils.getOrDefault(INSTANCE, valueProvider, DEFAULT_VALUE));
     }
 
     @Test
-    void testSupplySameInstance() {
+    void supplySameInstance() {
         Supplier<Object> testSubject = ObjectUtils.sameInstanceSupplier(Object::new);
         assertSame(testSubject.get(), testSubject.get());
     }

--- a/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ReflectionUtilsTest {
 
     @Test
-    void testFindFieldsInClass() {
+    void findFieldsInClass() {
         Iterable<Field> actualFields = ReflectionUtils.fieldsOf(SomeSubType.class);
         int t = 0;
         for (Field actual : actualFields) {
@@ -61,7 +61,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testNonRecursivelyFindFieldsInClass() {
+    void nonRecursivelyFindFieldsInClass() {
         Iterable<Field> actualFields = ReflectionUtils.fieldsOf(SomeSubType.class, NOT_RECURSIVE);
         int t = 0;
         for (Field actual : actualFields) {
@@ -76,7 +76,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testFindMethodsInClass() {
+    void findMethodsInClass() {
         Iterable<Method> actualMethods = ReflectionUtils.methodsOf(SomeSubType.class);
         int t = 0;
         for (Method actual : actualMethods) {
@@ -107,7 +107,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testNonRecursivelyFindMethodsInClass() {
+    void nonRecursivelyFindMethodsInClass() {
         Iterable<Method> actualMethods = ReflectionUtils.methodsOf(SomeSubType.class, NOT_RECURSIVE);
         int t = 0;
         for (Method actual : actualMethods) {
@@ -129,13 +129,13 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testGetFieldValue() throws NoSuchFieldException {
+    void getFieldValue() throws NoSuchFieldException {
         Object value = ReflectionUtils.getFieldValue(SomeType.class.getDeclaredField("field1"), new SomeSubType());
         assertEquals("field1", value);
     }
 
     @Test
-    void testSetFieldValue() throws Exception {
+    void setFieldValue() throws Exception {
         int expectedFieldValue = 4;
         SomeSubType testObject = new SomeSubType();
         ReflectionUtils.setFieldValue(SomeSubType.class.getDeclaredField("field3"), testObject, expectedFieldValue);
@@ -143,7 +143,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testIsAccessible() throws NoSuchFieldException {
+    void isAccessible() throws NoSuchFieldException {
         Field field1 = SomeType.class.getDeclaredField("field1");
         Field field2 = SomeType.class.getDeclaredField("field2");
         Field field3 = SomeSubType.class.getDeclaredField("field3");
@@ -153,14 +153,14 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testExplicitlyUnequal_NullValues() {
+    void explicitlyUnequal_NullValues() {
         assertFalse(explicitlyUnequal(null, null));
         assertTrue(explicitlyUnequal(null, ""));
         assertTrue(explicitlyUnequal("", null));
     }
 
     @Test
-    void testHasEqualsMethod() {
+    void hasEqualsMethodTest() {
         assertTrue(hasEqualsMethod(String.class));
         assertTrue(hasEqualsMethod(ArrayList.class));
         assertFalse(hasEqualsMethod(SomeType.class));
@@ -168,35 +168,35 @@ class ReflectionUtilsTest {
 
     @SuppressWarnings("StringOperationCanBeSimplified")
     @Test
-    void testExplicitlyUnequal_ComparableValues() {
+    void explicitlyUnequal_ComparableValues() {
         assertFalse(explicitlyUnequal("value", new String("value")));
         assertTrue(explicitlyUnequal("value1", "value2"));
     }
 
     @Test
-    void testExplicitlyUnequal_OverridesEqualsMethod() {
+    void explicitlyUnequal_OverridesEqualsMethod() {
         assertFalse(explicitlyUnequal(Collections.singletonList("value"), Collections.singletonList("value")));
         assertTrue(explicitlyUnequal(Collections.singletonList("value1"), Collections.singletonList("value")));
     }
 
     @Test
-    void testExplicitlyUnequal_NoEqualsOrComparable() {
+    void explicitlyUnequal_NoEqualsOrComparable() {
         assertFalse(explicitlyUnequal(new SomeType(), new SomeType()));
     }
 
     @Test
-    void testResolvePrimitiveWrapperTypeForLong() {
+    void resolvePrimitiveWrapperTypeForLong() {
         assertEquals(Long.class, resolvePrimitiveWrapperType(long.class));
     }
 
     @Test
-    void testGetMemberValueFromField() throws NoSuchFieldException {
+    void getMemberValueFromField() throws NoSuchFieldException {
         assertEquals("field1",
                      ReflectionUtils.getMemberValue(SomeType.class.getDeclaredField("field1"), new SomeSubType()));
     }
 
     @Test
-    void testGetMemberValueFromMethod() throws NoSuchMethodException {
+    void getMemberValueFromMethod() throws NoSuchMethodException {
         assertEquals("field1",
                      ReflectionUtils.getMemberValue(SomeType.class.getDeclaredMethod("getField1"), new SomeSubType()));
         assertEquals("someMethodResult",
@@ -204,7 +204,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testGetMemberValueFromVoidMethod() throws NoSuchMethodException {
+    void getMemberValueFromVoidMethod() throws NoSuchMethodException {
         SomeTypeWithMethods testObject = new SomeTypeWithMethods();
         Object voidReturnValue = getMemberValue(SomeTypeWithMethods.class.getDeclaredMethod("someVoidMethod"),
                                                 testObject);
@@ -213,20 +213,20 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testGetMemberValueFromConstructor() throws NoSuchMethodException {
+    void getMemberValueFromConstructor() throws NoSuchMethodException {
         Constructor<SomeType> testConstructor = SomeType.class.getDeclaredConstructor();
         SomeSubType testTarget = new SomeSubType();
         assertThrows(IllegalStateException.class, () -> ReflectionUtils.getMemberValue(testConstructor, testTarget));
     }
 
     @Test
-    void testGetMemberValueTypeFromField() throws NoSuchFieldException {
+    void getMemberValueTypeFromField() throws NoSuchFieldException {
         Class<?> fieldType = getMemberValueType(SomeType.class.getDeclaredField("field1"));
         assertEquals(String.class, fieldType);
     }
 
     @Test
-    void testGetMemberValueTypeFromMethod() throws NoSuchMethodException {
+    void getMemberValueTypeFromMethod() throws NoSuchMethodException {
         Class<?> methodValueType = getMemberValueType(SomeSubType.class.getDeclaredMethod("getField3"));
         assertEquals(int.class, methodValueType);
         Class<?> voidResultType = getMemberValueType(SomeTypeWithMethods.class.getDeclaredMethod("someVoidMethod"));
@@ -234,13 +234,13 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testGetMemberValueTypeFromConstructor() throws NoSuchMethodException {
+    void getMemberValueTypeFromConstructor() throws NoSuchMethodException {
         Constructor<SomeType> testConstructor = SomeType.class.getDeclaredConstructor();
         assertThrows(IllegalStateException.class, () -> getMemberValueType(testConstructor));
     }
 
     @Test
-    void testInvokeAndGetMethodValue() throws NoSuchMethodException {
+    void invokeAndGetMethodValueTest() throws NoSuchMethodException {
         assertEquals("field1",
                      invokeAndGetMethodValue(SomeTypeWithMethods.class.getDeclaredMethod("getField1"), new SomeTypeWithMethods()));
         assertEquals("someMethodResult",
@@ -254,41 +254,41 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void testMemberGenericTypeFromField() throws NoSuchFieldException {
+    void memberGenericTypeFromField() throws NoSuchFieldException {
         Field field = SomeType.class.getDeclaredField("field1");
         Type memberGenericType = getMemberGenericType(field);
         assertEquals(field.getGenericType(), memberGenericType);
     }
 
     @Test
-    void testMemberGenericTypeFromMethod() throws NoSuchMethodException {
+    void memberGenericTypeFromMethod() throws NoSuchMethodException {
         Method method = SomeTypeWithMethods.class.getDeclaredMethod("someMethod");
         Type memberGenericType = getMemberGenericType(method);
         assertEquals(method.getGenericReturnType(), memberGenericType);
     }
 
     @Test
-    void testMemberGenericTypeFromConstructor() throws NoSuchMethodException {
+    void memberGenericTypeFromConstructor() throws NoSuchMethodException {
         Constructor<SomeTypeWithMethods> constructor = SomeTypeWithMethods.class.getDeclaredConstructor();
         assertThrows(IllegalStateException.class, () -> getMemberGenericType(constructor));
     }
 
     @Test
-    void testMemberGenericStringFromField() throws NoSuchFieldException {
+    void memberGenericStringFromField() throws NoSuchFieldException {
         Field field = SomeType.class.getDeclaredField("field1");
         String memberGenericString = getMemberGenericString(field);
         assertEquals(field.toGenericString(), memberGenericString);
     }
 
     @Test
-    void testMemberGenericStringFromMethod() throws NoSuchMethodException {
+    void memberGenericStringFromMethod() throws NoSuchMethodException {
         Method method = SomeTypeWithMethods.class.getDeclaredMethod("someMethod");
         String memberGenericString = getMemberGenericString(method);
         assertEquals(method.toGenericString(), memberGenericString);
     }
 
     @Test
-    void testMemberGenericStringFromConstructor() throws NoSuchMethodException {
+    void memberGenericStringFromConstructor() throws NoSuchMethodException {
         Constructor<SomeTypeWithMethods> constructor = SomeTypeWithMethods.class.getDeclaredConstructor();
         String memberGenericString = getMemberGenericString(constructor);
         assertEquals(constructor.toGenericString(), memberGenericString);
@@ -296,14 +296,14 @@ class ReflectionUtilsTest {
 
 
     @Test
-    void testToDiscernableSignatureOfConstructor() throws NoSuchMethodException {
+    void toDiscernableSignatureOfConstructor() throws NoSuchMethodException {
         Constructor<SomeTypeWithMethods> constructor = SomeTypeWithMethods.class.getDeclaredConstructor();
         String memberGenericString = toDiscernibleSignature(constructor);
         assertEquals("org.axonframework.common.ReflectionUtilsTest$SomeTypeWithMethods()", memberGenericString);
     }
 
     @Test
-    void testToDiscernableSignatureOfMethod() throws NoSuchMethodException {
+    void toDiscernableSignatureOfMethod() throws NoSuchMethodException {
         Method method = SomeTypeWithMethods.class.getMethod("someMethodWithParameters", String.class, Integer.class, Object.class);
         String memberGenericString = toDiscernibleSignature(method);
         assertEquals("someMethodWithParameters(java.lang.String,java.lang.Integer,java.lang.Object)", memberGenericString);

--- a/messaging/src/test/java/org/axonframework/common/StringUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/StringUtilsTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class StringUtilsTest {
 
     @Test
-    void testNonEmptyOrNull() {
+    void nonEmptyOrNull() {
         assertFalse(StringUtils.nonEmptyOrNull(""));
         assertFalse(StringUtils.nonEmptyOrNull(null));
         assertTrue(StringUtils.nonEmptyOrNull("some-string"));

--- a/messaging/src/test/java/org/axonframework/common/annotation/AnnotationUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/annotation/AnnotationUtilsTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnnotationUtilsTest {
 
     @Test
-    void testFindAttributesOnDirectAnnotation() throws NoSuchMethodException {
+    void findAttributesOnDirectAnnotation() throws NoSuchMethodException {
         Optional<Map<String, Object>> optionalResult =
                 findAnnotationAttributes(getClass().getDeclaredMethod("directAnnotated"), TheTarget.class);
         assertTrue(optionalResult.isPresent());
@@ -56,7 +56,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testFindAttributesOnStaticMetaAnnotation() throws NoSuchMethodException {
+    void findAttributesOnStaticMetaAnnotation() throws NoSuchMethodException {
         Optional<Map<String, Object>> optionalResult =
                 findAnnotationAttributes(getClass().getDeclaredMethod("staticallyOverridden"), TheTarget.class);
         assertTrue(optionalResult.isPresent());
@@ -66,7 +66,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testFindAttributesOnDynamicMetaAnnotation() throws NoSuchMethodException {
+    void findAttributesOnDynamicMetaAnnotation() throws NoSuchMethodException {
         Optional<Map<String, Object>> optionalResult =
                 findAnnotationAttributes(getClass().getDeclaredMethod("dynamicallyOverridden"), TheTarget.class);
         assertTrue(optionalResult.isPresent());
@@ -77,7 +77,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testFindAttributesOnDynamicMetaAnnotationUsingAnnotationName() throws NoSuchMethodException {
+    void findAttributesOnDynamicMetaAnnotationUsingAnnotationName() throws NoSuchMethodException {
         Optional<Map<String, Object>> optionalResult = findAnnotationAttributes(
                 getClass().getDeclaredMethod("dynamicallyOverridden"), TheTarget.class.getName()
         );
@@ -90,14 +90,14 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testFindAttributesOnNonExistentAnnotation() throws NoSuchMethodException {
+    void findAttributesOnNonExistentAnnotation() throws NoSuchMethodException {
         Optional<Map<String, Object>> result =
                 findAnnotationAttributes(getClass().getDeclaredMethod("dynamicallyOverridden"), RoutingKey.class);
         assertFalse(result.isPresent(), "Didn't expect attributes to be found for non-existent annotation");
     }
 
     @Test
-    void testFindAnnotationAttributesOnlyReturnsTargetAttributesAndOverridesForClassAnnotation()
+    void findAnnotationAttributesOnlyReturnsTargetAttributesAndOverridesForClassAnnotation()
             throws NoSuchMethodException {
         Method annotatedElement = getClass().getDeclaredMethod("dynamicallyOverridden");
 
@@ -113,7 +113,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testFindAnnotationAttributesOnlyReturnsTargetAttributesAndOverridesForStringAnnotation()
+    void findAnnotationAttributesOnlyReturnsTargetAttributesAndOverridesForStringAnnotation()
             throws NoSuchMethodException {
         Method annotatedElement = getClass().getDeclaredMethod("someAnnotatedMethod");
 
@@ -129,7 +129,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testIsAnnotatedWithReturnsTrue() {
+    void isAnnotatedWithReturnsTrue() {
         Set<Class<? extends Annotation>> expectedAnnotatedWithSubject = new HashSet<>();
         expectedAnnotatedWithSubject.add(DynamicOverrideAnnotated.class);
         expectedAnnotatedWithSubject.add(AnotherMetaAnnotation.class);
@@ -153,7 +153,7 @@ class AnnotationUtilsTest {
     }
 
     @Test
-    void testIsAnnotatedWithReturnsFalse() {
+    void isAnnotatedWithReturnsFalse() {
         Set<Class<? extends Annotation>> expectedAnnotatedWithSubject = Collections.emptySet();
         Set<Class<? extends Annotation>> expectedVisited = new HashSet<>();
         expectedVisited.add(NotMetaAnnotated.class);

--- a/messaging/src/test/java/org/axonframework/common/annotation/PriorityAnnotationComparatorTest.java
+++ b/messaging/src/test/java/org/axonframework/common/annotation/PriorityAnnotationComparatorTest.java
@@ -37,7 +37,7 @@ class PriorityAnnotationComparatorTest {
     }
 
     @Test
-    void testCompareDifferentPriorities() {
+    void compareDifferentPriorities() {
         assertTrue(testSubject.compare(new LowPrio(), new HighPrio()) > 0);
         assertTrue(testSubject.compare(new LowPrio(), new NeutralPrio()) > 0);
         assertTrue(testSubject.compare(new NeutralPrio(), new HighPrio()) > 0);
@@ -48,14 +48,14 @@ class PriorityAnnotationComparatorTest {
     }
 
     @Test
-    void testCompareSamePriorities() {
+    void compareSamePriorities() {
         assertEquals(0, testSubject.compare(new LowPrio(), new LowPrio()));
         assertEquals(0, testSubject.compare(new NeutralPrio(), new NeutralPrio()));
         assertEquals(0, testSubject.compare(new HighPrio(), new HighPrio()));
     }
 
     @Test
-    void testUndefinedConsideredNeutralPriority() {
+    void undefinedConsideredNeutralPriority() {
         assertTrue(testSubject.compare(new UndefinedPrio(), new HighPrio()) > 0);
         assertTrue(testSubject.compare(new UndefinedPrio(), new LowPrio()) < 0);
         assertTrue(testSubject.compare(new UndefinedPrio(), new NeutralPrio()) == 0);

--- a/messaging/src/test/java/org/axonframework/common/caching/NoCacheTest.java
+++ b/messaging/src/test/java/org/axonframework/common/caching/NoCacheTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.mock;
 class NoCacheTest {
 
     @Test
-    void testCacheDoesNothing() throws CacheException {
+    void cacheDoesNothing() throws CacheException {
         // this is pretty stupid, but we're testing that it does absolutely nothing
         NoCache cache = NoCache.INSTANCE;
         Registration registration = cache.registerCacheEntryListener(mock(Cache.EntryListener.class));

--- a/messaging/src/test/java/org/axonframework/common/caching/WeakReferenceCacheTest.java
+++ b/messaging/src/test/java/org/axonframework/common/caching/WeakReferenceCacheTest.java
@@ -48,7 +48,7 @@ class WeakReferenceCacheTest {
     }
 
     @Test
-    void testItemPurgedWhenNoLongerReferenced() throws Exception {
+    void itemPurgedWhenNoLongerReferenced() throws Exception {
         // Mockito holds a reference to all parameters, preventing GC
         registration.cancel();
         final Set<String> expiredEntries = new CopyOnWriteArraySet<>();
@@ -86,7 +86,7 @@ class WeakReferenceCacheTest {
     }
 
     @Test
-    void testEntryListenerNotifiedOfCreationUpdateAndDeletion() {
+    void entryListenerNotifiedOfCreationUpdateAndDeletion() {
 
         Object value = new Object();
         Object value2 = new Object();
@@ -107,12 +107,12 @@ class WeakReferenceCacheTest {
     }
 
     @Test
-    void testShouldThrowIllegalArgumentExceptionWhenKeyIsNullOnGet() {
+    void shouldThrowIllegalArgumentExceptionWhenKeyIsNullOnGet() {
         assertThrows(IllegalArgumentException.class, () -> testSubject.get(null));
     }
 
     @Test
-    void testShouldThrowIllegalArgumentExceptionWhenKeyIsNullOnContainsKey() {
+    void shouldThrowIllegalArgumentExceptionWhenKeyIsNullOnContainsKey() {
         assertThrows(IllegalArgumentException.class, () -> testSubject.containsKey(null));
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/jdbc/ConnectionWrapperFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/jdbc/ConnectionWrapperFactoryTest.java
@@ -43,7 +43,7 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testWrapperDelegatesAllButClose() throws Exception {
+    void wrapperDelegatesAllButClose() throws Exception {
         Connection wrapped = wrap(connection, closeHandler);
         wrapped.commit();
         verify(closeHandler).commit(connection);
@@ -59,7 +59,7 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testEquals_WithWrapper() {
+    void equals_WithWrapper() {
         final Runnable runnable = mock(Runnable.class);
         Connection wrapped = wrap(connection, Runnable.class, runnable, closeHandler);
 
@@ -68,7 +68,7 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testEquals_WithoutWrapper() {
+    void equals_WithoutWrapper() {
         Connection wrapped = wrap(connection, closeHandler);
 
         assertNotEquals(wrapped, connection);
@@ -76,20 +76,20 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testHashCode_WithWrapper() {
+    void hashCode_WithWrapper() {
         final Runnable runnable = mock(Runnable.class);
         Connection wrapped = wrap(connection, Runnable.class, runnable, closeHandler);
         assertEquals(wrapped.hashCode(), wrapped.hashCode());
     }
 
     @Test
-    void testHashCode_WithoutWrapper() {
+    void hashCode_WithoutWrapper() {
         Connection wrapped = wrap(connection, closeHandler);
         assertEquals(wrapped.hashCode(), wrapped.hashCode());
     }
 
     @Test
-    void testUnwrapInvocationTargetException() throws Exception {
+    void unwrapInvocationTargetException() throws Exception {
         when(connection.prepareStatement(anyString())).thenThrow(new SQLException());
 
         Connection wrapper = wrap(connection, closeHandler);
@@ -97,7 +97,7 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testUnwrapInvocationTargetExceptionWithAdditionalWrapperInterface1() throws Exception {
+    void unwrapInvocationTargetExceptionWithAdditionalWrapperInterface1() throws Exception {
         WrapperInterface wrapperImplementation = mock(WrapperInterface.class);
         when(connection.prepareStatement(anyString())).thenThrow(new SQLException());
 
@@ -106,7 +106,7 @@ class ConnectionWrapperFactoryTest {
     }
 
     @Test
-    void testUnwrapInvocationTargetExceptionWithAdditionalWrapperInterface2() throws Exception {
+    void unwrapInvocationTargetExceptionWithAdditionalWrapperInterface2() throws Exception {
         WrapperInterface wrapperImplementation = mock(WrapperInterface.class);
         doThrow(new SQLException()).when(wrapperImplementation).foo();
 

--- a/messaging/src/test/java/org/axonframework/common/jdbc/JdbcUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/jdbc/JdbcUtilsTest.java
@@ -43,7 +43,7 @@ class JdbcUtilsTest {
      * @see JdbcUtils#extract(ResultSet, int, Class)
      */
     @Test
-    void testNextAndExtract_EmptyResultSet() throws Exception {
+    void nextAndExtract_EmptyResultSet() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
 
         when(resultSet.next()).thenReturn(false);
@@ -59,7 +59,7 @@ class JdbcUtilsTest {
      * @see JdbcUtils#extract(ResultSet, int, Class)
      */
     @Test
-    void testNextAndExtract_NullValue() throws Exception {
+    void nextAndExtract_NullValue() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
 
         when(resultSet.next()).thenReturn(true);
@@ -76,7 +76,7 @@ class JdbcUtilsTest {
      * @see JdbcUtils#extract(ResultSet, int, Class)
      */
     @Test
-    void testNextAndExtract_NonNullValue() throws Exception {
+    void nextAndExtract_NonNullValue() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
 
         when(resultSet.next()).thenReturn(true);
@@ -97,7 +97,7 @@ class JdbcUtilsTest {
      * @see JdbcUtils#extract(ResultSet, int, Class)
      */
     @Test
-    void testNextAndExtract_NonNullValue_WasNull() throws Exception {
+    void nextAndExtract_NonNullValue_WasNull() throws Exception {
         ResultSet resultSet = mock(ResultSet.class);
 
         when(resultSet.next()).thenReturn(true);

--- a/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
+++ b/messaging/src/test/java/org/axonframework/common/jdbc/UnitOfWorkAwareConnectionProviderWrapperTest.java
@@ -54,13 +54,13 @@ class UnitOfWorkAwareConnectionProviderWrapperTest {
     }
 
     @Test
-    void testConnectionReturnedImmediatelyWhenNoActiveUnitOfWork() throws SQLException {
+    void connectionReturnedImmediatelyWhenNoActiveUnitOfWork() throws SQLException {
         Connection actual = testSubject.getConnection();
         assertSame(actual, mockConnection);
     }
 
     @Test
-    void testConnectionIsWrappedWhenUnitOfWorkIsActive() throws SQLException {
+    void connectionIsWrappedWhenUnitOfWorkIsActive() throws SQLException {
         DefaultUnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         Connection actual = testSubject.getConnection();
         assertNotSame(actual, mockConnection);
@@ -75,7 +75,7 @@ class UnitOfWorkAwareConnectionProviderWrapperTest {
     }
 
     @Test
-    void testWrappedConnectionBlocksCommitCallsUntilUnitOfWorkCommit() throws SQLException {
+    void wrappedConnectionBlocksCommitCallsUntilUnitOfWorkCommit() throws SQLException {
         DefaultUnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         when(mockConnection.getAutoCommit()).thenReturn(false);
         when(mockConnection.isClosed()).thenReturn(false);
@@ -95,7 +95,7 @@ class UnitOfWorkAwareConnectionProviderWrapperTest {
     }
 
     @Test
-    void testWrappedConnectionRollsBackCallsWhenUnitOfWorkRollback() throws SQLException {
+    void wrappedConnectionRollsBackCallsWhenUnitOfWorkRollback() throws SQLException {
         DefaultUnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
         when(mockConnection.getAutoCommit()).thenReturn(false);
         when(mockConnection.isClosed()).thenReturn(false);
@@ -116,7 +116,7 @@ class UnitOfWorkAwareConnectionProviderWrapperTest {
     }
 
     @Test
-    void testOriginalExceptionThrewWhenRollbackFailed() throws SQLException {
+    void originalExceptionThrewWhenRollbackFailed() throws SQLException {
         DefaultUnitOfWork<Message<?>> uow = new DefaultUnitOfWork<Message<?>>(null) {
             @Override
             public ExecutionResult getExecutionResult() {
@@ -138,7 +138,7 @@ class UnitOfWorkAwareConnectionProviderWrapperTest {
     }
 
     @Test
-    void testInnerUnitOfWorkCommitDoesNotCloseConnection() throws SQLException {
+    void innerUnitOfWorkCommitDoesNotCloseConnection() throws SQLException {
         when(mockConnection.getAutoCommit()).thenReturn(false);
         when(mockConnection.isClosed()).thenReturn(false);
 

--- a/messaging/src/test/java/org/axonframework/common/lock/LockFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/LockFactoryTest.java
@@ -45,7 +45,7 @@ class LockFactoryTest {
     }
 
     @Test
-    void testObtainLock() {
+    void obtainLock() {
         ExecutorService service = Executors.newFixedThreadPool(THREAD_COUNT);
         LockUnlock[] attempts = new LockUnlock[ATTEMPTS];
         for (int t = 0; t < ATTEMPTS; t++) {

--- a/messaging/src/test/java/org/axonframework/common/lock/NoOpLockTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/NoOpLockTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class NoOpLockTest {
 
     @Test
-    void testIsHeldReturnsTrue() {
+    void isHeldReturnsTrue() {
         assertTrue(NoOpLock.INSTANCE.isHeld());
     }
 }

--- a/messaging/src/test/java/org/axonframework/common/lock/NullLockFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/NullLockFactoryTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class NullLockFactoryTest {
 
     @Test
-    void testObtainLockReturnsNoOpLockInstance() {
+    void obtainLockReturnsNoOpLockInstance() {
         LockFactory testSubject = NullLockFactory.INSTANCE;
 
         assertEquals(NoOpLock.INSTANCE, testSubject.obtainLock(null));

--- a/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/common/lock/PessimisticLockFactoryTest.java
@@ -36,7 +36,7 @@ class PessimisticLockFactoryTest {
     private String identifier = "mockId";
 
     @Test
-    void testLockReferenceCleanedUpAtUnlock() throws NoSuchFieldException, IllegalAccessException {
+    void lockReferenceCleanedUpAtUnlock() throws NoSuchFieldException, IllegalAccessException {
         PessimisticLockFactory manager = PessimisticLockFactory.builder().build();
         Lock lock = manager.obtainLock(identifier);
         lock.release();
@@ -48,7 +48,7 @@ class PessimisticLockFactoryTest {
     }
 
     @Test
-    void testLockOnlyCleanedUpIfNoLocksAreHeld() throws NoSuchFieldException, IllegalAccessException {
+    void lockOnlyCleanedUpIfNoLocksAreHeld() throws NoSuchFieldException, IllegalAccessException {
         PessimisticLockFactory manager = PessimisticLockFactory.builder().build();
         Lock lock1 = manager.obtainLock(identifier);
         Lock lock2 = manager.obtainLock(identifier);
@@ -66,7 +66,7 @@ class PessimisticLockFactoryTest {
 
     @Test
     @Timeout(value = 10)
-    void testDeadlockDetected_TwoThreadsInVector() throws InterruptedException {
+    void deadlockDetected_TwoThreadsInVector() throws InterruptedException {
         final PessimisticLockFactory lock = PessimisticLockFactory.builder().build();
         final CountDownLatch starter = new CountDownLatch(1);
         final CountDownLatch cdl = new CountDownLatch(1);
@@ -86,7 +86,7 @@ class PessimisticLockFactoryTest {
 
     @Test
     @Timeout(value = 12)
-    void testDeadlockDetected_TwoDifferentLockInstances() throws InterruptedException {
+    void deadlockDetected_TwoDifferentLockInstances() throws InterruptedException {
         final PessimisticLockFactory lock1 = PessimisticLockFactory.builder().build();
         final PessimisticLockFactory lock2 = PessimisticLockFactory.builder().build();
         final CountDownLatch starter = new CountDownLatch(1);
@@ -107,7 +107,7 @@ class PessimisticLockFactoryTest {
 
     @Test
     @Timeout(value = 10)
-    void testDeadlockDetected_ThreeThreadsInVector() throws InterruptedException {
+    void deadlockDetected_ThreeThreadsInVector() throws InterruptedException {
         final PessimisticLockFactory lock = PessimisticLockFactory.builder().build();
         final CountDownLatch starter = new CountDownLatch(3);
         final CountDownLatch cdl = new CountDownLatch(1);
@@ -151,7 +151,7 @@ class PessimisticLockFactoryTest {
 
     @Test
     @Timeout(value = 5)
-    void testAcquireBackoff() {
+    void acquireBackoff() {
         final PessimisticLockFactory lockFactory = PessimisticLockFactory.builder()
                                                                          .acquireAttempts(10)
                                                                          .queueLengthThreshold(Integer.MAX_VALUE)
@@ -172,7 +172,7 @@ class PessimisticLockFactoryTest {
 
     @Test
     @Timeout(value = 5)
-    void testQueueBackoff() {
+    void queueBackoff() {
         final PessimisticLockFactory lockFactory = PessimisticLockFactory.builder()
                                                                          .acquireAttempts(Integer.MAX_VALUE)
                                                                          .queueLengthThreshold(2)
@@ -196,25 +196,25 @@ class PessimisticLockFactoryTest {
     }
 
     @Test
-    void testBackoffParametersConstructorAquireAttempts() {
+    void backoffParametersConstructorAquireAttempts() {
         int illegalValue = 0;
         assertThrows(IllegalArgumentException.class, () -> PessimisticLockFactory.builder().acquireAttempts(illegalValue));
     }
 
     @Test
-    void testBackoffParametersConstructorMaximumQueued() {
+    void backoffParametersConstructorMaximumQueued() {
         int illegalValue = 0;
         assertThrows(IllegalArgumentException.class, () -> PessimisticLockFactory.builder().queueLengthThreshold(illegalValue));
     }
 
     @Test
-    void testBackoffParametersConstructorSpinTime() {
+    void backoffParametersConstructorSpinTime() {
         int illegalValue = -1;
         assertThrows(IllegalArgumentException.class, () -> PessimisticLockFactory.builder().lockAttemptTimeout(illegalValue));
     }
 
     @Test
-    void testShouldThrowIllegalArgumentExceptionWhenIdentifierIsNull() {
+    void shouldThrowIllegalArgumentExceptionWhenIdentifierIsNull() {
         this.identifier = null;
         PessimisticLockFactory manager = PessimisticLockFactory.builder().build();
 

--- a/messaging/src/test/java/org/axonframework/common/property/AbstractPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/AbstractPropertyAccessStrategyTest.java
@@ -26,26 +26,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public abstract class AbstractPropertyAccessStrategyTest<T> {
 
     @Test
-    void testGetValue() {
+    void getValue() {
         final Property<T> actualProperty = getProperty(regularPropertyName());
         assertNotNull(actualProperty);
         assertNotNull(actualProperty.<String>getValue(propertyHoldingInstance()));
     }
 
     @Test
-    void testGetValue_BogusProperty() {
+    void getValue_BogusProperty() {
         assertNull(getProperty(unknownPropertyName()));
     }
 
     @Test
-    void testGetValue_ExceptionOnAccess() {
+    void getValue_ExceptionOnAccess() {
         Property<T> property = getProperty(exceptionPropertyName());
 
         assertThrows(PropertyAccessException.class, () -> property.getValue(propertyHoldingInstance()));
     }
 
     @Test
-    void testVoidReturnTypeRejected() {
+    void voidReturnTypeRejected() {
         Property property = getProperty(voidPropertyName());
         assertNull(property, "void methods should not be accepted as property");
     }

--- a/messaging/src/test/java/org/axonframework/common/property/DirectPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/DirectPropertyAccessStrategyTest.java
@@ -23,24 +23,24 @@ import static org.junit.jupiter.api.Assertions.*;
 class DirectPropertyAccessStrategyTest {
 
 	@Test
-	void testGetValue() {
+	void getValue() {
 		final Property<TestMessage> actualProperty = getProperty(regularPropertyName());
 		assertNotNull(actualProperty);
 		assertNotNull(actualProperty.<String>getValue(propertyHoldingInstance()));
 	}
 
 	@Test
-	void testGetValue_BogusProperty() {
+	void getValue_BogusProperty() {
 		assertNull(getProperty(unknownPropertyName()));
 	}
 
 	@Test
-	void testGetValue_NullForPrivateProperty() {
+	void getValue_NullForPrivateProperty() {
 		assertNull(getProperty(privatePropertyName()));
 	}
 
 	@Test
-	void testOverriddenPropertyValue() {
+	void overriddenPropertyValue() {
 		assertEquals("realValue", getProperty(overriddenPropertyName()).getValue(propertyHoldingInstance()));
 	}
 

--- a/messaging/src/test/java/org/axonframework/common/property/PropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/PropertyAccessStrategyTest.java
@@ -40,26 +40,26 @@ class PropertyAccessStrategyTest {
     }
 
     @Test
-    void test_BeanPropertyAccess() {
+    void beanPropertyAccess() {
         assertEquals("beanProperty", PropertyAccessStrategy.getProperty(Bean.class, "beanProperty")
                                                            .getValue(new Bean()));
     }
 
     @Test
-    void test_UniformPropertyAccess() {
+    void uniformPropertyAccess() {
         assertEquals("uniformProperty", PropertyAccessStrategy.getProperty(Bean.class, "uniformProperty").getValue(
                 new Bean()));
     }
 
     @Test
-    void test_Register() {
+    void register() {
         PropertyAccessStrategy.register(testPropertyAccessStrategy);
         assertEquals("testGetterInvoked",
                      PropertyAccessStrategy.getProperty(Bean.class, "testProperty").getValue(new Bean()));
     }
 
     @Test
-    void testInvocationOrdering() {
+    void invocationOrdering() {
         PropertyAccessStrategy.register(mock1);
         PropertyAccessStrategy.register(mock2);
         assertEquals("mock2",
@@ -67,7 +67,7 @@ class PropertyAccessStrategyTest {
     }
 
     @Test
-    void testInvocationOrdering_EqualPriorityUsesClassName() {
+    void invocationOrdering_EqualPriorityUsesClassName() {
         PropertyAccessStrategy.register(mock3);
         PropertyAccessStrategy.register(mock4);
         assertEquals("mock3",

--- a/messaging/src/test/java/org/axonframework/deadline/annotation/DeadlineMethodMessageHandlerDefinitionTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/annotation/DeadlineMethodMessageHandlerDefinitionTest.java
@@ -38,7 +38,7 @@ class DeadlineMethodMessageHandlerDefinitionTest {
     }
 
     @Test
-    void testDeadlineManagerIsEvaluatedBeforeGenericEventHandler() throws Exception {
+    void deadlineManagerIsEvaluatedBeforeGenericEventHandler() throws Exception {
         handlerAdapter.handle(new GenericDeadlineMessage<>("someDeadline", "test"));
 
         assertThat("Deadline handler is invoked", listener.deadlineCounter.get() == 1);
@@ -46,7 +46,7 @@ class DeadlineMethodMessageHandlerDefinitionTest {
     }
 
     @Test
-    void testNamedDeadlineManagerIsEvaluatedBeforeGenericOne() throws Exception {
+    void namedDeadlineManagerIsEvaluatedBeforeGenericOne() throws Exception {
         handlerAdapter.handle(new GenericDeadlineMessage<>("specificDeadline", "test"));
 
         assertThat("Generic Deadline handler was not invoked", listener.deadlineCounter.get() == 0);

--- a/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
@@ -83,7 +83,7 @@ class DeadlineJobDataBinderTest {
 
     @MethodSource("serializerImplementationAndAssertionSpecifics")
     @ParameterizedTest
-    void testToJobData(
+    void toJobDataTest(
             Serializer serializer,
             Function<Class, String> expectedSerializedClassType,
             Predicate<Object> revisionMatcher
@@ -111,7 +111,7 @@ class DeadlineJobDataBinderTest {
     @SuppressWarnings("unchecked")
     @MethodSource("serializerImplementationAndAssertionSpecifics")
     @ParameterizedTest
-    void testRetrievingDeadlineMessage(
+    void retrievingDeadlineMessage(
             Serializer serializer,
             Function<Class, String> expectedSerializedClassType,
             Predicate<Object> revisionMatcher
@@ -157,7 +157,7 @@ class DeadlineJobDataBinderTest {
 
     @MethodSource("serializerImplementationAndAssertionSpecifics")
     @ParameterizedTest
-    void testRetrievingDeadlineScope(Serializer serializer) {
+    void retrievingDeadlineScope(Serializer serializer) {
         JobDataMap testJobDataMap = toJobData(serializer, testDeadlineMessage, testDeadlineScope);
 
         ScopeDescriptor result = deadlineScope(serializer, testJobDataMap);

--- a/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
@@ -62,7 +62,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testConsumersRegisteredWithUnitOfWorkWhenFirstEventIsPublished() {
+    void consumersRegisteredWithUnitOfWorkWhenFirstEventIsPublished() {
         EventMessage<?> event = newEvent();
         testSubject.publish(event);
         verify(unitOfWork).onPrepareCommit(any());
@@ -75,7 +75,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testNoMoreConsumersRegisteredWithUnitOfWorkWhenSecondEventIsPublished() {
+    void noMoreConsumersRegisteredWithUnitOfWorkWhenSecondEventIsPublished() {
         EventMessage<?> event = newEvent();
         testSubject.publish(event);
         verify(unitOfWork).onPrepareCommit(any());
@@ -97,7 +97,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testCommitOnUnitOfWork() {
+    void commitOnUnitOfWork() {
         EventMessage<?> event = newEvent();
         testSubject.publish(event);
         unitOfWork.commit();
@@ -105,7 +105,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testPublicationOrder() {
+    void publicationOrder() {
         EventMessage<?> eventA = newEvent(), eventB = newEvent();
         testSubject.publish(eventA);
         testSubject.publish(eventB);
@@ -114,7 +114,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testPublicationWithNestedUow() {
+    void publicationWithNestedUow() {
         testSubject.publish(numberedEvent(5));
         unitOfWork.commit();
         assertEquals(Arrays.asList(numberedEvent(5), numberedEvent(4), numberedEvent(3), numberedEvent(2),
@@ -130,7 +130,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testPublicationForbiddenDuringUowCommitPhase() {
+    void publicationForbiddenDuringUowCommitPhase() {
         StubPublishingEventBus.builder()
                               .publicationPhase(UnitOfWork.Phase.COMMIT)
                               .startNewUowBeforePublishing(false)
@@ -141,7 +141,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testPublicationForbiddenDuringRootUowCommitPhase() {
+    void publicationForbiddenDuringRootUowCommitPhase() {
         testSubject = spy(StubPublishingEventBus.builder().publicationPhase(UnitOfWork.Phase.COMMIT).build());
         testSubject.publish(numberedEvent(1));
 
@@ -149,7 +149,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testMessageMonitorRecordsIngestionAndPublication_InUnitOfWork() {
+    void messageMonitorRecordsIngestionAndPublication_InUnitOfWork() {
         //noinspection unchecked
         MessageMonitor<? super EventMessage<?>> mockMonitor = mock(MessageMonitor.class);
         MessageMonitor.MonitorCallback mockMonitorCallback = mock(MessageMonitor.MonitorCallback.class);
@@ -166,7 +166,7 @@ class AbstractEventBusTest {
     }
 
     @Test
-    void testDispatchInterceptor() {
+    void dispatchInterceptor() {
         //noinspection unchecked
         MessageDispatchInterceptor<EventMessage<?>> dispatchInterceptorMock = mock(MessageDispatchInterceptor.class);
         String key = "additional", value = "metaData";

--- a/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AddedTrackerStatusTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
 class AddedTrackerStatusTest {
 
     @Test
-    void testGetSegment() {
+    void getSegment() {
         Segment expectedSegment = Segment.ROOT_SEGMENT;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getSegment()).thenReturn(expectedSegment);
@@ -43,7 +43,7 @@ class AddedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsCaughtUp() {
+    void isCaughtUp() {
         boolean expectedIsCaughtUp = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isCaughtUp()).thenReturn(expectedIsCaughtUp);
@@ -55,7 +55,7 @@ class AddedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsReplaying() {
+    void isReplaying() {
         boolean expectedIsReplaying = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isReplaying()).thenReturn(expectedIsReplaying);
@@ -67,7 +67,7 @@ class AddedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsMerging() {
+    void isMerging() {
         boolean expectedIsMerging = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isMerging()).thenReturn(expectedIsMerging);
@@ -78,7 +78,7 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testGetTrackingToken() {
+    void getTrackingToken() {
         TrackingToken expectedTrackingToken = new GlobalSequenceTrackingToken(0);
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getTrackingToken()).thenReturn(expectedTrackingToken);
@@ -90,7 +90,7 @@ class AddedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsErrorState() {
+    void isErrorState() {
         boolean expectedIsErrorState = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isErrorState()).thenReturn(expectedIsErrorState);
@@ -101,7 +101,7 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testGetError() {
+    void getError() {
         Exception expectedException = new IllegalArgumentException("some-exception");
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getError()).thenReturn(expectedException);
@@ -112,7 +112,7 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testGetCurrentPosition() {
+    void getCurrentPosition() {
         long expectedCurrentPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getCurrentPosition()).thenReturn(OptionalLong.of(expectedCurrentPosition));
@@ -125,7 +125,7 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testGetResetPosition() {
+    void getResetPosition() {
         long expectedResetPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getResetPosition()).thenReturn(OptionalLong.of(expectedResetPosition));
@@ -138,7 +138,7 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testMergeCompletedPosition() {
+    void mergeCompletedPosition() {
         long expectedMergeCompletedPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.mergeCompletedPosition()).thenReturn(OptionalLong.of(expectedMergeCompletedPosition));
@@ -151,14 +151,14 @@ class AddedTrackerStatusTest {
     }
 
     @Test
-    void testTrackerAdded() {
+    void trackerAdded() {
         AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
 
         assertTrue(testSubject.trackerAdded());
     }
 
     @Test
-    void testTrackerRemoved() {
+    void trackerRemoved() {
         AddedTrackerStatus testSubject = new AddedTrackerStatus(mock(EventTrackerStatus.class));
 
         assertFalse(testSubject.trackerRemoved());

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotatedParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotatedParameterResolverFactoryTest.java
@@ -30,21 +30,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class AnnotatedParameterResolverFactoryTest {
     @Test
-    void testTimestampParameterResolverIsReturnedOnlyWhenAppropriate() throws NoSuchMethodException {
+    void timestampParameterResolverIsReturnedOnlyWhenAppropriate() throws NoSuchMethodException {
         Method method = TestClass.class.getMethod("methodWithTimestampParameter", Instant.class, Long.class, Instant.class);
         testMethod(new TimestampParameterResolverFactory(), method,
                    new Class<?>[]{TimestampParameterResolverFactory.TimestampParameterResolver.class, null, null});
     }
 
     @Test
-    void testSequenceNumberParameterResolverIsReturnedOnlyWhenAppropriate() throws NoSuchMethodException {
+    void sequenceNumberParameterResolverIsReturnedOnlyWhenAppropriate() throws NoSuchMethodException {
         Method method = TestClass.class.getMethod("methodWithSequenceNumberParameter", Long.class, Instant.class);
         testMethod(new SequenceNumberParameterResolverFactory(), method,
                    new Class<?>[]{SequenceNumberParameterResolverFactory.SequenceNumberParameterResolver.class, null});
     }
 
     @Test
-    void testSequenceNumberParameterResolverHandlesPrimitive() throws NoSuchMethodException {
+    void sequenceNumberParameterResolverHandlesPrimitive() throws NoSuchMethodException {
         Method method = TestClass.class.getMethod("methodWithPrimitiveParameter", long.class);
         testMethod(new SequenceNumberParameterResolverFactory(), method,
                    new Class<?>[]{SequenceNumberParameterResolverFactory.SequenceNumberParameterResolver.class});

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
@@ -57,21 +57,21 @@ class AnnotationEventHandlerAdapterTest {
     }
 
     @Test
-    void testInvokeResetHandler() {
+    void invokeResetHandler() {
         testSubject.prepareReset();
 
         assertTrue(annotatedEventListener.invocations.contains("reset"));
     }
 
     @Test
-    void testInvokeResetHandlerWithResetContext() {
+    void invokeResetHandlerWithResetContext() {
         testSubject.prepareReset("resetContext");
 
         assertTrue(annotatedEventListener.invocations.contains("resetWithContext"));
     }
 
     @Test
-    void testHandlerInterceptors() throws Exception {
+    void handlerInterceptors() throws Exception {
         SomeHandler annotatedEventListener = new SomeInterceptingHandler();
         testSubject = new AnnotationEventHandlerAdapter(annotatedEventListener, parameterResolverFactory);
 
@@ -80,7 +80,7 @@ class AnnotationEventHandlerAdapterTest {
     }
 
     @Test
-    void testWrapExceptionInResultInterceptor() {
+    void wrapExceptionInResultInterceptor() {
         EventMessage<Object> testEventMessage =
                 asEventMessage("testing").andMetaData(MetaData.with("key", "value"));
 
@@ -99,7 +99,7 @@ class AnnotationEventHandlerAdapterTest {
     }
 
     @Test
-    void testMismatchingExceptionTypeFromHandlerIgnored() {
+    void mismatchingExceptionTypeFromHandlerIgnored() {
         EventMessage<Object> testEventMessage =
                 asEventMessage("testing").andMetaData(MetaData.with("key", "value"));
 
@@ -116,7 +116,7 @@ class AnnotationEventHandlerAdapterTest {
     }
 
     @Test
-    void testCanHandleTypeDoesNotReturnResetHandlers() {
+    void canHandleTypeDoesNotReturnResetHandlers() {
         SomeResetHandlerWithContext annotatedEventListener = new SomeResetHandlerWithContext();
         testSubject = new AnnotationEventHandlerAdapter(annotatedEventListener, parameterResolverFactory);
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactoryTest.java
@@ -33,7 +33,7 @@ class ConcludesBatchParameterResolverFactoryTest {
     private ConcludesBatchParameterResolverFactory subject = new ConcludesBatchParameterResolverFactory();
 
     @Test
-    void testCreateInstance() throws Exception {
+    void createInstance() throws Exception {
         Method method = getClass().getDeclaredMethod("handle", String.class, Boolean.class);
         assertSame(subject.getResolver(), subject.createInstance(method, method.getParameters(), 1));
         method = getClass().getDeclaredMethod("handlePrimitive", String.class, boolean.class);
@@ -41,30 +41,30 @@ class ConcludesBatchParameterResolverFactoryTest {
     }
 
     @Test
-    void testOnlyMatchesEventMessages() {
+    void onlyMatchesEventMessages() {
         assertTrue(subject.matches(asEventMessage("testEvent")));
         assertFalse(subject.matches(new GenericCommandMessage<>("testCommand")));
     }
 
     @Test
-    void testResolvesToTrueWithoutUnitOfWork() {
+    void resolvesToTrueWithoutUnitOfWork() {
         assertTrue(subject.resolveParameterValue(asEventMessage("testEvent")));
     }
 
     @Test
-    void testResolvesToTrueWithRegularUnitOfWork() {
+    void resolvesToTrueWithRegularUnitOfWork() {
         EventMessage<?> event = asEventMessage("testEvent");
         DefaultUnitOfWork.startAndGet(event).execute(() -> assertTrue(subject.resolveParameterValue(event)));
     }
 
     @Test
-    void testResolvesToFalseWithBatchingUnitOfWorkIfMessageIsNotLast() {
+    void resolvesToFalseWithBatchingUnitOfWorkIfMessageIsNotLast() {
         List<? extends EventMessage<?>> events = createEvents(5);
         new BatchingUnitOfWork<>(events).execute(() -> assertFalse(subject.resolveParameterValue(events.get(0))));
     }
 
     @Test
-    void testResolvesToFalseWithBatchingUnitOfWorkIfMessageIsLast() {
+    void resolvesToFalseWithBatchingUnitOfWorkIfMessageIsLast() {
         List<? extends EventMessage<?>> events = createEvents(5);
         new BatchingUnitOfWork<>(events).execute(() -> assertTrue(subject.resolveParameterValue(events.get(4))));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/DirectEventProcessingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/DirectEventProcessingStrategyTest.java
@@ -31,7 +31,7 @@ class DirectEventProcessingStrategyTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testEventsPassedToProcessor() {
+    void eventsPassedToProcessor() {
         List<? extends EventMessage<?>> events = createEvents(10);
         Consumer<List<? extends EventMessage<?>>> mockProcessor = mock(Consumer.class);
         DirectEventProcessingStrategy.INSTANCE.handle(events, mockProcessor);

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventHandlerInvokerTest.java
@@ -43,14 +43,14 @@ class EventHandlerInvokerTest {
     });
 
     @Test
-    void testPerformResetWithNullResetContextInvokesPerformReset() {
+    void performResetWithNullResetContextInvokesPerformReset() {
         testSubject.performReset(null);
 
         verify(testSubject).performReset();
     }
 
     @Test
-    void testPerformResetWithNonNullThrowsUnsupportedOperationException() {
+    void performResetWithNonNullThrowsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> testSubject.performReset("non-null"));
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventMessageHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventMessageHandlerTest.java
@@ -37,14 +37,14 @@ class EventMessageHandlerTest {
     });
 
     @Test
-    void testPrepareResetWithNullResetContextInvokesPrepareReset() {
+    void prepareResetWithNullResetContextInvokesPrepareReset() {
         testSubject.prepareReset(null);
 
         verify(testSubject).prepareReset();
     }
 
     @Test
-    void testPrepareResetWithNonNullThrowsUnsupportedOperationException() {
+    void prepareResetWithNonNullThrowsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> testSubject.prepareReset("non-null"));
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusChangeListenerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusChangeListenerTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class EventTrackerStatusChangeListenerTest {
 
     @Test
-    void testValidatePositionReturnsFalse() {
+    void validatePositionReturnsFalse() {
         assertFalse(EventTrackerStatusChangeListener.noOp().validatePositions());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTrackerStatusTest.java
@@ -40,26 +40,26 @@ class EventTrackerStatusTest {
     }
 
     @Test
-    void testIsDifferentReturnsFalseForIdenticalObjects() {
+    void isDifferentReturnsFalseForIdenticalObjects() {
         assertFalse(thisStatus.isDifferent(thisStatus, DO_NOT_VALIDATE_POSITIONS));
         assertFalse(thisStatus.isDifferent(thisStatus));
     }
 
     @Test
-    void testIsDifferentReturnsTrueForDifferentEventTrackerStatusImplementations() {
+    void isDifferentReturnsTrueForDifferentEventTrackerStatusImplementations() {
         AddedTrackerStatus otherStatus = new AddedTrackerStatus(thatStatus);
         assertTrue(thisStatus.isDifferent(otherStatus, DO_NOT_VALIDATE_POSITIONS));
         assertTrue(thisStatus.isDifferent(otherStatus));
     }
 
     @Test
-    void testIsDifferentReturnsFalseForSimilarStatusObjects() {
+    void isDifferentReturnsFalseForSimilarStatusObjects() {
         assertFalse(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
         assertFalse(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
     }
 
     @Test
-    void testIsDifferentReturnsFalseForSimilarStatusObjectsWhenDisregardingPositions() {
+    void isDifferentReturnsFalseForSimilarStatusObjectsWhenDisregardingPositions() {
         assertFalse(thisStatus.isDifferent(thatStatus, DO_NOT_VALIDATE_POSITIONS));
         assertFalse(thisStatus.isDifferent(thatStatus, VALIDATE_POSITIONS));
 
@@ -76,7 +76,7 @@ class EventTrackerStatusTest {
     }
 
     @Test
-    void testMatchStates() {
+    void matchStates() {
         assertTrue(thisStatus.matchStates(thatStatus));
 
         thisStatus.setSegment(Segment.ROOT_SEGMENT);
@@ -99,7 +99,7 @@ class EventTrackerStatusTest {
     }
 
     @Test
-    void testMatchPositions() {
+    void matchPositions() {
         assertTrue(thisStatus.matchPositions(thatStatus));
 
         thisStatus.setCurrentPosition(10L);
@@ -114,12 +114,12 @@ class EventTrackerStatusTest {
     }
 
     @Test
-    void testTrackerAdded() {
+    void trackerAdded() {
         assertFalse(thisStatus.trackerAdded());
     }
 
     @Test
-    void testTrackerRemoved() {
+    void trackerRemoved() {
         assertFalse(thisStatus.trackerRemoved());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenSerializationTest.java
@@ -23,14 +23,14 @@ class GapAwareTrackingTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(Long.MAX_VALUE, asList(0L, 1L));
         assertEquals(subject, serializer.serializeDeserialize(subject));
     }
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenWithoutGapsShouldBeSerializable(TestSerializer serializer) {
+    void tokenWithoutGapsShouldBeSerializable(TestSerializer serializer) {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(0, emptyList());
         assertEquals(subject, serializer.serializeDeserialize(subject));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GapAwareTrackingTokenTest {
 
     @Test
-    void testGapAwareTokenConcurrency() throws InterruptedException {
+    void gapAwareTokenConcurrency() throws InterruptedException {
         AtomicLong counter = new AtomicLong();
         AtomicReference<GapAwareTrackingToken> currentToken = new AtomicReference<>(GapAwareTrackingToken.newInstance(-1, emptySortedSet()));
 
@@ -71,14 +71,14 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testInitializationWithNullGaps() {
+    void initializationWithNullGaps() {
         GapAwareTrackingToken token = new GapAwareTrackingToken(10, null);
         assertNotNull(token.getGaps());
         assertEquals(0, token.getGaps().size());
     }
 
     @Test
-    void testAdvanceToWithoutGaps() {
+    void advanceToWithoutGaps() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(0L, Collections.emptyList());
         subject = subject.advanceTo(1L, 10);
         assertEquals(1L, subject.getIndex());
@@ -86,7 +86,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceToWithInitialGaps() {
+    void advanceToWithInitialGaps() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(10L, asList(1L, 5L, 6L));
         subject = subject.advanceTo(5L, 10);
         assertEquals(10L, subject.getIndex());
@@ -94,7 +94,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceToWithNewGaps() {
+    void advanceToWithNewGaps() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(10L, Collections.emptyList());
         subject = subject.advanceTo(13L, 10);
         assertEquals(13L, subject.getIndex());
@@ -102,7 +102,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceToGapClearsOldGaps() {
+    void advanceToGapClearsOldGaps() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(15L, asList(1L, 5L, 12L));
         subject = subject.advanceTo(12L, 10);
         assertEquals(15L, subject.getIndex());
@@ -110,7 +110,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceToHigherSequenceClearsOldGaps() {
+    void advanceToHigherSequenceClearsOldGaps() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(15L, asList(1L, 5L, 12L));
         subject = subject.advanceTo(16L, 10);
         assertEquals(16L, subject.getIndex());
@@ -118,18 +118,18 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceToLowerSequenceThatIsNotAGapNotAllowed() {
+    void advanceToLowerSequenceThatIsNotAGapNotAllowed() {
         GapAwareTrackingToken subject = GapAwareTrackingToken.newInstance(15L, asList(1L, 5L, 12L));
         assertThrows(Exception.class, () -> subject.advanceTo(4L, 10));
     }
 
     @Test
-    void testNewInstanceWithGapHigherThanSequenceNotAllowed() {
+    void newInstanceWithGapHigherThanSequenceNotAllowed() {
         assertThrows(Exception.class, () -> GapAwareTrackingToken.newInstance(9L, asList(1L, 5L, 12L)));
     }
 
     @Test
-    void testTokenCoversOther() {
+    void tokenCoversOther() {
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(3L, singleton(1L));
         GapAwareTrackingToken token2 = GapAwareTrackingToken.newInstance(4L, singleton(2L));
         GapAwareTrackingToken token3 = GapAwareTrackingToken.newInstance(2L, asList(0L, 1L));
@@ -157,13 +157,13 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testOccurrenceOfInconsistentRangeException() {
+    void occurrenceOfInconsistentRangeException() {
         // verifies issue 655 (https://github.com/AxonFramework/AxonFramework/issues/655)
         GapAwareTrackingToken.newInstance(10L, asList(0L, 1L, 2L, 8L, 9L)).advanceTo(0L, 5).covers(GapAwareTrackingToken.newInstance(0L, emptySet()));
     }
 
     @Test
-    void testLowerBound() {
+    void lowerBound() {
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(3L, singleton(1L));
         GapAwareTrackingToken token2 = GapAwareTrackingToken.newInstance(4L, singleton(2L));
         GapAwareTrackingToken token3 = GapAwareTrackingToken.newInstance(2L, asList(0L, 1L));
@@ -180,7 +180,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testUpperBound() {
+    void upperBound() {
         GapAwareTrackingToken token0 = GapAwareTrackingToken.newInstance(9, emptyList());
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(10, singleton(9L));
         GapAwareTrackingToken token2 = GapAwareTrackingToken.newInstance(10, asList(9L, 8L));
@@ -197,7 +197,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testGapTruncationRetainsEquality() {
+    void gapTruncationRetainsEquality() {
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
 
         assertEquals(token1, token1.withGapsTruncatedAt(8L));
@@ -207,7 +207,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testTruncateGaps() {
+    void truncateGaps() {
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
 
         assertSame(token1, token1.withGapsTruncatedAt(7));
@@ -219,7 +219,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testGapTruncatedTokenCoveredByOriginal() {
+    void gapTruncatedTokenCoveredByOriginal() {
         GapAwareTrackingToken token1 = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
 
         assertTrue(token1.covers(token1.withGapsTruncatedAt(10)));
@@ -227,7 +227,7 @@ class GapAwareTrackingTokenTest {
     }
 
     @Test
-    void testPosition() {
+    void position() {
         GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(15, asList(14L, 9L, 8L));
 
         assertEquals(15L, token.position().getAsLong());

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericDomainEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericDomainEventMessageTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericDomainEventMessageTest {
 
     @Test
-    void testConstructor() {
+    void constructor() {
         Object payload = new Object();
         long seqNo = 0;
         String id = UUID.randomUUID().toString();
@@ -66,7 +66,7 @@ class GenericDomainEventMessageTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         Object payload = new Object();
         long seqNo = 0;
         String id = UUID.randomUUID().toString();
@@ -82,7 +82,7 @@ class GenericDomainEventMessageTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         Object payload = new Object();
         long seqNo = 0;
         String id = UUID.randomUUID().toString();

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericEventMessageTest {
 
     @Test
-    void testConstructor() {
+    void constructor() {
         Object payload = new Object();
         GenericEventMessage<Object> message1 = new GenericEventMessage<>(payload);
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
@@ -60,7 +60,7 @@ class GenericEventMessageTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         Object payload = new Object();
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
@@ -74,7 +74,7 @@ class GenericEventMessageTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         Object payload = new Object();
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
@@ -90,7 +90,7 @@ class GenericEventMessageTest {
     }
 
     @Test
-    void testTimestampInEventMessageIsAlwaysSerialized() throws IOException, ClassNotFoundException {
+    void timestampInEventMessageIsAlwaysSerialized() throws IOException, ClassNotFoundException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         GenericEventMessage<String> testSubject =

--- a/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenSerializationTest.java
@@ -21,7 +21,7 @@ class GlobalSequenceTrackingTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(Long.MAX_VALUE);
         assertEquals(token, serializer.serializeDeserialize(token));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GlobalSequenceTrackingTokenTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GlobalSequenceTrackingTokenTest {
 
     @Test
-    void testUpperBound() {
+    void upperBound() {
         GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
         GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
 
@@ -33,7 +33,7 @@ class GlobalSequenceTrackingTokenTest {
     }
 
     @Test
-    void testLowerBound() {
+    void lowerBound() {
         GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
         GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
 
@@ -43,7 +43,7 @@ class GlobalSequenceTrackingTokenTest {
     }
 
     @Test
-    void testCovers() {
+    void covers() {
         GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
         GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
 
@@ -54,7 +54,7 @@ class GlobalSequenceTrackingTokenTest {
     }
 
     @Test
-    void testPosition() {
+    void position() {
         GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(1L);
 
         assertEquals(1L, token.position().getAsLong());

--- a/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenSerializationTest.java
@@ -38,7 +38,7 @@ class MergedTrackingTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         MergedTrackingToken testSubject = new MergedTrackingToken(new MergedTrackingToken(token(1), token(5)), token(3));
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MergedTrackingTokenTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
 class MergedTrackingTokenTest {
 
     @Test
-    void testMergedTokenCoversOriginal() {
+    void mergedTokenCoversOriginal() {
         MergedTrackingToken testSubject = new MergedTrackingToken(token(1), token(3));
 
         assertTrue(testSubject.covers(token(1)));
@@ -33,7 +33,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testUpperBound() {
+    void upperBound() {
         MergedTrackingToken testSubject = new MergedTrackingToken(token(1), token(3));
 
         assertEquals(new MergedTrackingToken(token(2), token(3)), testSubject.upperBound(token(2)));
@@ -41,7 +41,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testLowerBound() {
+    void lowerBound() {
         MergedTrackingToken testSubject = new MergedTrackingToken(token(1), token(3));
 
         assertEquals(new MergedTrackingToken(token(1), token(2)), testSubject.lowerBound(token(2)));
@@ -49,13 +49,13 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testUnwrapToLowerBound() {
+    void unwrapToLowerBound() {
         assertEquals(token(1), new MergedTrackingToken(new MergedTrackingToken(token(1), token(5)), token(3)).lowerBound());
         assertEquals(token(1), new MergedTrackingToken(token(1), new MergedTrackingToken(token(5), token(3))).lowerBound());
     }
 
     @Test
-    void testUpperBound_NestedTokens() {
+    void upperBound_NestedTokens() {
         MergedTrackingToken testSubject = new MergedTrackingToken(new MergedTrackingToken(token(1), token(3)), token(5));
 
         assertEquals(new MergedTrackingToken(token(4), token(5)), testSubject.upperBound(token(4)));
@@ -64,7 +64,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testLowerBound_NestedTokens() {
+    void lowerBound_NestedTokens() {
         MergedTrackingToken testSubject = new MergedTrackingToken(new MergedTrackingToken(token(1), token(5)), token(3));
 
         assertEquals(new MergedTrackingToken(new MergedTrackingToken(token(1), token(3)), token(3)), testSubject.lowerBound(token(3)));
@@ -73,7 +73,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testAdvanceWithNestedReplayToken() {
+    void advanceWithNestedReplayToken() {
         TrackingToken incomingMessage = new GlobalSequenceTrackingToken(0);
 
         MergedTrackingToken currentToken = new MergedTrackingToken(
@@ -90,58 +90,58 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testUnwrapPrefersLastAdvancedToken_LowerSegmentAdvanced() {
+    void unwrapPrefersLastAdvancedToken_LowerSegmentAdvanced() {
         TrackingToken merged = new MergedTrackingToken(token(1), token(3)).advancedTo(token(2));
         assertTrue(merged instanceof MergedTrackingToken);
         assertEquals(token(2), WrappedToken.unwrap(merged, GlobalSequenceTrackingToken.class).orElse(null));
     }
 
     @Test
-    void testUnwrapPrefersLastAdvancedToken_UpperSegmentAdvanced() {
+    void unwrapPrefersLastAdvancedToken_UpperSegmentAdvanced() {
         TrackingToken merged = new MergedTrackingToken(token(3), token(1)).advancedTo(token(2));
         assertTrue(merged instanceof MergedTrackingToken);
         assertEquals(token(2), WrappedToken.unwrap(merged, GlobalSequenceTrackingToken.class).orElse(null));
     }
 
     @Test
-    void testUnwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced() {
+    void unwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced() {
         TrackingToken merged = new MergedTrackingToken(token(3), token(3)).advancedTo(token(2));
         assertTrue(merged instanceof MergedTrackingToken);
         assertEquals(token(3), WrappedToken.unwrap(merged, GlobalSequenceTrackingToken.class).orElse(null));
     }
 
     @Test
-    void testUnwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced_OnlyLowerIsCandidate() {
+    void unwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced_OnlyLowerIsCandidate() {
         MergedTrackingToken merged = new MergedTrackingToken(token(3), mock(TrackingToken.class));
         assertEquals(token(3), merged.unwrap(GlobalSequenceTrackingToken.class).orElse(null));
     }
 
     @Test
-    void testUnwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced_OnlyUpperIsCandidate() {
+    void unwrapPrefersLastAdvancedToken_NeitherSegmentAdvanced_OnlyUpperIsCandidate() {
         MergedTrackingToken merged = new MergedTrackingToken(mock(TrackingToken.class), token(3));
         assertEquals(token(3), merged.unwrap(GlobalSequenceTrackingToken.class).orElse(null));
     }
 
     @Test
-    void testPositionReportsLowestSegment() {
+    void positionReportsLowestSegment() {
         MergedTrackingToken merged = new MergedTrackingToken(token(4), token(3));
         assertEquals(3L, merged.position().orElse(0L));
     }
 
     @Test
-    void testPositionIsNotPresent() {
+    void positionIsNotPresent() {
         MergedTrackingToken merged = new MergedTrackingToken(mock(TrackingToken.class), token(3));
         assertFalse(merged.position().isPresent());
     }
 
     @Test
-    void testIsMergeInProgress() {
+    void isMergeInProgress() {
         MergedTrackingToken testSubject = new MergedTrackingToken(token(1), token(3));
         assertTrue(MergedTrackingToken.isMergeInProgress(testSubject));
     }
 
     @Test
-    void testMergePosition() {
+    void mergePosition() {
         MergedTrackingToken testSubject = new MergedTrackingToken(new MergedTrackingToken(token(1), token(3)), token(5));
 
         assertTrue(MergedTrackingToken.mergePosition(testSubject).isPresent());
@@ -149,7 +149,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testCoversWithNestedMergedNullTokens() {
+    void coversWithNestedMergedNullTokens() {
         MergedTrackingToken testSubject = new MergedTrackingToken(new MergedTrackingToken(null, null), null);
 
         assertFalse(testSubject.covers(token(0)));
@@ -160,7 +160,7 @@ class MergedTrackingTokenTest {
     }
 
     @Test
-    void testCoversWithNullTokens() {
+    void coversWithNullTokens() {
         MergedTrackingToken testSubject = new MergedTrackingToken(null, null);
 
         assertFalse(testSubject.covers(token(0)));

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
@@ -57,7 +57,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testDelegatesReturnsSetDelegates() {
+    void delegatesReturnsSetDelegates() {
         List<EventHandlerInvoker> result = testSubject.delegates();
 
         assertTrue(result.contains(mockedEventHandlerInvokerOne));
@@ -65,7 +65,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testCanHandleCallsCanHandleOnTheFirstDelegateToReturn() {
+    void canHandleCallsCanHandleOnTheFirstDelegateToReturn() {
         testSubject.canHandle(testEventMessage, testSegment);
 
         verify(mockedEventHandlerInvokerOne).canHandle(testEventMessage, testSegment);
@@ -73,7 +73,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testHandleCallsCanHandleAndHandleOfAllDelegates() throws Exception {
+    void handleCallsCanHandleAndHandleOfAllDelegates() throws Exception {
         testSubject.handle(testEventMessage, testSegment);
 
         verify(mockedEventHandlerInvokerOne).canHandle(testEventMessage, testSegment);
@@ -83,14 +83,14 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testHandleThrowsExceptionIfDelegatesThrowAnException() throws Exception {
+    void handleThrowsExceptionIfDelegatesThrowAnException() throws Exception {
         doThrow(new RuntimeException()).when(mockedEventHandlerInvokerTwo).handle(testEventMessage, testSegment);
 
         assertThrows(RuntimeException.class, () -> testSubject.handle(testEventMessage, testSegment));
     }
 
     @Test
-    void testSupportResetWhenAllSupport() {
+    void supportResetWhenAllSupport() {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(true);
 
@@ -98,7 +98,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testSupportResetWhenSomeSupport() {
+    void supportResetWhenSomeSupport() {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(false);
 
@@ -106,7 +106,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testSupportResetWhenNoneSupport() {
+    void supportResetWhenNoneSupport() {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(false);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(false);
 
@@ -114,7 +114,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testPerformReset() {
+    void performReset() {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(false);
 
@@ -125,7 +125,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testPerformResetWithResetContext() {
+    void performResetWithResetContext() {
         String resetContext = "reset-context";
 
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
@@ -138,7 +138,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testInvokersNotSupportingResetDoNotReceiveRedeliveries() throws Exception {
+    void invokersNotSupportingResetDoNotReceiveRedeliveries() throws Exception {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(false);
 
@@ -155,7 +155,7 @@ class MultiEventHandlerInvokerTest {
     }
 
     @Test
-    void testPerformResetThrowsException() {
+    void performResetThrowsException() {
         when(mockedEventHandlerInvokerOne.supportsReset()).thenReturn(true);
         when(mockedEventHandlerInvokerTwo.supportsReset()).thenReturn(false);
         doThrow(RuntimeException.class).when(mockedEventHandlerInvokerOne).performReset(any());

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenSerializationTest.java
@@ -39,7 +39,7 @@ class MultiSourceTrackingTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         Map<String, TrackingToken> tokenMap = new HashMap<>();
         tokenMap.put("token1", new GlobalSequenceTrackingToken(0));
         tokenMap.put("token2", new GlobalSequenceTrackingToken(0));

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenTest.java
@@ -45,12 +45,12 @@ class MultiSourceTrackingTokenTest {
     }
 
     @Test
-    void testIncompatibleToken() {
+    void incompatibleToken() {
         assertThrows(IllegalArgumentException.class, () -> testSubject.covers(new GlobalSequenceTrackingToken(0)));
     }
 
     @Test
-    void testTrackingTokenIsImmutable() {
+    void trackingTokenIsImmutable() {
         MultiSourceTrackingToken newToken = testSubject.advancedTo("token1", new GlobalSequenceTrackingToken(1));
 
         assertEquals(new GlobalSequenceTrackingToken(0), testSubject.getTokenForStream("token1"));
@@ -139,7 +139,7 @@ class MultiSourceTrackingTokenTest {
     }
 
     @Test
-    void testPositionNotProvidedWhenUnderlyingTokensDontProvide() {
+    void positionNotProvidedWhenUnderlyingTokensDontProvide() {
         TrackingToken trackingToken = mock(TrackingToken.class);
         when(trackingToken.position()).thenReturn(OptionalLong.empty());
         testSubject = new MultiSourceTrackingToken(Collections.singletonMap("key", trackingToken));

--- a/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/RemovedTrackerStatusTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
 class RemovedTrackerStatusTest {
 
     @Test
-    void testGetSegment() {
+    void getSegment() {
         Segment expectedSegment = Segment.ROOT_SEGMENT;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getSegment()).thenReturn(expectedSegment);
@@ -43,7 +43,7 @@ class RemovedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsCaughtUp() {
+    void isCaughtUp() {
         boolean expectedIsCaughtUp = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isCaughtUp()).thenReturn(expectedIsCaughtUp);
@@ -55,7 +55,7 @@ class RemovedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsReplaying() {
+    void isReplaying() {
         boolean expectedIsReplaying = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isReplaying()).thenReturn(expectedIsReplaying);
@@ -67,7 +67,7 @@ class RemovedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsMerging() {
+    void isMerging() {
         boolean expectedIsMerging = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isMerging()).thenReturn(expectedIsMerging);
@@ -78,7 +78,7 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testGetTrackingToken() {
+    void getTrackingToken() {
         TrackingToken expectedTrackingToken = new GlobalSequenceTrackingToken(0);
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getTrackingToken()).thenReturn(expectedTrackingToken);
@@ -90,7 +90,7 @@ class RemovedTrackerStatusTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void testIsErrorState() {
+    void isErrorState() {
         boolean expectedIsErrorState = true;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.isErrorState()).thenReturn(expectedIsErrorState);
@@ -101,7 +101,7 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testGetError() {
+    void getError() {
         Exception expectedException = new IllegalArgumentException("some-exception");
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getError()).thenReturn(expectedException);
@@ -112,7 +112,7 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testGetCurrentPosition() {
+    void getCurrentPosition() {
         long expectedCurrentPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getCurrentPosition()).thenReturn(OptionalLong.of(expectedCurrentPosition));
@@ -125,7 +125,7 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testGetResetPosition() {
+    void getResetPosition() {
         long expectedResetPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.getResetPosition()).thenReturn(OptionalLong.of(expectedResetPosition));
@@ -138,7 +138,7 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testMergeCompletedPosition() {
+    void mergeCompletedPosition() {
         long expectedMergeCompletedPosition = 0L;
         EventTrackerStatus delegate = mock(EventTrackerStatus.class);
         when(delegate.mergeCompletedPosition()).thenReturn(OptionalLong.of(expectedMergeCompletedPosition));
@@ -151,14 +151,14 @@ class RemovedTrackerStatusTest {
     }
 
     @Test
-    void testTrackerAdded() {
+    void trackerAdded() {
         RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
 
         assertFalse(testSubject.trackerAdded());
     }
 
     @Test
-    void testTrackerRemoved() {
+    void trackerRemoved() {
         RemovedTrackerStatus testSubject = new RemovedTrackerStatus(mock(EventTrackerStatus.class));
 
         assertTrue(testSubject.trackerRemoved());

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenSerializationTest.java
@@ -22,7 +22,7 @@ class ReplayTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         TrackingToken innerToken = GapAwareTrackingToken.newInstance(10, Collections.singleton(9L));
         ReplayToken token = new ReplayToken(innerToken);
         assertEquals(token, serializer.serializeDeserialize(token));

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -41,7 +41,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testAdvanceReplayTokenWithinReplaySegment() {
+    void advanceReplayTokenWithinReplaySegment() {
         ReplayToken testSubject = new ReplayToken(innerToken);
         TrackingToken actual = testSubject.advancedTo(GapAwareTrackingToken.newInstance(8, emptySet()));
         assertTrue(actual instanceof ReplayToken);
@@ -49,7 +49,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testRegularTokenIsProvidedWhenResetBeyondCurrentPosition() {
+    void regularTokenIsProvidedWhenResetBeyondCurrentPosition() {
         TrackingToken token1 = new GlobalSequenceTrackingToken(1);
         TrackingToken token2 = new GlobalSequenceTrackingToken(2);
 
@@ -58,7 +58,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testSerializationDeserialization() throws IOException {
+    void serializationDeserialization() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         ReplayToken replayToken = new ReplayToken(innerToken);
         String serializedReplayToken = objectMapper.writer().writeValueAsString(replayToken);
@@ -68,7 +68,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testPosition() {
+    void position() {
         GapAwareTrackingToken startPosition = GapAwareTrackingToken.newInstance(11L, Collections.singleton(9L));
 
         TrackingToken replayToken = ReplayToken.createReplayToken(innerToken, startPosition);
@@ -78,13 +78,13 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testPositionIsNotPresent() {
+    void positionIsNotPresent() {
         TrackingToken replayToken = ReplayToken.createReplayToken(innerToken);
         assertFalse(replayToken.position().isPresent());
     }
 
     @Test
-    void testGetTokenAtReset() {
+    void getTokenAtReset() {
         ReplayToken testSubject = new ReplayToken(innerToken);
         TrackingToken actual = testSubject.advancedTo(GapAwareTrackingToken.newInstance(6, emptySet()));
         assertTrue(actual instanceof ReplayToken);
@@ -92,7 +92,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testCreateReplayTokenReturnsStartPositionIfTokenAtResetIsNull() {
+    void createReplayTokenReturnsStartPositionIfTokenAtResetIsNull() {
         TrackingToken tokenAtReset = null;
         TrackingToken startPosition = new GlobalSequenceTrackingToken(1);
 
@@ -103,7 +103,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testCreateReplayTokenReturnsStartPositionIfStartPositionCoversTokenAtReset() {
+    void createReplayTokenReturnsStartPositionIfStartPositionCoversTokenAtReset() {
         TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(1);
         TrackingToken startPosition = new GlobalSequenceTrackingToken(2);
 
@@ -113,7 +113,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testCreateReplayTokenReturnsWrappedReplayTokenIfTokenAtResetIsReplayToken() {
+    void createReplayTokenReturnsWrappedReplayTokenIfTokenAtResetIsReplayToken() {
         TrackingToken tokenAtReset = ReplayToken.createReplayToken(new GlobalSequenceTrackingToken(1));
         TrackingToken startPosition = new GlobalSequenceTrackingToken(2);
 
@@ -123,7 +123,7 @@ class ReplayTokenTest {
     }
 
     @Test
-    void testCreateReplayTokenReturnsReplayToken() {
+    void createReplayTokenReturnsReplayToken() {
         TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(2);
         TrackingToken startPosition = new GlobalSequenceTrackingToken(1);
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/SegmentTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/SegmentTest.java
@@ -44,7 +44,7 @@ class SegmentTest {
     }
 
     @Test
-    void testSegmentSplitAddsUp() {
+    void segmentSplitAddsUp() {
 
         final List<Long> identifiers = domainEventMessages.stream().map(de -> {
             final String aggregateIdentifier = de.getAggregateIdentifier();
@@ -64,7 +64,7 @@ class SegmentTest {
     }
 
     @Test
-    void testSegmentSplit() {
+    void segmentSplit() {
 
         // Split segment 0
         final Segment[] splitSegment0 = Segment.ROOT_SEGMENT.split();
@@ -131,7 +131,7 @@ class SegmentTest {
     }
 
     @Test
-    void testSegmentSplitNTimes() {
+    void segmentSplitNTimes() {
         {
             //
             final List<Segment> segmentMasks = Segment.splitBalanced(Segment.ROOT_SEGMENT, 5);
@@ -146,7 +146,7 @@ class SegmentTest {
     }
 
     @Test
-    void testSplitFromRootSegmentAlwaysYieldsSequentialSegmentIds() {
+    void splitFromRootSegmentAlwaysYieldsSequentialSegmentIds() {
         for (int i = 0; i < 500; i++) {
             List<Segment> segments = Segment.splitBalanced(Segment.ROOT_SEGMENT, i);
             assertEquals(i + 1, segments.size());
@@ -157,7 +157,7 @@ class SegmentTest {
     }
 
     @Test
-    void testMergeable() {
+    void mergeable() {
         Segment[] segments = Segment.ROOT_SEGMENT.split();
         assertFalse(segments[0].isMergeableWith(segments[0]));
         assertFalse(segments[1].isMergeableWith(segments[1]));
@@ -176,7 +176,7 @@ class SegmentTest {
     }
 
     @Test
-    void testMergeableSegment() {
+    void mergeableSegment() {
         Segment[] segments = Segment.ROOT_SEGMENT.split();
         assertEquals(segments[1].getSegmentId(), segments[0].mergeableSegmentId());
         assertEquals(segments[0].getSegmentId(), segments[1].mergeableSegmentId());
@@ -184,7 +184,7 @@ class SegmentTest {
     }
 
     @Test
-    void testMergeSegments() {
+    void mergeSegments() {
         Segment[] segments = Segment.ROOT_SEGMENT.split();
         Segment[] segments2 = segments[0].split();
 
@@ -195,7 +195,7 @@ class SegmentTest {
     }
 
     @Test
-    void testSegmentResolve() {
+    void segmentResolve() {
         {
             final int[] segments = {};
             final Segment[] segmentMasks = Segment.computeSegments(segments);
@@ -289,7 +289,7 @@ class SegmentTest {
     }
 
     @Test
-    void testComputeSegment() {
+    void computeSegment() {
         for (int segmentCount = 0; segmentCount < 256; segmentCount++) {
             List<Segment> segments = Segment.splitBalanced(Segment.ROOT_SEGMENT, segmentCount);
             int[] segmentIds = new int[segments.size()];
@@ -305,7 +305,7 @@ class SegmentTest {
     }
 
     @Test
-    void testComputeSegment_Imbalanced() {
+    void computeSegment_Imbalanced() {
         List<Segment> segments = new ArrayList<>();
         Segment initialSegment = Segment.ROOT_SEGMENT;
         for (int i = 0; i < 8; i++) {
@@ -326,13 +326,13 @@ class SegmentTest {
     }
 
     @Test
-    void testSegmentSplitBeyondBoundary() {
+    void segmentSplitBeyondBoundary() {
         final Segment segment = new Segment(0, Integer.MAX_VALUE);
         assertThrows(IllegalStateException.class, segment::split);
     }
 
     @Test
-    void testSegmentSplitOnBoundary() {
+    void segmentSplitOnBoundary() {
 
         final Segment segment = new Segment(0, Integer.MAX_VALUE >>> 1);
         final Segment[] splitSegment = segment.split();
@@ -344,7 +344,7 @@ class SegmentTest {
     }
 
     @Test
-    void testItemsAssignedToOnlyOneSegment() {
+    void itemsAssignedToOnlyOneSegment() {
         for (int j = 0; j < 10; j++) {
             List<Segment> segments = Segment.splitBalanced(Segment.ROOT_SEGMENT, ThreadLocalRandom.current().nextInt(50) + 1);
             for (int i = 0; i < 100_000; i++) {

--- a/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventBusTest.java
@@ -44,7 +44,7 @@ class SimpleEventBusTest {
     }
 
     @Test
-    void testEventIsDispatchedToSubscribedListeners() throws Exception {
+    void eventIsDispatchedToSubscribedListeners() throws Exception {
         testSubject.publish(newEvent());
         testSubject.subscribe(listener1);
         // subscribing twice should not make a difference

--- a/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventHandlerInvokerTest.java
@@ -49,7 +49,7 @@ class SimpleEventHandlerInvokerTest {
     }
 
     @Test
-    void testSingleEventPublication() throws Exception {
+    void singleEventPublication() throws Exception {
         EventMessage<?> event = createEvent();
 
         testSubject.handle(event, Segment.ROOT_SEGMENT);
@@ -61,7 +61,7 @@ class SimpleEventHandlerInvokerTest {
     }
 
     @Test
-    void testRepeatedEventPublication() throws Exception {
+    void repeatedEventPublication() throws Exception {
         List<? extends EventMessage<?>> events = createEvents(2);
 
         for (EventMessage<?> event : events) {
@@ -77,7 +77,7 @@ class SimpleEventHandlerInvokerTest {
     }
 
     @Test
-    void testPerformReset() {
+    void performReset() {
         testSubject.performReset();
 
         verify(mockHandler1).prepareReset(NO_RESET_PAYLOAD);
@@ -85,7 +85,7 @@ class SimpleEventHandlerInvokerTest {
     }
 
     @Test
-    void testPerformResetWithResetContext() {
+    void performResetWithResetContext() {
         String resetContext = "reset-context";
 
         testSubject.performReset(resetContext);

--- a/messaging/src/test/java/org/axonframework/eventhandling/TimestampParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/TimestampParameterResolverFactoryTest.java
@@ -79,7 +79,7 @@ class TimestampParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesToDateTimeWhenAnnotated() {
+    void resolvesToDateTimeWhenAnnotated() {
         ParameterResolver<Instant> resolver =
                 testSubject.createInstance(instantMethod, instantMethod.getParameters(), 0);
 
@@ -89,7 +89,7 @@ class TimestampParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesToReadableInstantWhenAnnotated() {
+    void resolvesToReadableInstantWhenAnnotated() {
         ParameterResolver<Instant> resolver =
                 testSubject.createInstance(temporalMethod, temporalMethod.getParameters(), 0);
 
@@ -99,20 +99,20 @@ class TimestampParameterResolverFactoryTest {
     }
 
     @Test
-    void testIgnoredWhenNotAnnotated() {
+    void ignoredWhenNotAnnotated() {
         ParameterResolver resolver =
                 testSubject.createInstance(nonAnnotatedInstantMethod, nonAnnotatedInstantMethod.getParameters(), 0);
         assertNull(resolver);
     }
 
     @Test
-    void testIgnoredWhenWrongType() {
+    void ignoredWhenWrongType() {
         ParameterResolver resolver = testSubject.createInstance(stringMethod, stringMethod.getParameters(), 0);
         assertNull(resolver);
     }
 
     @Test
-    void testResolvesToDateTimeWhenAnnotatedWithMetaAnnotation() {
+    void resolvesToDateTimeWhenAnnotatedWithMetaAnnotation() {
         Parameter[] parameters = metaAnnotatedMethod.getParameters();
         ParameterResolver<?> resolver = testSubject.createInstance(metaAnnotatedMethod, parameters, 0);
         final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");

--- a/messaging/src/test/java/org/axonframework/eventhandling/TrackingEventProcessorConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/TrackingEventProcessorConfigurationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TrackingEventProcessorConfigurationTest {
 
     @Test
-    void testConfiguredEventTrackerStatusChangeListener() {
+    void configuredEventTrackerStatusChangeListener() {
         Map<Integer, EventTrackerStatus> expectedTrackerStatus = Collections.emptyMap();
         EventTrackerStatusChangeListener expectedChangeListener =
                 updatedTrackerStatus -> assertEquals(expectedTrackerStatus, updatedTrackerStatus);

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessingStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessingStrategyTest.java
@@ -68,7 +68,7 @@ class AsynchronousEventProcessingStrategyTest {
     }
 
     @Test
-    void testOrderingOfEvents() throws Exception {
+    void orderingOfEvents() throws Exception {
         testSubject =
                 new AsynchronousEventProcessingStrategy(Executors.newSingleThreadExecutor(), new SequentialPolicy());
 
@@ -104,7 +104,7 @@ class AsynchronousEventProcessingStrategyTest {
     }
 
     @Test
-    void testEventsScheduledForHandling() {
+    void eventsScheduledForHandling() {
         EventMessage<?> message1 = createEvent("aggregate1", 1);
         EventMessage<?> message2 = createEvent("aggregate2", 1);
 
@@ -114,7 +114,7 @@ class AsynchronousEventProcessingStrategyTest {
     }
 
     @Test
-    void testEventsScheduledForHandlingWhenSurroundingUnitOfWorkCommits() {
+    void eventsScheduledForHandlingWhenSurroundingUnitOfWorkCommits() {
         EventMessage<?> message1 = createEvent("aggregate1", 1);
         EventMessage<?> message2 = createEvent("aggregate2", 1);
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
@@ -50,7 +50,7 @@ class AsynchronousEventProcessorConcurrencyTest {
 
     @Test
     @Timeout(value = EventsPublisher.EVENTS_COUNT, unit = TimeUnit.MILLISECONDS)
-    void testHandleEvents() throws InterruptedException {
+    void handleEvents() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
         Consumer<List<? extends EventMessage<?>>> processor = eventMessages -> counter.addAndGet(eventMessages.size());
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/FullConcurrencyPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/FullConcurrencyPolicyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class FullConcurrencyPolicyTest {
 
     @Test
-    void testSequencingIdentifier() {
+    void sequencingIdentifier() {
         FullConcurrencyPolicy testSubject = new FullConcurrencyPolicy();
         assertNotNull(testSubject.getSequenceIdentifierFor(newStubDomainEvent(UUID.randomUUID())));
         assertNotNull(testSubject.getSequenceIdentifierFor(newStubDomainEvent(UUID.randomUUID())));

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/SequentialPerAggregatePolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/SequentialPerAggregatePolicyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SequentialPerAggregatePolicyTest {
 
     @Test
-    void testSequentialIdentifier() {
+    void sequentialIdentifier() {
         // ok, pretty useless, but everything should be tested
         SequentialPerAggregatePolicy testSubject = new SequentialPerAggregatePolicy();
         String aggregateIdentifier = UUID.randomUUID().toString();

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/SequentialPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/SequentialPolicyTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class SequentialPolicyTest {
 
     @Test
-    void testSequencingIdentifier() {
+    void sequencingIdentifier() {
         // ok, pretty useless, but everything should be tested
         SequentialPolicy testSubject = new SequentialPolicy();
         Object id1 = testSubject.getSequenceIdentifierFor(newStubDomainEvent(UUID.randomUUID()));

--- a/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
@@ -51,7 +51,7 @@ class DefaultEventGatewayTest {
 
     @SuppressWarnings({"unchecked", "serial"})
     @Test
-    void testPublish() {
+    void publish() {
         testSubject.publish("Event1");
         verify(mockEventBus).publish(
                 argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event1")));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -88,7 +88,7 @@ class CoordinatorTest {
     }
 
     @Test
-    void testIfCoordinationTaskRescheduledAfterTokenReleaseClaimFails() {
+    void ifCoordinationTaskRescheduledAfterTokenReleaseClaimFails() {
         //arrange
         final RuntimeException streamOpenException = new RuntimeException("Some exception during event stream open");
         final RuntimeException releaseClaimException = new RuntimeException("Some exception during release claim");
@@ -113,7 +113,7 @@ class CoordinatorTest {
     }
 
     @Test
-    void testIfCoordinationTaskInitializesTokenStoreWhenNeeded() {
+    void ifCoordinationTaskInitializesTokenStoreWhenNeeded() {
         //arrange
         final GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
 
@@ -132,7 +132,7 @@ class CoordinatorTest {
 
     @SuppressWarnings("rawtypes") // Mockito cannot deal with the wildcard generics of the TrackedEventMessage
     @Test
-    void testIfCoordinationTaskSchedulesEventsWithTheSameTokenTogether() throws InterruptedException {
+    void ifCoordinationTaskSchedulesEventsWithTheSameTokenTogether() throws InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(0);
         TrackedEventMessage testEventOne =
                 new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/MergeTaskTest.java
@@ -52,7 +52,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunReturnsFalseThroughSegmentIdsWhichCannotMerge() throws ExecutionException, InterruptedException {
+    void runReturnsFalseThroughSegmentIdsWhichCannotMerge() throws ExecutionException, InterruptedException {
         when(tokenStore.fetchSegments(PROCESSOR_NAME)).thenReturn(new int[]{SEGMENT_TO_MERGE});
 
         testSubject.run();
@@ -63,7 +63,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunMergeSegmentsFromWorkPackages() throws ExecutionException, InterruptedException {
+    void runMergeSegmentsFromWorkPackages() throws ExecutionException, InterruptedException {
         TrackingToken testTokenToMerge = new GlobalSequenceTrackingToken(0);
         TrackingToken testTokenToBeMerged = new GlobalSequenceTrackingToken(1);
 
@@ -94,7 +94,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunMergeSegmentsAfterClaimingBoth() throws ExecutionException, InterruptedException {
+    void runMergeSegmentsAfterClaimingBoth() throws ExecutionException, InterruptedException {
         TrackingToken testTokenToMerge = new GlobalSequenceTrackingToken(0);
         TrackingToken testTokenToBeMerged = new GlobalSequenceTrackingToken(1);
         when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_TO_MERGE)).thenReturn(testTokenToMerge);
@@ -118,7 +118,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunMergeSegmentsFromWorkPackageAndClaimedSegment() throws ExecutionException, InterruptedException {
+    void runMergeSegmentsFromWorkPackageAndClaimedSegment() throws ExecutionException, InterruptedException {
         TrackingToken testTokenToMerge = new GlobalSequenceTrackingToken(0);
         TrackingToken testTokenToBeMerged = new GlobalSequenceTrackingToken(1);
 
@@ -146,7 +146,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunCompletesExceptionallyThroughUnableToClaimTokenExceptionOnFetch() {
+    void runCompletesExceptionallyThroughUnableToClaimTokenExceptionOnFetch() {
         when(tokenStore.fetchSegments(PROCESSOR_NAME)).thenReturn(SEGMENT_IDS);
         when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_TO_MERGE))
                 .thenThrow(new UnableToClaimTokenException("some exception"));
@@ -159,7 +159,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunCompletesExceptionallyThroughUnableToClaimTokenExceptionOnDelete() {
+    void runCompletesExceptionallyThroughUnableToClaimTokenExceptionOnDelete() {
         when(workPackageOne.segment()).thenReturn(SEGMENT_ZERO);
         when(workPackageOne.abort(null)).thenReturn(CompletableFuture.completedFuture(null));
         when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_TO_MERGE)).thenReturn(new GlobalSequenceTrackingToken(0));
@@ -181,7 +181,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testRunCompletesExceptionallyThroughOtherException() {
+    void runCompletesExceptionallyThroughOtherException() {
         when(workPackageOne.segment()).thenReturn(SEGMENT_ZERO);
         when(workPackageOne.abort(null)).thenReturn(CompletableFuture.completedFuture(null));
         when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_TO_MERGE)).thenReturn(new GlobalSequenceTrackingToken(0));
@@ -203,7 +203,7 @@ class MergeTaskTest {
     }
 
     @Test
-    void testDescription() {
+    void description() {
         String result = testSubject.getDescription();
         assertNotNull(result);
         assertTrue(result.contains("Merge"));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -130,7 +130,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testRetriesWhenTokenInitializationInitiallyFails() {
+    void retriesWhenTokenInitializationInitiallyFails() {
         InMemoryTokenStore spy = spy(tokenStore);
         setTestSubject(createTestSubject(b -> b.tokenStore(spy)));
 
@@ -159,7 +159,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testStartShutsDownImmediatelyIfCoordinatorExecutorThrowsAnException() {
+    void startShutsDownImmediatelyIfCoordinatorExecutorThrowsAnException() {
         ScheduledExecutorService spiedCoordinatorExecutor = spy(coordinatorExecutor);
         doThrow(new IllegalArgumentException("Some exception")).when(spiedCoordinatorExecutor)
                                                                .submit(any(Runnable.class));
@@ -171,7 +171,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testSecondStartInvocationIsIgnored() {
+    void secondStartInvocationIsIgnored() {
         ScheduledExecutorService spiedCoordinatorExecutor = spy(coordinatorExecutor);
 
         setTestSubject(createTestSubject(builder -> builder.coordinatorExecutor(spiedCoordinatorExecutor)));
@@ -183,7 +183,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testStartingProcessorClaimsAllAvailableTokens() {
+    void startingProcessorClaimsAllAvailableTokens() {
         startAndAssertProcessorClaimsAllTokens();
     }
 
@@ -208,7 +208,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testProcessorOnlyTriesToClaimAvailableSegments() {
+    void processorOnlyTriesToClaimAvailableSegments() {
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 0);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(2L), "test", 1);
         tokenStore.storeToken(new GlobalSequenceTrackingToken(1L), "test", 2);
@@ -223,7 +223,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testStartingAfterShutdownLetsProcessorProceed() {
+    void startingAfterShutdownLetsProcessorProceed() {
         when(stubEventHandler.supportsReset()).thenReturn(true);
 
         testSubject.start();
@@ -251,7 +251,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testAllTokensUpdatedToLatestValue() {
+    void allTokensUpdatedToLatestValue() {
         List<EventMessage<Integer>> events = IntStream.range(0, 100)
                                                       .mapToObj(GenericEventMessage::new)
                                                       .collect(Collectors.toList());
@@ -276,7 +276,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testExceptionWhileHandlingEventAbortsWorker() throws Exception {
+    void exceptionWhileHandlingEventAbortsWorker() throws Exception {
         List<EventMessage<Integer>> events = Stream.of(1, 2, 2, 4, 5)
                                                    .map(GenericEventMessage::new)
                                                    .collect(Collectors.toList());
@@ -313,7 +313,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testWorkPackageIsAbortedWhenExtendingClaimFails() {
+    void workPackageIsAbortedWhenExtendingClaimFails() {
         InMemoryTokenStore spy = spy(tokenStore);
         setTestSubject(createTestSubject(b -> b.tokenStore(spy)
                                                .messageSource(new InMemoryMessageSource(true))
@@ -331,7 +331,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testHandlingUnknownMessageTypeWillAdvanceToken() {
+    void handlingUnknownMessageTypeWillAdvanceToken() {
         setTestSubject(createTestSubject(builder -> builder.initialSegmentCount(1)));
 
         when(stubEventHandler.canHandle(any(), any())).thenReturn(false);
@@ -351,7 +351,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testTokenStoreReturningSingleNullToken() {
+    void tokenStoreReturningSingleNullToken() {
         when(stubEventHandler.canHandle(any(), any())).thenReturn(false);
         when(stubEventHandler.canHandleType(Integer.class)).thenReturn(false);
 
@@ -366,7 +366,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testEventsWhichMustBeIgnoredAreNotHandledOnlyValidated() throws Exception {
+    void eventsWhichMustBeIgnoredAreNotHandledOnlyValidated() throws Exception {
         setTestSubject(createTestSubject(builder -> builder.initialSegmentCount(1)));
 
         // The custom ArgumentMatcher, for some reason, first runs the assertion with null, failing the current check.
@@ -439,7 +439,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testCoordinationIsTriggeredThroughEventAvailabilityCallback() {
+    void coordinationIsTriggeredThroughEventAvailabilityCallback() {
         boolean streamCallbackSupported = true;
         //noinspection ConstantConditions
         InMemoryMessageSource testMessageSource = new InMemoryMessageSource(streamCallbackSupported);
@@ -478,7 +478,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testShutdownCompletesAfterAbortingWorkPackages()
+    void shutdownCompletesAfterAbortingWorkPackages()
             throws InterruptedException, ExecutionException, TimeoutException {
         testSubject.start();
         Stream.of(1, 2, 2, 4, 5).map(GenericEventMessage::new).forEach(stubMessageSource::publishMessage);
@@ -493,12 +493,12 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testShutdownProcessorWhichHasNotStartedYetReturnsCompletedFuture() {
+    void shutdownProcessorWhichHasNotStartedYetReturnsCompletedFuture() {
         assertTrue(testSubject.shutdownAsync().isDone());
     }
 
     @Test
-    void testShutdownProcessorAsyncTwiceReturnsSameFuture() {
+    void shutdownProcessorAsyncTwiceReturnsSameFuture() {
         testSubject.start();
 
         CompletableFuture<Void> resultOne = testSubject.shutdownAsync();
@@ -508,7 +508,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testStartFailsWhenShutdownIsInProgress() throws Exception {
+    void startFailsWhenShutdownIsInProgress() throws Exception {
         when(stubEventHandler.canHandle(any(), any())).thenReturn(true);
         // Use CountDownLatch to block worker threads from actually doing work, and thus shutting down successfully.
         CountDownLatch latch = new CountDownLatch(1);
@@ -534,7 +534,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testIsRunningOnlyReturnsTrueForStartedProcessor() {
+    void isRunningOnlyReturnsTrueForStartedProcessor() {
         assertFalse(testSubject.isRunning());
 
         testSubject.start();
@@ -543,7 +543,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testIsErrorForFailingMessageSourceOperation() {
+    void isErrorForFailingMessageSourceOperation() {
         assertFalse(testSubject.isError());
 
         testSubject.start();
@@ -562,7 +562,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testIsErrorWhenOpeningTheStreamFails() {
+    void isErrorWhenOpeningTheStreamFails() {
         StreamableMessageSource<TrackedEventMessage<?>> spiedMessageSource = spy(new InMemoryMessageSource());
         when(spiedMessageSource.openStream(any())).thenThrow(new IllegalStateException("Failed to open the stream"))
                                                   .thenCallRealMethod();
@@ -582,7 +582,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testGetTokenStoreIdentifier() {
+    void getTokenStoreIdentifier() {
         String expectedIdentifier = "some-identifier";
 
         TokenStore tokenStore = mock(TokenStore.class);
@@ -593,7 +593,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testReleaseSegmentMakesTheTokenUnclaimedForTwiceTheTokenClaimInterval() {
+    void releaseSegmentMakesTheTokenUnclaimedForTwiceTheTokenClaimInterval() {
         // Given...
         int testSegmentId = 0;
         int testTokenClaimInterval = 500;
@@ -622,7 +622,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testSplitSegmentIsNotSupported() {
+    void splitSegmentIsNotSupported() {
         TokenStore tokenStoreWhichCannotSplitSegments = mock(TokenStore.class);
         when(tokenStoreWhichCannotSplitSegments.requiresExplicitSegmentInitialization()).thenReturn(false);
         setTestSubject(createTestSubject(builder -> builder.tokenStore(tokenStoreWhichCannotSplitSegments)));
@@ -638,7 +638,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testSplitSegment() {
+    void splitSegment() {
         // Given...
         int testSegmentId = 0;
         int testTokenClaimInterval = 500;
@@ -670,7 +670,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testMergeSegmentIsNotSupported() {
+    void mergeSegmentIsNotSupported() {
         TokenStore tokenStoreWhichCannotMergeSegments = mock(TokenStore.class);
         when(tokenStoreWhichCannotMergeSegments.requiresExplicitSegmentInitialization()).thenReturn(false);
         setTestSubject(createTestSubject(builder -> builder.tokenStore(tokenStoreWhichCannotMergeSegments)));
@@ -686,7 +686,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testMergeSegment() {
+    void mergeSegment() {
         // Given...
         int testSegmentId = 0;
         int testSegmentIdToMerge = 1;
@@ -722,7 +722,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testSupportReset() {
+    void supportReset() {
         when(stubEventHandler.supportsReset()).thenReturn(true);
 
         assertTrue(testSubject.supportsReset());
@@ -733,14 +733,14 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensFailsIfTheProcessorIsStillRunning() {
+    void resetTokensFailsIfTheProcessorIsStillRunning() {
         testSubject.start();
 
         assertThrows(IllegalStateException.class, () -> testSubject.resetTokens());
     }
 
     @Test
-    void testResetTokens() {
+    void resetTokens() {
         int expectedSegmentCount = 2;
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(42);
 
@@ -764,7 +764,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensWithContext() {
+    void resetTokensWithContext() {
         int expectedSegmentCount = 2;
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(42);
         String expectedContext = "my-context";
@@ -789,7 +789,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensFromDefinedPosition() {
+    void resetTokensFromDefinedPosition() {
         TrackingToken testToken = new GlobalSequenceTrackingToken(42);
 
         int expectedSegmentCount = 2;
@@ -814,7 +814,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testResetTokensFromDefinedPositionAndWithResetContext() {
+    void resetTokensFromDefinedPositionAndWithResetContext() {
         TrackingToken testToken = new GlobalSequenceTrackingToken(42);
 
         int expectedSegmentCount = 2;
@@ -840,12 +840,12 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testMaxCapacityDefaultsToShortMax() {
+    void maxCapacityDefaultsToShortMax() {
         assertEquals(Short.MAX_VALUE, testSubject.maxCapacity());
     }
 
     @Test
-    void testMaxCapacityReturnsConfiguredCapacity() {
+    void maxCapacityReturnsConfiguredCapacity() {
         int expectedMaxCapacity = 500;
         setTestSubject(createTestSubject(builder -> builder.maxClaimedSegments(expectedMaxCapacity)));
 
@@ -853,7 +853,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testProcessingStatusIsUpdatedWithTrackingToken() {
+    void processingStatusIsUpdatedWithTrackingToken() {
         testSubject.start();
         mockEventHandlerInvoker();
 
@@ -879,14 +879,14 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullMessageSourceThrowsAxonConfigurationException() {
+    void buildWithNullMessageSourceThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.messageSource(null));
     }
 
     @Test
-    void testBuildWithoutMessageSourceThrowsAxonConfigurationException() {
+    void buildWithoutMessageSourceThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject =
                 PooledStreamingEventProcessor.builder()
                                              .tokenStore(new InMemoryTokenStore())
@@ -896,14 +896,14 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullTokenStoreThrowsAxonConfigurationException() {
+    void buildWithNullTokenStoreThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.tokenStore(null));
     }
 
     @Test
-    void testBuildWithoutTokenStoreThrowsAxonConfigurationException() {
+    void buildWithoutTokenStoreThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject =
                 PooledStreamingEventProcessor.builder()
                                              .name(PROCESSOR_NAME)
@@ -915,14 +915,14 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullTransactionManagerThrowsAxonConfigurationException() {
+    void buildWithNullTransactionManagerThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.transactionManager(null));
     }
 
     @Test
-    void testBuildWithoutTransactionManagerThrowsAxonConfigurationException() {
+    void buildWithoutTransactionManagerThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject =
                 PooledStreamingEventProcessor.builder()
                                              .name(PROCESSOR_NAME)
@@ -934,7 +934,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullCoordinatorExecutorThrowsAxonConfigurationException() {
+    void buildWithNullCoordinatorExecutorThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(
@@ -944,7 +944,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullCoordinatorExecutorBuilderThrowsAxonConfigurationException() {
+    void buildWithNullCoordinatorExecutorBuilderThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(
@@ -954,7 +954,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithoutCoordinatorExecutorThrowsAxonConfigurationException() {
+    void buildWithoutCoordinatorExecutorThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject =
                 PooledStreamingEventProcessor.builder()
                                              .name(PROCESSOR_NAME)
@@ -967,7 +967,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullWorkerExecutorThrowsAxonConfigurationException() {
+    void buildWithNullWorkerExecutorThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(
@@ -977,7 +977,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullWorkerExecutorBuilderThrowsAxonConfigurationException() {
+    void buildWithNullWorkerExecutorBuilderThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(
@@ -987,7 +987,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithoutWorkerExecutorThrowsAxonConfigurationException() {
+    void buildWithoutWorkerExecutorThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject =
                 PooledStreamingEventProcessor.builder()
                                              .name(PROCESSOR_NAME)
@@ -1001,7 +1001,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithZeroOrNegativeInitialSegmentCountThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeInitialSegmentCountThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.initialSegmentCount(0));
@@ -1009,14 +1009,14 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithNullInitialTokenThrowsAxonConfigurationException() {
+    void buildWithNullInitialTokenThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.initialToken(null));
     }
 
     @Test
-    void testBuildWithZeroOrNegativeTokenClaimIntervalThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeTokenClaimIntervalThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.tokenClaimInterval(0));
@@ -1024,7 +1024,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithZeroOrNegativeMaxCapacityThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeMaxCapacityThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.maxClaimedSegments(0));
@@ -1032,7 +1032,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithZeroOrNegativeClaimExtensionThresholdThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeClaimExtensionThresholdThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.claimExtensionThreshold(0));
@@ -1040,7 +1040,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testBuildWithZeroOrNegativeBatchSizeThrowsAxonConfigurationException() {
+    void buildWithZeroOrNegativeBatchSizeThrowsAxonConfigurationException() {
         PooledStreamingEventProcessor.Builder builderTestSubject = PooledStreamingEventProcessor.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.batchSize(0));
@@ -1048,7 +1048,7 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
-    void testIsReplaying() {
+    void isReplaying() {
         mockEventHandlerInvoker();
         when(stubEventHandler.supportsReset()).thenReturn(true);
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/SplitTaskTest.java
@@ -45,7 +45,7 @@ class SplitTaskTest {
     }
 
     @Test
-    void testRunSplitsSegmentFromWorkPackage() throws ExecutionException, InterruptedException {
+    void runSplitsSegmentFromWorkPackage() throws ExecutionException, InterruptedException {
         Segment testSegmentToSplit = Segment.ROOT_SEGMENT;
         TrackingToken testTokenToSplit = new GlobalSequenceTrackingToken(0);
 
@@ -69,7 +69,7 @@ class SplitTaskTest {
     }
 
     @Test
-    void testRunSplitsSegmentAfterClaiming() throws ExecutionException, InterruptedException {
+    void runSplitsSegmentAfterClaiming() throws ExecutionException, InterruptedException {
         int[] testSegmentIds = {SEGMENT_ID};
         Segment testSegmentToSplit = Segment.computeSegment(SEGMENT_ID, testSegmentIds);
         TrackingToken testTokenToSplit = new GlobalSequenceTrackingToken(0);
@@ -92,7 +92,7 @@ class SplitTaskTest {
     }
 
     @Test
-    void testRunCompletesExceptionallyThroughUnableToClaimTokenException() {
+    void runCompletesExceptionallyThroughUnableToClaimTokenException() {
         when(tokenStore.fetchSegments(PROCESSOR_NAME)).thenReturn(new int[]{SEGMENT_ID});
         when(tokenStore.fetchToken(PROCESSOR_NAME, SEGMENT_ID))
                 .thenThrow(new UnableToClaimTokenException("some exception"));
@@ -105,7 +105,7 @@ class SplitTaskTest {
     }
 
     @Test
-    void testRunCompletesExceptionallyThroughOtherException() {
+    void runCompletesExceptionallyThroughOtherException() {
         when(tokenStore.fetchSegments(PROCESSOR_NAME)).thenThrow(new IllegalStateException("some exception"));
 
         testSubject.run();
@@ -116,7 +116,7 @@ class SplitTaskTest {
     }
 
     @Test
-    void testDescription() {
+    void description() {
         String result = testSubject.getDescription();
         assertNotNull(result);
         assertTrue(result.contains("Split"));

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
@@ -118,7 +118,7 @@ class WorkPackageTest {
      * The "last delivered token" is configured as the initialToken for a fresh WorkPackage.
      */
     @Test
-    void testScheduleEventDoesNotScheduleIfTheLastDeliveredTokenCoversTheEventsToken() {
+    void scheduleEventDoesNotScheduleIfTheLastDeliveredTokenCoversTheEventsToken() {
         TrackedEventMessage<String> testEvent = new GenericTrackedEventMessage<>(
                 new GlobalSequenceTrackingToken(1L), GenericEventMessage.asEventMessage("some-event")
         );
@@ -133,7 +133,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventUpdatesLastDeliveredToken() {
+    void scheduleEventUpdatesLastDeliveredToken() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
                 new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
@@ -144,7 +144,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventFailsOnEventValidator() throws ExecutionException, InterruptedException {
+    void scheduleEventFailsOnEventValidator() throws ExecutionException, InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
                 new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("some-event"));
@@ -168,7 +168,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventFailsOnBatchProcessor() throws ExecutionException, InterruptedException {
+    void scheduleEventFailsOnBatchProcessor() throws ExecutionException, InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
                 new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("some-event"));
@@ -196,7 +196,7 @@ class WorkPackageTest {
      * BatchProcessor and the updated token stored.
      */
     @Test
-    void testScheduleEventRunsSuccessfully() {
+    void scheduleEventRunsSuccessfully() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
                 new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
@@ -222,7 +222,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testReplayTokenIsPropagatedAndAdvancedWithoutCurrent() {
+    void replayTokenIsPropagatedAndAdvancedWithoutCurrent() {
         testSubjectBuilder.initialToken(new ReplayToken(new GlobalSequenceTrackingToken(1L)));
         testSubject = testSubjectBuilder.build();
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
@@ -243,7 +243,7 @@ class WorkPackageTest {
 
 
     @Test
-    void testReplayTokenIsPropagatedAndAdvancedWithCurrent() {
+    void replayTokenIsPropagatedAndAdvancedWithCurrent() {
         testSubjectBuilder.initialToken(new ReplayToken(new GlobalSequenceTrackingToken(1L),
                                                         new GlobalSequenceTrackingToken(0L)));
         testSubject = testSubjectBuilder.build();
@@ -264,7 +264,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventExtendsTokenClaimAfterClaimThresholdExtension() {
+    void scheduleEventExtendsTokenClaimAfterClaimThresholdExtension() {
         // The short threshold ensures the packages assume the token should be reclaimed.
         int extremelyShortClaimExtensionThreshold = 1;
         WorkPackage testSubjectWithShortThreshold =
@@ -301,7 +301,7 @@ class WorkPackageTest {
      * This requires the WorkPackage to have received events which it should not handle.
      */
     @Test
-    void testScheduleEventUpdatesTokenAfterClaimThresholdExtension() {
+    void scheduleEventUpdatesTokenAfterClaimThresholdExtension() {
         // The short threshold ensures the packages assume the token should be reclaimed.
         int extremelyShortClaimExtensionThreshold = 1;
         WorkPackage testSubjectWithShortThreshold =
@@ -336,7 +336,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleWorkerForAbortedPackage() throws ExecutionException, InterruptedException {
+    void scheduleWorkerForAbortedPackage() throws ExecutionException, InterruptedException {
         CompletableFuture<Exception> result = testSubject.abort(null);
 
         testSubject.scheduleWorker();
@@ -347,33 +347,33 @@ class WorkPackageTest {
     }
 
     @Test
-    void testHasRemainingCapacityReturnsTrueForWorkPackageWithoutScheduledEvents() {
+    void hasRemainingCapacityReturnsTrueForWorkPackageWithoutScheduledEvents() {
         assertTrue(testSubject.hasRemainingCapacity());
     }
 
     @Test
-    void testSegment() {
+    void segment() {
         assertEquals(segment, testSubject.segment());
     }
 
     @Test
-    void testLastDeliveredTokenEqualsInitialTokenWhenNoEventsHaveBeenScheduled() {
+    void lastDeliveredTokenEqualsInitialTokenWhenNoEventsHaveBeenScheduled() {
         assertEquals(initialTrackingToken, testSubject.lastDeliveredToken());
     }
 
     @Test
-    void testIsAbortTriggeredReturnsFalseInAbsenceOfAbort() {
+    void isAbortTriggeredReturnsFalseInAbsenceOfAbort() {
         assertFalse(testSubject.isAbortTriggered());
     }
 
     @Test
-    void testIsAbortTriggeredReturnsTrueAfterAbortInvocation() {
+    void isAbortTriggeredReturnsTrueAfterAbortInvocation() {
         testSubject.abort(null);
         assertTrue(testSubject.isAbortTriggered());
     }
 
     @Test
-    void testAbortReturnsAbortReason() throws ExecutionException, InterruptedException {
+    void abortReturnsAbortReason() throws ExecutionException, InterruptedException {
         Exception expectedResult = new IllegalStateException();
 
         CompletableFuture<Exception> result = testSubject.abort(expectedResult);
@@ -383,7 +383,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testAbortReturnsOriginalAbortReason() throws ExecutionException, InterruptedException {
+    void abortReturnsOriginalAbortReason() throws ExecutionException, InterruptedException {
         Exception originalAbortReason = new IllegalStateException();
         Exception otherAbortReason = new IllegalArgumentException();
         testSubject.abort(originalAbortReason);
@@ -395,12 +395,12 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventsReturnsFalseForEmptyList() {
+    void scheduleEventsReturnsFalseForEmptyList() {
         assertFalse(testSubject.scheduleEvents(Collections.emptyList()));
     }
 
     @Test
-    void testScheduleEventsThrowsIllegalArgumentExceptionForNoneMatchingTokens() {
+    void scheduleEventsThrowsIllegalArgumentExceptionForNoneMatchingTokens() {
         TrackingToken testTokenOne = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEventOne =
                 new GenericTrackedEventMessage<>(testTokenOne, GenericEventMessage.asEventMessage("this-event"));
@@ -418,7 +418,7 @@ class WorkPackageTest {
      * The "last delivered token" is configured as the initialToken for a fresh WorkPackage.
      */
     @Test
-    void testScheduleEventsDoesNotScheduleIfTheLastDeliveredTokensCoversTheEventsToken() {
+    void scheduleEventsDoesNotScheduleIfTheLastDeliveredTokensCoversTheEventsToken() {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEventOne =
                 new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));
@@ -439,7 +439,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventsReturnsTrueIfOnlyOneEventIsAcceptedByTheEventValidator() {
+    void scheduleEventsReturnsTrueIfOnlyOneEventIsAcceptedByTheEventValidator() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> filteredEvent =
                 new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));
@@ -474,7 +474,7 @@ class WorkPackageTest {
     }
 
     @Test
-    void testScheduleEventsHandlesAllEventsInOneTransactionWhenAllEventsCanBeHandled() {
+    void scheduleEventsHandlesAllEventsInOneTransactionWhenAllEventsCanBeHandled() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEventOne =
                 new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
@@ -36,7 +36,7 @@ class GenericResetContextTest {
     private static final Object TEST_PAYLOAD = new Object();
 
     @Test
-    void testConstructor() {
+    void constructor() {
         ResetContext<Object> messageOne = asResetContext(TEST_PAYLOAD);
         ResetContext<Object> messageTwo = asResetContext(new GenericMessage<>(TEST_PAYLOAD));
         ResetContext<Object> messageThree = asResetContext(new GenericResetContext<>(TEST_PAYLOAD));
@@ -73,7 +73,7 @@ class GenericResetContextTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         MetaData metaData = MetaData.from(Collections.<String, Object>singletonMap("key", "value"));
         ResetContext<Object> startMessage = new GenericResetContext<>(TEST_PAYLOAD, metaData);
 
@@ -86,7 +86,7 @@ class GenericResetContextTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         MetaData metaData = MetaData.from(Collections.<String, Object>singletonMap("key", "value"));
         ResetContext<Object> startMessage = new GenericResetContext<>(TEST_PAYLOAD, metaData);
 
@@ -101,7 +101,7 @@ class GenericResetContextTest {
     }
 
     @Test
-    void testDescribeType() {
+    void describeType() {
         assertEquals("GenericResetContext", new GenericResetContext<>(TEST_PAYLOAD).describeType());
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperTest.java
@@ -45,7 +45,7 @@ class ReplayAwareMessageHandlerWrapperTest {
     }
 
     @Test
-    void testInvokeWithReplayTokens() throws Exception {
+    void invokeWithReplayTokens() throws Exception {
         GenericTrackedEventMessage<Object> stringEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage("1"));
         GenericTrackedEventMessage<Object> longEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage(1L));
         assertTrue(testSubject.canHandle(stringEvent));

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -55,7 +55,7 @@ class ReplayAwareMessageHandlerWrapperWithDisallowReplayTest {
     }
 
     @Test
-    void testInvokeWithReplayTokens() throws Exception {
+    void invokeWithReplayTokens() throws Exception {
         GenericTrackedEventMessage<Object> stringEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage("1"));
         GenericTrackedEventMessage<Object> longEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage(1L));
         assertTrue(testSubject.canHandle(stringEvent));

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayContextParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayContextParameterResolverFactoryTest.java
@@ -51,7 +51,7 @@ class ReplayContextParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesIfMatching() throws Exception {
+    void resolvesIfMatching() throws Exception {
         GenericTrackedEventMessage<Object> replayEvent = new GenericTrackedEventMessage<>(replayToken,
                                                                                           asEventMessage(1L));
         GenericTrackedEventMessage<Object> liveEvent = new GenericTrackedEventMessage<>(regularToken,

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayParameterResolverFactoryTest.java
@@ -46,7 +46,7 @@ class ReplayParameterResolverFactoryTest {
     }
 
     @Test
-    void testInvokeWithReplayTokens() throws Exception {
+    void invokeWithReplayTokens() throws Exception {
         GenericTrackedEventMessage<Object> replayEvent = new GenericTrackedEventMessage<>(replayToken, asEventMessage(1L));
         GenericTrackedEventMessage<Object> liveEvent = new GenericTrackedEventMessage<>(regularToken, asEventMessage(2L));
         assertTrue(testSubject.canHandle(replayEvent));

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleEventSchedulerTest.java
@@ -71,7 +71,7 @@ class SimpleEventSchedulerTest {
     }
 
     @Test
-    void testScheduleJob() throws InterruptedException {
+    void scheduleJob() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
             latch.countDown();
@@ -83,7 +83,7 @@ class SimpleEventSchedulerTest {
     }
 
     @Test
-    void testScheduleTokenIsSerializable() throws IOException, ClassNotFoundException {
+    void scheduleTokenIsSerializable() throws IOException, ClassNotFoundException {
         ScheduleToken token = testSubject.schedule(Duration.ZERO, new Object());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
@@ -95,7 +95,7 @@ class SimpleEventSchedulerTest {
     }
 
     @Test
-    void testCancelJob() throws InterruptedException {
+    void cancelJob() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
             latch.countDown();
@@ -117,7 +117,7 @@ class SimpleEventSchedulerTest {
     }
 
     @Test
-    void testShutdownInvokesExecutorServiceShutdown(@Mock ScheduledExecutorService scheduledExecutorService) {
+    void shutdownInvokesExecutorServiceShutdown(@Mock ScheduledExecutorService scheduledExecutorService) {
         SimpleEventScheduler testSubject = SimpleEventScheduler.builder()
                                                                .scheduledExecutorService(scheduledExecutorService)
                                                                .eventBus(eventBus)

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleScheduleTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleScheduleTokenSerializationTest.java
@@ -21,7 +21,7 @@ class SimpleScheduleTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         SimpleScheduleToken tokenToTest = new SimpleScheduleToken("28bda08d-2dd5-4420-98cb-75ca073446b4");
         assertEquals(tokenToTest, serializer.serializeDeserialize(tokenToTest));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -75,7 +75,7 @@ class DirectEventJobDataBinderTest {
 
     @MethodSource("serializerImplementationAndAssertionSpecifics")
     @ParameterizedTest
-    void testEventMessageToJobData(
+    void eventMessageToJobData(
             Serializer serializer,
             Function<Class, String> expectedSerializedClassType,
             Predicate<Object> revisionMatcher
@@ -101,7 +101,7 @@ class DirectEventJobDataBinderTest {
     @SuppressWarnings("unchecked")
     @MethodSource("serializerImplementationAndAssertionSpecifics")
     @ParameterizedTest
-    void testEventMessageFromJobData(
+    void eventMessageFromJobData(
             Serializer serializer,
             Function<Class, String> expectedSerializedClassType,
             Predicate<Object> revisionMatcher

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventSchedulerTest.java
@@ -81,7 +81,7 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testScheduleJob() throws InterruptedException {
+    void scheduleJob() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocation -> {
             latch.countDown();
@@ -95,7 +95,7 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testScheduleJobTransactionalUnitOfWork() throws InterruptedException {
+    void scheduleJobTransactionalUnitOfWork() throws InterruptedException {
         Transaction mockTransaction = mock(Transaction.class);
         final TransactionManager transactionManager = mock(TransactionManager.class);
         when(transactionManager.startTransaction()).thenReturn(mockTransaction);
@@ -125,7 +125,7 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testScheduleJobTransactionalUnitOfWorkFailingTransaction() throws InterruptedException {
+    void scheduleJobTransactionalUnitOfWorkFailingTransaction() throws InterruptedException {
         final TransactionManager transactionManager = mock(TransactionManager.class);
         final CountDownLatch latch = new CountDownLatch(1);
         when(transactionManager.startTransaction()).thenAnswer(i -> {
@@ -154,7 +154,7 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testCancelJob() throws SchedulerException {
+    void cancelJob() throws SchedulerException {
         ScheduleToken token = testSubject.schedule(Duration.ofMillis(1000), buildTestEvent());
         assertEquals(1, scheduler.getJobKeys(GroupMatcher.groupEquals(GROUP_ID)).size());
         testSubject.cancelSchedule(token);
@@ -164,14 +164,14 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testShutdownInvokesSchedulerShutdown() throws SchedulerException {
+    void shutdownInvokesSchedulerShutdown() throws SchedulerException {
         testSubject.shutdown();
 
         verify(scheduler).shutdown(true);
     }
 
     @Test
-    void testShutdownFailureResultsInSchedulingException() throws SchedulerException {
+    void shutdownFailureResultsInSchedulingException() throws SchedulerException {
         Scheduler scheduler = spy(new StdSchedulerFactory().getScheduler());
         doAnswer(invocation -> {
             throw new SchedulerException();
@@ -186,21 +186,21 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testBuildWithNullEventJobDataBinderThrowsAxonConfigurationException() {
+    void buildWithNullEventJobDataBinderThrowsAxonConfigurationException() {
         QuartzEventScheduler.Builder builderTestSubject = QuartzEventScheduler.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.jobDataBinder(null));
     }
 
     @Test
-    void testBuildWithNullSerializerThrowsAxonConfigurationException() {
+    void buildWithNullSerializerThrowsAxonConfigurationException() {
         QuartzEventScheduler.Builder builderTestSubject = QuartzEventScheduler.builder();
 
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.serializer(null));
     }
 
     @Test
-    void testBuildWithoutSchedulerThrowsAxonConfigurationException() {
+    void buildWithoutSchedulerThrowsAxonConfigurationException() {
         EventBus eventBus = SimpleEventBus.builder().build();
         QuartzEventScheduler.Builder builderTestSubject =
                 QuartzEventScheduler.builder()
@@ -211,7 +211,7 @@ class QuartzEventSchedulerTest {
     }
 
     @Test
-    void testBuildWithoutEventBusThrowsAxonConfigurationException() {
+    void buildWithoutEventBusThrowsAxonConfigurationException() {
         Scheduler scheduler = mock(Scheduler.class);
         QuartzEventScheduler.Builder builderTestSubject =
                 QuartzEventScheduler.builder()

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzScheduleTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/QuartzScheduleTokenSerializationTest.java
@@ -21,7 +21,7 @@ class QuartzScheduleTokenSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         QuartzScheduleToken tokenToTest = new QuartzScheduleToken("jobIdentifier", "groupIdentifier");
         assertEquals(tokenToTest, serializer.serializeDeserialize(tokenToTest));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/ConfigTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/ConfigTokenTest.java
@@ -39,7 +39,7 @@ class ConfigTokenTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializable(TestSerializer serializer) {
+    void tokenShouldBeSerializable(TestSerializer serializer) {
         Map<String, String> configMap = Collections.singletonMap("some-key", "some-value");
         ConfigToken token = new ConfigToken(configMap);
         assertEquals(token, serializer.serializeDeserialize(token));

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/TokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/TokenStoreTest.java
@@ -29,7 +29,7 @@ class TokenStoreTest {
     private final TokenStore tokenStore = spy(TokenStore.class);
 
     @Test
-    void testFetchAvailableSegments() {
+    void fetchAvailableSegments() {
         when(tokenStore.fetchSegments("")).thenReturn(new int[]{0, 1, 2, 3});
         List<Segment> availableSegments = tokenStore.fetchAvailableSegments("");
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStoreTest.java
@@ -38,7 +38,7 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testInitializeTokens() {
+    void initializeTokens() {
         testSubject.initializeTokenSegments("test1", 7);
 
         int[] actual = testSubject.fetchSegments("test1");
@@ -47,12 +47,12 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testIdentifierIsPresent() {
+    void identifierIsPresent() {
         assertTrue(testSubject.retrieveStorageIdentifier().isPresent());
     }
 
     @Test
-    void testInitializeTokensAtGivenPosition() {
+    void initializeTokensAtGivenPosition() {
         testSubject.initializeTokenSegments("test1", 7, new GlobalSequenceTrackingToken(10));
 
         int[] actual = testSubject.fetchSegments("test1");
@@ -65,7 +65,7 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testUpdateToken() {
+    void updateToken() {
         testSubject.initializeTokenSegments("test1", 1);
         testSubject.storeToken(new GlobalSequenceTrackingToken(1), "test1", 0);
 
@@ -73,7 +73,7 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testInitializeAtGivenToken() {
+    void initializeAtGivenToken() {
         testSubject.initializeTokenSegments("test1", 2, new GlobalSequenceTrackingToken(1));
 
         assertEquals(new GlobalSequenceTrackingToken(1), testSubject.fetchToken("test1", 0));
@@ -81,12 +81,12 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testInitializeTokensWhileAlreadyPresent() {
+    void initializeTokensWhileAlreadyPresent() {
         assertThrows(UnableToClaimTokenException.class, () -> testSubject.fetchToken("test1", 1));
     }
 
     @Test
-    void testQuerySegments() {
+    void querySegments() {
         testSubject.initializeTokenSegments("test", 1);
 
         assertNull(testSubject.fetchToken("test", 0));
@@ -110,7 +110,7 @@ class InMemoryTokenStoreTest {
     }
 
     @Test
-    void testQueryAvailableSegments() {
+    void queryAvailableSegments() {
         testSubject.storeToken(new GlobalSequenceTrackingToken(1L), "proc1", 0);
         testSubject.storeToken(new GlobalSequenceTrackingToken(2L), "proc1", 1);
         testSubject.storeToken(new GlobalSequenceTrackingToken(2L), "proc2", 1);

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStoreTest.java
@@ -97,7 +97,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testClaimAndUpdateToken() {
+    void claimAndUpdateToken() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 1));
 
         transactionManager.executeInTransaction(() -> assertNull(tokenStore.fetchToken("test", 0)));
@@ -108,7 +108,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testUpdateAndLoadNullToken() {
+    void updateAndLoadNullToken() {
         tokenStore.initializeTokenSegments("test", 1);
         tokenStore.fetchToken("test", 0);
 
@@ -120,7 +120,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegment() {
+    void fetchTokenBySegment() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 2));
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
 
@@ -129,7 +129,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegmentSegment0() {
+    void fetchTokenBySegmentSegment0() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 1));
         Segment segmentToFetch = Segment.computeSegment(0, 0);
 
@@ -138,7 +138,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegmentFailsDuringMerge() {
+    void fetchTokenBySegmentFailsDuringMerge() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 1));
         //Create a segment as if there would be two segments in total. This simulates that these two segments have been merged into one.
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
@@ -150,7 +150,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegmentFailsDuringMergeSegment0() {
+    void fetchTokenBySegmentFailsDuringMergeSegment0() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 1));
         Segment segmentToFetch = Segment.computeSegment(0, 0, 1);
 
@@ -161,7 +161,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegmentFailsDuringSplit() {
+    void fetchTokenBySegmentFailsDuringSplit() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 4));
         //Create a segment as if there would be only two segments in total. This simulates that the segments have been split into 4 segments.
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
@@ -173,7 +173,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testFetchTokenBySegmentFailsDuringSplitSegment0() {
+    void fetchTokenBySegmentFailsDuringSplitSegment0() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 2));
         Segment segmentToFetch = Segment.computeSegment(0, 0);
 
@@ -184,7 +184,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testInitializeTokens() {
+    void initializeTokens() {
         tokenStore.initializeTokenSegments("test1", 7);
 
         int[] actual = tokenStore.fetchSegments("test1");
@@ -195,7 +195,7 @@ class JdbcTokenStoreTest {
     @SuppressWarnings("Duplicates")
     @Transactional
     @Test
-    void testInitializeTokensAtGivenPosition() {
+    void initializeTokensAtGivenPosition() {
         tokenStore.initializeTokenSegments("test1", 7, new GlobalSequenceTrackingToken(10));
 
         int[] actual = tokenStore.fetchSegments("test1");
@@ -209,13 +209,13 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testInitializeTokensWhileAlreadyPresent() {
+    void initializeTokensWhileAlreadyPresent() {
         assertThrows(UnableToClaimTokenException.class, () -> tokenStore.fetchToken("test1", 1));
     }
 
     @Transactional
     @Test
-    void testQuerySegments() {
+    void querySegments() {
         prepareTokenStore();
 
         transactionManager.executeInTransaction(() -> {
@@ -234,7 +234,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testQueryAvailableSegments() {
+    void queryAvailableSegments() {
         prepareTokenStore();
 
         transactionManager.executeInTransaction(() -> {
@@ -278,7 +278,7 @@ class JdbcTokenStoreTest {
 
 
     @Test
-    void testClaimAndUpdateTokenWithoutTransaction() {
+    void claimAndUpdateTokenWithoutTransaction() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test", 1));
 
         assertNull(tokenStore.fetchToken("test", 0));
@@ -288,7 +288,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testClaimTokenConcurrently() {
+    void claimTokenConcurrently() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("concurrent", 1));
 
         transactionManager.executeInTransaction(() -> assertNull(tokenStore.fetchToken("concurrent", 0)));
@@ -301,7 +301,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testClaimTokenConcurrentlyAfterRelease() {
+    void claimTokenConcurrentlyAfterRelease() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("concurrent", 1));
 
         transactionManager.executeInTransaction(() -> tokenStore.fetchToken("concurrent", 0));
@@ -310,7 +310,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testClaimTokenConcurrentlyAfterTimeLimit() {
+    void claimTokenConcurrentlyAfterTimeLimit() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("concurrent", 1));
 
         transactionManager.executeInTransaction(() -> tokenStore.fetchToken("concurrent", 0));
@@ -319,7 +319,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testStealToken() {
+    void stealToken() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("stealing", 1));
 
         transactionManager.executeInTransaction(() -> assertNull(tokenStore.fetchToken("stealing", 0)));
@@ -339,7 +339,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testStoreAndLoadAcrossTransactions() {
+    void storeAndLoadAcrossTransactions() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("multi", 1));
 
         transactionManager.executeInTransaction(() -> {
@@ -360,7 +360,7 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testClaimAndDeleteToken() {
+    void claimAndDeleteToken() {
         transactionManager.executeInTransaction(() -> tokenStore.initializeTokenSegments("test1", 2));
 
         tokenStore.fetchToken("test1", 0);
@@ -372,19 +372,19 @@ class JdbcTokenStoreTest {
     }
 
     @Test
-    void testDeleteUnclaimedTokenFails() {
+    void deleteUnclaimedTokenFails() {
         assertThrows(UnableToClaimTokenException.class, () -> tokenStore.fetchToken("test1", 1));
     }
 
     @Transactional
     @Test
-    void testDeleteTokenFailsWhenClaimedByOtherNode() {
+    void deleteTokenFailsWhenClaimedByOtherNode() {
         assertThrows(UnableToClaimTokenException.class, () -> concurrentTokenStore.fetchToken("test1", 1));
     }
 
     @Transactional
     @Test
-    void testIdentifierInitializedOnDemand() {
+    void identifierInitializedOnDemand() {
         Optional<String> id1 = tokenStore.retrieveStorageIdentifier();
         assertTrue(id1.isPresent());
         Optional<String> id2 = tokenStore.retrieveStorageIdentifier();
@@ -394,7 +394,7 @@ class JdbcTokenStoreTest {
 
     @Transactional
     @Test
-    void testIdentifierReadIfAvailable() throws SQLException {
+    void identifierReadIfAvailable() throws SQLException {
         ConfigToken token = new ConfigToken(Collections.singletonMap("id", "test123"));
         PreparedStatement ps = dataSource.getConnection()
                                          .prepareStatement("INSERT INTO TokenEntry(processorName, segment, tokenType, token) VALUES(?, ?, ?, ?)");

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -70,7 +70,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testUpdateNullToken() {
+    void updateNullToken() {
         jpaTokenStore.initializeTokenSegments("test", 1);
         jpaTokenStore.fetchToken("test", 0);
         jpaTokenStore.storeToken(null, "test", 0);
@@ -85,7 +85,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testUpdateAndLoadNullToken() {
+    void updateAndLoadNullToken() {
         jpaTokenStore.initializeTokenSegments("test", 1);
         jpaTokenStore.fetchToken("test", 0);
         entityManager.flush();
@@ -97,7 +97,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testIdentifierInitializedOnDemand() {
+    void identifierInitializedOnDemand() {
         Optional<String> id1 = jpaTokenStore.retrieveStorageIdentifier();
         assertTrue(id1.isPresent());
         Optional<String> id2 = jpaTokenStore.retrieveStorageIdentifier();
@@ -106,7 +106,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testIdentifierReadIfAvailable() {
+    void identifierReadIfAvailable() {
         entityManager.persist(new TokenEntry("__config", 0, new ConfigToken(Collections.singletonMap("id", "test")), jpaTokenStore.serializer()));
         Optional<String> id1 = jpaTokenStore.retrieveStorageIdentifier();
         assertTrue(id1.isPresent());
@@ -118,7 +118,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testCustomLockMode() {
+    void customLockMode() {
         EntityManager spyEntityManager = mock(EntityManager.class);
 
         JpaTokenStore testSubject = JpaTokenStore.builder()
@@ -137,7 +137,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testInitializeTokens() {
+    void initializeTokens() {
         jpaTokenStore.initializeTokenSegments("test1", 7);
 
         int[] actual = jpaTokenStore.fetchSegments("test1");
@@ -147,7 +147,7 @@ class JpaTokenStoreTest {
 
     @SuppressWarnings("Duplicates")
     @Test
-    void testInitializeTokensAtGivenPosition() {
+    void initializeTokensAtGivenPosition() {
         jpaTokenStore.initializeTokenSegments("test1", 7, new GlobalSequenceTrackingToken(10));
 
         int[] actual = jpaTokenStore.fetchSegments("test1");
@@ -160,12 +160,12 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testInitializeTokensWhileAlreadyPresent() {
+    void initializeTokensWhileAlreadyPresent() {
         assertThrows(UnableToClaimTokenException.class, () -> jpaTokenStore.fetchToken("test1", 1));
     }
 
     @Test
-    void testDeleteTokenRejectedIfNotClaimedOrNotInitialized() {
+    void deleteTokenRejectedIfNotClaimedOrNotInitialized() {
         jpaTokenStore.initializeTokenSegments("test", 2);
 
         try {
@@ -184,7 +184,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testDeleteToken() {
+    void deleteToken() {
         jpaTokenStore.initializeSegment(null, "delete", 0);
         jpaTokenStore.fetchToken("delete", 0);
 
@@ -198,7 +198,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testClaimAndUpdateToken() {
+    void claimAndUpdateToken() {
         jpaTokenStore.initializeTokenSegments("test", 1);
 
         assertNull(jpaTokenStore.fetchToken("test", 0));
@@ -221,7 +221,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegment() {
+    void fetchTokenBySegment() {
         jpaTokenStore.initializeTokenSegments("test", 2);
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
 
@@ -229,7 +229,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegmentSegment0() {
+    void fetchTokenBySegmentSegment0() {
         jpaTokenStore.initializeTokenSegments("test", 1);
         Segment segmentToFetch = Segment.computeSegment(0, 0);
 
@@ -237,7 +237,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegmentFailsDuringMerge() {
+    void fetchTokenBySegmentFailsDuringMerge() {
         jpaTokenStore.initializeTokenSegments("test", 1);
         //Create a segment as if there would be two segments in total. This simulates that these two segments have been merged into one.
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
@@ -248,7 +248,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegmentFailsDuringMergeSegment0() {
+    void fetchTokenBySegmentFailsDuringMergeSegment0() {
         jpaTokenStore.initializeTokenSegments("test", 1);
         Segment segmentToFetch = Segment.computeSegment(0, 0, 1);
 
@@ -258,7 +258,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegmentFailsDuringSplit() {
+    void fetchTokenBySegmentFailsDuringSplit() {
         jpaTokenStore.initializeTokenSegments("test", 4);
         //Create a segment as if there would be only two segments in total. This simulates that the segments have been split into 4 segments.
         Segment segmentToFetch = Segment.computeSegment(1, 0, 1);
@@ -269,7 +269,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testFetchTokenBySegmentFailsDuringSplitSegment0() {
+    void fetchTokenBySegmentFailsDuringSplitSegment0() {
         jpaTokenStore.initializeTokenSegments("test", 2);
         Segment segmentToFetch = Segment.computeSegment(0, 0);
 
@@ -279,7 +279,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testQuerySegments() {
+    void querySegments() {
         prepareTokenStore();
 
         {
@@ -300,7 +300,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testQueryAvailableSegments() {
+    void queryAvailableSegments() {
         prepareTokenStore();
 
         {
@@ -343,7 +343,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testClaimTokenConcurrently() {
+    void claimTokenConcurrently() {
         jpaTokenStore.initializeTokenSegments("concurrent", 1);
         jpaTokenStore.fetchToken("concurrent", 0);
         try {
@@ -355,7 +355,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testStealToken() {
+    void stealToken() {
         jpaTokenStore.initializeTokenSegments("stealing", 1);
 
         jpaTokenStore.fetchToken("stealing", 0);
@@ -373,7 +373,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testExtendingLostClaimFails() {
+    void extendingLostClaimFails() {
         jpaTokenStore.initializeTokenSegments("processor", 1);
         jpaTokenStore.fetchToken("processor", 0);
 
@@ -386,7 +386,7 @@ class JpaTokenStoreTest {
     }
 
     @Test
-    void testStoreAndLoadAcrossTransactions() {
+    void storeAndLoadAcrossTransactions() {
 
         jpaTokenStore.initializeTokenSegments("multi", 1);
         newTransAction();

--- a/messaging/src/test/java/org/axonframework/lifecycle/ShutdownLatchTest.java
+++ b/messaging/src/test/java/org/axonframework/lifecycle/ShutdownLatchTest.java
@@ -16,7 +16,7 @@ class ShutdownLatchTest {
     private final ShutdownLatch testSubject = new ShutdownLatch();
 
     @Test
-    void testInitializeCancelsEarlierShutdown() {
+    void initializeCancelsEarlierShutdown() {
         testSubject.registerActivity();
 
         CompletableFuture<Void> latch = testSubject.initiateShutdown();
@@ -26,14 +26,14 @@ class ShutdownLatchTest {
     }
 
     @Test
-    void testIncrementThrowsShutdownInProgressExceptionIfShuttingDown() {
+    void incrementThrowsShutdownInProgressExceptionIfShuttingDown() {
         testSubject.initiateShutdown();
 
         assertThrows(ShutdownInProgressException.class, testSubject::registerActivity);
     }
 
     @Test
-    void testDecrementCompletesWaitProcess() {
+    void decrementCompletesWaitProcess() {
         ShutdownLatch.ActivityHandle activityHandle = testSubject.registerActivity();
 
         CompletableFuture<Void> latch = testSubject.initiateShutdown();
@@ -46,19 +46,19 @@ class ShutdownLatchTest {
     }
 
     @Test
-    void testIsShuttingDownIsFalseForNonAwaitedLatch() {
+    void isShuttingDownIsFalseForNonAwaitedLatch() {
         assertFalse(testSubject.isShuttingDown());
     }
 
     @Test
-    void testInitiateShutdownOnEmptyLatchOpensImmediately() {
+    void initiateShutdownOnEmptyLatchOpensImmediately() {
         CompletableFuture<Void> latch = testSubject.initiateShutdown();
 
         assertTrue(latch.isDone());
     }
 
     @Test
-    void testIsShuttingDownIsTrueForAwaitedLatch() {
+    void isShuttingDownIsTrueForAwaitedLatch() {
         CompletableFuture<Void> latch = testSubject.initiateShutdown();
 
         assertTrue(testSubject.isShuttingDown());
@@ -66,7 +66,7 @@ class ShutdownLatchTest {
     }
 
     @Test
-    void testIsShuttingDownThrowsSuppliedExceptionForAwaitedLatch() {
+    void isShuttingDownThrowsSuppliedExceptionForAwaitedLatch() {
         CompletableFuture<Void> latch = testSubject.initiateShutdown();
 
         assertThrows(SomeException.class, () -> testSubject.ifShuttingDown(SomeException::new));
@@ -74,7 +74,7 @@ class ShutdownLatchTest {
     }
 
     @Test
-    void testSubsequentActivityHandleEndCallsDoNotInfluenceOtherHandles() {
+    void subsequentActivityHandleEndCallsDoNotInfluenceOtherHandles() {
         ShutdownLatch.ActivityHandle handleOne = testSubject.registerActivity();
         ShutdownLatch.ActivityHandle handleTwo = testSubject.registerActivity();
 

--- a/messaging/src/test/java/org/axonframework/messaging/DefaultInterceptorChainTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DefaultInterceptorChainTest.java
@@ -44,7 +44,7 @@ class DefaultInterceptorChainTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testChainWithDifferentProceedCalls() throws Exception {
+    void chainWithDifferentProceedCalls() throws Exception {
         MessageHandlerInterceptor interceptor1 = (unitOfWork, interceptorChain) -> {
             unitOfWork.transformMessage(m -> new GenericMessage<>("testing"));
             return interceptorChain.proceed();

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -54,7 +54,7 @@ class GenericMessageTest {
     }
 
     @Test
-    void testCorrelationDataAddedToNewMessage() {
+    void correlationDataAddedToNewMessage() {
         assertEquals(correlationData, new HashMap<>(new GenericMessage<>(new Object()).getMetaData()));
 
         MetaData newMetaData = MetaData.from(Collections.singletonMap("whatever", new Object()));
@@ -63,7 +63,7 @@ class GenericMessageTest {
     }
 
     @Test
-    void testMessageSerialization() {
+    void messageSerialization() {
         GenericMessage<String> message = new GenericMessage<>("payload", Collections.singletonMap("key", "value"));
         Serializer jacksonSerializer = JacksonSerializer.builder().build();
 
@@ -75,7 +75,7 @@ class GenericMessageTest {
     }
 
     @Test
-    void testAsMessageReturnsProvidedMessageAsIs() {
+    void asMessageReturnsProvidedMessageAsIs() {
         GenericMessage<String> testMessage = new GenericMessage<>("payload");
 
         Message<?> result = GenericMessage.asMessage(testMessage);
@@ -84,7 +84,7 @@ class GenericMessageTest {
     }
 
     @Test
-    void testAsMessageWrapsProvidedObjectsInMessage() {
+    void asMessageWrapsProvidedObjectsInMessage() {
         String testPayload = "payload";
 
         Message<?> result = GenericMessage.asMessage(testPayload);

--- a/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericResultMessageTest {
 
     @Test
-    void testExceptionalResult() {
+    void exceptionalResult() {
         Throwable t = new Throwable("oops");
         ResultMessage<?> resultMessage = asResultMessage(t);
         try {
@@ -42,7 +42,7 @@ class GenericResultMessageTest {
     }
 
     @Test
-    void testExceptionSerialization() {
+    void exceptionSerialization() {
         Throwable expected = new Throwable("oops");
         ResultMessage<?> resultMessage = asResultMessage(expected);
         JacksonSerializer jacksonSerializer = JacksonSerializer.builder().build();

--- a/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
@@ -23,26 +23,26 @@ import static org.junit.jupiter.api.Assertions.*;
 class HandlerExecutionExceptionTest {
 
     @Test
-    void testResolveDetailsFromNestedExecutionException() {
+    void resolveDetailsFromNestedExecutionException() {
         Exception exception = new RuntimeException(new StubHandlerExecutionException("test", null, "Details!"));
 
         assertEquals("Details!", HandlerExecutionException.resolveDetails(exception).orElse(null));
     }
 
     @Test
-    void testResolveDetailsFromExecutionException() {
+    void resolveDetailsFromExecutionException() {
         Exception exception = new StubHandlerExecutionException("test", null, "Details!");
 
         assertEquals("Details!", HandlerExecutionException.resolveDetails(exception).orElse(null));
     }
 
     @Test
-    void testResolveDetailsFromNull() {
+    void resolveDetailsFromNull() {
         assertFalse(HandlerExecutionException.resolveDetails(null).isPresent());
     }
 
     @Test
-    void testResolveDetailsFromRuntimeException() {
+    void resolveDetailsFromRuntimeException() {
         assertFalse(HandlerExecutionException.resolveDetails(new RuntimeException()).isPresent());
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/HeadersTests.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HeadersTests.java
@@ -54,47 +54,47 @@ class HeadersTests {
     }
 
     @Test
-    void testMessageIdText() {
+    void messageIdText() {
         assertThat(MESSAGE_ID, is("axon-message-id"));
     }
 
     @Test
-    void testMessageTypeText() {
+    void messageTypeText() {
         assertThat(MESSAGE_TYPE, is("axon-message-type"));
     }
 
     @Test
-    void testMessageRevisionText() {
+    void messageRevisionText() {
         assertThat(MESSAGE_REVISION, is("axon-message-revision"));
     }
 
     @Test
-    void testMessageTimeStampText() {
+    void messageTimeStampText() {
         assertThat(MESSAGE_TIMESTAMP, is("axon-message-timestamp"));
     }
 
     @Test
-    void testMessageAggregateIdText() {
+    void messageAggregateIdText() {
         assertThat(AGGREGATE_ID, is("axon-message-aggregate-id"));
     }
 
     @Test
-    void testMessageAggregateSeqText() {
+    void messageAggregateSeqText() {
         assertThat(AGGREGATE_SEQ, is("axon-message-aggregate-seq"));
     }
 
     @Test
-    void testMessageAggregateTypeText() {
+    void messageAggregateTypeText() {
         assertThat(AGGREGATE_TYPE, is("axon-message-aggregate-type"));
     }
 
     @Test
-    void testMessageMetadataText() {
+    void messageMetadataText() {
         assertThat(MESSAGE_METADATA, is("axon-metadata"));
     }
 
     @Test
-    void testGeneratingDefaultMessagingHeaders() {
+    void generatingDefaultMessagingHeaders() {
         EventMessage<Object> message = asEventMessage("foo");
         SerializedObject<byte[]> serializedObject = message.serializePayload(serializer, byte[].class);
         Map<String, Object> expected = new HashMap<String, Object>() {{
@@ -108,13 +108,13 @@ class HeadersTests {
     }
 
     @Test
-    void testGeneratingDefaultMessagingHeaders_InvalidSerializedObject() {
+    void generatingDefaultMessagingHeaders_InvalidSerializedObject() {
         EventMessage<Object> message = asEventMessage("foo");
         assertThrows(IllegalArgumentException.class, () -> defaultHeaders(message, null));
     }
 
     @Test
-    void testGeneratingDomainMessagingHeaders() {
+    void generatingDomainMessagingHeaders() {
         DomainEventMessage<String> message = domainMessage();
         SerializedObject<byte[]> serializedObject = message.serializePayload(serializer, byte[].class);
 

--- a/messaging/src/test/java/org/axonframework/messaging/MetaDataTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MetaDataTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class MetaDataTest {
 
     @Test
-    void testAddNullValueToMetaData() {
+    void addNullValueToMetaData() {
         MetaData metaData = MetaData.with("nullkey", null).and("otherkey", "value").and("lastkey", "lastvalue")
                 .subset("nullkey", "otherkey");
 

--- a/messaging/src/test/java/org/axonframework/messaging/RemoteExceptionDescriptionSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/RemoteExceptionDescriptionSerializationTest.java
@@ -21,7 +21,7 @@ class RemoteExceptionDescriptionSerializationTest {
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testTokenShouldBeSerializableWithJackson(TestSerializer serializer) {
+    void tokenShouldBeSerializableWithJackson(TestSerializer serializer) {
         Throwable cause = new IllegalArgumentException("This is a test");
         Throwable exception = new IllegalStateException("Test with cause", cause);
         RemoteExceptionDescription descriptionToTest = RemoteExceptionDescription.describing(exception);

--- a/messaging/src/test/java/org/axonframework/messaging/SimpleHandlerAttributesTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/SimpleHandlerAttributesTest.java
@@ -19,14 +19,14 @@ class SimpleHandlerAttributesTest {
     private static final int ATTRIBUTE = 42;
 
     @Test
-    void testConstructEmptyHandlerAttributes() {
+    void constructEmptyHandlerAttributes() {
         SimpleHandlerAttributes testSubject = new SimpleHandlerAttributes(Collections.emptyMap());
 
         assertTrue(testSubject.isEmpty());
     }
 
     @Test
-    void testConstructNonEmptyHandlerAttributes() {
+    void constructNonEmptyHandlerAttributes() {
         Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
 
@@ -38,7 +38,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testGet() {
+    void get() {
         Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
 
@@ -48,7 +48,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testGetAll() {
+    void getAll() {
         Map<String, Object> expectedAttributes = new HashMap<>();
         expectedAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
 
@@ -58,7 +58,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testContains() {
+    void contains() {
         Map<String, Object> expectedAttributes = new HashMap<>();
         expectedAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
 
@@ -69,7 +69,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testMergedWith() {
+    void mergedWith() {
         Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
         Map<String, Object> testOtherAttributes = new HashMap<>();
@@ -88,7 +88,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testMergedWithReturnsThis() {
+    void mergedWithReturnsThis() {
         Map<String, Object> testAttributes = new HashMap<>();
         testAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
 
@@ -98,7 +98,7 @@ class SimpleHandlerAttributesTest {
     }
 
     @Test
-    void testMergedWithReturnsAdditionalAttributes() {
+    void mergedWithReturnsAdditionalAttributes() {
         Map<String, Object> testOtherAttributes = new HashMap<>();
         testOtherAttributes.put(ATTRIBUTE_KEY, ATTRIBUTE);
         SimpleHandlerAttributes testOther = new SimpleHandlerAttributes(testOtherAttributes);

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerAttributesTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerAttributesTest.java
@@ -40,7 +40,7 @@ class AnnotatedHandlerAttributesTest {
     }
 
     @Test
-    void testConstructHandlerAttributesForAnnotatedCommandHandler() throws NoSuchMethodException {
+    void constructHandlerAttributesForAnnotatedCommandHandler() throws NoSuchMethodException {
         Method messageHandlingMember = getClass().getMethod("annotatedCommandHandler", Object.class);
 
         Map<String, Object> expected = new HashMap<>();
@@ -59,7 +59,7 @@ class AnnotatedHandlerAttributesTest {
     }
 
     @Test
-    void testConstructHandlerAttributesForAnnotatedAllowReplayAndEventHandler() throws NoSuchMethodException {
+    void constructHandlerAttributesForAnnotatedAllowReplayAndEventHandler() throws NoSuchMethodException {
         Method messageHandlingMember = getClass().getMethod("annotatedAllowReplayAndEventHandler", Object.class);
 
         Map<String, Object> expected = new HashMap<>();
@@ -84,7 +84,7 @@ class AnnotatedHandlerAttributesTest {
      * have their attributes returned, which thus should be validated to work.
      */
     @Test
-    void testConstructHandlerAttributesForAnnotatedExceptionHandler() throws NoSuchMethodException {
+    void constructHandlerAttributesForAnnotatedExceptionHandler() throws NoSuchMethodException {
         Method messageHandlingMember = getClass().getMethod("annotatedExceptionHandler", Object.class);
 
         Map<String, Object> expected = new HashMap<>();
@@ -106,7 +106,7 @@ class AnnotatedHandlerAttributesTest {
     }
 
     @Test
-    void testConstructHandlerAttributesForAnnotatedCustomCommandHandler() throws NoSuchMethodException {
+    void constructHandlerAttributesForAnnotatedCustomCommandHandler() throws NoSuchMethodException {
         Method messageHandlingMember = getClass().getMethod("annotatedCustomCommandHandler", Object.class);
 
         Map<String, Object> expected = new HashMap<>();
@@ -127,7 +127,7 @@ class AnnotatedHandlerAttributesTest {
     }
 
     @Test
-    void testConstructHandlerAttributesForAnnotatedCustomCombinedHandlerWithAttributes() throws NoSuchMethodException {
+    void constructHandlerAttributesForAnnotatedCustomCombinedHandlerWithAttributes() throws NoSuchMethodException {
         Method messageHandlingMember =
                 getClass().getMethod("annotatedCustomCombinedHandlerWithAttributes", Object.class);
 
@@ -145,7 +145,7 @@ class AnnotatedHandlerAttributesTest {
     }
 
     @Test
-    void testConstructHandlerAttributesForAnnotatedNonMessageHandler() {
+    void constructHandlerAttributesForAnnotatedNonMessageHandler() {
         Map<String, Map<String, Object>> expected = new HashMap<>();
 
         assertEquals(expected, testSubject.getAll());

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
@@ -64,7 +64,7 @@ class AnnotatedHandlerInspectorTest {
     }
 
     @Test
-    void testComplexHandlerHierarchy() throws NoSuchMethodException {
+    void complexHandlerHierarchy() throws NoSuchMethodException {
         AnnotatedMessageHandlingMember<pA> paHandle = new AnnotatedMessageHandlingMember<>(pA.class.getMethod(
                 "paHandle", String.class), CommandMessage.class, String.class, parameterResolverFactory);
         AnnotatedMessageHandlingMember<A> aHandle = new AnnotatedMessageHandlingMember<>(A.class.getMethod(
@@ -120,7 +120,7 @@ class AnnotatedHandlerInspectorTest {
     }
 
     @Test
-    void testDoesNotRegisterAbstractHandlersTwice() {
+    void doesNotRegisterAbstractHandlersTwice() {
         AnnotatedHandlerInspector<AB> aaInspector = AnnotatedHandlerInspector.inspectType(AB.class,
                                                                                           parameterResolverFactory);
 
@@ -138,7 +138,7 @@ class AnnotatedHandlerInspectorTest {
     }
 
     @Test
-    void testInterceptors() throws Exception {
+    void interceptors() throws Exception {
         D testTarget = new D();
         EventMessage<Object> testEvent = asEventMessage("Hello");
         EventMessage<Object> testEventTwo = asEventMessage(1);
@@ -161,7 +161,7 @@ class AnnotatedHandlerInspectorTest {
     }
 
     @Test
-    void testGetAllInspectedTypes() {
+    void getAllInspectedTypes() {
         Set<Class<?>> expectedInspectedTypes = Sets.newSet(pA.class, A.class, B.class, C.class, D.class);
 
         Set<Class<?>> resultInspectedTypes = inspector.getAllInspectedTypes();

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
@@ -31,19 +31,19 @@ class AnnotatedMessageHandlingMemberTest {
     }
 
     @Test
-    void testCanHandleMessageType() {
+    void canHandleMessageType() {
         assertTrue(testSubject.canHandleMessageType(EventMessage.class));
         assertFalse(testSubject.canHandleMessageType(CommandMessage.class));
     }
 
     @Test
-    void testHasAnnotation() {
+    void hasAnnotation() {
         assertTrue(testSubject.hasAnnotation(EventHandler.class));
         assertFalse(testSubject.hasAnnotation(CommandHandler.class));
     }
 
     @Test
-    void testAttributeReturnsNonEmptyOptionalForMatchingAttributeKey() {
+    void attributeReturnsNonEmptyOptionalForMatchingAttributeKey() {
         Optional<Object> resultMessageType = testSubject.attribute(HandlerAttributes.MESSAGE_TYPE);
         Optional<Object> resultPayloadType = testSubject.attribute(HandlerAttributes.PAYLOAD_TYPE);
 

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
@@ -52,7 +52,7 @@ class HandlerComparatorTest {
     }
 
     @Test
-    void testSubclassesBeforeSuperclasses() {
+    void subclassesBeforeSuperclasses() {
         assertTrue(testSubject.compare(stringHandler, objectHandler) < 0, "String should appear before Object");
         assertTrue(testSubject.compare(objectHandler, stringHandler) > 0, "String should appear before Object");
 
@@ -67,7 +67,7 @@ class HandlerComparatorTest {
     }
 
     @Test
-    void testHandlersIsEqualWithItself() {
+    void handlersIsEqualWithItself() {
         assertEquals(0, testSubject.compare(stringHandler, stringHandler));
         assertEquals(0, testSubject.compare(objectHandler, objectHandler));
         assertEquals(0, testSubject.compare(longHandler, longHandler));
@@ -83,7 +83,7 @@ class HandlerComparatorTest {
     }
 
     @Test
-    void testHandlersSortedCorrectly() {
+    void handlersSortedCorrectly() {
         List<MessageHandlingMember<?>> members = new ArrayList<>(Arrays.asList(objectHandler, numberHandler, stringHandler, longHandler));
 
         members.sort(this.testSubject);
@@ -92,7 +92,7 @@ class HandlerComparatorTest {
     }
 
     @Test
-    void testNotInSameHierarchyUsesPriorityBasedEvaluation() {
+    void notInSameHierarchyUsesPriorityBasedEvaluation() {
         assertTrue(testSubject.compare(priorityHandler, stringHandler) < 0, "priorityHandler should appear before String based on priority");
         assertTrue(testSubject.compare(stringHandler, priorityHandler) > 0, "priorityHandler should appear before String based on priority");
     }

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerHierarchyTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerHierarchyTest.java
@@ -53,7 +53,7 @@ class HandlerHierarchyTest {
     }
 
     @Test
-    void testHierarchySort() throws NoSuchMethodException {
+    void hierarchySort() throws NoSuchMethodException {
         MultiParameterResolverFactory multiParameterResolverFactory = MultiParameterResolverFactory.ordered(new DefaultParameterResolverFactory());
 
         MessageHandlingMember<?> bHandler = new AnnotatedMessageHandlingMember<>(MyEventHandler.class.getMethod("handle", B.class),

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/MessageIdentifierParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/MessageIdentifierParameterResolverFactoryTest.java
@@ -59,7 +59,7 @@ class MessageIdentifierParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesToMessageIdentifierWhenAnnotatedForEventMessage() {
+    void resolvesToMessageIdentifierWhenAnnotatedForEventMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(messageIdentifierMethod, messageIdentifierMethod.getParameters(), 0);
         final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
@@ -68,7 +68,7 @@ class MessageIdentifierParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesToMessageIdentifierWhenAnnotatedForCommandMessage() {
+    void resolvesToMessageIdentifierWhenAnnotatedForCommandMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(messageIdentifierMethod, messageIdentifierMethod.getParameters(), 0);
         CommandMessage<Object> commandMessage = GenericCommandMessage.asCommandMessage("test");
@@ -77,14 +77,14 @@ class MessageIdentifierParameterResolverFactoryTest {
     }
 
     @Test
-    void testIgnoredWhenNotAnnotated() {
+    void ignoredWhenNotAnnotated() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(nonAnnotatedMethod, nonAnnotatedMethod.getParameters(), 0);
         assertNull(resolver);
     }
 
     @Test
-    void testIgnoredWhenWrongType() {
+    void ignoredWhenWrongType() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(integerMethod, integerMethod.getParameters(), 0);
         assertNull(resolver);

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/MultiParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/MultiParameterResolverFactoryTest.java
@@ -64,7 +64,7 @@ class MultiParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolversQueriedInOrderProvided() throws Exception {
+    void resolversQueriedInOrderProvided() throws Exception {
         Method equals = getClass().getMethod("equals", Object.class);
         ParameterResolver factory = testSubject.createInstance(equals, equals.getParameters(), 0);
         assertFalse(factory.matches(null));
@@ -83,7 +83,7 @@ class MultiParameterResolverFactoryTest {
     }
 
     @Test
-    void testFirstMatchingResolverMayReturnValue() throws Exception {
+    void firstMatchingResolverMayReturnValue() throws Exception {
         Method equals = getClass().getMethod("equals", Object.class);
         final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");
         when(mockFactory1.createInstance(ArgumentMatchers.any(Executable.class),
@@ -101,7 +101,7 @@ class MultiParameterResolverFactoryTest {
     }
 
     @Test
-    void testNestedParameterResolversAreOrdered() {
+    void nestedParameterResolversAreOrdered() {
         final LowPrioParameterResolverFactory lowPrio = new LowPrioParameterResolverFactory();
         final HighPrioParameterResolverFactory highPrio = new HighPrioParameterResolverFactory();
         testSubject = MultiParameterResolverFactory.ordered(mockFactory1,

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/ScopeDescriptorParameterResolverFactoryTest.java
@@ -31,12 +31,12 @@ class ScopeDescriptorParameterResolverFactoryTest {
     }
 
     @Test
-    void testParameterResolverIsNullForScopeDescriptorLessMethod() {
+    void parameterResolverIsNullForScopeDescriptorLessMethod() {
         assertNull(testSubject.createInstance(scopeDescriptorLessMethod, scopeDescriptorLessMethod.getParameters(), 0));
     }
 
     @Test
-    void testResolvesNoScopeDescriptor() {
+    void resolvesNoScopeDescriptor() {
         ParameterResolver<ScopeDescriptor> resolver =
                 testSubject.createInstance(scopeDescriptorUsingMethod, scopeDescriptorUsingMethod.getParameters(), 0);
 

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
@@ -68,7 +68,7 @@ class SimpleResourceParameterResolverFactoryTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testResolvesToResourceWhenMessageHandlingMethodHasResourceParameter() {
+    void resolvesToResourceWhenMessageHandlingMethodHasResourceParameter() {
         ParameterResolver resolver =
                 testSubject.createInstance(messageHandlingMethodWithResourceParameter, messageHandlingMethodWithResourceParameter.getParameters(), 1);
         final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
@@ -78,7 +78,7 @@ class SimpleResourceParameterResolverFactoryTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testResolvesToResourceWhenMessageHandlingMethodHasAnotherResourceParameter() {
+    void resolvesToResourceWhenMessageHandlingMethodHasAnotherResourceParameter() {
         ParameterResolver resolver =
                 testSubject.createInstance(messageHandlingMethodWithResource2Parameter, messageHandlingMethodWithResource2Parameter.getParameters(), 1);
         final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
@@ -87,14 +87,14 @@ class SimpleResourceParameterResolverFactoryTest {
     }
 
     @Test
-    void testIgnoredWhenMessageHandlingMethodHasNoResourceParameter() {
+    void ignoredWhenMessageHandlingMethodHasNoResourceParameter() {
         ParameterResolver resolver =
                 testSubject.createInstance(messageHandlingMethodWithoutResourceParameter, messageHandlingMethodWithoutResourceParameter.getParameters(), 0);
         assertNull(resolver);
     }
 
     @Test
-    void testIgnoredWhenMessageHandlingMethodHasResourceParameterOfDifferentType() {
+    void ignoredWhenMessageHandlingMethodHasResourceParameterOfDifferentType() {
         ParameterResolver resolver = testSubject.createInstance(messageHandlingMethodWithResourceParameterOfDifferentType, messageHandlingMethodWithResourceParameterOfDifferentType.getParameters(), 1);
         assertNull(resolver);
     }

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/SourceIdParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/SourceIdParameterResolverFactoryTest.java
@@ -43,7 +43,7 @@ class SourceIdParameterResolverFactoryTest {
     }
 
     @Test
-    void testResolvesToAggregateIdentifierWhenAnnotatedForDomainEventMessage() {
+    void resolvesToAggregateIdentifierWhenAnnotatedForDomainEventMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(sourceIdMethod, sourceIdMethod.getParameters(), 0);
         final GenericDomainEventMessage<Object> eventMessage =
@@ -53,7 +53,7 @@ class SourceIdParameterResolverFactoryTest {
     }
 
     @Test
-    void testDoesNotMatchWhenAnnotatedForCommandMessage() {
+    void doesNotMatchWhenAnnotatedForCommandMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(sourceIdMethod, sourceIdMethod.getParameters(), 0);
         CommandMessage<Object> commandMessage = GenericCommandMessage.asCommandMessage("test");
@@ -61,14 +61,14 @@ class SourceIdParameterResolverFactoryTest {
     }
 
     @Test
-    void testIgnoredWhenNotAnnotated() {
+    void ignoredWhenNotAnnotated() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(nonAnnotatedMethod, nonAnnotatedMethod.getParameters(), 0);
         assertNull(resolver);
     }
 
     @Test
-    void testIgnoredWhenWrongType() {
+    void ignoredWhenWrongType() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(integerMethod, integerMethod.getParameters(), 0);
         assertNull(resolver);

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMemberTest.java
@@ -26,13 +26,13 @@ class WrappedMessageHandlingMemberTest {
     }
 
     @Test
-    void testCanHandleMessageType() {
+    void canHandleMessageType() {
         testSubject.canHandleMessageType(QueryMessage.class);
         verify(mockedHandlingMember).canHandleMessageType(QueryMessage.class);
     }
 
     @Test
-    void testAttribute() {
+    void attribute() {
         testSubject.attribute(HandlerAttributes.COMMAND_ROUTING_KEY);
         verify(mockedHandlingMember).attribute(HandlerAttributes.COMMAND_ROUTING_KEY);
     }

--- a/messaging/src/test/java/org/axonframework/messaging/correlation/MetaDataValueTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/correlation/MetaDataValueTest.java
@@ -45,7 +45,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testMergedMetaData() {
+    void mergedMetaData() {
         Map<String, Object> metaDataValues = new HashMap<>();
         metaDataValues.put("first", "value");
         MetaData metaData = new MetaData(metaDataValues);
@@ -58,7 +58,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testRemovedMetaData() {
+    void removedMetaData() {
         Map<String, Object> metaDataValues = new HashMap<>();
         metaDataValues.put("first", "value");
         metaDataValues.put("second", "value");
@@ -69,7 +69,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testEquals() {
+    void equals() {
         Map<String, Object> metaDataValues = new HashMap<>();
         metaDataValues.put("first", "value");
         MetaData metaData1 = new MetaData(metaDataValues);
@@ -91,7 +91,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testSerialization() throws IOException, ClassNotFoundException {
+    void serialization() throws IOException, ClassNotFoundException {
         MetaData metaData1 = MetaData.from(Collections.singletonMap("Key1", "Value"));
         MetaData metaData2 = MetaData.from(Collections.singletonMap("Key2", "Value"));
         MetaData emptyMetaData = MetaData.emptyInstance();
@@ -112,7 +112,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testBuildMetaDataThroughFrom() {
+    void buildMetaDataThroughFrom() {
         Map<String, String> testMetaDataMap = new HashMap<>();
         testMetaDataMap.put("firstKey", "firstVal");
         testMetaDataMap.put("secondKey", "secondVal");
@@ -124,14 +124,14 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testBuildMetaDataThroughWith() {
+    void buildMetaDataThroughWith() {
         MetaData result = MetaData.with("key", "val");
 
         assertEquals("val", result.get("key"));
     }
 
     @Test
-    void testBuildMetaDataThroughWithAnd() {
+    void buildMetaDataThroughWithAnd() {
         MetaData result = MetaData.with("firstKey", "firstVal").and("secondKey", "secondVal");
 
         assertEquals("firstVal", result.get("firstKey"));
@@ -139,7 +139,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testBuildMetaDataThroughAndIfNotPresentAddsNewValue() {
+    void buildMetaDataThroughAndIfNotPresentAddsNewValue() {
         MetaData result = MetaData.with("firstKey", "firstVal").andIfNotPresent("secondKey", () -> "secondVal");
 
         assertEquals("firstVal", result.get("firstKey"));
@@ -147,7 +147,7 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testBuildMetaDataThroughAndIfNotPresentDoesntAddNewValue() {
+    void buildMetaDataThroughAndIfNotPresentDoesntAddNewValue() {
         MetaData result = MetaData.with("firstKey", "firstVal").andIfNotPresent("firstKey", () -> "firstVal");
 
         assertEquals("firstVal", result.get("firstKey"));
@@ -155,42 +155,42 @@ class MetaDataValueTest {
     }
 
     @Test
-    void testMetaDataModification_Clear() {
+    void metaDataModification_Clear() {
         MetaData metaData = new MetaData(Collections.emptyMap());
 
         assertThrows(UnsupportedOperationException.class, metaData::clear);
     }
 
     @Test
-    void testMetaDataModification_Put() {
+    void metaDataModification_Put() {
         MetaData metaData = new MetaData(Collections.emptyMap());
 
         assertThrows(UnsupportedOperationException.class, () -> metaData.put("", ""));
     }
 
     @Test
-    void testMetaDataModification_Remove() {
+    void metaDataModification_Remove() {
         MetaData metaData = new MetaData(Collections.emptyMap());
 
         assertThrows(UnsupportedOperationException.class, () -> metaData.remove(""));
     }
 
     @Test
-    void testMetaDataModification_PutAll() {
+    void metaDataModification_PutAll() {
         MetaData metaData = new MetaData(Collections.emptyMap());
 
         assertThrows(UnsupportedOperationException.class, () -> metaData.putAll(Collections.emptyMap()));
     }
 
     @Test
-    void testMetaDataModification_KeySet_Remove() {
+    void metaDataModification_KeySet_Remove() {
         Set<String> keySet = new MetaData(Collections.emptyMap()).keySet();
 
         assertThrows(UnsupportedOperationException.class, () -> keySet.remove("Hello"));
     }
 
     @Test
-    void testMetaDataModification_Values_Remove() {
+    void metaDataModification_Values_Remove() {
         Collection<Object> values = new MetaData(Collections.emptyMap()).values();
 
         assertThrows(UnsupportedOperationException.class, () -> values.remove("Hello"));
@@ -198,14 +198,14 @@ class MetaDataValueTest {
 
     @SuppressWarnings({"SuspiciousMethodCalls"})
     @Test
-    void testMetaDataModification_EntrySet_Remove() {
+    void metaDataModification_EntrySet_Remove() {
         Set<Map.Entry<String,Object>> entrySet = new MetaData(Collections.emptyMap()).entrySet();
 
         assertThrows(UnsupportedOperationException.class, () -> entrySet.remove("Hello"));
     }
 
     @Test
-    void testMetaDataSubsetReturnsSubsetOfMetaDataInstance() {
+    void metaDataSubsetReturnsSubsetOfMetaDataInstance() {
         MetaData testMetaData = MetaData.with("firstKey", "firstValue")
                 .and("secondKey", "secondValue")
                 .and("thirdKey", "thirdValue")

--- a/messaging/src/test/java/org/axonframework/messaging/correlation/SimpleCorrelationDataProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/correlation/SimpleCorrelationDataProviderTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class SimpleCorrelationDataProviderTest {
 
     @Test
-    void testResolveCorrelationData() {
+    void resolveCorrelationData() {
         Map<String, Object> metaData = new HashMap<>();
         metaData.put("key1", "value1");
         metaData.put("key2", "value2");

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/BeanValidationInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/BeanValidationInterceptorTest.java
@@ -52,7 +52,7 @@ class BeanValidationInterceptorTest {
     }
 
     @Test
-    void testValidateSimpleObject() throws Exception {
+    void validateSimpleObject() throws Exception {
         uow.transformMessage(m -> new GenericMessage<>("Simple instance"));
 
         testSubject.handle(uow, interceptorChain);
@@ -61,7 +61,7 @@ class BeanValidationInterceptorTest {
     }
 
     @Test
-    void testValidateAnnotatedObject_IllegalNullValue() throws Exception {
+    void validateAnnotatedObject_IllegalNullValue() throws Exception {
         uow.transformMessage(m -> new GenericMessage<Object>(new JSR303AnnotatedInstance(null)));
         try {
             testSubject.handle(uow, interceptorChain);
@@ -73,7 +73,7 @@ class BeanValidationInterceptorTest {
     }
 
     @Test
-    void testValidateAnnotatedObject_LegalValue() throws Exception {
+    void validateAnnotatedObject_LegalValue() throws Exception {
         uow.transformMessage(m -> new GenericMessage<>(new JSR303AnnotatedInstance("abc")));
 
         testSubject.handle(uow, interceptorChain);
@@ -82,7 +82,7 @@ class BeanValidationInterceptorTest {
     }
 
     @Test
-    void testValidateAnnotatedObject_IllegalValue() throws Exception {
+    void validateAnnotatedObject_IllegalValue() throws Exception {
         uow.transformMessage(m -> new GenericMessage<Object>(new JSR303AnnotatedInstance("bea")));
 
         try {
@@ -96,7 +96,7 @@ class BeanValidationInterceptorTest {
     }
 
     @Test
-    void testCustomValidatorFactory() throws Exception {
+    void customValidatorFactory() throws Exception {
         uow.transformMessage(m -> new GenericMessage<Object>(new JSR303AnnotatedInstance("abc")));
         ValidatorFactory mockValidatorFactory = spy(Validation.buildDefaultValidatorFactory());
         testSubject = new BeanValidationInterceptor<>(mockValidatorFactory);

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptorTest.java
@@ -50,7 +50,7 @@ class CorrelationDataInterceptorTest {
     }
 
     @Test
-    void testAttachesCorrelationDataProvidersToUnitOfWork() throws Exception {
+    void attachesCorrelationDataProvidersToUnitOfWork() throws Exception {
         subject.handle(mockUnitOfWork, mockInterceptorChain);
         verify(mockUnitOfWork).registerCorrelationDataProvider(mockProvider1);
         verify(mockUnitOfWork).registerCorrelationDataProvider(mockProvider2);

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/LoggingInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/LoggingInterceptorTest.java
@@ -64,7 +64,7 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    void testConstructorWithCustomLogger() throws Exception {
+    void constructorWithCustomLogger() throws Exception {
         testSubject = new LoggingInterceptor<>("my.custom.logger");
 
         Field field = testSubject.getClass().getDeclaredField("logger");
@@ -75,7 +75,7 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    void testHandlerInterceptorWithIncomingLoggingNullReturnValue() throws Exception {
+    void handlerInterceptorWithIncomingLoggingNullReturnValue() throws Exception {
         when(mockLogger.isInfoEnabled()).thenReturn(true);
         when(interceptorChain.proceed()).thenReturn(null);
 
@@ -89,7 +89,7 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    void testHandlerInterceptorWithSuccessfulExecutionVoidReturnValue() throws Exception {
+    void handlerInterceptorWithSuccessfulExecutionVoidReturnValue() throws Exception {
         when(mockLogger.isInfoEnabled()).thenReturn(true);
         when(interceptorChain.proceed()).thenReturn(null);
 
@@ -103,7 +103,7 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    void testHandlerInterceptorWithSuccessfulExecutionCustomReturnValue() throws Exception {
+    void handlerInterceptorWithSuccessfulExecutionCustomReturnValue() throws Exception {
         when(interceptorChain.proceed()).thenReturn(new StubResponse());
         when(mockLogger.isInfoEnabled()).thenReturn(true);
 
@@ -118,7 +118,7 @@ class LoggingInterceptorTest {
 
     @SuppressWarnings({"ThrowableInstanceNeverThrown"})
     @Test
-    void testHandlerInterceptorWithFailedExecution() throws Exception {
+    void handlerInterceptorWithFailedExecution() throws Exception {
         RuntimeException exception = new RuntimeException();
         when(interceptorChain.proceed()).thenThrow(exception);
         when(mockLogger.isInfoEnabled()).thenReturn(true);
@@ -138,7 +138,7 @@ class LoggingInterceptorTest {
     }
 
     @Test
-    void testDispatchInterceptorLogging() {
+    void dispatchInterceptorLogging() {
         when(mockLogger.isInfoEnabled()).thenReturn(true);
 
         testSubject.handle(new GenericMessage<Object>(new StubMessage()));

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptorTest.java
@@ -56,7 +56,7 @@ class TransactionManagingInterceptorTest {
     }
 
     @Test
-    void testStartTransaction() throws Exception {
+    void startTransaction() throws Exception {
         UnitOfWork<Message<?>> unitOfWork = spy(this.unitOfWork);
 
         subject.handle(unitOfWork, interceptorChain);
@@ -68,7 +68,7 @@ class TransactionManagingInterceptorTest {
     }
 
     @Test
-    void testUnitOfWorkCommit() throws Exception {
+    void unitOfWorkCommit() throws Exception {
         subject.handle(unitOfWork, interceptorChain);
         unitOfWork.commit();
 

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ConvertingResponseMessageTest {
 
     @Test
-    void testPayloadIsConvertedToExpectedType() {
+    void payloadIsConvertedToExpectedType() {
         QueryResponseMessage<?> msg = new GenericQueryResponseMessage<>(new String[]{"Some string result"})
                 .withMetaData(MetaData.with("test", "value"));
         QueryResponseMessage<List<String>> wrapped = new ConvertingResponseMessage<>(
@@ -27,7 +27,7 @@ class ConvertingResponseMessageTest {
     }
 
     @Test
-    void testIllegalAccessPayloadWhenResultIsExceptional() {
+    void illegalAccessPayloadWhenResultIsExceptional() {
         QueryResponseMessage<?> msg = GenericQueryResponseMessage.asResponseMessage(List.class, new RuntimeException());
         QueryResponseMessage<List<String>> wrapped = new ConvertingResponseMessage<>(
                 ResponseTypes.multipleInstancesOf(String.class),

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/InstanceResponseTypeSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/InstanceResponseTypeSerializationTest.java
@@ -25,7 +25,7 @@ class InstanceResponseTypeSerializationTest extends AbstractResponseTypeTest<Abs
        
     @MethodSource("serializers")
     @ParameterizedTest
-    void testResponseTypeShouldBeSerializable(TestSerializer serializer) {
+    void responseTypeShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject.getExpectedResponseType(), serializer.serializeDeserialize(testSubject).getExpectedResponseType());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/InstanceResponseTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/InstanceResponseTypeTest.java
@@ -34,208 +34,208 @@ class InstanceResponseTypeTest extends AbstractResponseTypeTest<AbstractResponse
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsTheSame() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsTheSame() throws NoSuchMethodException {
         testMatchRanked("someQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someLowerBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingUpperBoundedWildcardQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
             throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someUnboundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsBoundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsBoundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someBoundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiUnboundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiUnboundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiUnboundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiBoundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiBoundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSetQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someStreamQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMapQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someFutureQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsListOfFutureOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsListOfFutureOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someFutureListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsOptionalOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsOptionalOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someOptionalQueryResponse", MATCHES);
     }
 
     @Test
-    void testConvertReturnsSingleResponseAsIs() {
+    void convertReturnsSingleResponseAsIs() {
         QueryResponse testResponse = new QueryResponse();
 
         QueryResponse result = testSubject.convert(testResponse);
@@ -244,7 +244,7 @@ class InstanceResponseTypeTest extends AbstractResponseTypeTest<AbstractResponse
     }
 
     @Test
-    void testConvertReturnsSingleResponseAsIsForSubTypedResponse() {
+    void convertReturnsSingleResponseAsIsForSubTypedResponse() {
         SubTypedQueryResponse testResponse = new SubTypedQueryResponse();
 
         QueryResponse result = testSubject.convert(testResponse);
@@ -254,7 +254,7 @@ class InstanceResponseTypeTest extends AbstractResponseTypeTest<AbstractResponse
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsClassCastExceptionForDifferentSingleInstanceResponse() {
+    void convertThrowsClassCastExceptionForDifferentSingleInstanceResponse() {
         assertThrows(Exception.class, () -> {
             QueryResponse convert = testSubject.convert(new QueryResponseInterface() {
             });
@@ -263,7 +263,7 @@ class InstanceResponseTypeTest extends AbstractResponseTypeTest<AbstractResponse
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsClassCastExceptionForMultipleInstanceResponse() {
+    void convertThrowsClassCastExceptionForMultipleInstanceResponse() {
         assertThrows(Exception.class, () -> {
             QueryResponse convert = testSubject.convert(new ArrayList<QueryResponse>());
         });

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseTypeSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseTypeSerializationTest.java
@@ -26,7 +26,7 @@ class MultipleInstancesResponseTypeSerializationTest extends AbstractResponseTyp
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testResponseTypeShouldBeSerializable(TestSerializer serializer) {
+    void responseTypeShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject.getExpectedResponseType(), serializer.serializeDeserialize(testSubject).getExpectedResponseType());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/MultipleInstancesResponseTypeTest.java
@@ -40,153 +40,153 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testMatchesReturnsMatchSingleIfResponseTypeIsOfTheSame() throws NoSuchMethodException {
+    void matchesReturnsMatchSingleIfResponseTypeIsOfTheSame() throws NoSuchMethodException {
         testMatchRanked("someQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsMatchSingleIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchSingleIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsSingleMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsSingleMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsSingleMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsSingleMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someArrayQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedArrayQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericArrayQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericArrayQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someLowerBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someUpperBoundedWildcardListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingUpperBoundedWildcardQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
             throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someGenericUpperBoundedWildcardListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiGenericUpperBoundedWildcardListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsListImplementationOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsListImplementationOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someListImplementationQuery", MATCHES_LIST);
     }
 
@@ -212,62 +212,62 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someUnboundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsBoundedListImplementationOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsBoundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someBoundedListImplementationQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiUnboundedListImplementationOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiUnboundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiUnboundedListImplementationQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsMultiBoundedListImplementationOfProvidedType()
+    void matchesReturnsListMatchIfResponseTypeIsMultiBoundedListImplementationOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedListImplementationQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSetQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someStreamQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMapQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsSingleMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsSingleMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someFutureQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsListMatchIfResponseTypeIsListOfFutureOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsListMatchIfResponseTypeIsListOfFutureOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someFutureListQuery", MATCHES_LIST);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsOptionalOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsOptionalOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someOptionalQueryResponse", MATCHES);
     }
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertReturnsListForSingleInstanceResponse() {
+    void convertReturnsListForSingleInstanceResponse() {
         QueryResponse testResponse = new QueryResponse();
 
         List<QueryResponse> result = testSubject.convert(testResponse);
@@ -276,7 +276,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsListOnResponseOfArrayType() {
+    void convertReturnsListOnResponseOfArrayType() {
         QueryResponse[] testResponse = new QueryResponse[]{new QueryResponse()};
 
         List<QueryResponse> result = testSubject.convert(testResponse);
@@ -286,7 +286,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsListOnResponseOfSubTypedArrayType() {
+    void convertReturnsListOnResponseOfSubTypedArrayType() {
         SubTypedQueryResponse[] testResponse = new SubTypedQueryResponse[]{new SubTypedQueryResponse()};
 
         List<QueryResponse> result = testSubject.convert(testResponse);
@@ -297,7 +297,7 @@ public class MultipleInstancesResponseTypeTest
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsExceptionForResponseOfDifferentArrayType() {
+    void convertThrowsExceptionForResponseOfDifferentArrayType() {
         QueryResponseInterface[] testResponse = new QueryResponseInterface[]{new QueryResponseInterface() {
         }};
 
@@ -305,7 +305,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsListOnResponseOfListType() {
+    void convertReturnsListOnResponseOfListType() {
         List<QueryResponse> testResponse = new ArrayList<>();
         testResponse.add(new QueryResponse());
 
@@ -316,7 +316,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsListOnResponseOfSubTypedListType() {
+    void convertReturnsListOnResponseOfSubTypedListType() {
         List<SubTypedQueryResponse> testResponse = new ArrayList<>();
         testResponse.add(new SubTypedQueryResponse());
 
@@ -327,7 +327,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsListOnResponseOfSetType() {
+    void convertReturnsListOnResponseOfSetType() {
         Set<QueryResponse> testResponse = new HashSet<>();
         testResponse.add(new QueryResponse());
 
@@ -339,7 +339,7 @@ public class MultipleInstancesResponseTypeTest
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsExceptionForResponseOfDifferentListType() {
+    void convertThrowsExceptionForResponseOfDifferentListType() {
         List<QueryResponseInterface> testResponse = new ArrayList<>();
         testResponse.add(new QueryResponseInterface() {
         });
@@ -348,7 +348,7 @@ public class MultipleInstancesResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsEmptyListForResponseOfDifferentListTypeIfTheListIsEmpty() {
+    void convertReturnsEmptyListForResponseOfDifferentListTypeIfTheListIsEmpty() {
         List<QueryResponseInterface> testResponse = new ArrayList<>();
 
         List<QueryResponse> result = testSubject.convert(testResponse);

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/OptionalResponseTypeSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/OptionalResponseTypeSerializationTest.java
@@ -43,7 +43,7 @@ class OptionalResponseTypeSerializationTest
 
     @MethodSource("serializers")
     @ParameterizedTest
-    void testResponseTypeShouldBeSerializable(TestSerializer serializer) {
+    void responseTypeShouldBeSerializable(TestSerializer serializer) {
         assertEquals(testSubject.getExpectedResponseType(), serializer.serializeDeserialize(testSubject).getExpectedResponseType());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/OptionalResponseTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/OptionalResponseTypeTest.java
@@ -39,181 +39,181 @@ class OptionalResponseTypeTest
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsTheSame() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsTheSame() throws NoSuchMethodException {
         testMatchRanked("someQuery", MATCHES);
     }
 
     @Test
-    void testOptionalMatchesExpectedType() throws NoSuchMethodException {
+    void optionalMatchesExpectedType() throws NoSuchMethodException {
         Method methodToTest = methodOf(getClass(), "someOptionalQueryResponse");
         Type methodReturnType = methodToTest.getGenericReturnType();
         assertEquals(Boolean.TRUE, ResponseTypes.instanceOf(QueryResponse.class).matches(methodReturnType));
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGeneric() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsMultiBoundedGenericOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericQuery", MATCHES);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayWithSubTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubTypedArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsArrayWithSuperTypeOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperTypedArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericArray() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsBoundedGenericArrayOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericArrayOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericArrayOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericArrayQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSubListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSubListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSuperListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSuperListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsBoundedGenericListOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiBoundedGenericListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsGenericListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingBoundedGenericListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someUnboundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsLowerBoundedWildcardList() throws NoSuchMethodException {
         testMatchRanked("someLowerBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsWildcardListOfOtherType() throws NoSuchMethodException {
         testMatchRanked("someNonMatchingUpperBoundedWildcardQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
+    void matchesReturnsNoMatchIfResponseTypeIsMultiGenericUpperBoundedWildcardListOfProvidedType()
             throws NoSuchMethodException {
         testMatchRanked("someMultiGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
+    void matchesReturnsNoMatchIfResponseTypeIsUnboundedGenericUpperBoundedWildcardList()
             throws NoSuchMethodException {
         testMatchRanked("someUnboundedGenericUpperBoundedWildcardListQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsSetOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someSetQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsStreamOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someStreamQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsNoMatchIfResponseTypeIsMapOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someMapQuery", DOES_NOT_MATCH);
     }
 
     @Test
-    void testMatchesReturnsMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
+    void matchesReturnsMatchIfResponseTypeIsFutureOfProvidedType() throws NoSuchMethodException {
         testMatchRanked("someFutureQuery", MATCHES);
     }
 
     @Test
-    void testConvertReturnsSingleResponseAsProvidedOptional() {
+    void convertReturnsSingleResponseAsProvidedOptional() {
         QueryResponse testResponse = new QueryResponse();
 
         Optional<QueryResponse> result = testSubject.convert(testResponse);
@@ -223,14 +223,14 @@ class OptionalResponseTypeTest
     }
 
     @Test
-    void testConvertReturnsNullResponseAsEmptyOptional() {
+    void convertReturnsNullResponseAsEmptyOptional() {
         Optional<QueryResponse> result = testSubject.convert(null);
 
         assertFalse(result.isPresent());
     }
 
     @Test
-    void testConvertReturnsSingleResponseAsIsForSubTypedResponse() {
+    void convertReturnsSingleResponseAsIsForSubTypedResponse() {
         SubTypedQueryResponse testResponse = new SubTypedQueryResponse();
 
         Optional<QueryResponse> result = testSubject.convert(testResponse);
@@ -241,14 +241,14 @@ class OptionalResponseTypeTest
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsClassCastExceptionForDifferentSingleInstanceResponse() {
+    void convertThrowsClassCastExceptionForDifferentSingleInstanceResponse() {
         assertThrows(Exception.class, () -> testSubject.convert(new QueryResponseInterface() {
         }));
     }
 
     @SuppressWarnings("unused")
     @Test
-    void testConvertThrowsClassCastExceptionForMultipleInstanceResponse() {
+    void convertThrowsClassCastExceptionForMultipleInstanceResponse() {
         assertThrows(Exception.class, () -> testSubject.convert(new ArrayList<QueryResponse>()));
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
@@ -74,7 +74,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testHandlersForCurrentPhaseAreExecuted() {
+    void handlersForCurrentPhaseAreExecuted() {
         AtomicBoolean prepareCommit = new AtomicBoolean();
         AtomicBoolean commit = new AtomicBoolean();
         AtomicBoolean afterCommit = new AtomicBoolean();
@@ -94,7 +94,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testExecuteTask() {
+    void executeTask() {
         Runnable task = mock(Runnable.class);
         doNothing().when(task).run();
         subject.execute(task);
@@ -106,7 +106,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testExecuteFailingTask() {
+    void executeFailingTask() {
         Runnable task = mock(Runnable.class);
         MockException mockException = new MockException();
         doThrow(mockException).when(task).run();
@@ -125,7 +125,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testExecuteTaskWithResult() throws Exception {
+    void executeTaskWithResult() throws Exception {
         Object taskResult = new Object();
         Callable<Object> task = mock(Callable.class);
         when(task.call()).thenReturn(taskResult);
@@ -141,7 +141,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testExecuteTaskReturnsResultMessage() throws Exception {
+    void executeTaskReturnsResultMessage() throws Exception {
         ResultMessage<Object> resultMessage = asResultMessage(new Object());
         Callable<ResultMessage<Object>> task = mock(Callable.class);
         when(task.call()).thenReturn(resultMessage);
@@ -150,7 +150,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testAttachedTransactionCommittedOnUnitOfWorkCommit() {
+    void attachedTransactionCommittedOnUnitOfWorkCommit() {
         TransactionManager transactionManager = mock(TransactionManager.class);
         Transaction transaction = mock(Transaction.class);
         when(transactionManager.startTransaction()).thenReturn(transaction);
@@ -163,7 +163,7 @@ class AbstractUnitOfWorkTest {
     }
 
     @Test
-    void testAttachedTransactionRolledBackOnUnitOfWorkRollBack() {
+    void attachedTransactionRolledBackOnUnitOfWorkRollBack() {
         TransactionManager transactionManager = mock(TransactionManager.class);
         Transaction transaction = mock(Transaction.class);
         when(transactionManager.startTransaction()).thenReturn(transaction);

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
@@ -59,7 +59,7 @@ class BatchingUnitOfWorkTest {
     }
 
     @Test
-    void testExecuteTask() throws Exception {
+    void executeTask() throws Exception {
         List<Message<?>> messages = Arrays.asList(toMessage(0), toMessage(1), toMessage(2));
         subject = new BatchingUnitOfWork<>(messages);
         subject.executeWithResult(() -> {
@@ -73,7 +73,7 @@ class BatchingUnitOfWorkTest {
     }
 
     @Test
-    void testRollback() {
+    void rollback() {
         List<Message<?>> messages = Arrays.asList(toMessage(0), toMessage(1), toMessage(2));
         subject = new BatchingUnitOfWork<>(messages);
         MockException e = new MockException();
@@ -94,7 +94,7 @@ class BatchingUnitOfWorkTest {
     }
 
     @Test
-    void testSuppressedExceptionOnRollback() {
+    void suppressedExceptionOnRollback() {
         List<Message<?>> messages = Arrays.asList(toMessage(0), toMessage(1), toMessage(2));
         AtomicInteger cleanupCounter = new AtomicInteger();
         subject = new BatchingUnitOfWork<>(messages);

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWorkTest.java
@@ -45,12 +45,12 @@ class CurrentUnitOfWorkTest {
     }
 
     @Test
-    void testGetSession_NoCurrentSession() {
+    void getSession_NoCurrentSession() {
         assertThrows(IllegalStateException.class, CurrentUnitOfWork::get);
     }
 
     @Test
-    void testSetSession() {
+    void setSession() {
         UnitOfWork<?> mockUnitOfWork = mock(UnitOfWork.class);
         CurrentUnitOfWork.set(mockUnitOfWork);
         assertSame(mockUnitOfWork, CurrentUnitOfWork.get());
@@ -60,7 +60,7 @@ class CurrentUnitOfWorkTest {
     }
 
     @Test
-    void testNotCurrentUnitOfWorkCommitted() {
+    void notCurrentUnitOfWorkCommitted() {
         DefaultUnitOfWork<?> outerUoW = new DefaultUnitOfWork<>(null);
         outerUoW.start();
         new DefaultUnitOfWork<>(null).start();

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/ExecutionResultTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/ExecutionResultTest.java
@@ -28,7 +28,7 @@ import static org.axonframework.messaging.GenericResultMessage.asResultMessage;
 class ExecutionResultTest {
 
     @Test
-    void testNormalExecutionResult() {
+    void normalExecutionResult() {
         Object resultPayload = new Object();
         ResultMessage<Object> result = asResultMessage(resultPayload);
         ExecutionResult subject = new ExecutionResult(result);
@@ -38,7 +38,7 @@ class ExecutionResultTest {
     }
 
     @Test
-    void testUncheckedExceptionResult() {
+    void uncheckedExceptionResult() {
         RuntimeException mockException = new RuntimeException();
         ResultMessage<RuntimeException> resultMessage = asResultMessage(mockException);
         ExecutionResult subject = new ExecutionResult(resultMessage);
@@ -48,7 +48,7 @@ class ExecutionResultTest {
     }
 
     @Test
-    void testCheckedExceptionResult() {
+    void checkedExceptionResult() {
         Exception mockException = new Exception();
         ResultMessage<Exception> resultMessage = asResultMessage(mockException);
         ExecutionResult subject = new ExecutionResult(resultMessage);

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/RollbackConfigurationTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/RollbackConfigurationTypeTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RollbackConfigurationTypeTest {
 
     @Test
-    void testAnyExceptionsRollback() {
+    void anyExceptionsRollback() {
         RollbackConfiguration testSubject = RollbackConfigurationType.ANY_THROWABLE;
         assertTrue(testSubject.rollBackOn(new RuntimeException()));
         assertTrue(testSubject.rollBackOn(new Exception()));
@@ -35,7 +35,7 @@ class RollbackConfigurationTypeTest {
     }
 
     @Test
-    void testUncheckedExceptionsRollback() {
+    void uncheckedExceptionsRollback() {
         RollbackConfiguration testSubject = RollbackConfigurationType.UNCHECKED_EXCEPTIONS;
         assertTrue(testSubject.rollBackOn(new RuntimeException()));
         assertFalse(testSubject.rollBackOn(new Exception()));
@@ -43,7 +43,7 @@ class RollbackConfigurationTypeTest {
     }
 
     @Test
-    void testRuntimeExceptionsRollback() {
+    void runtimeExceptionsRollback() {
         RollbackConfiguration testSubject = RollbackConfigurationType.RUNTIME_EXCEPTIONS;
         assertTrue(testSubject.rollBackOn(new RuntimeException()));
         assertFalse(testSubject.rollBackOn(new Exception()));

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/UnitOfWorkNestingTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/UnitOfWorkNestingTest.java
@@ -84,7 +84,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testInnerUnitOfWorkNotifiedOfOuterCommitFailure() {
+    void innerUnitOfWorkNotifiedOfOuterCommitFailure() {
         outer.onPrepareCommit(u -> {
             inner.start();
             inner.commit();
@@ -113,7 +113,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testInnerUnitOfWorkNotifiedOfOuterPrepareCommitFailure() {
+    void innerUnitOfWorkNotifiedOfOuterPrepareCommitFailure() {
         outer.onPrepareCommit(u -> {
             inner.start();
             inner.commit();
@@ -140,7 +140,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testInnerUnitOfWorkNotifiedOfOuterCommit() {
+    void innerUnitOfWorkNotifiedOfOuterCommit() {
         outer.onPrepareCommit(u -> {
             inner.start();
             inner.commit();
@@ -161,7 +161,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testInnerUnitRollbackDoesNotAffectOuterCommit() {
+    void innerUnitRollbackDoesNotAffectOuterCommit() {
         outer.onPrepareCommit(u -> {
             inner.start();
             inner.rollback(new MockException());
@@ -180,7 +180,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testRollbackOfMiddleUnitOfWorkRollsBackInner() {
+    void rollbackOfMiddleUnitOfWorkRollsBackInner() {
         outer.onPrepareCommit(u -> {
             middle.start();
             inner.start();
@@ -209,7 +209,7 @@ class UnitOfWorkNestingTest {
     }
 
     @Test
-    void testInnerUnitCommitFailureDoesNotAffectOuterCommit() {
+    void innerUnitCommitFailureDoesNotAffectOuterCommit() {
         outer.onPrepareCommit(u -> {
             inner.start();
             inner.onCommit(uow -> {

--- a/messaging/src/test/java/org/axonframework/monitoring/MultiMessageMonitorTest.java
+++ b/messaging/src/test/java/org/axonframework/monitoring/MultiMessageMonitorTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 class MultiMessageMonitorTest {
 
     @Test
-    void test_onMessageIngested_SingleMessageMonitor_failure() {
+    void onMessageIngested_SingleMessageMonitor_failure() {
         MessageMonitor<Message<?>> messageMonitorMock = mock(MessageMonitor.class);
         MessageMonitor.MonitorCallback callback = mock(MessageMonitor.MonitorCallback.class);
         MultiMessageMonitor multiMessageMonitor = new MultiMessageMonitor(Arrays.asList(messageMonitorMock));
@@ -43,7 +43,7 @@ class MultiMessageMonitorTest {
     }
 
     @Test
-    void test_onMessageIngested_SingleMessageMonitor_success() {
+    void onMessageIngested_SingleMessageMonitor_success() {
         MessageMonitor<Message<?>> messageMonitorMock = mock(MessageMonitor.class);
         MessageMonitor.MonitorCallback callback = mock(MessageMonitor.MonitorCallback.class);
         MultiMessageMonitor multiMessageMonitor = new MultiMessageMonitor(Arrays.asList(messageMonitorMock));
@@ -58,7 +58,7 @@ class MultiMessageMonitorTest {
     }
 
     @Test
-    void test_onMessageIngested_MultipleMessageMonitors() {
+    void onMessageIngested_MultipleMessageMonitors() {
         MessageMonitor<Message<?>> messageMonitorMock1 = mock(MessageMonitor.class);
         MessageMonitor.MonitorCallback callback1 = mock(MessageMonitor.MonitorCallback.class);
         MessageMonitor<Message<?>> messageMonitorMock2 = mock(MessageMonitor.class);

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -64,7 +64,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPointToPointQuery() throws Exception {
+    void pointToPointQuery() throws Exception {
         when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
 
         CompletableFuture<String> queryResponse = testSubject.query("query", String.class);
@@ -85,7 +85,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPointToPointQuerySpecifyingQueryName() throws Exception {
+    void pointToPointQuerySpecifyingQueryName() throws Exception {
         String expectedQueryName = "myQueryName";
 
         when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
@@ -108,7 +108,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPointToPointQueryWithMetaData() throws Exception {
+    void pointToPointQueryWithMetaData() throws Exception {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
 
@@ -137,7 +137,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPointToPointQueryWhenQueryBusReportsAnError() throws Exception {
+    void pointToPointQueryWhenQueryBusReportsAnError() throws Exception {
         Throwable expected = new Throwable("oops");
         when(mockBus.query(anyMessage(String.class, String.class)))
                 .thenReturn(completedFuture(new GenericQueryResponseMessage<>(String.class, expected)));
@@ -150,7 +150,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPointToPointQueryWhenQueryBusThrowsException() throws Exception {
+    void pointToPointQueryWhenQueryBusThrowsException() throws Exception {
         Throwable expected = new Throwable("oops");
         CompletableFuture<QueryResponseMessage<String>> queryResponseCompletableFuture = new CompletableFuture<>();
         queryResponseCompletableFuture.completeExceptionally(expected);
@@ -164,7 +164,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testScatterGatherQuery() {
+    void scatterGatherQuery() {
         long expectedTimeout = 1L;
         TimeUnit expectedTimeUnit = TimeUnit.SECONDS;
 
@@ -192,7 +192,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testScatterGatherQuerySpecifyingQueryName() {
+    void scatterGatherQuerySpecifyingQueryName() {
         String expectedQueryName = "myQueryName";
         long expectedTimeout = 1L;
         TimeUnit expectedTimeUnit = TimeUnit.SECONDS;
@@ -222,7 +222,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testScatterGatherQueryWithMetaData() {
+    void scatterGatherQueryWithMetaData() {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
         long expectedTimeout = 1L;
@@ -257,7 +257,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testSubscriptionQuery() {
+    void subscriptionQuery() {
         when(mockBus.subscriptionQuery(any(), anyInt()))
                 .thenReturn(new DefaultSubscriptionQueryResult<>(Mono.empty(), Flux.empty(), () -> true));
 
@@ -281,7 +281,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testSubscriptionQuerySpecifyingQueryName() {
+    void subscriptionQuerySpecifyingQueryName() {
         String expectedQueryName = "myQueryName";
 
         when(mockBus.subscriptionQuery(any(), anyInt()))
@@ -307,7 +307,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testSubscriptionQueryWithMetaData() {
+    void subscriptionQueryWithMetaData() {
         String expectedMetaDataKey = "key";
         String expectedMetaDataValue = "value";
 
@@ -339,7 +339,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testDispatchInterceptor() {
+    void dispatchInterceptor() {
         when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
         testSubject.registerDispatchInterceptor(messages -> (integer, queryMessage) -> new GenericQueryMessage<>(
                 "dispatch-" + queryMessage.getPayload(),
@@ -354,7 +354,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testExceptionInInitialResultOfSubscriptionQueryReportedInMono() {
+    void exceptionInInitialResultOfSubscriptionQueryReportedInMono() {
         when(mockBus.subscriptionQuery(anySubscriptionMessage(String.class, String.class), anyInt()))
                 .thenReturn(new DefaultSubscriptionQueryResult<>(
                         Mono.just(new GenericQueryResponseMessage<>(String.class, new MockException())),
@@ -372,7 +372,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testNullInitialResultOfSubscriptionQueryReportedAsEmptyMono() {
+    void nullInitialResultOfSubscriptionQueryReportedAsEmptyMono() {
         when(mockBus.subscriptionQuery(anySubscriptionMessage(String.class, String.class), anyInt()))
                 .thenReturn(new DefaultSubscriptionQueryResult<>(
                         Mono.just(new GenericQueryResponseMessage<>(String.class, (String) null)),
@@ -387,7 +387,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testNullUpdatesOfSubscriptionQuerySkipped() {
+    void nullUpdatesOfSubscriptionQuerySkipped() {
         when(mockBus.subscriptionQuery(anySubscriptionMessage(String.class, String.class), anyInt()))
                 .thenReturn(new DefaultSubscriptionQueryResult<>(
                         Mono.empty(),
@@ -403,7 +403,7 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
-    void testPayloadExtractionProblemsReportedInException() throws ExecutionException, InterruptedException {
+    void payloadExtractionProblemsReportedInException() throws ExecutionException, InterruptedException {
         when(mockBus.query(anyMessage(String.class, String.class)))
                 .thenReturn(completedFuture(new GenericQueryResponseMessage<String>("test") {
                     @Override

--- a/messaging/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -58,7 +58,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testQueryWithMultipleResponses() throws ExecutionException, InterruptedException {
+    void queryWithMultipleResponses() throws ExecutionException, InterruptedException {
         QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class)
         );
@@ -69,7 +69,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testQueryWithSingleResponse() throws ExecutionException, InterruptedException {
+    void queryWithSingleResponse() throws ExecutionException, InterruptedException {
         QueryMessage<String, String> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryWithSingleResponse", ResponseTypes.instanceOf(String.class)
         );
@@ -80,7 +80,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testScatterGatherQueryWithMultipleResponses() {
+    void scatterGatherQueryWithMultipleResponses() {
         QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class)
         );
@@ -95,7 +95,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testScatterGatherQueryWithSingleResponse() {
+    void scatterGatherQueryWithSingleResponse() {
         QueryMessage<String, String> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryWithSingleResponse", ResponseTypes.instanceOf(String.class)
         );
@@ -110,7 +110,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testSubscriptionQueryWithMultipleResponses() {
+    void subscriptionQueryWithMultipleResponses() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "criteria", "myQueryWithMultipleResponses",
                 ResponseTypes.multipleInstancesOf(String.class), ResponseTypes.instanceOf(String.class)
@@ -126,7 +126,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testSubscriptionQueryWithSingleResponse() {
+    void subscriptionQueryWithSingleResponse() {
         SubscriptionQueryMessage<String, String, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "criteria", "myQueryWithSingleResponse",
                 ResponseTypes.instanceOf(String.class), ResponseTypes.instanceOf(String.class)
@@ -142,7 +142,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testFutureQueryWithMultipleResponses() throws ExecutionException, InterruptedException {
+    void futureQueryWithMultipleResponses() throws ExecutionException, InterruptedException {
         QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryFutureWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class)
         );
@@ -155,7 +155,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testFutureScatterGatherQueryWithMultipleResponses() {
+    void futureScatterGatherQueryWithMultipleResponses() {
         QueryMessage<String, List<String>> queryMessage = new GenericQueryMessage<>(
                 "criteria", "myQueryFutureWithMultipleResponses", ResponseTypes.multipleInstancesOf(String.class)
         );
@@ -170,7 +170,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
     }
 
     @Test
-    void testFutureSubscriptionQueryWithMultipleResponses() {
+    void futureSubscriptionQueryWithMultipleResponses() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "criteria", "myQueryFutureWithMultipleResponses",
                 ResponseTypes.multipleInstancesOf(String.class), ResponseTypes.instanceOf(String.class)

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericQueryMessageTest {
 
     @Test
-    void testQueryNameResemblesPayloadClassName() {
+    void queryNameResemblesPayloadClassName() {
         String testPayload = "payload";
 
         String result = QueryMessage.queryName(testPayload);
@@ -40,7 +40,7 @@ class GenericQueryMessageTest {
     }
 
     @Test
-    void testQueryNameResemblesMessagePayloadTypeClassName() {
+    void queryNameResemblesMessagePayloadTypeClassName() {
         String testPayload = "payload";
         Message<?> testMessage = GenericMessage.asMessage(testPayload);
 
@@ -50,7 +50,7 @@ class GenericQueryMessageTest {
     }
 
     @Test
-    void testQueryNameResemblesQueryMessageQueryName() {
+    void queryNameResemblesQueryMessageQueryName() {
         String expectedQueryName = "myQueryName";
         QueryMessage<String, String> testMessage =
                 new GenericQueryMessage<>("payload", expectedQueryName, ResponseTypes.instanceOf(String.class));

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericSubscriptionQueryUpdateMessageTest {
 
     @Test
-    void testMessageCreation() {
+    void messageCreation() {
         String payload = "payload";
 
         SubscriptionQueryUpdateMessage<Object> result = GenericSubscriptionQueryUpdateMessage.asUpdateMessage(payload);
@@ -45,7 +45,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testMessageCreationWithNullPayload() {
+    void messageCreationWithNullPayload() {
         String payload = null;
 
         GenericSubscriptionQueryUpdateMessage<String> result =
@@ -55,7 +55,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         Map<String, String> metaData = Collections.singletonMap("k1", "v2");
         SubscriptionQueryUpdateMessage<Object> original = new GenericSubscriptionQueryUpdateMessage<>(
                 new GenericMessage<>("payload", metaData));
@@ -71,7 +71,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         Map<String, String> metaData = Collections.singletonMap("k1", "v2");
         SubscriptionQueryUpdateMessage<Object> original = new GenericSubscriptionQueryUpdateMessage<>(
                 new GenericMessage<>("payload", metaData));
@@ -85,7 +85,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testMessageCreationBasedOnExistingMessage() {
+    void messageCreationBasedOnExistingMessage() {
         GenericSubscriptionQueryUpdateMessage<String> original = new GenericSubscriptionQueryUpdateMessage<>("payload");
 
         SubscriptionQueryUpdateMessage<Object> result = GenericSubscriptionQueryUpdateMessage.asUpdateMessage(original);
@@ -94,7 +94,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testMessageCreationBasedOnResultMessage() {
+    void messageCreationBasedOnResultMessage() {
         Map<String, String> metaData = Collections.singletonMap("k1", "v1");
         CommandResultMessage<String> resultMessage = GenericCommandResultMessage.asCommandResultMessage(
                 new GenericResultMessage<>("result", metaData));
@@ -107,7 +107,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testMessageCreationBasedOnExceptionalResultMessage() {
+    void messageCreationBasedOnExceptionalResultMessage() {
         Map<String, String> metaData = Collections.singletonMap("k1", "v1");
         RuntimeException exception = new RuntimeException();
         CommandResultMessage<String> resultMessage = GenericCommandResultMessage.asCommandResultMessage(
@@ -122,7 +122,7 @@ class GenericSubscriptionQueryUpdateMessageTest {
     }
 
     @Test
-    void testMessageCreationBasedOnAnyMessage() {
+    void messageCreationBasedOnAnyMessage() {
         Map<String, String> metaData = Collections.singletonMap("k1", "v1");
         GenericMessage<String> message = new GenericMessage<>("payload", metaData);
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -95,7 +95,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    public void testHandlerInterceptorThrowsException() throws ExecutionException, InterruptedException {
+    public void handlerInterceptorThrowsException() throws ExecutionException, InterruptedException {
         testSubject.subscribe("test", String.class, q -> q.getPayload().toString());
 
         testSubject.registerHandlerInterceptor((unitOfWork, interceptorChain) -> {
@@ -111,7 +111,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testSubscribe() {
+    void subscribe() {
         testSubject.subscribe("test", String.class, Message::getPayload);
 
         assertEquals(1, testSubject.getSubscriptions().size());
@@ -128,7 +128,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testSubscribingSameHandlerTwiceInvokedOnce() throws Exception {
+    void subscribingSameHandlerTwiceInvokedOnce() throws Exception {
         AtomicInteger invocationCount = new AtomicInteger();
         MessageHandler<QueryMessage<?, String>> handler = message -> {
             invocationCount.incrementAndGet();
@@ -149,7 +149,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testSubscribingSameQueryTwiceWithThrowingDuplicateResolver() throws Exception {
+    void subscribingSameQueryTwiceWithThrowingDuplicateResolver() throws Exception {
         // Modify query bus with failing duplicate resolver
         testSubject = SimpleQueryBus.builder()
                                     .messageMonitor(messageMonitor)
@@ -169,7 +169,7 @@ class SimpleQueryBusTest {
      * contains the correlation data registered with the Unit of Work
      */
     @Test
-    void testQueryResultContainsCorrelationData() throws Exception {
+    void queryResultContainsCorrelationData() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + "1234");
 
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("hello", singleStringResponse)
@@ -185,7 +185,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testNullResponseProperlyReturned() throws ExecutionException, InterruptedException {
+    void nullResponseProperlyReturned() throws ExecutionException, InterruptedException {
         testSubject.subscribe(String.class.getName(), String.class, p -> null);
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("hello", singleStringResponse)
                 .andMetaData(Collections.singletonMap(TRACE_ID, "fakeTraceId"));
@@ -201,7 +201,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryWithTransaction() throws Exception {
+    void queryWithTransaction() throws Exception {
         TransactionManager mockTxManager = mock(TransactionManager.class);
         Transaction mockTx = mock(Transaction.class);
         when(mockTxManager.startTransaction()).thenReturn(mockTx);
@@ -232,7 +232,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQuerySingleWithTransaction() throws Exception {
+    void querySingleWithTransaction() throws Exception {
         TransactionManager mockTxManager = mock(TransactionManager.class);
         Transaction mockTx = mock(Transaction.class);
         when(mockTxManager.startTransaction()).thenReturn(mockTx);
@@ -252,7 +252,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryListWithSingleHandlerReturnsSingleAsList() throws Exception {
+    void queryListWithSingleHandlerReturnsSingleAsList() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + "1234");
 
         QueryMessage<String, List<String>> testQueryMessage = new GenericQueryMessage<>("hello", multipleStringResponse);
@@ -265,7 +265,7 @@ class SimpleQueryBusTest {
 
 
     @Test
-    void testQueryListWithBothSingleHandlerAndListHandlerReturnsListResult() throws Exception {
+    void queryListWithBothSingleHandlerAndListHandlerReturnsListResult() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + "1234");
         testSubject.subscribe(String.class.getName(), String[].class, (q) -> Arrays.asList(
                 q.getPayload() + "1234", q.getPayload() + "5678"
@@ -281,7 +281,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryForSingleResultWithUnsuitableHandlers() throws Exception {
+    void queryForSingleResultWithUnsuitableHandlers() throws Exception {
         AtomicInteger invocationCount = new AtomicInteger();
         MessageHandler<? super QueryMessage<?, ?>> failingHandler = message -> {
             invocationCount.incrementAndGet();
@@ -307,7 +307,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryWithOnlyUnsuitableResultsInException() throws Exception {
+    void queryWithOnlyUnsuitableResultsInException() throws Exception {
         testSubject.subscribe("query", String.class, message -> {
             throw new NoHandlerForQueryException("Mock");
         });
@@ -324,7 +324,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryReturnsResponseMessageFromHandlerAsIs() throws Exception {
+    void queryReturnsResponseMessageFromHandlerAsIs() throws Exception {
         GenericQueryResponseMessage<String> soleResult =
                 new GenericQueryResponseMessage<>("soleResult");
         testSubject.subscribe("query", String.class, message -> soleResult);
@@ -338,7 +338,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryWithHandlersResultsInException() throws Exception {
+    void queryWithHandlersResultsInException() throws Exception {
         QueryMessage<String, String> testQueryMessage =
                 new GenericQueryMessage<>("query", "query", singleStringResponse);
         CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQueryMessage);
@@ -351,7 +351,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryForSingleResultWillReportErrors() throws Exception {
+    void queryForSingleResultWillReportErrors() throws Exception {
         MessageHandler<? super QueryMessage<?, ?>> failingHandler = message -> {
             throw new MockException("Mock");
         };
@@ -369,7 +369,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryWithInterceptors() throws Exception {
+    void queryWithInterceptors() throws Exception {
         testSubject.registerDispatchInterceptor(
                 messages -> (i, m) -> m.andMetaData(Collections.singletonMap("key", "value"))
         );
@@ -389,7 +389,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryDoesNotArriveAtUnsubscribedHandler() throws Exception {
+    void queryDoesNotArriveAtUnsubscribedHandler() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> "1234");
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + " is not here!").close();
 
@@ -401,7 +401,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryReturnsException() throws Exception {
+    void queryReturnsException() throws Exception {
         MockException mockException = new MockException();
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
             throw mockException;
@@ -418,7 +418,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryUnknown() throws Exception {
+    void queryUnknown() throws Exception {
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("hello", singleStringResponse);
         CompletableFuture<?> result = testSubject.query(testQueryMessage);
 
@@ -431,7 +431,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryUnsubscribedHandlers() throws Exception {
+    void queryUnsubscribedHandlers() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + " is not here!").close();
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + " is not here!").close();
 
@@ -449,7 +449,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGather() {
+    void scatterGather() {
         int expectedResults = 3;
 
         testSubject.subscribe(String.class.getName(), String.class, q -> q.getPayload() + "1234");
@@ -468,7 +468,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherOnArrayQueryHandlers() throws NoSuchMethodException {
+    void scatterGatherOnArrayQueryHandlers() throws NoSuchMethodException {
         int expectedQueryResponses = 3;
         int expectedResults = 6;
 
@@ -504,7 +504,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherWithTransaction() {
+    void scatterGatherWithTransaction() {
         TransactionManager mockTxManager = mock(TransactionManager.class);
         Transaction mockTx = mock(Transaction.class);
         when(mockTxManager.startTransaction()).thenReturn(mockTx);
@@ -528,7 +528,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherWithTransactionRollsBackOnFailure() {
+    void scatterGatherWithTransactionRollsBackOnFailure() {
         TransactionManager mockTxManager = mock(TransactionManager.class);
         Transaction mockTx = mock(Transaction.class);
         when(mockTxManager.startTransaction()).thenReturn(mockTx);
@@ -556,7 +556,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryFirstFromScatterGatherWillCommitUnitOfWork() {
+    void queryFirstFromScatterGatherWillCommitUnitOfWork() {
         TransactionManager mockTxManager = mock(TransactionManager.class);
         Transaction mockTx = mock(Transaction.class);
         when(mockTxManager.startTransaction()).thenReturn(mockTx);
@@ -581,7 +581,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherWithInterceptors() {
+    void scatterGatherWithInterceptors() {
         testSubject.registerDispatchInterceptor(
                 messages -> (i, m) -> m.andMetaData(Collections.singletonMap("key", "value"))
         );
@@ -606,7 +606,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherReturnsEmptyStreamWhenNoHandlersAvailable() {
+    void scatterGatherReturnsEmptyStreamWhenNoHandlersAvailable() {
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("Hello, World", singleStringResponse);
         Set<Object> allResults = testSubject.scatterGather(testQueryMessage, 0, TimeUnit.SECONDS).collect(toSet());
 
@@ -616,7 +616,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testScatterGatherReportsExceptionsWithErrorHandler() {
+    void scatterGatherReportsExceptionsWithErrorHandler() {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + "1234");
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
             throw new MockException();
@@ -633,7 +633,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryResponseMessageCorrelationData() throws ExecutionException, InterruptedException {
+    void queryResponseMessageCorrelationData() throws ExecutionException, InterruptedException {
         testSubject.subscribe(String.class.getName(), String.class, (q) -> q.getPayload() + "1234");
         testSubject.registerHandlerInterceptor(new CorrelationDataInterceptor<>(new MessageOriginProvider()));
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("Hello, World", singleStringResponse);
@@ -644,7 +644,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testSubscriptionQueryReportsExceptionInInitialResult() {
+    void subscriptionQueryReportsExceptionInInitialResult() {
         testSubject.subscribe(String.class.getName(), String.class, q -> {
             throw new MockException();
         });
@@ -662,7 +662,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testSubscriptionQueryIncreasingProjection() throws InterruptedException {
+    void subscriptionQueryIncreasingProjection() throws InterruptedException {
         CountDownLatch ten = new CountDownLatch(1);
         CountDownLatch hundred = new CountDownLatch(1);
         CountDownLatch thousand = new CountDownLatch(1);
@@ -704,7 +704,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryReportsExceptionInResponseMessage() throws ExecutionException, InterruptedException {
+    void queryReportsExceptionInResponseMessage() throws ExecutionException, InterruptedException {
         testSubject.subscribe(String.class.getName(), String.class, q -> {
             throw new MockException();
         });
@@ -718,7 +718,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryHandlerDeclaresFutureResponseType() throws Exception {
+    void queryHandlerDeclaresFutureResponseType() throws Exception {
         Type responseType = ReflectionUtils.methodOf(getClass(), "futureMethod").getGenericReturnType();
         testSubject.subscribe(String.class.getName(),
                               responseType,
@@ -732,7 +732,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testQueryHandlerDeclaresCompletableFutureResponseType() throws Exception {
+    void queryHandlerDeclaresCompletableFutureResponseType() throws Exception {
         Type responseType = ReflectionUtils.methodOf(getClass(), "completableFutureMethod").getGenericReturnType();
         testSubject.subscribe(String.class.getName(),
                               responseType,
@@ -746,7 +746,7 @@ class SimpleQueryBusTest {
     }
 
     @Test
-    void testOnSubscriptionQueryCancelTheActiveSubscriptionIsRemovedFromTheEmitterIfFluxIsNotSubscribed() {
+    void onSubscriptionQueryCancelTheActiveSubscriptionIsRemovedFromTheEmitterIfFluxIsNotSubscribed() {
         //noinspection resource
         testSubject.subscribe(String.class.getName(), String.class, q -> q.getPayload() + "1234");
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -22,7 +22,7 @@ class SimpleQueryUpdateEmitterTest {
     private final SimpleQueryUpdateEmitter testSubject = SimpleQueryUpdateEmitter.builder().build();
 
     @Test
-    void testCompletingRegistrationOldApi() {
+    void completingRegistrationOldApi() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",
@@ -45,7 +45,7 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
-    void testConcurrentUpdateEmitting() {
+    void concurrentUpdateEmitting() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",
@@ -67,7 +67,7 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
-    void testConcurrentUpdateEmitting_WithBackpressure() {
+    void concurrentUpdateEmitting_WithBackpressure() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",
@@ -91,7 +91,7 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
-    void testCancelingRegistrationDoesNotCompleteFluxOfUpdatesOldApi() {
+    void cancelingRegistrationDoesNotCompleteFluxOfUpdatesOldApi() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",
@@ -114,7 +114,7 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
-    void testCompletingRegistration() {
+    void completingRegistration() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",
@@ -137,7 +137,7 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
-    void testCancelingRegistrationDoesNotCompleteFluxOfUpdates() {
+    void cancelingRegistrationDoesNotCompleteFluxOfUpdates() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",
                 "chatMessages",

--- a/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
@@ -72,7 +72,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingFluxResults() {
+    void streamingFluxResults() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "fluxQuery", String.class);
 
@@ -82,7 +82,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testSwitchHandlerOnError() {
+    void switchHandlerOnError() {
         handlersInvoked.removeIf(n -> true);
         errorQueryHandlerAdapter.subscribe(queryBus);
 
@@ -98,7 +98,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testOptionalResults() {
+    void optionalResults() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "optionalResultQuery", String.class);
 
@@ -108,7 +108,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testEmptyOptionalResults() {
+    void emptyOptionalResults() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "emptyOptionalResultQuery", String.class);
 
@@ -118,7 +118,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingListResults() {
+    void streamingListResults() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "listQuery", String.class);
 
@@ -128,7 +128,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingStreamResults() {
+    void streamingStreamResults() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "streamQuery", String.class);
 
@@ -138,7 +138,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingSingleResult() {
+    void streamingSingleResult() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "singleResultQuery", String.class);
 
@@ -148,7 +148,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingCompletableFutureResult() {
+    void streamingCompletableFutureResult() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "completableFutureQuery", String.class);
 
@@ -158,7 +158,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingFluxAfterHandlerCompletes() {
+    void streamingFluxAfterHandlerCompletes() {
         StreamingQueryMessage<String, Long> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria",
                                                    "streamingAfterHandlerCompletesQuery",
@@ -170,7 +170,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingMonoResult() {
+    void streamingMonoResult() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "monoQuery", String.class);
 
@@ -180,7 +180,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testStreamingNullResult() {
+    void streamingNullResult() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "nullQuery", String.class);
 
@@ -190,7 +190,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testErrorResult() {
+    void errorResult() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "exceptionQuery", String.class);
 
@@ -201,7 +201,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testThrottledFluxQuery() {
+    void throttledFluxQuery() {
         StreamingQueryMessage<String, Long> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria",
                                                    "throttledFluxQuery",
@@ -213,7 +213,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testBackpressureFluxQuery() {
+    void backpressureFluxQuery() {
         StreamingQueryMessage<String, Long> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria",
                                                    "backPressure",
@@ -228,7 +228,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testDispatchInterceptor() {
+    void dispatchInterceptor() {
         AtomicBoolean hasBeenCalled = new AtomicBoolean();
 
         queryBus.registerDispatchInterceptor(messages -> {
@@ -247,7 +247,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testHandlerInterceptor() {
+    void handlerInterceptor() {
         queryBus.registerHandlerInterceptor((unitOfWork, interceptorChain) ->
                                                     ((Flux) interceptorChain.proceed()).map(it -> "a"));
 
@@ -260,7 +260,7 @@ class StreamingQueryTest {
     }
 
     @Test
-    void testErrorStream() {
+    void errorStream() {
         StreamingQueryMessage<String, String> queryMessage =
                 new GenericStreamingQueryMessage<>("criteria", "errorStream", String.class);
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/UpdateHandlerRegistrationTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/UpdateHandlerRegistrationTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UpdateHandlerRegistrationTest {
 
     @Test
-    void testCompleteClosesTheRegistration() {
+    void completeClosesTheRegistration() {
         AtomicBoolean registrationInvocation = new AtomicBoolean(false);
         AtomicBoolean completeInvocation = new AtomicBoolean(false);
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapterTest.java
@@ -55,7 +55,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testSubscribe() {
+    void subscribe() {
         when(queryBus.subscribe(any(), any(), any())).thenReturn(() -> true);
         Registration registration = testSubject.subscribe(queryBus);
 
@@ -66,7 +66,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testSubscribeFailsForHandlerWithInvalidParameters() {
+    void subscribeFailsForHandlerWithInvalidParameters() {
         assertThrows(
                 UnsupportedHandlerException.class,
                 () -> new AnnotationQueryHandlerAdapter<>(new MySecondQueryHandler())
@@ -74,7 +74,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testSubscribeFailsForHandlerWithVoidReturnType() {
+    void subscribeFailsForHandlerWithVoidReturnType() {
         assertThrows(
                 UnsupportedHandlerException.class,
                 () -> new AnnotationQueryHandlerAdapter<>(new MyThirdQueryHandler())
@@ -82,7 +82,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQuery() throws Exception {
+    void handleQuery() throws Exception {
         String testResponse = "hello";
         QueryMessage<String, String> testQueryMessage =
                 new GenericQueryMessage<>(testResponse, ResponseTypes.instanceOf(String.class));
@@ -92,7 +92,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQueryWithException() {
+    void handleQueryWithException() {
         QueryMessage<String, Integer> testQuery =
                 new GenericQueryMessage<>("hello", ResponseTypes.instanceOf(Integer.class));
 
@@ -100,7 +100,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQueryWithEmptyOptional() throws Exception {
+    void handleQueryWithEmptyOptional() throws Exception {
         QueryMessage<String, String> testQuery =
                 new GenericQueryMessage<>("hello", "noEcho", ResponseTypes.instanceOf(String.class));
 
@@ -108,7 +108,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQueryWithProvidedOptional() throws Exception {
+    void handleQueryWithProvidedOptional() throws Exception {
         QueryMessage<String, String> testQuery =
                 new GenericQueryMessage<>("hello", "Hello", ResponseTypes.instanceOf(String.class));
 
@@ -116,7 +116,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQueryForCollection() throws Exception {
+    void handleQueryForCollection() throws Exception {
         int testResponse = 5;
         QueryMessage<Integer, List<String>> testQueryMessage =
                 new GenericQueryMessage<>(testResponse, ResponseTypes.multipleInstancesOf(String.class));
@@ -128,7 +128,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testHandleQueryThrowsNoHandlerForQueryException() {
+    void handleQueryThrowsNoHandlerForQueryException() {
         QueryMessage<Long, List<String>> testQueryMessage =
                 new GenericQueryMessage<>(42L, ResponseTypes.multipleInstancesOf(String.class));
 
@@ -136,7 +136,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testInterceptMessages() throws Exception {
+    void interceptMessages() throws Exception {
         List<QueryMessage<?, ?>> withInterceptor = new ArrayList<>();
         List<QueryMessage<?, ?>> withoutInterceptor = new ArrayList<>();
         testSubject = new AnnotationQueryHandlerAdapter<>(
@@ -154,7 +154,7 @@ class AnnotationQueryHandlerAdapterTest {
     }
 
     @Test
-    void testCanHandleMessage() {
+    void canHandleMessage() {
         QueryMessage<String, Integer> testIntegerQuery =
                 new GenericQueryMessage<>("hello", ResponseTypes.instanceOf(Integer.class));
         QueryMessage<String, Long> testLongQuery =

--- a/messaging/src/test/java/org/axonframework/queryhandling/annotation/MethodQueryMessageHandlerDefinitionTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/annotation/MethodQueryMessageHandlerDefinitionTest.java
@@ -51,18 +51,18 @@ class MethodQueryMessageHandlerDefinitionTest {
     }
 
     @Test
-    void testVoidNotAcceptedAsReturnType() {
+    void voidNotAcceptedAsReturnType() {
         assertThrows(UnsupportedHandlerException.class, () -> messageHandler("illegalQueryResponseType"));
     }
 
     @Test
-    void testFutureResponseTypeUnwrapped() {
+    void futureResponseTypeUnwrapped() {
         QueryHandlingMember<?> handler = messageHandler("futureReturnType");
         assertEquals(String.class, handler.getResultType());
     }
 
     @Test
-    void testOptionalResponseTypeUnwrapped() throws Exception {
+    void optionalResponseTypeUnwrapped() throws Exception {
         QueryHandlingMember<MethodQueryMessageHandlerDefinitionTest> handler = messageHandler("optionalReturnType");
         assertEquals(String.class, handler.getResultType());
 
@@ -77,19 +77,19 @@ class MethodQueryMessageHandlerDefinitionTest {
 
 
     @Test
-    void testUnspecifiedOptionalResponseTypeUnwrapped() {
+    void unspecifiedOptionalResponseTypeUnwrapped() {
         QueryHandlingMember<?> handler = messageHandler("unspecifiedOptionalType");
         assertEquals(Object.class, handler.getResultType());
     }
 
     @Test
-    void testWildcardOptionalResponseTypeUnwrapped() {
+    void wildcardOptionalResponseTypeUnwrapped() {
         QueryHandlingMember<?> handler = messageHandler("wildcardOptionalType");
         assertEquals(Object.class, handler.getResultType());
     }
 
     @Test
-    void testUpperBoundWildcardOptionalResponseTypeUnwrapped() {
+    void upperBoundWildcardOptionalResponseTypeUnwrapped() {
         QueryHandlingMember<?> handler = messageHandler("upperBoundWildcardOptionalType");
         assertEquals(CharSequence.class, handler.getResultType());
     }

--- a/messaging/src/test/java/org/axonframework/serialization/AnnotationRevisionResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/AnnotationRevisionResolverTest.java
@@ -35,12 +35,12 @@ class AnnotationRevisionResolverTest {
     }
 
     @Test
-    void testRevisionOfAnnotatedClass() {
+    void revisionOfAnnotatedClass() {
         assertEquals("2.3-TEST", testSubject.revisionOf(WithAnnotation.class));
     }
 
     @Test
-    void testRevisionOfNonAnnotatedClass() {
+    void revisionOfNonAnnotatedClass() {
         assertNull(testSubject.revisionOf(WithoutAnnotation.class));
     }
 

--- a/messaging/src/test/java/org/axonframework/serialization/ChainedConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/ChainedConverterTest.java
@@ -75,7 +75,7 @@ class ChainedConverterTest {
     }
 
     @Test
-    void testComplexRoute() throws Exception {
+    void complexRoute() throws Exception {
         target = InputStream.class;
         source = 1L;
         testSubject = ChainedConverter.calculateChain(Number.class, target, candidates);
@@ -100,7 +100,7 @@ class ChainedConverterTest {
     }
     
     @Test
-    void testSimpleRoute() {
+    void simpleRoute() {
         target = String.class;
         source = 1L;
         testSubject = ChainedConverter.calculateChain(Number.class, target, candidates);
@@ -120,7 +120,7 @@ class ChainedConverterTest {
     }
 
     @Test
-    void testInexistentRoute() {
+    void inexistentRoute() {
         target = InputStream.class;
         source = new StringReader("hello");
         assertThrows(CannotConvertBetweenTypesException.class, () -> ChainedConverter.calculateChain(Reader.class, target, candidates));
@@ -128,7 +128,7 @@ class ChainedConverterTest {
 
     // Detects an issue where the ChainedConverter hangs as it evaluates a recursive route
     @Test
-    void testAnotherInexistentRoute() {
+    void anotherInexistentRoute() {
         target = Number.class;
         source = "hello";
         assertFalse(ChainedConverter.canConvert(String.class, target, candidates));
@@ -136,14 +136,14 @@ class ChainedConverterTest {
     }
 
     @Test
-    void testAThirdInexistentRoute() {
+    void aThirdInexistentRoute() {
         target = Documented.class;
         source = "hello".getBytes();
         assertThrows(CannotConvertBetweenTypesException.class, () -> ChainedConverter.calculateChain(byte[].class, target, candidates));
     }
 
     @Test
-    void testDiscontinuousChainIsRejected() {
+    void discontinuousChainIsRejected() {
         try {
             testSubject = new ChainedConverter(Arrays.<ContentTypeConverter>asList(numberToStringConverter,
                                                                                    bytesToInputStreamConverter));

--- a/messaging/src/test/java/org/axonframework/serialization/FixedValueRevisionResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/FixedValueRevisionResolverTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class FixedValueRevisionResolverTest {
 
     @Test
-    void testRevisionOf() {
+    void revisionOf() {
         assertEquals("test", new FixedValueRevisionResolver("test").revisionOf(Object.class));
     }
 }

--- a/messaging/src/test/java/org/axonframework/serialization/JavaSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/JavaSerializerTest.java
@@ -35,7 +35,7 @@ class JavaSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserialize() {
+    void serializeAndDeserialize() {
         SerializedObject<byte[]> serializedObject = testSubject.serialize(new MySerializableObject("hello"),
                                                                           byte[].class);
         assertEquals(MySerializableObject.class.getName(), serializedObject.getType().getName());
@@ -47,14 +47,14 @@ class JavaSerializerTest {
     }
 
     @Test
-    void testClassForType() {
+    void classForType() {
         Class actual = testSubject.classForType(new SimpleSerializedType(MySerializableObject.class.getName(),
                                                                          "2166108932776672373"));
         assertEquals(MySerializableObject.class, actual);
     }
 
     @Test
-    void testClassForType_CustomRevisionResolver() {
+    void classForType_CustomRevisionResolver() {
         testSubject = JavaSerializer.builder()
                                     .revisionResolver(new FixedValueRevisionResolver("fixed"))
                                     .build();
@@ -64,12 +64,12 @@ class JavaSerializerTest {
     }
 
     @Test
-    void testClassForType_UnknownClass() {
+    void classForType_UnknownClass() {
         assertEquals(UnknownSerializedType.class, testSubject.classForType(new SimpleSerializedType("unknown", "0")));
     }
 
     @Test
-    void testDeserializeNullValue() {
+    void deserializeNullValue() {
         SerializedObject<byte[]> serializedNull = testSubject.serialize(null, byte[].class);
         SimpleSerializedObject<byte[]> serializedNullString = new SimpleSerializedObject<>(
                 serializedNull.getData(), byte[].class, testSubject.typeForClass(String.class)
@@ -79,7 +79,7 @@ class JavaSerializerTest {
     }
 
     @Test
-    void testDeserializeEmptyBytes() {
+    void deserializeEmptyBytes() {
         assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
         assertNull(testSubject.deserialize(new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())));
     }

--- a/messaging/src/test/java/org/axonframework/serialization/LazyDeserializingObjectTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/LazyDeserializingObjectTest.java
@@ -47,7 +47,7 @@ class LazyDeserializingObjectTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testLazilyDeserialized() {
+    void lazilyDeserialized() {
         LazyDeserializingObject<Object> testSubject = new LazyDeserializingObject<>(mockObject, mockSerializer);
         verify(mockSerializer, never()).deserialize(any(SerializedObject.class));
         assertEquals(String.class, testSubject.getType());
@@ -58,17 +58,17 @@ class LazyDeserializingObjectTest {
     }
 
     @Test
-    void testLazilyDeserialized_NullObject() {
+    void lazilyDeserialized_NullObject() {
         assertThrows(Exception.class, () -> new LazyDeserializingObject<>(null, mockSerializer));
     }
 
     @Test
-    void testLazilyDeserialized_NullSerializer() {
+    void lazilyDeserialized_NullSerializer() {
         assertThrows(IllegalArgumentException.class, () -> new LazyDeserializingObject<>(mockObject, null));
     }
 
     @Test
-    void testWithProvidedDeserializedInstance() {
+    void withProvidedDeserializedInstance() {
         LazyDeserializingObject<Object> testSubject = new LazyDeserializingObject<>(mockDeserializedObject);
         assertEquals(mockDeserializedObject.getClass(), testSubject.getType());
         assertSame(mockDeserializedObject, testSubject.getObject());
@@ -76,7 +76,7 @@ class LazyDeserializingObjectTest {
     }
 
     @Test
-    void testWithProvidedDeserializedNullInstance() {
+    void withProvidedDeserializedNullInstance() {
         assertThrows(IllegalArgumentException.class, () -> new LazyDeserializingObject<>(null));
     }
 }

--- a/messaging/src/test/java/org/axonframework/serialization/MavenArtifactRevisionResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/MavenArtifactRevisionResolverTest.java
@@ -27,14 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class MavenArtifactRevisionResolverTest {
 
     @Test
-    void testFindVersionOfExistingPomProperties() throws Exception {
+    void findVersionOfExistingPomProperties() throws Exception {
         MavenArtifactRevisionResolver testSubject = new MavenArtifactRevisionResolver("org.axonframework", "axon-modelling");
 
         assertEquals("2.1-SNAPSHOT", testSubject.revisionOf(Object.class));
     }
 
     @Test
-    void testFindVersionOfNonExistingProperties() throws Exception {
+    void findVersionOfNonExistingProperties() throws Exception {
         MavenArtifactRevisionResolver testSubject = new MavenArtifactRevisionResolver("does.not.exist", "axon-modelling");
 
         assertNull(testSubject.revisionOf(Object.class));

--- a/messaging/src/test/java/org/axonframework/serialization/SerialVersionUIDRevisionResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerialVersionUIDRevisionResolverTest.java
@@ -37,12 +37,12 @@ class SerialVersionUIDRevisionResolverTest {
     }
 
     @Test
-    void testRevisionOfAnnotatedClass() {
+    void revisionOfAnnotatedClass() {
         assertEquals("7038084420164786502", testSubject.revisionOf(IsSerializable.class));
     }
 
     @Test
-    void testRevisionOfNonAnnotatedClass() {
+    void revisionOfNonAnnotatedClass() {
         assertNull(testSubject.revisionOf(NotSerializable.class));
     }
 

--- a/messaging/src/test/java/org/axonframework/serialization/SerializationAwareTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializationAwareTest.java
@@ -40,7 +40,7 @@ class SerializationAwareTest {
     }
 
     @Test
-    void testIsSerializedAsGenericEventMessage() throws IOException, ClassNotFoundException {
+    void isSerializedAsGenericEventMessage() throws IOException, ClassNotFoundException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(testSubject);
@@ -51,7 +51,7 @@ class SerializationAwareTest {
     }
 
     @Test
-    void testSerializePayloadTwice() {
+    void serializePayloadTwice() {
         Serializer serializer = mock(Serializer.class);
         Converter converter = new ChainingConverter();
         when(serializer.getConverter()).thenReturn(converter);
@@ -67,7 +67,7 @@ class SerializationAwareTest {
     }
 
     @Test
-    void testSerializePayloadTwice_DifferentRepresentations() {
+    void serializePayloadTwice_DifferentRepresentations() {
         Serializer serializer = mock(Serializer.class);
         Converter converter = new ChainingConverter();
         when(serializer.getConverter()).thenReturn(converter);
@@ -85,7 +85,7 @@ class SerializationAwareTest {
     }
 
     @Test
-    void testSerializeMetaDataTwice() {
+    void serializeMetaDataTwice() {
         Serializer serializer = mock(Serializer.class);
         Converter converter = new ChainingConverter();
         when(serializer.getConverter()).thenReturn(converter);
@@ -100,7 +100,7 @@ class SerializationAwareTest {
     }
 
     @Test
-    void testSerializeMetaDataTwice_DifferentRepresentations() {
+    void serializeMetaDataTwice_DifferentRepresentations() {
         Serializer serializer = mock(Serializer.class);
         Converter converter = new ChainingConverter();
         when(serializer.getConverter()).thenReturn(converter);

--- a/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
@@ -54,7 +54,7 @@ class SerializedMessageTest {
     }
 
     @Test
-    void testConstructor() {
+    void constructor() {
         SerializedMessage<Object> message1 = new SerializedMessage<>(eventId,
                                                                            serializedPayload,
                                                                            serializedMetaData, serializer);
@@ -67,7 +67,7 @@ class SerializedMessageTest {
     }
 
     @Test
-    void testWithMetaData() {
+    void withMetaData() {
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
         when(serializer.deserialize(serializedMetaData)).thenReturn(metaData);
@@ -82,7 +82,7 @@ class SerializedMessageTest {
     }
 
     @Test
-    void testAndMetaData() {
+    void andMetaData() {
         Map<String, Object> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
         when(serializer.deserialize(serializedMetaData)).thenReturn(metaData);
@@ -99,7 +99,7 @@ class SerializedMessageTest {
     }
 
     @Test
-    void testSerializePayloadImmediately() {
+    void serializePayloadImmediately() {
         SerializedMessage<Object> message = new SerializedMessage<>(eventId, serializedPayload,
                                                                           serializedMetaData, serializer);
 
@@ -112,7 +112,7 @@ class SerializedMessageTest {
     }
 
     @Test
-    void testSerializeMetaDataImmediately() {
+    void serializeMetaDataImmediately() {
         SerializedMessage<Object> message = new SerializedMessage<>(eventId, serializedPayload,
                                                                           serializedMetaData, serializer);
 

--- a/messaging/src/test/java/org/axonframework/serialization/SerializedMetaDataValueTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializedMetaDataValueTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class SerializedMetaDataValueTest {
 
     @Test
-    void testSerializeMetaData() {
+    void serializeMetaData() {
         byte[] stubData = new byte[]{};
         SerializedMetaData<byte[]> serializedMetaData = new SerializedMetaData<>(stubData, byte[].class);
         assertEquals(stubData, serializedMetaData.getData());
@@ -37,7 +37,7 @@ class SerializedMetaDataValueTest {
     }
 
     @Test
-    void testIsSerializedMetaData() {
+    void isSerializedMetaData() {
         SerializedMetaData<byte[]> serializedMetaData = new SerializedMetaData<>(new byte[]{}, byte[].class);
         assertTrue(SerializedMetaData.isSerializedMetaData(serializedMetaData));
         assertFalse(SerializedMetaData.isSerializedMetaData(

--- a/messaging/src/test/java/org/axonframework/serialization/converters/ByteArrayToStringConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/converters/ByteArrayToStringConverterTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ByteArrayToStringConverterTest {
 
     @Test
-    void testConvert() throws UnsupportedEncodingException {
+    void convert() throws UnsupportedEncodingException {
         ByteArrayToStringConverter testSubject = new ByteArrayToStringConverter();
         assertEquals(String.class, testSubject.targetType());
         assertEquals(byte[].class, testSubject.expectedSourceType());

--- a/messaging/src/test/java/org/axonframework/serialization/converters/InputStreamToByteArrayConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/converters/InputStreamToByteArrayConverterTest.java
@@ -37,7 +37,7 @@ class InputStreamToByteArrayConverterTest {
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         byte[] bytes = "Hello, world!".getBytes();
         InputStream inputStream = new ByteArrayInputStream(bytes);
         byte[] actual = testSubject.convert(inputStream);

--- a/messaging/src/test/java/org/axonframework/serialization/converters/StringToByteArrayConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/converters/StringToByteArrayConverterTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class StringToByteArrayConverterTest {
 
     @Test
-    void testConvert() throws UnsupportedEncodingException {
+    void convert() throws UnsupportedEncodingException {
         StringToByteArrayConverter testSubject = new StringToByteArrayConverter();
         assertEquals(String.class, testSubject.expectedSourceType());
         assertEquals(byte[].class, testSubject.targetType());

--- a/messaging/src/test/java/org/axonframework/serialization/json/ByteArrayToJsonNodeConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/ByteArrayToJsonNodeConverterTest.java
@@ -39,7 +39,7 @@ class ByteArrayToJsonNodeConverterTest {
     }
 
     @Test
-    void testConvertNodeToBytes() throws Exception {
+    void convertNodeToBytes() throws Exception {
         final String content = "{\"someKey\":\"someValue\",\"someOther\":true}";
         JsonNode expected = objectMapper.readTree(content);
         assertEquals(expected, testSubject.convert(content.getBytes(IOUtils.UTF8)));

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -68,7 +68,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testCanSerializeToByteArrayStringInputStreamJsonNodeAndObjectNode() {
+    void canSerializeToByteArrayStringInputStreamJsonNodeAndObjectNode() {
         assertTrue(testSubject.canSerializeTo(byte[].class));
         assertTrue(testSubject.canSerializeTo(String.class));
         assertTrue(testSubject.canSerializeTo(InputStream.class));
@@ -77,7 +77,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeObject_StringFormat() {
+    void serializeAndDeserializeObject_StringFormat() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -89,7 +89,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeArray() {
+    void serializeAndDeserializeArray() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -103,7 +103,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeList() {
+    void serializeAndDeserializeList() {
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
@@ -117,7 +117,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeObject_ByteArrayFormat() {
+    void serializeAndDeserializeObject_ByteArrayFormat() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -130,7 +130,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeObjectUnknownType() {
+    void serializeAndDeserializeObjectUnknownType() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -152,7 +152,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeObject_JsonNodeFormat() {
+    void serializeAndDeserializeObject_JsonNodeFormat() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -164,7 +164,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testCustomObjectMapperRevisionResolverAndConverter() {
+    void customObjectMapperRevisionResolverAndConverter() {
         RevisionResolver revisionResolver = spy(new AnnotationRevisionResolver());
         ChainingConverter converter = spy(new ChainingConverter());
         ObjectMapper objectMapper = spy(new ObjectMapper());
@@ -188,7 +188,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testCustomObjectMapperAndRevisionResolver() {
+    void customObjectMapperAndRevisionResolver() {
         ObjectMapper objectMapper = spy(new ObjectMapper());
         RevisionResolver revisionResolver = spy(new AnnotationRevisionResolver());
 
@@ -209,7 +209,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testCustomObjectMapper() {
+    void customObjectMapper() {
         ObjectMapper objectMapper = spy(new ObjectMapper());
 
         testSubject = JacksonSerializer.builder()
@@ -227,7 +227,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeMetaData() {
+    void serializeMetaData() {
         testSubject = JacksonSerializer.builder().build();
 
         SerializedObject<byte[]> serialized =
@@ -240,7 +240,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeMetaDataWithComplexObjects() {
+    void serializeMetaDataWithComplexObjects() {
         // Typing must be enabled for this (which we expect end-users to do)
         JacksonSerializer testSubject = JacksonSerializer.builder().defaultTyping().build();
 
@@ -259,7 +259,7 @@ class JacksonSerializerTest {
      * is configured with {@link ObjectMapper#enableDefaultTyping(ObjectMapper.DefaultTyping)}.
      */
     @Test
-    void testSerializeCollectionOfObjects() {
+    void serializeCollectionOfObjects() {
         // Typing must be enabled for this (which we expect end-users to do)
         JacksonSerializer testSubject = JacksonSerializer.builder().defaultTyping().build();
 
@@ -276,7 +276,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testDeserializeNullValue() {
+    void deserializeNullValue() {
         SerializedObject<byte[]> serializedNull = testSubject.serialize(null, byte[].class);
         SimpleSerializedObject<byte[]> serializedNullString = new SimpleSerializedObject<>(
                 serializedNull.getData(), byte[].class, testSubject.typeForClass(String.class)
@@ -286,7 +286,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testDeserializeEmptyBytes() {
+    void deserializeEmptyBytes() {
         assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
         assertNull(testSubject.deserialize(
                 new SimpleSerializedObject<>(new byte[0], byte[].class, SerializedType.emptyType())
@@ -294,7 +294,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testDeserializeLenientIgnoresUnknownValues() {
+    void deserializeLenientIgnoresUnknownValues() {
         testSubject = JacksonSerializer.builder().lenientDeserialization().objectMapper(objectMapper).build();
         SerializedObject<JsonNode> serialized =
                 testSubject.serialize(new ComplexObject("one", "two", 3), JsonNode.class);
@@ -311,7 +311,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeObjectObjectNodeFormat() {
+    void serializeAndDeserializeObjectObjectNodeFormat() {
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 
@@ -323,7 +323,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    void testConfiguredRevisionResolverIsReturned() {
+    void configuredRevisionResolverIsReturned() {
         String expectedRevision = "some-revision";
         RevisionResolver expectedRevisionResolver = payloadType -> expectedRevision;
 

--- a/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToByteArrayConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToByteArrayConverterTest.java
@@ -39,7 +39,7 @@ class JsonNodeToByteArrayConverterTest {
     }
 
     @Test
-    void testConvertNodeToBytes() throws Exception {
+    void convertNodeToBytes() throws Exception {
         final String content = "{\"someKey\":\"someValue\",\"someOther\":true}";
         JsonNode node = objectMapper.readTree(content);
         assertArrayEquals(content.getBytes(IOUtils.UTF8), testSubject.convert(node));

--- a/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JsonNodeToObjectNodeConverterTest.java
@@ -35,17 +35,17 @@ class JsonNodeToObjectNodeConverterTest {
     private final JsonNodeToObjectNodeConverter testSubject = new JsonNodeToObjectNodeConverter();
 
     @Test
-    void testExpectedSourceType() {
+    void expectedSourceType() {
         assertEquals(JsonNode.class, testSubject.expectedSourceType());
     }
 
     @Test
-    void testTargetType() {
+    void targetType() {
         assertEquals(ObjectNode.class, testSubject.targetType());
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         JsonNode expectedJsonNode = new ObjectNode(JsonNodeFactory.instance);
 
         ObjectNode result = testSubject.convert(expectedJsonNode);
@@ -54,7 +54,7 @@ class JsonNodeToObjectNodeConverterTest {
     }
 
     @Test
-    void testConvertThrowsException() {
+    void convertThrowsException() {
         JsonNode testJsonNode = new TextNode("some-text");
 
         assertThrows(SerializationException.class, () -> testSubject.convert(testJsonNode));

--- a/messaging/src/test/java/org/axonframework/serialization/json/MetaDataDeserializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/MetaDataDeserializerTest.java
@@ -59,7 +59,7 @@ class MetaDataDeserializerTest {
 
     @MethodSource("objectMappers")
     @ParameterizedTest
-    void testMetaDataSerializationWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
+    void metaDataSerializationWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
         MetaData metaData = new MetaData(Collections.singletonMap("one", "two"));
         String serializedString = objectMapper.writeValueAsString(metaData);
 
@@ -70,7 +70,7 @@ class MetaDataDeserializerTest {
 
     @MethodSource("objectMappers")
     @ParameterizedTest
-    void testEmptyMetaDataSerializationWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
+    void emptyMetaDataSerializationWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
         MetaData metaData1 = new MetaData(new HashMap<>());
         String emptySerializedString = objectMapper.writeValueAsString(metaData1);
 
@@ -82,7 +82,7 @@ class MetaDataDeserializerTest {
 
     @MethodSource("objectMappers")
     @ParameterizedTest
-    void testMetaDataContainerWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
+    void metaDataContainerWithDefaultTyping(ObjectMapper objectMapper) throws IOException {
         MetaData metaData = new MetaData(Collections.singletonMap("one", "two"));
 
         Container container = new Container("a", metaData, 1);
@@ -96,7 +96,7 @@ class MetaDataDeserializerTest {
 
     @MethodSource("objectMappers")
     @ParameterizedTest
-    void testMetaDataContainerWithDataInDataWithDefaultTyping(ObjectMapper objectMapper, ObjectMapper.DefaultTyping defaultTyping) throws IOException {
+    void metaDataContainerWithDataInDataWithDefaultTyping(ObjectMapper objectMapper, ObjectMapper.DefaultTyping defaultTyping) throws IOException {
         MetaData metaData = new MetaData(Collections.singletonMap("one", "two"));
 
         Map<String, Object> map2 = new HashMap<>();

--- a/messaging/src/test/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/ObjectNodeToJsonNodeConverterTest.java
@@ -33,17 +33,17 @@ class ObjectNodeToJsonNodeConverterTest {
     private final ObjectNodeToJsonNodeConverter testSubject = new ObjectNodeToJsonNodeConverter();
 
     @Test
-    void testExpectedSourceType() {
+    void expectedSourceType() {
         assertEquals(ObjectNode.class, testSubject.expectedSourceType());
     }
 
     @Test
-    void testTargetType() {
+    void targetType() {
         assertEquals(JsonNode.class, testSubject.targetType());
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         ObjectNode expectedJsonNode = new ObjectNode(JsonNodeFactory.instance);
 
         JsonNode result = testSubject.convert(expectedJsonNode);

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/GenericUpcasterChainTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/GenericUpcasterChainTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericUpcasterChainTest {
 
     @Test
-    void testChainWithSingleUpcasterCanUpcastMultipleEvents() {
+    void chainWithSingleUpcasterCanUpcastMultipleEvents() {
         Object a = "a", b = "b", c = "c";
         Upcaster<Object> testSubject = new GenericUpcasterChain<>(new AToBUpcaster(a, b));
         Stream<Object> result = testSubject.upcast(Stream.of(a, b, a, c));
@@ -44,7 +44,7 @@ class GenericUpcasterChainTest {
     }
 
     @Test
-    void testUpcastingResultOfOtherUpcaster() {
+    void upcastingResultOfOtherUpcaster() {
         Object a = "a", b = "b", c = "c";
         Upcaster<Object> testSubject = new GenericUpcasterChain<>(new AToBUpcaster(a, b), new AToBUpcaster(b, c));
         Stream<Object> result = testSubject.upcast(Stream.of(a, b, a, c));
@@ -52,7 +52,7 @@ class GenericUpcasterChainTest {
     }
 
     @Test
-    void testUpcastingResultOfOtherUpcasterOnlyWorksIfUpcastersAreInCorrectOrder() {
+    void upcastingResultOfOtherUpcasterOnlyWorksIfUpcastersAreInCorrectOrder() {
         Object a = "a", b = "b", c = "c";
         Upcaster<Object> testSubject = new GenericUpcasterChain<>(new AToBUpcaster(b, c), new AToBUpcaster(a, b));
         Stream<Object> result = testSubject.upcast(Stream.of(a, b, a, c));
@@ -60,7 +60,7 @@ class GenericUpcasterChainTest {
     }
 
     @Test
-    void testRemainderAddedAndUpcasted() {
+    void remainderAddedAndUpcasted() {
         Object a = "a", b = "b", c = "c";
         Upcaster<Object> testSubject =
                 new GenericUpcasterChain<>(new UpcasterWithRemainder(a, b), new AToBUpcaster(b, c));
@@ -69,7 +69,7 @@ class GenericUpcasterChainTest {
     }
 
     @Test
-    void testRemainderReleasedAfterUpcasting() {
+    void remainderReleasedAfterUpcasting() {
         Object a = "a", b = "b", c = "c", d = "d";
         Upcaster<Object> testSubject =
                 new GenericUpcasterChain<>(new ConditionalUpcaster(a, b, c), new ConditionalUpcaster(c, d, a));
@@ -78,7 +78,7 @@ class GenericUpcasterChainTest {
     }
 
     @Test
-    void testUpcastToMultipleTypes() {
+    void upcastToMultipleTypes() {
         Object a = "a", b = "b", c = "c";
         Upcaster<Object> testSubject = new GenericUpcasterChain<>(new MultipleTypesUpcaster(), new AToBUpcaster(b, c));
         Stream<Object> result = testSubject.upcast(Stream.of(a, b, c));

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/ContextAwareEventMultiUpcasterTest.java
@@ -78,7 +78,7 @@ class ContextAwareEventMultiUpcasterTest {
     }
 
     @Test
-    void testUpcastsAddsContextValueFromFirstEvent() {
+    void upcastsAddsContextValueFromFirstEvent() {
         int expectedNumberOfEvents = 4;
         String expectedContextEventString = "oldName";
         Integer expectedContextEventNumber = 1;

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/ContextAwareSingleEventUpcasterTest.java
@@ -68,7 +68,7 @@ class ContextAwareSingleEventUpcasterTest {
     }
 
     @Test
-    void testUpcastsAddsContextValueFromFirstEvent() {
+    void upcastsAddsContextValueFromFirstEvent() {
         int expectedNumberOfEvents = 2;
         String expectedContextEventString = "oldName";
         Integer expectedContextEventNumber = 1;

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventMultiUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventMultiUpcasterTest.java
@@ -80,7 +80,7 @@ class EventMultiUpcasterTest {
     }
 
     @Test
-    void testUpcasterIgnoresWrongEventType() {
+    void upcasterIgnoresWrongEventType() {
         GenericDomainEventMessage<String> testEventMessage =
                 new GenericDomainEventMessage<>("test", "aggregateId", 0, "someString");
         EventData<?> testEventData = new TestDomainEventEntry(testEventMessage, serializer);
@@ -97,7 +97,7 @@ class EventMultiUpcasterTest {
     }
 
     @Test
-    void testUpcasterIgnoresWrongEventRevision() {
+    void upcasterIgnoresWrongEventRevision() {
         String expectedRevisionNumber = "1";
 
         GenericDomainEventMessage<StubDomainEvent> testEventMessage =
@@ -123,7 +123,7 @@ class EventMultiUpcasterTest {
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
-    void testUpcastingDomainEventData() {
+    void upcastingDomainEventData() {
         String testAggregateType = "test";
         String testAggregateId = "aggregateId";
         GlobalSequenceTrackingToken testTrackingToken = new GlobalSequenceTrackingToken(10);
@@ -163,7 +163,7 @@ class EventMultiUpcasterTest {
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    void testUpcastsKnownType() {
+    void upcastsKnownType() {
         String expectedRevisionNumber = "1";
         String expectedSecondAndThirdRevisionNumber = null;
 

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventTypeUpcasterTest.java
@@ -62,28 +62,28 @@ class EventTypeUpcasterTest {
             new EventTypeUpcaster(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
 
     @Test
-    void testUpcasterBuilderFailsForNullExpectedPayloadTypeClass() {
+    void upcasterBuilderFailsForNullExpectedPayloadTypeClass() {
         assertThrows(
                 AxonConfigurationException.class, () -> EventTypeUpcaster.from((Class<?>) null, EXPECTED_REVISION)
         );
     }
 
     @Test
-    void testUpcasterBuilderFailsForNullExpectedPayloadType() {
+    void upcasterBuilderFailsForNullExpectedPayloadType() {
         assertThrows(
                 AxonConfigurationException.class, () -> EventTypeUpcaster.from((String) null, EXPECTED_REVISION)
         );
     }
 
     @Test
-    void testUpcasterBuilderFailsForEmptyExpectedPayloadType() {
+    void upcasterBuilderFailsForEmptyExpectedPayloadType() {
         assertThrows(
                 AxonConfigurationException.class, () -> EventTypeUpcaster.from("", EXPECTED_REVISION)
         );
     }
 
     @Test
-    void testUpcasterBuilderFailsForNullUpcastedPayloadTypeClass() {
+    void upcasterBuilderFailsForNullUpcastedPayloadTypeClass() {
         EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
         assertThrows(
                 AxonConfigurationException.class, () -> testSubject.to((Class<?>) null, UPCASTED_REVISION)
@@ -91,7 +91,7 @@ class EventTypeUpcasterTest {
     }
 
     @Test
-    void testUpcasterBuilderFailsForNullUpcastedPayloadType() {
+    void upcasterBuilderFailsForNullUpcastedPayloadType() {
         EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
         assertThrows(
                 AxonConfigurationException.class, () -> testSubject.to((String) null, UPCASTED_REVISION)
@@ -99,7 +99,7 @@ class EventTypeUpcasterTest {
     }
 
     @Test
-    void testUpcasterBuilderFailsForEmptyUpcastedPayloadType() {
+    void upcasterBuilderFailsForEmptyUpcastedPayloadType() {
         EventTypeUpcaster.Builder testSubject = EventTypeUpcaster.from(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION);
         assertThrows(
                 AxonConfigurationException.class, () -> testSubject.to("", UPCASTED_REVISION)
@@ -108,7 +108,7 @@ class EventTypeUpcasterTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testCanUpcastReturnsTrueForMatchingPayloadTypeAndRevision(Serializer serializer) {
+    void canUpcastReturnsTrueForMatchingPayloadTypeAndRevision(Serializer serializer) {
         EventData<?> testEventData = new TestEventEntry(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, serializer);
         IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
 
@@ -117,7 +117,7 @@ class EventTypeUpcasterTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testCanUpcastReturnsFalseForIncorrectPayloadType(Serializer serializer) {
+    void canUpcastReturnsFalseForIncorrectPayloadType(Serializer serializer) {
         EventData<?> testEventData =
                 new TestEventEntry("some-non-matching-payload-type", EXPECTED_REVISION, serializer);
         IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
@@ -127,7 +127,7 @@ class EventTypeUpcasterTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testCanUpcastReturnsFalseForIncorrectRevision(Serializer serializer) {
+    void canUpcastReturnsFalseForIncorrectRevision(Serializer serializer) {
         EventData<?> testEventData =
                 new TestEventEntry(EXPECTED_PAYLOAD_TYPE, "some-non-matching-revision", serializer);
         IntermediateEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
@@ -136,20 +136,20 @@ class EventTypeUpcasterTest {
     }
 
     @Test
-    void testIsExpectedPayloadType() {
+    void isExpectedPayloadType() {
         assertTrue(testSubject.isExpectedPayloadType(EXPECTED_PAYLOAD_TYPE));
         assertFalse(testSubject.isExpectedPayloadType(UPCASTED_PAYLOAD_TYPE));
     }
 
     @Test
-    void testIsExpectedRevision() {
+    void isExpectedRevision() {
         assertTrue(testSubject.isExpectedRevision(EXPECTED_REVISION));
         assertFalse(testSubject.isExpectedRevision(UPCASTED_REVISION));
     }
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testDoUpcast(Serializer serializer) {
+    void doUpcast(Serializer serializer) {
         EventData<?> testEventData = new TestEventEntry(EXPECTED_PAYLOAD_TYPE, EXPECTED_REVISION, serializer);
         InitialEventRepresentation testRepresentation = new InitialEventRepresentation(testEventData, serializer);
 
@@ -161,7 +161,7 @@ class EventTypeUpcasterTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testShouldDeserializeToNewType(Serializer serializer) {
+    void shouldDeserializeToNewType(Serializer serializer) {
         // If we're dealing with an XStreamSerializer the FQCN in the XML tags defines the type.
         // Due to this, it's more reasonable to use type aliases on the XStream instance i.o. using this upcaster.
         if (serializer instanceof XStreamSerializer) {
@@ -179,7 +179,7 @@ class EventTypeUpcasterTest {
     }
 
     @Test
-    void testUpcastedType() {
+    void upcastedType() {
         SerializedType expectedType = new SimpleSerializedType(UPCASTED_PAYLOAD_TYPE, UPCASTED_REVISION);
         assertEquals(expectedType, testSubject.upcastedType());
     }

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventUpcasterChainTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/EventUpcasterChainTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
 class EventUpcasterChainTest {
 
     @Test
-    void testCreateChainAndUpcast() {
+    void createChainAndUpcast() {
         EventUpcasterChain eventUpcasterChain = new EventUpcasterChain(new SomeEventUpcaster(),
                                                                        new SomeOtherEventUpcaster());
         IntermediateEventRepresentation mockRepresentation = mock(IntermediateEventRepresentation.class);

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentationTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/InitialEventRepresentationTest.java
@@ -50,7 +50,7 @@ class InitialEventRepresentationTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testContentType(Serializer serializer) {
+    void contentType(Serializer serializer) {
         GenericDomainEventMessage<StubDomainEvent> event = new GenericDomainEventMessage<>(
                 "test", "aggregateId", 0, new StubDomainEvent("some-name"), MetaData.emptyInstance()
         );

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/SingleEventUpcasterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/SingleEventUpcasterTest.java
@@ -51,7 +51,7 @@ class SingleEventUpcasterTest {
     private final Serializer serializer = TestSerializer.XSTREAM.getSerializer();
 
     @Test
-    void testUpcastsKnownType() {
+    void upcastsKnownType() {
         String newValue = "newNameValue";
         MetaData metaData = MetaData.with("key", "value");
         EventData<?> eventData = new TestDomainEventEntry(
@@ -72,7 +72,7 @@ class SingleEventUpcasterTest {
 
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    void testUpcastingDomainEventData() {
+    void upcastingDomainEventData() {
         String aggregateType = "test";
         String aggregateId = "aggregateId";
         GlobalSequenceTrackingToken trackingToken = new GlobalSequenceTrackingToken(10);
@@ -100,7 +100,7 @@ class SingleEventUpcasterTest {
     }
 
     @Test
-    void testIgnoresUnknownType() {
+    void ignoresUnknownType() {
         EventData<?> eventData = new TestDomainEventEntry(
                 new GenericDomainEventMessage<>("test", "aggregateId", 0, "someString"), serializer
         );
@@ -114,7 +114,7 @@ class SingleEventUpcasterTest {
     }
 
     @Test
-    void testIgnoresWrongVersion() {
+    void ignoresWrongVersion() {
         EventData<?> eventData = new TestDomainEventEntry(
                 new GenericDomainEventMessage<>("test", "aggregateId", 0, new StubDomainEvent("oldName")), serializer
         );

--- a/messaging/src/test/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentationTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/upcasting/event/UpcastedEventRepresentationTest.java
@@ -48,7 +48,7 @@ class UpcastedEventRepresentationTest {
 
     @ParameterizedTest
     @MethodSource(SOURCE_METHOD_NAME)
-    void testContentType(Serializer serializer) {
+    void contentType(Serializer serializer) {
         Class<JsonNode> expectedContentType = JsonNode.class;
 
         UpcastedEventRepresentation<JsonNode> testSubject = new UpcastedEventRepresentation<>(

--- a/messaging/src/test/java/org/axonframework/serialization/xml/Dom4JToByteArrayConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/Dom4JToByteArrayConverterTest.java
@@ -36,13 +36,13 @@ class Dom4JToByteArrayConverterTest {
     }
 
     @Test
-    void testCanConvert() {
+    void canConvert() {
         assertEquals(Document.class, testSubject.expectedSourceType());
         assertEquals(byte[].class, testSubject.targetType());
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         DocumentFactory df = DocumentFactory.getInstance();
         Document doc = df.createDocument("UTF-8");
         doc.setRootElement(df.createElement("rootElement"));

--- a/messaging/src/test/java/org/axonframework/serialization/xml/InputStreamToDom4jConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/InputStreamToDom4jConverterTest.java
@@ -38,7 +38,7 @@ class InputStreamToDom4jConverterTest {
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         byte[] bytes = "<parent><child/></parent>".getBytes();
         InputStream inputStream = new ByteArrayInputStream(bytes);
         Document actual = testSubject.convert(inputStream);

--- a/messaging/src/test/java/org/axonframework/serialization/xml/InputStreamToXomConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/InputStreamToXomConverterTest.java
@@ -38,7 +38,7 @@ class InputStreamToXomConverterTest {
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         byte[] bytes = "<parent><child/></parent>".getBytes();
         InputStream inputStream = new ByteArrayInputStream(bytes);
         Document actual = testSubject.convert(inputStream);

--- a/messaging/src/test/java/org/axonframework/serialization/xml/XStreamSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/XStreamSerializerTest.java
@@ -61,7 +61,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeDomainEvent() {
+    void serializeAndDeserializeDomainEvent() {
         SerializedObject<byte[]> serializedEvent = testSubject.serialize(testEvent, byte[].class);
         Object actualResult = testSubject.deserialize(serializedEvent);
         assertTrue(actualResult instanceof TestEvent);
@@ -70,14 +70,14 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeDomainEvent_WithXomUpcasters() {
+    void serializeAndDeserializeDomainEvent_WithXomUpcasters() {
         SerializedObject<nu.xom.Document> serializedEvent = testSubject.serialize(testEvent, nu.xom.Document.class);
         Object actualResult = testSubject.deserialize(serializedEvent);
         assertEquals(testEvent, actualResult);
     }
 
     @Test
-    void testSerializeAndDeserializeDomainEvent_WithDom4JUpcasters() {
+    void serializeAndDeserializeDomainEvent_WithDom4JUpcasters() {
         SerializedObject<org.dom4j.Document> serializedEvent =
                 testSubject.serialize(testEvent, org.dom4j.Document.class);
         Object actualResult = testSubject.deserialize(serializedEvent);
@@ -85,7 +85,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeArray() {
+    void serializeAndDeserializeArray() {
         TestEvent toSerialize = new TestEvent("first");
 
         SerializedObject<String> serialized = testSubject.serialize(new TestEvent[]{toSerialize}, String.class);
@@ -99,7 +99,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testSerializeAndDeserializeList() {
+    void serializeAndDeserializeList() {
         TestEvent toSerialize = new TestEvent("first");
 
         SerializedObject<String> serialized = testSubject.serialize(singletonList(toSerialize), String.class);
@@ -110,7 +110,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testDeserializeEmptyBytes() {
+    void deserializeEmptyBytes() {
         assertEquals(Void.class, testSubject.classForType(SerializedType.emptyType()));
         assertNull(testSubject.deserialize(new SimpleSerializedObject<>(
                 new byte[0], byte[].class, SerializedType.emptyType())
@@ -118,7 +118,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testPackageAlias() {
+    void packageAlias() {
         testSubject.addPackageAlias("axon-eh", "org.axonframework.utils");
         testSubject.addPackageAlias("axon", "org.axonframework");
 
@@ -131,7 +131,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testDeserializeNullValue() {
+    void deserializeNullValue() {
         SerializedObject<byte[]> serializedNull = testSubject.serialize(null, byte[].class);
         assertEquals("empty", serializedNull.getType().getName());
         SimpleSerializedObject<byte[]> serializedNullString = new SimpleSerializedObject<>(
@@ -142,7 +142,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testAlias() {
+    void alias() {
         testSubject.addAlias("stub", StubDomainEvent.class);
 
         SerializedObject<byte[]> serialized = testSubject.serialize(new StubDomainEvent(), byte[].class);
@@ -154,7 +154,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testFieldAlias() {
+    void fieldAlias() {
         testSubject.addFieldAlias("relevantPeriod", TestEvent.class, "period");
 
         SerializedObject<byte[]> serialized = testSubject.serialize(testEvent, byte[].class);
@@ -166,7 +166,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testRevisionNumber() {
+    void revisionNumber() {
         SerializedObject<byte[]> serialized = testSubject.serialize(new RevisionSpecifiedEvent(), byte[].class);
         assertNotNull(serialized);
         assertEquals("2", serialized.getType().getRevision());
@@ -175,7 +175,7 @@ class XStreamSerializerTest {
 
     @SuppressWarnings("Duplicates")
     @Test
-    void testSerializedTypeUsesClassAlias() {
+    void serializedTypeUsesClassAlias() {
         testSubject.addAlias("rse", RevisionSpecifiedEvent.class);
         SerializedObject<byte[]> serialized = testSubject.serialize(new RevisionSpecifiedEvent(), byte[].class);
         assertNotNull(serialized);
@@ -188,14 +188,14 @@ class XStreamSerializerTest {
      * #150</a>.
      */
     @Test
-    void testSerializeWithSpecialCharacters_WithDom4JUpcasters() {
+    void serializeWithSpecialCharacters_WithDom4JUpcasters() {
         SerializedObject<byte[]> serialized = testSubject.serialize(new TestEvent(SPECIAL__CHAR__STRING), byte[].class);
         TestEvent deserialized = testSubject.deserialize(serialized);
         assertArrayEquals(SPECIAL__CHAR__STRING.getBytes(), deserialized.getName().getBytes());
     }
 
     @Test
-    void testSerializeNullValue() {
+    void serializeNullValue() {
         SerializedObject<byte[]> serialized = testSubject.serialize(null, byte[].class);
         String deserialized = testSubject.deserialize(serialized);
         assertNull(deserialized);
@@ -206,14 +206,14 @@ class XStreamSerializerTest {
      * #150</a>.
      */
     @Test
-    void testSerializeWithSpecialCharacters_WithoutUpcasters() {
+    void serializeWithSpecialCharacters_WithoutUpcasters() {
         SerializedObject<byte[]> serialized = testSubject.serialize(new TestEvent(SPECIAL__CHAR__STRING), byte[].class);
         TestEvent deserialized = testSubject.deserialize(serialized);
         assertEquals(SPECIAL__CHAR__STRING, deserialized.getName());
     }
 
     @Test
-    void testUnknownPropertiesAreIgnoredWhenConfiguringLenientDeserialization() {
+    void unknownPropertiesAreIgnoredWhenConfiguringLenientDeserialization() {
         testSubject = XStreamSerializer.builder()
                                        .xStream(new XStream())
                                        .lenientDeserialization()
@@ -231,7 +231,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testUnknownPropertiesFailDeserializationByDefault() {
+    void unknownPropertiesFailDeserializationByDefault() {
         testSubject = XStreamSerializer.builder()
                                        .xStream(new XStream())
                                        .build();
@@ -247,7 +247,7 @@ class XStreamSerializerTest {
     }
 
     @Test
-    void testDisableAxonTypeSecurity() {
+    void disableAxonTypeSecurity() {
         XStream xStream = mock(XStream.class);
 
         XStreamSerializer.builder()

--- a/messaging/src/test/java/org/axonframework/serialization/xml/XomToStringConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/XomToStringConverterTest.java
@@ -36,13 +36,13 @@ class XomToStringConverterTest {
     }
 
     @Test
-    void testCanConvert() {
+    void canConvert() {
         assertEquals(Document.class, testSubject.expectedSourceType());
         assertEquals(String.class, testSubject.targetType());
     }
 
     @Test
-    void testConvert() {
+    void convert() {
         Document doc = new Document(new Element("rootElement"));
 
         String actual = testSubject.convert(doc);

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CapacityMonitorTest {
 
     @Test
-    void testCapacityWithoutTags() {
+    void capacityWithoutTags() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1",
@@ -62,7 +62,7 @@ class CapacityMonitorTest {
     }
 
     @Test
-    void testCapacityWithPayloadTypeAsCustomTag() {
+    void capacityWithPayloadTypeAsCustomTag() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1",
@@ -94,7 +94,7 @@ class CapacityMonitorTest {
     }
 
     @Test
-    void testCapacityWithMetadataAsCustomTag() {
+    void capacityWithMetadataAsCustomTag() {
         MockClock testClock = new MockClock();
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         CapacityMonitor testSubject = CapacityMonitor.buildMonitor("1",

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/EventProcessorLatencyMonitorTest.java
@@ -54,7 +54,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testMessagesWithoutTags() {
+    void messagesWithoutTags() {
         EventProcessorLatencyMonitor testSubject = testSubjectBuilder.build();
 
         //noinspection unchecked
@@ -76,7 +76,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testMessagesWithPayloadAsCustomTag() {
+    void messagesWithPayloadAsCustomTag() {
         EventProcessorLatencyMonitor testSubject = testSubjectBuilder.tagsBuilder(
                 message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName())
         ).build();
@@ -104,7 +104,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testFailureMessageWithPayloadAsCustomTag() {
+    void failureMessageWithPayloadAsCustomTag() {
         EventProcessorLatencyMonitor testSubject = testSubjectBuilder.tagsBuilder(
                 message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName())
         ).build();
@@ -128,45 +128,45 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testBuildWithNullMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithNullMeterNamePrefixThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject = EventProcessorLatencyMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(null));
     }
 
     @Test
-    void testBuildWithEmptyMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithEmptyMeterNamePrefixThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject = EventProcessorLatencyMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(""));
     }
 
     @Test
-    void testBuildWithoutMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithoutMeterNamePrefixThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject =
                 EventProcessorLatencyMonitor.builder().meterRegistry(meterRegistry);
         assertThrows(AxonConfigurationException.class, testSubject::build);
     }
 
     @Test
-    void testBuildWithNullMeterRegistryThrowsAxonConfigurationException() {
+    void buildWithNullMeterRegistryThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject = EventProcessorLatencyMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterRegistry(null));
     }
 
     @Test
-    void testBuildWithoutMeterRegistryThrowsAxonConfigurationException() {
+    void buildWithoutMeterRegistryThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject =
                 EventProcessorLatencyMonitor.builder().meterNamePrefix(METER_NAME_PREFIX);
         assertThrows(AxonConfigurationException.class, testSubject::build);
     }
 
     @Test
-    void testBuildWithNullClockThrowsAxonConfigurationException() {
+    void buildWithNullClockThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject = EventProcessorLatencyMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.clock(null));
     }
 
     @Test
-    void testBuildWithNullTagsBuilderThrowsAxonConfigurationException() {
+    void buildWithNullTagsBuilderThrowsAxonConfigurationException() {
         EventProcessorLatencyMonitor.Builder testSubject = EventProcessorLatencyMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.tagsBuilder(null));
     }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
@@ -40,7 +40,7 @@ class MessageCountingMonitorTest {
     private static final String PROCESSOR_NAME = "processorName";
 
     @Test
-    void testMessagesWithoutTags() {
+    void messagesWithoutTags() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         MessageCountingMonitor testSubject = MessageCountingMonitor.buildMonitor(PROCESSOR_NAME,
                                                                                  meterRegistry);
@@ -67,7 +67,7 @@ class MessageCountingMonitorTest {
     }
 
     @Test
-    void testMessagesWithPayloadTypeAsCustomTag() {
+    void messagesWithPayloadTypeAsCustomTag() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         MessageCountingMonitor testSubject = MessageCountingMonitor.buildMonitor(PROCESSOR_NAME,
                                                                                  meterRegistry,
@@ -138,7 +138,7 @@ class MessageCountingMonitorTest {
     }
 
     @Test
-    void testMessagesWithMetadataAsCustomTag() {
+    void messagesWithMetadataAsCustomTag() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         MessageCountingMonitor testSubject = MessageCountingMonitor.buildMonitor(PROCESSOR_NAME,
                                                                                  meterRegistry,

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
@@ -64,7 +64,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testMessagesWithoutTags() {
+    void messagesWithoutTags() {
         MessageTimerMonitor testSubject = testSubjectBuilder.build();
 
         EventMessage<Object> foo = asEventMessage(1);
@@ -91,7 +91,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testMessagesWithPayloadTypeAsCustomTag() {
+    void messagesWithPayloadTypeAsCustomTag() {
         MessageTimerMonitor testSubject = testSubjectBuilder.tagsBuilder(
                 message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName())
         ).build();
@@ -144,7 +144,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testMessagesWithMetadataAsCustomTag() {
+    void messagesWithMetadataAsCustomTag() {
         MessageTimerMonitor testSubject = testSubjectBuilder.tagsBuilder(
                 message -> Tags.of("myMetaData", message.getMetaData().get("myMetadataKey").toString())
         ).build();
@@ -200,7 +200,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testTimeCustomization() {
+    void timeCustomization() {
         MessageTimerMonitor customTimerTestSubject =
                 testSubjectBuilder.timerCustomization(
                         timerBuilder -> timerBuilder.publishPercentiles(0.5, 0.75, 0.95)
@@ -233,51 +233,51 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testBuildWithNullMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithNullMeterNamePrefixThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(null));
     }
 
     @Test
-    void testBuildWithEmptyMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithEmptyMeterNamePrefixThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterNamePrefix(""));
     }
 
     @Test
-    void testBuildWithoutMeterNamePrefixThrowsAxonConfigurationException() {
+    void buildWithoutMeterNamePrefixThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder()
                                                                      .meterRegistry(meterRegistry);
         assertThrows(AxonConfigurationException.class, testSubject::build);
     }
 
     @Test
-    void testBuildWithNullMeterRegistryThrowsAxonConfigurationException() {
+    void buildWithNullMeterRegistryThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.meterRegistry(null));
     }
 
     @Test
-    void testBuildWithoutMeterRegistryThrowsAxonConfigurationException() {
+    void buildWithoutMeterRegistryThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder()
                                                                      .meterNamePrefix(METER_NAME_PREFIX);
         assertThrows(AxonConfigurationException.class, testSubject::build);
     }
 
     @Test
-    void testBuildWithNullClockThrowsAxonConfigurationException() {
+    void buildWithNullClockThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.clock(null));
     }
 
     @Test
-    void testBuildWithNullTagsBuilderThrowsAxonConfigurationException() {
+    void buildWithNullTagsBuilderThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.tagsBuilder(null));
     }
 
     @Test
-    void testBuildWithNullTimerCustomizationThrowsAxonConfigurationException() {
+    void buildWithNullTimerCustomizationThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.timerCustomization(null));
     }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MetricsConfigurerModuleTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MetricsConfigurerModuleTest.java
@@ -33,7 +33,7 @@ class MetricsConfigurerModuleTest {
     }
 
     @Test
-    void testConfigureModuleCallsGlobalMetricRegistry() {
+    void configureModuleCallsGlobalMetricRegistry() {
         Configurer configurerMock = mock(Configurer.class);
 
         metricsConfigurerModule.configureModule(configurerMock);

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapperTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/PayloadTypeMessageMonitorWrapperTest.java
@@ -50,7 +50,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>>>
     }
 
     @Test
-    void testInstantiateMessageMonitorOfTypeMonitorOnMessageIngested() throws Exception {
+    void instantiateMessageMonitorOfTypeMonitorOnMessageIngested() throws Exception {
         Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
         payloadTypeMonitorsField.setAccessible(true);
 
@@ -68,7 +68,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>>>
     }
 
     @Test
-    void testInstantiatesOneMessageMonitorPerIngestedPayloadType() throws Exception {
+    void instantiatesOneMessageMonitorPerIngestedPayloadType() throws Exception {
         Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
         payloadTypeMonitorsField.setAccessible(true);
 
@@ -95,7 +95,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>>>
     }
 
     @Test
-    void testMonitorNameFollowsGivenMonitorNameBuilderSpecifics() {
+    void monitorNameFollowsGivenMonitorNameBuilderSpecifics() {
         String testPrefix = "additional-monitor-name.";
         PayloadTypeMessageMonitorWrapper<CapacityMonitor> testSubject = new PayloadTypeMessageMonitorWrapper<>(
                 name -> CapacityMonitor.buildMonitor(name, meterRegistry),

--- a/metrics/src/test/java/org/axonframework/metrics/CapacityMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/CapacityMonitorTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CapacityMonitorTest {
 
     @Test
-    void testSingleThreadedCapacity() {
+    void singleThreadedCapacity() {
         TestClock testClock = new TestClock();
         CapacityMonitor testSubject = new CapacityMonitor(1, TimeUnit.SECONDS, testClock);
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
@@ -47,7 +47,7 @@ class CapacityMonitorTest {
     }
 
     @Test
-    void testMultithreadedCapacity() {
+    void multithreadedCapacity() {
         TestClock testClock = new TestClock();
         CapacityMonitor testSubject = new CapacityMonitor(1, TimeUnit.SECONDS, testClock);
         EventMessage<Object> foo = asEventMessage("foo");
@@ -64,7 +64,7 @@ class CapacityMonitorTest {
     }
 
     @Test
-    void testEmptyCapacity() {
+    void emptyCapacity() {
         TestClock testClock = new TestClock();
         CapacityMonitor testSubject = new CapacityMonitor(1, TimeUnit.SECONDS, testClock);
         Map<String, Metric> metricSet = testSubject.getMetrics();

--- a/metrics/src/test/java/org/axonframework/metrics/EventProcessorLatencyMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/EventProcessorLatencyMonitorTest.java
@@ -41,7 +41,7 @@ class EventProcessorLatencyMonitorTest {
     private final Map<String, Metric> metricSet = testSubject.getMetrics();
 
     @Test
-    void testMessages() {
+    void messages() {
         EventMessage<?> firstEventMessage = mock(EventMessage.class);
         when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
 
@@ -61,7 +61,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testFailureMessage() {
+    void failureMessage() {
         EventMessage<?> firstEventMessage = mock(EventMessage.class);
         when(firstEventMessage.getTimestamp()).thenReturn(Instant.ofEpochMilli(0));
 
@@ -81,7 +81,7 @@ class EventProcessorLatencyMonitorTest {
     }
 
     @Test
-    void testNullMessage() {
+    void nullMessage() {
         testSubject.onMessageIngested(null).reportSuccess();
 
         //noinspection unchecked

--- a/metrics/src/test/java/org/axonframework/metrics/MessageCountingMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MessageCountingMonitorTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MessageCountingMonitorTest {
 
     @Test
-    void testMessages(){
+    void messages(){
         MessageCountingMonitor testSubject = new MessageCountingMonitor();
         EventMessage<Object> foo = asEventMessage("foo");
         EventMessage<Object> bar = asEventMessage("bar");

--- a/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MessageTimerMonitorTest.java
@@ -47,7 +47,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testSuccessMessage() {
+    void successMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportSuccess();
@@ -66,7 +66,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testFailureMessage() {
+    void failureMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportFailure(null);
@@ -85,7 +85,7 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testIgnoredMessage() {
+    void ignoredMessage() {
         MessageMonitor.MonitorCallback monitorCallback = testSubject.onMessageIngested(null);
         testClock.increase(1000);
         monitorCallback.reportIgnored();
@@ -109,7 +109,7 @@ class MessageTimerMonitorTest {
      * in {@link #testSuccessMessage()}.
      */
     @Test
-    void testCustomReservoir() {
+    void customReservoir() {
         MessageTimerMonitor customReservoirTestSubject =
                 MessageTimerMonitor.builder()
                                    .clock(testClock)
@@ -133,13 +133,13 @@ class MessageTimerMonitorTest {
     }
 
     @Test
-    void testBuildWithNullClockThrowsAxonConfigurationException() {
+    void buildWithNullClockThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.clock(null));
     }
 
     @Test
-    void testBuildWithNullReservoirFactoryThrowsAxonConfigurationException() {
+    void buildWithNullReservoirFactoryThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.reservoirFactory(null));
     }

--- a/metrics/src/test/java/org/axonframework/metrics/MetricsConfigurerModuleTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MetricsConfigurerModuleTest.java
@@ -33,7 +33,7 @@ class MetricsConfigurerModuleTest {
     }
 
     @Test
-    void testConfigureModuleCallsGlobalMetricRegistry() {
+    void configureModuleCallsGlobalMetricRegistry() {
         Configurer configurerMock = mock(Configurer.class);
 
         metricsConfigurerModule.configureModule(configurerMock);

--- a/metrics/src/test/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapperTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapperTest.java
@@ -49,7 +49,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>> 
     }
 
     @Test
-    void testInstantiateMessageMonitorOfTypeMonitorOnMessageIngested() throws Exception {
+    void instantiateMessageMonitorOfTypeMonitorOnMessageIngested() throws Exception {
         Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
         payloadTypeMonitorsField.setAccessible(true);
 
@@ -69,7 +69,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>> 
     }
 
     @Test
-    void testInstantiatesOneMessageMonitorPerIngestedPayloadType() throws Exception {
+    void instantiatesOneMessageMonitorPerIngestedPayloadType() throws Exception {
         Field payloadTypeMonitorsField = testSubject.getClass().getDeclaredField("payloadTypeMonitors");
         payloadTypeMonitorsField.setAccessible(true);
 
@@ -98,7 +98,7 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message<?>> 
     }
 
     @Test
-    void testMonitorNameFollowsGivenMonitorNameBuilderSpecifics() {
+    void monitorNameFollowsGivenMonitorNameBuilderSpecifics() {
         String testPrefix = "additional-monitor-name.";
         PayloadTypeMessageMonitorWrapper<CapacityMonitor> testSubject = new PayloadTypeMessageMonitorWrapper<>(
                 CapacityMonitor::new, payloadType -> testPrefix + payloadType.getName());

--- a/modelling/src/test/java/org/axonframework/modelling/command/AbstractRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AbstractRepositoryTest.java
@@ -97,19 +97,19 @@ class AbstractRepositoryTest {
     }
 
     @Test
-    void testAggregateTypeVerification_CorrectType() throws Exception {
+    void aggregateTypeVerification_CorrectType() throws Exception {
         testSubject.newInstance(() -> new JpaAggregate("hi"));
     }
 
     @Test
-    void testAggregateTypeVerification_SubclassesAreAllowed() throws Exception {
+    void aggregateTypeVerification_SubclassesAreAllowed() throws Exception {
         testSubject.newInstance(() -> new JpaAggregate("hi") {
             // anonymous subclass
         });
     }
 
     @Test
-    void testAggregateTypeVerification_WrongType() {
+    void aggregateTypeVerification_WrongType() {
         //noinspection rawtypes
         AbstractRepository anonymousTestSubject =
                 new AbstractRepository<JpaAggregate, AnnotatedAggregate<JpaAggregate>>(
@@ -143,24 +143,24 @@ class AbstractRepositoryTest {
     }
 
     @Test
-    void testCanResolveReturnsTrueForMatchingAggregateDescriptor() {
+    void canResolveReturnsTrueForMatchingAggregateDescriptor() {
         assertTrue(testSubject.canResolve(new AggregateScopeDescriptor(
                 JpaAggregate.class.getSimpleName(), AGGREGATE_ID)
         ));
     }
 
     @Test
-    void testCanResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
+    void canResolveReturnsFalseNonAggregateScopeDescriptorImplementation() {
         assertFalse(testSubject.canResolve(new SagaScopeDescriptor("some-saga-type", AGGREGATE_ID)));
     }
 
     @Test
-    void testCanResolveReturnsFalseForNonMatchingAggregateType() {
+    void canResolveReturnsFalseForNonMatchingAggregateType() {
         assertFalse(testSubject.canResolve(new AggregateScopeDescriptor("other-non-matching-type", AGGREGATE_ID)));
     }
 
     @Test
-    void testSendWorksAsExpected() throws Exception {
+    void sendWorksAsExpected() throws Exception {
         DeadlineMessage<String> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", "payload", Instant.now());
         AggregateScopeDescriptor testDescriptor =
@@ -172,7 +172,7 @@ class AbstractRepositoryTest {
     }
 
     @Test
-    void testSendThrowsIllegalArgumentExceptionIfHandleFails() throws Exception {
+    void sendThrowsIllegalArgumentExceptionIfHandleFails() throws Exception {
         AggregateScopeDescriptor testDescriptor =
                 new AggregateScopeDescriptor(JpaAggregate.class.getSimpleName(), AGGREGATE_ID);
 
@@ -184,7 +184,7 @@ class AbstractRepositoryTest {
     }
 
     @Test
-    void testSendFailsSilentlyOnAggregateNotFoundException() throws Exception {
+    void sendFailsSilentlyOnAggregateNotFoundException() throws Exception {
         DeadlineMessage<String> testMsg =
                 GenericDeadlineMessage.asDeadlineMessage("deadline-name", "payload", Instant.now());
         AggregateScopeDescriptor testDescriptor =
@@ -196,7 +196,7 @@ class AbstractRepositoryTest {
     }
 
     @Test
-    void testCheckedExceptionFromConstructorDoesNotAttemptToStoreAggregate() {
+    void checkedExceptionFromConstructorDoesNotAttemptToStoreAggregate() {
         // committing the unit of work does not throw an exception
         UnitOfWork<?> uow = CurrentUnitOfWork.get();
         uow.executeWithResult(() -> testSubject.newInstance(() -> {

--- a/modelling/src/test/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandlerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandlerTest.java
@@ -116,7 +116,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testAggregateConstructorThrowsException() {
+    void aggregateConstructorThrowsException() {
         commandBus.dispatch(asCommandMessage(new FailingCreateCommand("id", "parameter")),
                             (CommandCallback<FailingCreateCommand, Object>) (commandMessage, commandResultMessage) -> {
                                 if (commandResultMessage.isExceptional()) {
@@ -128,7 +128,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testAggregateCommandHandlerThrowsException() {
+    void aggregateCommandHandlerThrowsException() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(eq(aggregateIdentifier), any()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -144,7 +144,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testSupportedCommands() {
+    void supportedCommands() {
         Set<String> actual = testSubject.supportedCommandNames();
         Set<String> expected = new HashSet<>(Arrays.asList(
                 CreateCommand.class.getName(),
@@ -169,7 +169,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerSubscribesToCommands() {
+    void commandHandlerSubscribesToCommands() {
         verify(commandBus).subscribe(eq(CreateCommand.class.getName()),
                                      any(MessageHandler.class));
         // Is subscribed two times because of the duplicate handler. This is good and indicates usage of the
@@ -179,7 +179,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerCreatesAggregateInstance() throws Exception {
+    void commandHandlerCreatesAggregateInstance() throws Exception {
         final CommandCallback<Object, Object> callback = spy(LoggingCallback.INSTANCE);
         final CommandMessage<Object> message = asCommandMessage(new CreateCommand("id", "Hi"));
         commandBus.dispatch(message, callback);
@@ -194,7 +194,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    public void testCommandHandlerCreatesOrUpdatesAggregateInstance() throws Exception {
+    public void commandHandlerCreatesOrUpdatesAggregateInstance() throws Exception {
         final CommandCallback<Object, Object> callback = spy(LoggingCallback.INSTANCE);
         final CommandMessage<Object> message = asCommandMessage(new CreateOrUpdateCommand("id", "Hi"));
 
@@ -214,7 +214,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    public void testCommandHandlerAlwaysCreatesAggregateInstance() throws Exception {
+    public void commandHandlerAlwaysCreatesAggregateInstance() throws Exception {
         final CommandCallback<Object, Object> callback = spy(LoggingCallback.INSTANCE);
         final CommandMessage<Object> message = asCommandMessage(new AlwaysCreateCommand("id", "Hi"));
 
@@ -229,7 +229,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerCreatesAggregateInstanceWithFactoryMethod() throws Exception {
+    void commandHandlerCreatesAggregateInstanceWithFactoryMethod() throws Exception {
         final CommandCallback<Object, Object> callback = spy(LoggingCallback.INSTANCE);
         final CommandMessage<Object> message = asCommandMessage(new CreateFactoryMethodCommand("id", "Hi"));
         commandBus.dispatch(message, callback);
@@ -244,7 +244,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceAnnotatedMethod() {
+    void commandHandlerUpdatesAggregateInstanceAnnotatedMethod() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), any()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -263,7 +263,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedMethod() {
+    void commandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedMethod() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), anyLong()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -292,7 +292,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceWithNullVersionAnnotatedMethod() {
+    void commandHandlerUpdatesAggregateInstanceWithNullVersionAnnotatedMethod() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), any()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -312,7 +312,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceAnnotatedField() {
+    void commandHandlerUpdatesAggregateInstanceAnnotatedField() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), any()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -331,7 +331,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedField() {
+    void commandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedField() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), anyLong()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -351,7 +351,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedIntegerField() {
+    void commandHandlerUpdatesAggregateInstanceWithCorrectVersionAnnotatedIntegerField() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), anyLong()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -372,7 +372,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandForEntityRejectedWhenNoInstanceIsAvailable() {
+    void commandForEntityRejectedWhenNoInstanceIsAvailable() {
         String aggregateIdentifier = "abc123";
         when(mockRepository.load(any(String.class), any()))
                 .thenAnswer(i -> createAggregate(aggregateIdentifier));
@@ -394,7 +394,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntity() {
+    void commandHandledByEntity() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate aggregate = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         aggregate.initializeEntity("1");
@@ -416,7 +416,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromCollection() {
+    void commandHandledByEntityFromCollection() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -439,7 +439,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromCollectionNoEntityAvailable() {
+    void commandHandledByEntityFromCollectionNoEntityAvailable() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -460,7 +460,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromCollectionNullIdInCommand() {
+    void commandHandledByEntityFromCollectionNullIdInCommand() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -481,7 +481,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByNestedEntity() {
+    void commandHandledByNestedEntity() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -503,7 +503,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testAnnotatedCollectionFieldMustContainGenericParameterWhenTypeIsNotExplicitlyDefined(
+    void annotatedCollectionFieldMustContainGenericParameterWhenTypeIsNotExplicitlyDefined(
             @Mock Repository<CollectionFieldWithoutGenerics> mockRepo) {
         AggregateAnnotationCommandHandler.Builder<CollectionFieldWithoutGenerics> repoBuilder = AggregateAnnotationCommandHandler.<CollectionFieldWithoutGenerics>builder()
                 .aggregateType(CollectionFieldWithoutGenerics.class)
@@ -513,7 +513,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromMap() {
+    void commandHandledByEntityFromMap() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -536,7 +536,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromMapNoEntityAvailable() {
+    void commandHandledByEntityFromMapNoEntityAvailable() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -557,7 +557,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandledByEntityFromMapNullIdInCommand() {
+    void commandHandledByEntityFromMapNullIdInCommand() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -577,7 +577,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testUsesDuplicateCommandHandlerResolver() {
+    void usesDuplicateCommandHandlerResolver() {
         commandBus = SimpleCommandBus.builder()
                                      .duplicateCommandHandlerResolver(rejectDuplicates())
                                      .build();
@@ -594,7 +594,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerByAbstractEntityWithTheSameCommandType() {
+    void commandHandlerByAbstractEntityWithTheSameCommandType() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -615,7 +615,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testCommandHandlerByAbstractEntityWithNoAvailableEntity() {
+    void commandHandlerByAbstractEntityWithNoAvailableEntity() {
         String aggregateIdentifier = "abc123";
         final StubCommandAnnotatedAggregate root = new StubCommandAnnotatedAggregate(aggregateIdentifier);
         root.initializeEntity("1");
@@ -634,7 +634,7 @@ class AggregateAnnotationCommandHandlerTest {
     }
 
     @Test
-    void testDuplicateCommandHandlerSubscriptionExceptionIsNotThrownForPolymorphicAggregateWithRootCommandHandler() {
+    void duplicateCommandHandlerSubscriptionExceptionIsNotThrownForPolymorphicAggregateWithRootCommandHandler() {
         commandBus = SimpleCommandBus.builder()
                                      .duplicateCommandHandlerResolver(rejectDuplicates())
                                      .build();

--- a/modelling/src/test/java/org/axonframework/modelling/command/AggregateScopeDescriptorSerializationTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AggregateScopeDescriptorSerializationTest.java
@@ -51,7 +51,7 @@ class AggregateScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testJavaSerializationCorrectlySetsIdentifierField() throws Exception {
+    void javaSerializationCorrectlySetsIdentifierField() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream objectOutputStream = new ObjectOutputStream(out);
         objectOutputStream.writeObject(testSubject);
@@ -66,7 +66,7 @@ class AggregateScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testXStreamSerializationWorksAsExpected() {
+    void xStreamSerializationWorksAsExpected() {
         XStreamSerializer xStreamSerializer = TestSerializer.xStreamSerializer();
         xStreamSerializer.getXStream().setClassLoader(this.getClass().getClassLoader());
 
@@ -79,7 +79,7 @@ class AggregateScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testJacksonSerializationWorksAsExpected() {
+    void jacksonSerializationWorksAsExpected() {
         JacksonSerializer jacksonSerializer = JacksonSerializer.defaultSerializer();
 
 
@@ -91,7 +91,7 @@ class AggregateScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testResponseTypeShouldBeSerializableWithJacksonUsingConstructorProperties() {
+    void responseTypeShouldBeSerializableWithJacksonUsingConstructorProperties() {
         ObjectMapper objectMapper = OnlyAcceptConstructorPropertiesAnnotation.attachTo(new ObjectMapper());
         JacksonSerializer jacksonSerializer = JacksonSerializer.builder().objectMapper(objectMapper).build();
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
@@ -79,7 +79,7 @@ public class AnnotatedAggregateTest {
     }
 
     @Test
-    void testApplyingEventInHandlerPublishesInRightOrder() {
+    void applyingEventInHandlerPublishesInRightOrder() {
         Command command = new Command(ID, 0);
         DefaultUnitOfWork<CommandMessage<Object>> uow = DefaultUnitOfWork.startAndGet(asCommandMessage(command));
         Aggregate<AggregateRoot> aggregate = uow.executeWithResult(() -> repository
@@ -95,7 +95,7 @@ public class AnnotatedAggregateTest {
 
     // Test for issue #1506 - https://github.com/AxonFramework/AxonFramework/issues/1506
     @Test
-    void testLastSequenceReturnsNullIfNoEventsHaveBeenPublishedYet() {
+    void lastSequenceReturnsNullIfNoEventsHaveBeenPublishedYet() {
         final Command command = new Command(ID, 0);
         DefaultUnitOfWork<CommandMessage<Object>> uow = DefaultUnitOfWork.startAndGet(asCommandMessage(command));
         AnnotatedAggregate<AggregateRoot> testSubject =
@@ -107,7 +107,7 @@ public class AnnotatedAggregateTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testConditionalApplyingEventInHandlerPublishesInRightOrder(boolean applyConditional) {
+    void conditionalApplyingEventInHandlerPublishesInRightOrder(boolean applyConditional) {
         Command_2 command = new Command_2(ID, 0, applyConditional);
         DefaultUnitOfWork<CommandMessage<Object>> uow = DefaultUnitOfWork.startAndGet(asCommandMessage(command));
         Aggregate<AggregateRoot> aggregate = uow.executeWithResult(() -> repository

--- a/modelling/src/test/java/org/axonframework/modelling/command/AnnotationCommandTargetResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AnnotationCommandTargetResolverTest.java
@@ -45,12 +45,12 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_CommandWithoutAnnotations() {
+    void resolveTarget_CommandWithoutAnnotations() {
         assertThrows(IllegalArgumentException.class, () -> testSubject.resolveTarget(asCommandMessage("That won't work")));
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedMethod() {
+    void resolveTarget_WithAnnotatedMethod() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(asCommandMessage(new Object() {
             @TargetAggregateIdentifier
@@ -64,7 +64,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedMethodAndVersion() {
+    void resolveTarget_WithAnnotatedMethodAndVersion() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(asCommandMessage(new Object() {
             @TargetAggregateIdentifier
@@ -83,7 +83,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedMethodAndStringVersion() {
+    void resolveTarget_WithAnnotatedMethodAndStringVersion() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(asCommandMessage(new Object() {
             @TargetAggregateIdentifier
@@ -102,7 +102,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedMethodAndVoidIdentifier() {
+    void resolveTarget_WithAnnotatedMethodAndVoidIdentifier() {
         CommandMessage<Object> command = asCommandMessage(new Object() {
             @TargetAggregateIdentifier
             private void getIdentifier() {
@@ -112,7 +112,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedFields() {
+    void resolveTarget_WithAnnotatedFields() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         final Object version = 1L;
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(
@@ -122,7 +122,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedFields_StringIdentifier() {
+    void resolveTarget_WithAnnotatedFields_StringIdentifier() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         final Object version = 1L;
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(
@@ -132,7 +132,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedFields_ObjectIdentifier() {
+    void resolveTarget_WithAnnotatedFields_ObjectIdentifier() {
         final Object aggregateIdentifier = new Object();
         final Object version = 1L;
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(
@@ -142,7 +142,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedFields_ParsableVersion() {
+    void resolveTarget_WithAnnotatedFields_ParsableVersion() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         final Object version = "1";
         VersionedAggregateIdentifier actual = testSubject.resolveTarget(
@@ -152,7 +152,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
     @Test
-    void testResolveTarget_WithAnnotatedFields_NonNumericVersion() {
+    void resolveTarget_WithAnnotatedFields_NonNumericVersion() {
         final UUID aggregateIdentifier = UUID.randomUUID();
         final Object version = "abc";
         CommandMessage<Object> command = asCommandMessage(new FieldAnnotatedCommand(aggregateIdentifier, version));
@@ -160,7 +160,7 @@ class AnnotationCommandTargetResolverTest {
     }
 
 	@Test
-    void testMetaAnnotationsOnMethods() {
+    void metaAnnotationsOnMethods() {
 		final UUID aggregateIdentifier = UUID.randomUUID();
 		final Long version = Long.valueOf(98765432109L);
 
@@ -180,7 +180,7 @@ class AnnotationCommandTargetResolverTest {
 	}
 
 	@Test
-    void testMetaAnnotationsOnFields() {
+    void metaAnnotationsOnFields() {
 		final UUID aggregateIdentifier = UUID.randomUUID();
 		final Long version = Long.valueOf(98765432109L);
 
@@ -192,7 +192,7 @@ class AnnotationCommandTargetResolverTest {
 	}
 
 	@Test
-    void testCustomAnnotationsOnMethods() {
+    void customAnnotationsOnMethods() {
 		testSubject = AnnotationCommandTargetResolver.builder()
                 .targetAggregateIdentifierAnnotation(CustomTargetAggregateIdentifier.class)
                 .targetAggregateVersionAnnotation(CustomTargetAggregateVersion.class)
@@ -217,7 +217,7 @@ class AnnotationCommandTargetResolverTest {
 	}
 
 	@Test
-    void testCustomAnnotationsOnFields() {
+    void customAnnotationsOnFields() {
 		testSubject = AnnotationCommandTargetResolver.builder()
                 .targetAggregateIdentifierAnnotation(CustomTargetAggregateIdentifier.class)
                 .targetAggregateVersionAnnotation(CustomTargetAggregateVersion.class)

--- a/modelling/src/test/java/org/axonframework/modelling/command/EntityEventForwardingModelInspectorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/EntityEventForwardingModelInspectorTest.java
@@ -37,7 +37,7 @@ class EntityEventForwardingModelInspectorTest {
     private static final String ANOTHER_ENTITY_ID = "anotherEntityId";
 
     @Test
-    void testExpectEventsToBeRoutedToNoEntityForForwardModeSetToNone() {
+    void expectEventsToBeRoutedToNoEntityForForwardModeSetToNone() {
         AggregateModel<SomeNoneEventForwardingEntityAggregate> inspector =
                 inspectAggregate(SomeNoneEventForwardingEntityAggregate.class);
 
@@ -54,7 +54,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnly() {
+    void expectEventsToBeRoutedToRightEntityOnly() {
         AggregateModel<SomeEventForwardingEntityAggregate> inspector =
                 inspectAggregate(SomeEventForwardingEntityAggregate.class);
 
@@ -72,7 +72,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyViaMethod() {
+    void expectEventsToBeRoutedToRightEntityOnlyViaMethod() {
         AggregateModel<SomeGetterEventForwardingEntityAggregate> inspector =
                 inspectAggregate(SomeGetterEventForwardingEntityAggregate.class);
 
@@ -90,7 +90,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyWithSpecificRoutingKey() {
+    void expectEventsToBeRoutedToRightEntityOnlyWithSpecificRoutingKey() {
         AggregateModel<SomeEventForwardingEntityAggregateWithSpecificEventRoutingKey> inspector =
                 inspectAggregate(SomeEventForwardingEntityAggregateWithSpecificEventRoutingKey.class);
 
@@ -109,7 +109,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyWithSpecificRoutingKeyViaMethod() {
+    void expectEventsToBeRoutedToRightEntityOnlyWithSpecificRoutingKeyViaMethod() {
         AggregateModel<SomeGetterEventForwardingEntityAggregateWithSpecificEventRoutingKey> inspector =
                 inspectAggregate(SomeGetterEventForwardingEntityAggregateWithSpecificEventRoutingKey.class);
 
@@ -128,7 +128,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyForEntityCollection() {
+    void expectEventsToBeRoutedToRightEntityOnlyForEntityCollection() {
         AggregateModel<SomeEventForwardingEntityCollectionAggregate> inspector =
                 inspectAggregate(SomeEventForwardingEntityCollectionAggregate.class);
 
@@ -148,7 +148,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyForEntityCollectionViaMethod() {
+    void expectEventsToBeRoutedToRightEntityOnlyForEntityCollectionViaMethod() {
         AggregateModel<SomeGetterEventForwardingEntityCollectionAggregate> inspector =
                 inspectAggregate(SomeGetterEventForwardingEntityCollectionAggregate.class);
 
@@ -168,7 +168,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyForEntityMap() {
+    void expectEventsToBeRoutedToRightEntityOnlyForEntityMap() {
         AggregateModel<SomeEventForwardingEntityMapAggregate> inspector =
                 inspectAggregate(SomeEventForwardingEntityMapAggregate.class);
 
@@ -188,7 +188,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyForEntityMapViaMethod() {
+    void expectEventsToBeRoutedToRightEntityOnlyForEntityMapViaMethod() {
         AggregateModel<SomeGetterEventForwardingEntityMapAggregate> inspector =
                 inspectAggregate(SomeGetterEventForwardingEntityMapAggregate.class);
 
@@ -208,7 +208,7 @@ class EntityEventForwardingModelInspectorTest {
     }
 
     @Test
-    void testExpectEventsToBeRoutedToRightEntityOnlyWithMultipleEntities() {
+    void expectEventsToBeRoutedToRightEntityOnlyWithMultipleEntities() {
         AggregateModel<SomeMixedEventForwardingEntityAggregate> inspector =
                 inspectAggregate(SomeMixedEventForwardingEntityAggregate.class);
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -88,7 +88,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testAggregateStoredBeforeEventsPublished() throws Exception {
+    void aggregateStoredBeforeEventsPublished() throws Exception {
         //noinspection unchecked
         Consumer<List<? extends EventMessage<?>>> mockConsumer = mock(Consumer.class);
         eventBus.subscribe(mockConsumer);
@@ -102,20 +102,20 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testLoadAggregate() {
+    void loadAggregate() {
         Aggregate<StubJpaAggregate> actualResult = testSubject.load(aggregateId);
         assertSame(aggregate, actualResult.invoke(Function.identity()));
     }
 
     @Test
-    void testLoadAggregateWithConverter() {
+    void loadAggregateWithConverter() {
         when(identifierConverter.apply("original")).thenAnswer(new Returns(aggregateId));
         Aggregate<StubJpaAggregate> actualResult = testSubject.load("original");
         assertSame(aggregate, actualResult.invoke(Function.identity()));
     }
 
     @Test
-    void testAggregateCreatesSequenceNumbersForNewAggregatesWhenUsingDomainEventSequenceAwareEventBus() {
+    void aggregateCreatesSequenceNumbersForNewAggregatesWhenUsingDomainEventSequenceAwareEventBus() {
         DomainSequenceAwareEventBus testEventBus = new DomainSequenceAwareEventBus();
 
         testSubject = GenericJpaRepository.builder(StubJpaAggregate.class)
@@ -158,7 +158,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testAggregateDoesNotCreateSequenceNumbersWhenEventBusIsNotDomainEventSequenceAware() {
+    void aggregateDoesNotCreateSequenceNumbersWhenEventBusIsNotDomainEventSequenceAware() {
         SimpleEventBus testEventBus = spy(SimpleEventBus.builder().build());
 
         testSubject = GenericJpaRepository.builder(StubJpaAggregate.class)
@@ -189,7 +189,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testLoadAggregate_NotFound() {
+    void loadAggregate_NotFound() {
         String aggregateIdentifier = UUID.randomUUID().toString();
         try {
             testSubject.load(aggregateIdentifier);
@@ -200,7 +200,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testLoadAggregate_WrongVersion() {
+    void loadAggregate_WrongVersion() {
         try {
             testSubject.load(aggregateId, 2L);
             fail("Expected ConflictingAggregateVersionException");
@@ -211,14 +211,14 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testPersistAggregate_DefaultFlushMode() {
+    void persistAggregate_DefaultFlushMode() {
         testSubject.doSave(testSubject.load(aggregateId));
         verify(mockEntityManager).persist(aggregate);
         verify(mockEntityManager).flush();
     }
 
     @Test
-    void testPersistAggregate_ExplicitFlushModeOn() {
+    void persistAggregate_ExplicitFlushModeOn() {
         testSubject.setForceFlushOnSave(true);
         testSubject.doSave(testSubject.load(aggregateId));
         verify(mockEntityManager).persist(aggregate);
@@ -226,7 +226,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testPersistAggregate_ExplicitFlushModeOff() {
+    void persistAggregate_ExplicitFlushModeOff() {
         testSubject.setForceFlushOnSave(false);
         testSubject.doSave(testSubject.load(aggregateId));
         verify(mockEntityManager).persist(aggregate);
@@ -234,7 +234,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testBuildWithNullSubtypesThrowsAxonConfigurationException() {
+    void buildWithNullSubtypesThrowsAxonConfigurationException() {
         GenericJpaRepository.Builder<StubJpaAggregate> builderTestSubject =
                 GenericJpaRepository.builder(StubJpaAggregate.class)
                                     .entityManagerProvider(new SimpleEntityManagerProvider(mockEntityManager))
@@ -244,7 +244,7 @@ class GenericJpaRepositoryTest {
     }
 
     @Test
-    void testBuildWithNullSubtypeThrowsAxonConfigurationException() {
+    void buildWithNullSubtypeThrowsAxonConfigurationException() {
         GenericJpaRepository.Builder<StubJpaAggregate> builderTestSubject =
                 GenericJpaRepository.builder(StubJpaAggregate.class)
                                     .entityManagerProvider(new SimpleEntityManagerProvider(mockEntityManager))

--- a/modelling/src/test/java/org/axonframework/modelling/command/LockAwareAggregateTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/LockAwareAggregateTest.java
@@ -48,40 +48,40 @@ class LockAwareAggregateTest {
             new LockAwareAggregate<>(mockAggregate, lockSupplier);
 
     @Test
-    void testGetWrappedAggregate() {
+    void getWrappedAggregate() {
         assertEquals(mockAggregate, testSubject.getWrappedAggregate());
     }
 
     @Test
-    void testIsLockHeld() {
+    void isLockHeld() {
         when(mockLock.isHeld()).thenReturn(true);
 
         assertTrue(testSubject.isLockHeld());
     }
 
     @Test
-    void testTypeMethodInvokesWrappedAggregate() {
+    void typeMethodInvokesWrappedAggregate() {
         testSubject.type();
 
         verify(mockAggregate).type();
     }
 
     @Test
-    void testIdentifierMethodInvokesWrappedAggregate() {
+    void identifierMethodInvokesWrappedAggregate() {
         testSubject.identifier();
 
         verify(mockAggregate).identifier();
     }
 
     @Test
-    void testVersionMethodInvokesWrappedAggregate() {
+    void versionMethodInvokesWrappedAggregate() {
         testSubject.version();
 
         verify(mockAggregate).version();
     }
 
     @Test
-    void testHandleMethodInvokesWrappedAggregateAndInspectsLock() throws Exception {
+    void handleMethodInvokesWrappedAggregateAndInspectsLock() throws Exception {
         Message<?> testMessage = GenericMessage.asMessage("some-message");
 
         testSubject.handle(testMessage);
@@ -91,7 +91,7 @@ class LockAwareAggregateTest {
     }
 
     @Test
-    void testInvokeMethodInvokesWrappedAggregateAndInspectsLock() {
+    void invokeMethodInvokesWrappedAggregateAndInspectsLock() {
         testSubject.invoke(someField -> "some-return");
 
         verify(mockAggregate).invoke(any());
@@ -99,7 +99,7 @@ class LockAwareAggregateTest {
     }
 
     @Test
-    void testExecuteMethodInvokesWrappedAggregateAndInspectsLock() {
+    void executeMethodInvokesWrappedAggregateAndInspectsLock() {
         testSubject.execute(someField -> {
         });
 
@@ -108,14 +108,14 @@ class LockAwareAggregateTest {
     }
 
     @Test
-    void testIsDeletedMethodInvokesWrappedAggregate() {
+    void isDeletedMethodInvokesWrappedAggregate() {
         testSubject.isDeleted();
 
         verify(mockAggregate).isDeleted();
     }
 
     @Test
-    void testRootTypeMethodInvokesWrappedAggregate() {
+    void rootTypeMethodInvokesWrappedAggregate() {
         testSubject.rootType();
 
         verify(mockAggregate).rootType();

--- a/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
@@ -79,7 +79,7 @@ class LockingRepositoryTest {
     }
 
     @Test
-    void testStoreNewAggregate() throws Exception {
+    void storeNewAggregate() throws Exception {
         startAndGetUnitOfWork();
         StubAggregate aggregate = new StubAggregate();
         testSubject.newInstance(() -> aggregate).execute(StubAggregate::doSomething);
@@ -98,7 +98,7 @@ class LockingRepositoryTest {
      * aggregate with.
      */
     @Test
-    void testStoringAggregateWithoutSettingAggregateIdentifierDoesNotInvokeLockFactory() throws Exception {
+    void storingAggregateWithoutSettingAggregateIdentifierDoesNotInvokeLockFactory() throws Exception {
         UnitOfWork<?> uow = startAndGetUnitOfWork();
         Aggregate<StubAggregate> result = testSubject.newInstance(
                 () -> new StubAggregate(null),
@@ -113,7 +113,7 @@ class LockingRepositoryTest {
     }
 
     @Test
-    void testLoadOrCreateAggregate() {
+    void loadOrCreateAggregate() {
         startAndGetUnitOfWork();
         Aggregate<StubAggregate> createdAggregate = testSubject.loadOrCreate("newAggregate", StubAggregate::new);
         //noinspection resource
@@ -126,7 +126,7 @@ class LockingRepositoryTest {
     }
 
     @Test
-    void testLoadAndStoreAggregate() throws Exception {
+    void loadAndStoreAggregate() throws Exception {
         startAndGetUnitOfWork();
         StubAggregate aggregate = new StubAggregate();
         testSubject.newInstance(() -> aggregate).execute(StubAggregate::doSomething);
@@ -149,7 +149,7 @@ class LockingRepositoryTest {
     }
 
     @Test
-    void testLoadAndStoreAggregate_LockReleasedOnException() throws Exception {
+    void loadAndStoreAggregate_LockReleasedOnException() throws Exception {
         startAndGetUnitOfWork();
         StubAggregate aggregate = new StubAggregate();
 
@@ -180,7 +180,7 @@ class LockingRepositoryTest {
     }
 
     @Test
-    void testLoadAndStoreAggregate_PessimisticLockReleasedOnException() throws Exception {
+    void loadAndStoreAggregate_PessimisticLockReleasedOnException() throws Exception {
         lockFactory = spy(PessimisticLockFactory.usingDefaults());
         testSubject = InMemoryLockingRepository.builder().lockFactory(lockFactory).eventBus(eventBus).build();
         testSubject = spy(testSubject);

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateAggregateMemberMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateAggregateMemberMetaModelFactoryTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnnotatedAggregateAggregateMemberMetaModelFactoryTest {
 
     @Test
-    void testInterfaceAggregateMemberThrowsAxonConfigurationException() {
+    void interfaceAggregateMemberThrowsAxonConfigurationException() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestAggregate.class)
@@ -28,7 +28,7 @@ class AnnotatedAggregateAggregateMemberMetaModelFactoryTest {
     }
 
     @Test
-    void testInterfaceAggregateMemberCollectionThrowsAxonConfigurationException() {
+    void interfaceAggregateMemberCollectionThrowsAxonConfigurationException() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestCollectionAggregate.class)
@@ -36,7 +36,7 @@ class AnnotatedAggregateAggregateMemberMetaModelFactoryTest {
     }
 
     @Test
-    void testInterfaceAggregateMemberMapThrowsAxonConfigurationException() {
+    void interfaceAggregateMemberMapThrowsAxonConfigurationException() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(TestMapAggregate.class)

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
@@ -65,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnnotatedAggregateMetaModelFactoryTest {
 
     @Test
-    void testDetectAllAnnotatedHandlers() throws Exception {
+    void detectAllAnnotatedHandlers() throws Exception {
         AggregateModel<SomeAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeAnnotatedHandlers.class);
 
@@ -75,7 +75,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testDetectAllAnnotatedHandlersInHierarchy() throws Exception {
+    void detectAllAnnotatedHandlersInHierarchy() throws Exception {
         AggregateModel<SomeSubclass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeSubclass.class);
 
@@ -86,7 +86,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testDetectFactoryMethodHandler() {
+    void detectFactoryMethodHandler() {
         AggregateModel<SomeAnnotatedFactoryMethodClass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeAnnotatedFactoryMethodClass.class);
 
@@ -103,7 +103,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
 
 
     @Test
-    void testEventIsPublishedThroughoutRecursiveHierarchy() {
+    void eventIsPublishedThroughoutRecursiveHierarchy() {
         // Note that if the inspector does not support recursive entities this will throw an StackOverflowError.
         AggregateModel<SomeRecursiveEntity> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeRecursiveEntity.class);
@@ -161,22 +161,22 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testLinkedListIsModifiedDuringIterationInRecursiveHierarchy() {
+    void linkedListIsModifiedDuringIterationInRecursiveHierarchy() {
         testCollectionIsModifiedDuringIterationInRecursiveHierarchy(LinkedList::new);
     }
 
     @Test
-    void testHashSetIsModifiedDuringIterationInRecursiveHierarchy() {
+    void hashSetIsModifiedDuringIterationInRecursiveHierarchy() {
         testCollectionIsModifiedDuringIterationInRecursiveHierarchy(HashSet::new);
     }
 
     @Test
-    void testCopyOnWriteArrayListIsModifiedDuringIterationInRecursiveHierarchy() {
+    void copyOnWriteArrayListIsModifiedDuringIterationInRecursiveHierarchy() {
         testCollectionIsModifiedDuringIterationInRecursiveHierarchy(CopyOnWriteArrayList::new);
     }
 
     @Test
-    void testConcurrentLinkedQueueIsModifiedDuringIterationInRecursiveHierarchy() {
+    void concurrentLinkedQueueIsModifiedDuringIterationInRecursiveHierarchy() {
         testCollectionIsModifiedDuringIterationInRecursiveHierarchy(ConcurrentLinkedQueue::new);
     }
 
@@ -219,7 +219,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testEventIsPublishedThroughoutHierarchy() {
+    void eventIsPublishedThroughoutHierarchy() {
         AggregateModel<SomeSubclass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeSubclass.class);
 
@@ -231,7 +231,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testExpectCommandToBeForwardedToEntity() throws Exception {
+    void expectCommandToBeForwardedToEntity() throws Exception {
         AggregateModel<SomeSubclass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeSubclass.class);
 
@@ -242,7 +242,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testMethodIdentifierWithMethodParameters() {
+    void methodIdentifierWithMethodParameters() {
         assertThrows(AggregateModellingException.class,
                      () -> AnnotatedAggregateMetaModelFactory
                              .inspectAggregate(SomeIllegalAnnotatedIdMethodClass.class));
@@ -252,7 +252,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testAggregateIdentifierPriority() {
+    void aggregateIdentifierPriority() {
         AggregateModel<SomeDifferentDoubleIdAnnotatedHandler> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeDifferentDoubleIdAnnotatedHandler.class);
 
@@ -262,7 +262,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindIdentifier() {
+    void findIdentifier() {
         AggregateModel<SomeAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeAnnotatedHandlers.class);
 
@@ -272,7 +272,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindGetterIdentifier() {
+    void findGetterIdentifier() {
         AggregateModel<SomeGetterIdAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeGetterIdAnnotatedHandlers.class);
 
@@ -282,7 +282,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindMethodIdentifier() {
+    void findMethodIdentifier() {
         AggregateModel<SomeMethodIdAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeMethodIdAnnotatedHandlers.class);
 
@@ -292,7 +292,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindJavaxPersistenceIdentifier() {
+    void findJavaxPersistenceIdentifier() {
         AggregateModel<JavaxPersistenceAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(JavaxPersistenceAnnotatedHandlers.class);
 
@@ -301,7 +301,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindJavaxPersistenceGetterIdentifier() {
+    void findJavaxPersistenceGetterIdentifier() {
         AggregateModel<JavaxPersistenceGetterAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(JavaxPersistenceGetterAnnotatedHandlers.class);
 
@@ -310,7 +310,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindJavaxPersistenceMethodIdentifier() {
+    void findJavaxPersistenceMethodIdentifier() {
         AggregateModel<JavaxPersistenceMethodIdAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(JavaxPersistenceMethodIdAnnotatedHandlers.class);
 
@@ -319,7 +319,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindIdentifierInSuperClass() {
+    void findIdentifierInSuperClass() {
         AggregateModel<SomeSubclass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeSubclass.class);
 
@@ -328,7 +328,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testFindGetterIdentifierInSuperClass() {
+    void findGetterIdentifierInSuperClass() {
         AggregateModel<SomeGetterIdSubclass> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeGetterIdSubclass.class);
 
@@ -337,7 +337,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testEntityInitializationIsThreadSafe() {
+    void entityInitializationIsThreadSafe() {
         for (int i = 0; i < 100; i++) {
             AggregateModel<PolyMorphAggregate> inspector =
                     AnnotatedAggregateMetaModelFactory.inspectAggregate(PolyMorphAggregate.class);
@@ -360,7 +360,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testIllegalFactoryMethodThrowsExceptionClass() {
+    void illegalFactoryMethodThrowsExceptionClass() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> AnnotatedAggregateMetaModelFactory
@@ -376,7 +376,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testGetterTypedAggregateIdentifier() {
+    void getterTypedAggregateIdentifier() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> AnnotatedAggregateMetaModelFactory.inspectAggregate(GetterTypedIdentifierAggregate.class)
@@ -384,7 +384,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testIllegalDoubleIdentifiers() {
+    void illegalDoubleIdentifiers() {
         assertThrows(AxonConfigurationException.class, () ->
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(IllegalDoubleIdFieldsAnnotatedAggregate.class)
         );
@@ -397,14 +397,14 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testVoidMethodIdentifier() {
+    void voidMethodIdentifier() {
         assertThrows(AxonConfigurationException.class, () ->
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(IllegalVoidIdMethodAnnotatedAggregate.class)
         );
     }
 
     @Test
-    void testAggregateVersionAnnotatedField() {
+    void aggregateVersionAnnotatedField() {
         AggregateModel<AggregateWithAggregateVersionField> testSubject =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(AggregateWithAggregateVersionField.class);
 
@@ -412,7 +412,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testAggregateVersionAnnotatedMethod() {
+    void aggregateVersionAnnotatedMethod() {
         AggregateModel<AggregateWithAggregateVersionMethod> testSubject =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(AggregateWithAggregateVersionMethod.class);
 
@@ -420,7 +420,7 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testIllegalDoubleAggregateVersions() {
+    void illegalDoubleAggregateVersions() {
         assertThrows(AggregateModellingException.class, () ->
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(IllegalAggregateWithSeveralAggregateVersions.class)
         );

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedPolymorphicAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedPolymorphicAggregateMetaModelFactoryTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnnotatedPolymorphicAggregateMetaModelFactoryTest {
 
     @Test
-    void testPolymorphicHierarchy() throws NoSuchMethodException {
+    void polymorphicHierarchy() throws NoSuchMethodException {
         Executable aHandle = A.class.getMethod("handle", String.class);
         Executable bHandle = B.class.getMethod("handle", Boolean.class);
         Executable cHandle = C.class.getMethod("handle", Boolean.class);
@@ -86,14 +86,14 @@ class AnnotatedPolymorphicAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testUniqueAggregateIdentifierField() {
+    void uniqueAggregateIdentifierField() {
         assertThrows(AggregateModellingException.class,
                      () -> AnnotatedAggregateMetaModelFactory
                              .inspectAggregate(D.class, new HashSet<>(singleton(E.class))));
     }
 
     @Test
-    void testUniqueAggregateIdentifierFieldShouldIgnorePersistenceId() {
+    void uniqueAggregateIdentifierFieldShouldIgnorePersistenceId() {
         // should not throw an exception
         AnnotatedAggregateMetaModelFactory.inspectAggregate(D.class, new HashSet<>(singleton(F.class)));
     }

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest.java
@@ -102,7 +102,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreateAggregateModelDoesNotDuplicateRootLevelAggregateMembers() {
+    void createAggregateModelDoesNotDuplicateRootLevelAggregateMembers() {
         int expectedNumberOfAggregateEventHandlerInvocations = 2;
         int expectedNumberOfMemberEventHandlerInvocations = 1;
 
@@ -120,7 +120,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreateAggregateModelDoesNotDuplicateRootLevelAggregateMembersForPolymorphicAggregates() {
+    void createAggregateModelDoesNotDuplicateRootLevelAggregateMembersForPolymorphicAggregates() {
         int expectedNumberOfAggregateEventHandlerInvocations = 2;
         int expectedNumberOfMemberEventHandlerInvocations = 1;
 
@@ -140,7 +140,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreatedAggregateModelReturnsCommandHandlingFunctionFromParentAggregate() throws Exception {
+    void createdAggregateModelReturnsCommandHandlingFunctionFromParentAggregate() throws Exception {
         CommandMessage<MemberCommand> testMemberCommand = GenericCommandMessage.asCommandMessage(MEMBER_COMMAND);
         DefaultUnitOfWork.startAndGet(testMemberCommand);
 
@@ -156,7 +156,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreatedAggregateModelReturnsCommandHandlingFunctionFromParentAggregateForPolymorphicAggregate()
+    void createdAggregateModelReturnsCommandHandlingFunctionFromParentAggregateForPolymorphicAggregate()
             throws Exception {
         CommandMessage<MemberCommand> testMemberCommand = GenericCommandMessage.asCommandMessage(MEMBER_COMMAND);
         DefaultUnitOfWork.startAndGet(testMemberCommand);
@@ -176,7 +176,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreatedAggregateModelInvokesAllCommandInterceptors() throws Exception {
+    void createdAggregateModelInvokesAllCommandInterceptors() throws Exception {
         int expectedNumberOfMemberCommandInterceptorInvocations = 3;
 
         CommandMessage<MemberCommand> testMemberCommand = GenericCommandMessage.asCommandMessage(MEMBER_COMMAND);
@@ -194,7 +194,7 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void testCreatedAggregateModelInvokesAllCommandInterceptorsForPolymorphicAggregate() throws Exception {
+    void createdAggregateModelInvokesAllCommandInterceptorsForPolymorphicAggregate() throws Exception {
         int expectedNumberOfMemberCommandInterceptorInvocations = 3;
         CommandMessage<MemberCommand> testMemberCommand = GenericCommandMessage.asCommandMessage(MEMBER_COMMAND);
         DefaultUnitOfWork.startAndGet(testMemberCommand);

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMemberTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMemberTest.java
@@ -35,7 +35,7 @@ class ChildForwardingCommandMessageHandlingMemberTest {
     }
 
     @Test
-    void testCanHandleMessageTypeIsDelegatedToChildHandler() {
+    void canHandleMessageTypeIsDelegatedToChildHandler() {
         when(childMember.canHandleMessageType(any())).thenReturn(true);
 
         assertTrue(testSubject.canHandleMessageType(CommandMessage.class));
@@ -44,7 +44,7 @@ class ChildForwardingCommandMessageHandlingMemberTest {
     }
 
     @Test
-    void testHasAnnotationIsDelegatedToChildHandler() {
+    void hasAnnotationIsDelegatedToChildHandler() {
         when(childMember.hasAnnotation(any())).thenReturn(true);
 
         assertTrue(testSubject.hasAnnotation(CommandHandler.class));
@@ -53,7 +53,7 @@ class ChildForwardingCommandMessageHandlingMemberTest {
     }
 
     @Test
-    void testAttributeIsDelegatedToChildHandler() {
+    void attributeIsDelegatedToChildHandler() {
         AggregateCreationPolicy expectedPolicy = AggregateCreationPolicy.NEVER;
         when(childMember.attribute(HandlerAttributes.AGGREGATE_CREATION_POLICY))
                 .thenReturn(Optional.of(expectedPolicy));

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
@@ -69,26 +69,26 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testCreationPolicy_NoneExists() throws Exception {
+    void creationPolicy_NoneExists() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent("123")));
         assertEquals(1, repositoryContents("123").size());
     }
 
     @Test
-    void testCreationPolicy_OneAlreadyExists() throws Exception {
+    void creationPolicy_OneAlreadyExists() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent("123")));
         handle(new GenericEventMessage<>(new StartingEvent("123")));
         assertEquals(1, repositoryContents("123").size());
     }
 
     @Test
-    void testHandleUnrelatedEvent() throws Exception {
+    void handleUnrelatedEvent() throws Exception {
         handle(new GenericEventMessage<>("Unrelated"));
         verify(sagaRepository, never()).find(isNull());
     }
 
     @Test
-    void testCreationPolicy_CreationForced() throws Exception {
+    void creationPolicy_CreationForced() throws Exception {
         StartingEvent startingEvent = new StartingEvent("123");
         handle(new GenericEventMessage<>(startingEvent));
         handle(new GenericEventMessage<>(new ForcingStartEvent("123")));
@@ -103,13 +103,13 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testCreationPolicy_SagaNotCreated() throws Exception {
+    void creationPolicy_SagaNotCreated() throws Exception {
         handle(new GenericEventMessage<>(new MiddleEvent("123")));
         assertEquals(0, repositoryContents("123").size());
     }
 
     @Test
-    void testMostSpecificHandlerEvaluatedFirst() throws Exception {
+    void mostSpecificHandlerEvaluatedFirst() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent("12")));
         handle(new GenericEventMessage<>(new StartingEvent("23")));
         assertEquals(1, repositoryContents("12").size());
@@ -122,14 +122,14 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testNullAssociationValueIsIgnored() throws Exception {
+    void nullAssociationValueIsIgnored() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent(null)));
 
         verify(sagaRepository, never()).find(null);
     }
 
     @Test
-    void testLifecycle_DestroyedOnEnd() throws Exception {
+    void lifecycle_DestroyedOnEnd() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent("12")));
         handle(new GenericEventMessage<>(new StartingEvent("23")));
         handle(new GenericEventMessage<>(new MiddleEvent("12")));
@@ -148,12 +148,12 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testNullAssociationValueDoesNotThrowNullPointer() throws Exception {
+    void nullAssociationValueDoesNotThrowNullPointer() throws Exception {
         handle(asEventMessage(new StartingEvent(null)));
     }
 
     @Test
-    void testLifeCycle_ExistingInstanceIgnoresEvent() throws Exception {
+    void lifeCycle_ExistingInstanceIgnoresEvent() throws Exception {
         handle(new GenericEventMessage<>(new StartingEvent("12")));
         handle(new GenericEventMessage<>(new StubDomainEvent()));
         assertEquals(1, repositoryContents("12").size());
@@ -161,13 +161,13 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testLifeCycle_IgnoredEventDoesNotCreateInstance() throws Exception {
+    void lifeCycle_IgnoredEventDoesNotCreateInstance() throws Exception {
         handle(new GenericEventMessage<>(new StubDomainEvent()));
         assertEquals(0, repositoryContents("12").size());
     }
 
     @Test
-    void testPerformResetThrowsResetNotSupportedException() {
+    void performResetThrowsResetNotSupportedException() {
         AnnotatedSagaManager<MyTestSaga> spiedTestSubject = spy(testSubject);
 
         assertThrows(ResetNotSupportedException.class, spiedTestSubject::performReset);
@@ -176,7 +176,7 @@ public class AnnotatedSagaManagerTest {
     }
 
     @Test
-    void testPerformResetWithResetInfoThrowsResetNotSupportedException() {
+    void performResetWithResetInfoThrowsResetNotSupportedException() {
         assertThrows(ResetNotSupportedException.class, () -> testSubject.performReset("reset-info"));
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -56,7 +56,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testInvokeSaga() {
+    void invokeSaga() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         testSubject.handle(new GenericEventMessage<>(new RegularEvent("id")));
         testSubject.handle(new GenericEventMessage<>(new RegularEvent("wrongId")));
@@ -66,7 +66,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testInvokeSagaAssociationPropertyNotExistingInPayload() {
+    void invokeSagaAssociationPropertyNotExistingInPayload() {
         AnnotationSagaMetaModelFactory testSubject = new AnnotationSagaMetaModelFactory();
         assertThrows(
                 AxonConfigurationException.class,
@@ -75,13 +75,13 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testInvokeSagaAssociationPropertyEmpty() {
+    void invokeSagaAssociationPropertyEmpty() {
         AnnotationSagaMetaModelFactory testSubject = new AnnotationSagaMetaModelFactory();
         assertThrows(AxonConfigurationException.class, () -> testSubject.modelOf(SagaAssociationPropertyEmpty.class));
     }
 
     @Test
-    void testInvokeSagaMetaDataAssociationResolver() {
+    void invokeSagaMetaDataAssociationResolver() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         Map<String, Object> metaData = new HashMap<>();
         metaData.put("propertyName", "id");
@@ -92,7 +92,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testInvokeSagaResolverWithoutNoArgConstructor() {
+    void invokeSagaResolverWithoutNoArgConstructor() {
         assertThrows(
                 AxonConfigurationException.class,
                 () -> new AnnotationSagaMetaModelFactory().modelOf(SagaUsingResolverWithoutNoArgConstructor.class)
@@ -100,7 +100,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testEndedAfterInvocationBeanProperty() {
+    void endedAfterInvocationBeanProperty() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         testSubject.handle(new GenericEventMessage<>(new RegularEvent("id")));
         testSubject.handle(new GenericEventMessage<>(new Object()));
@@ -111,7 +111,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testEndedAfterInvocationWhenAssociationIsRemoved() {
+    void endedAfterInvocationWhenAssociationIsRemoved() {
         StubAnnotatedSaga testSaga = new StubAnnotatedSagaWithExplicitAssociationRemoval();
         AnnotatedSaga<StubAnnotatedSaga> testSubject = new AnnotatedSaga<>(
                 "id", Collections.emptySet(), testSaga,
@@ -128,7 +128,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testEndedAfterInvocationUniformAccessPrinciple() {
+    void endedAfterInvocationUniformAccessPrinciple() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         testSubject.handle(new GenericEventMessage<>(new UniformAccessEvent("id")));
         testSubject.handle(new GenericEventMessage<>(new Object()));
@@ -139,7 +139,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testPrepareResetThrowsResetNotSupportedException() {
+    void prepareResetThrowsResetNotSupportedException() {
         AnnotatedSaga<StubAnnotatedSaga> spiedTestSubject = spy(testSubject);
 
         assertThrows(ResetNotSupportedException.class, spiedTestSubject::prepareReset);
@@ -148,12 +148,12 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testPrepareResetWithResetContextThrowsResetNotSupportedException() {
+    void prepareResetWithResetContextThrowsResetNotSupportedException() {
         assertThrows(ResetNotSupportedException.class, () -> testSubject.prepareReset("some-reset-context"));
     }
 
     @Test
-    void testLifecycleAssociationValues() {
+    void lifecycleAssociationValues() {
         testSubject.doAssociateWith(new AssociationValue("propertyName", "id"));
         testSubject.execute(() -> {
             Set<AssociationValue> associationValues = SagaLifecycle.associationValues();

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AssociationValuesImplTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AssociationValuesImplTest.java
@@ -38,7 +38,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testAddAssociationValue() {
+    void addAssociationValue() {
         testSubject.add(associationValue);
 
         assertEquals(1, testSubject.addedAssociations().size());
@@ -46,7 +46,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testAddAssociationValue_AddedTwice() {
+    void addAssociationValue_AddedTwice() {
         testSubject.add(associationValue);
         testSubject.commit();
         testSubject.add(associationValue);
@@ -55,7 +55,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testRemoveAssociationValue() {
+    void removeAssociationValue() {
         assertTrue(testSubject.add(associationValue));
         testSubject.commit();
         assertTrue(testSubject.remove(associationValue));
@@ -64,14 +64,14 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testRemoveAssociationValue_NotInContainer() {
+    void removeAssociationValue_NotInContainer() {
         testSubject.remove(associationValue);
         assertTrue(testSubject.addedAssociations().isEmpty());
         assertTrue(testSubject.removedAssociations().isEmpty());
     }
 
     @Test
-    void testAddAndRemoveEntry() {
+    void addAndRemoveEntry() {
         testSubject.add(associationValue);
         testSubject.remove(associationValue);
 
@@ -80,7 +80,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testContains() {
+    void contains() {
         assertFalse(testSubject.contains(associationValue));
         testSubject.add(associationValue);
         assertTrue(testSubject.contains(associationValue));
@@ -90,7 +90,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testAsSet() {
+    void asSet() {
         testSubject.add(associationValue);
         int t = 0;
         for (AssociationValue actual : testSubject.asSet()) {
@@ -101,7 +101,7 @@ class AssociationValuesImplTest {
     }
 
     @Test
-    void testIterator() {
+    void iterator() {
         testSubject.add(associationValue);
         Iterator<AssociationValue> iterator = testSubject.iterator();
         assertSame(associationValue, iterator.next());

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
@@ -87,7 +87,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testSagasLoaded() throws Exception {
+    void sagasLoaded() throws Exception {
         EventMessage<?> event = new GenericEventMessage<>(new Object());
         UnitOfWork<? extends EventMessage<?>> unitOfWork = new DefaultUnitOfWork<>(event);
         unitOfWork.executeWithResult(() -> {
@@ -101,7 +101,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testExceptionPropagated() throws Exception {
+    void exceptionPropagated() throws Exception {
         EventMessage<?> event = new GenericEventMessage<>(new Object());
         MockException toBeThrown = new MockException();
         doThrow(toBeThrown).when(mockSaga1).handle(event);
@@ -123,7 +123,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testSagaIsCreatedInRootSegment() throws Exception {
+    void sagaIsCreatedInRootSegment() throws Exception {
         testSubject = TestableAbstractSagaManager.builder()
                                                  .sagaRepository(mockSagaRepository)
                                                  .listenerInvocationErrorHandler(mockErrorHandler)
@@ -140,7 +140,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testSagaIsOnlyCreatedInSegmentMatchingAssociationValue() throws Exception {
+    void sagaIsOnlyCreatedInSegmentMatchingAssociationValue() throws Exception {
         testSubject = TestableAbstractSagaManager.builder()
                                                  .sagaRepository(mockSagaRepository)
                                                  .listenerInvocationErrorHandler(mockErrorHandler)
@@ -172,7 +172,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testSagaIsNotCreatedIfAssociationValueAndSagaIdMatchDifferentSegments() throws Exception {
+    void sagaIsNotCreatedIfAssociationValueAndSagaIdMatchDifferentSegments() throws Exception {
         AssociationValue associationValue = new AssociationValue("someKey", "someValue");
         testSubject = TestableAbstractSagaManager.builder()
                 .sagaRepository(mockSagaRepository)
@@ -206,7 +206,7 @@ class SagaManagerTest {
     }
 
     @Test
-    void testExceptionSuppressed() throws Exception {
+    void exceptionSuppressed() throws Exception {
         EventMessage<?> event = new GenericEventMessage<>(new Object());
         MockException toBeThrown = new MockException();
         doThrow(toBeThrown).when(mockSaga1).handle(event);

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaScopeDescriptorSerializationTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaScopeDescriptorSerializationTest.java
@@ -49,7 +49,7 @@ class SagaScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testJavaSerializationCorrectlySetsIdentifierField() throws Exception {
+    void javaSerializationCorrectlySetsIdentifierField() throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ObjectOutputStream objectOutputStream = new ObjectOutputStream(out);
         objectOutputStream.writeObject(testSubject);
@@ -64,7 +64,7 @@ class SagaScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testXStreamSerializationWorksAsExpected() {
+    void xStreamSerializationWorksAsExpected() {
         XStreamSerializer xStreamSerializer = TestSerializer.xStreamSerializer();
         xStreamSerializer.getXStream().setClassLoader(this.getClass().getClassLoader());
 
@@ -76,7 +76,7 @@ class SagaScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testJacksonSerializationWorksAsExpected() {
+    void jacksonSerializationWorksAsExpected() {
         JacksonSerializer jacksonSerializer = JacksonSerializer.defaultSerializer();
 
         SerializedObject<String> serializedObject = jacksonSerializer.serialize(testSubject, String.class);
@@ -87,7 +87,7 @@ class SagaScopeDescriptorSerializationTest {
     }
 
     @Test
-    void testResponseTypeShouldBeSerializableWithJacksonUsingConstructorProperties() {
+    void responseTypeShouldBeSerializableWithJacksonUsingConstructorProperties() {
         ObjectMapper objectMapper = OnlyAcceptConstructorPropertiesAnnotation.attachTo(new ObjectMapper());
         JacksonSerializer jacksonSerializer = JacksonSerializer.builder().objectMapper(objectMapper).build();
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SimpleResourceInjectorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SimpleResourceInjectorTest.java
@@ -35,7 +35,7 @@ class SimpleResourceInjectorTest {
     private SimpleResourceInjector testSubject;
 
     @Test
-    void testInjectFieldResource() {
+    void injectFieldResource() {
         SomeFieldResource expectedFieldResource = new SomeFieldResource();
         testSubject = new SimpleResourceInjector(expectedFieldResource);
         final StubSaga saga = new StubSaga();
@@ -46,7 +46,7 @@ class SimpleResourceInjectorTest {
     }
 
     @Test
-    void testInjectMethodResource() {
+    void injectMethodResource() {
         final SomeMethodResource expectedMethodResource = new SomeMethodResource();
         testSubject = new SimpleResourceInjector(expectedMethodResource);
         final StubSaga saga = new StubSaga();
@@ -57,7 +57,7 @@ class SimpleResourceInjectorTest {
     }
 
     @Test
-    void testInjectFieldAndMethodResources() {
+    void injectFieldAndMethodResources() {
         final SomeFieldResource expectedFieldResource = new SomeFieldResource();
         final SomeMethodResource expectedMethodResource = new SomeMethodResource();
         testSubject = new SimpleResourceInjector(expectedFieldResource, expectedMethodResource);
@@ -70,7 +70,7 @@ class SimpleResourceInjectorTest {
     }
 
     @Test
-    void testInjectResource_ExceptionsIgnored() {
+    void injectResource_ExceptionsIgnored() {
         final SomeMethodResource resource = new SomeMethodResource();
         testSubject = new SimpleResourceInjector(resource, new SomeWeirdResource());
         final StubSaga saga = new StubSaga();

--- a/modelling/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
@@ -38,7 +38,7 @@ class AnnotationSagaMetaModelFactoryTest {
     }
 
     @Test
-    void testInspectSaga() {
+    void inspectSaga() {
         SagaModel<MySaga> sagaModel = testSubject.modelOf(MySaga.class);
 
         Optional<AssociationValue> actual = sagaModel.resolveAssociation(asEventMessage(new MySagaStartEvent("value")));

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
@@ -57,7 +57,7 @@ class AnnotatedSagaRepositoryTest {
     }
 
     @Test
-    void testLoadedFromUnitOfWorkAfterCreate() {
+    void loadedFromUnitOfWorkAfterCreate() {
         Saga<Object> saga =
                 testSubject.createInstance(IdentifierFactory.getInstance().generateIdentifier(), Object::new);
         saga.getAssociationValues().add(new AssociationValue("test", "value"));
@@ -72,7 +72,7 @@ class AnnotatedSagaRepositoryTest {
     }
 
     @Test
-    void testLoadedFromNestedUnitOfWorkAfterCreate() throws Exception {
+    void loadedFromNestedUnitOfWorkAfterCreate() throws Exception {
         Saga<Object> saga =
                 testSubject.createInstance(IdentifierFactory.getInstance().generateIdentifier(), Object::new);
         saga.getAssociationValues().add(new AssociationValue("test", "value"));
@@ -88,7 +88,7 @@ class AnnotatedSagaRepositoryTest {
     }
 
     @Test
-    void testLoadedFromNestedUnitOfWorkAfterCreateAndStore() {
+    void loadedFromNestedUnitOfWorkAfterCreateAndStore() {
         Saga<Object> saga =
                 testSubject.createInstance(IdentifierFactory.getInstance().generateIdentifier(), Object::new);
         saga.getAssociationValues().add(new AssociationValue("test", "value"));
@@ -108,7 +108,7 @@ class AnnotatedSagaRepositoryTest {
     }
 
     @Test
-    void testLoadedFromUnitOfWorkAfterPreviousLoad() {
+    void loadedFromUnitOfWorkAfterPreviousLoad() {
         Saga<Object> preparedSaga =
                 testSubject.createInstance(IdentifierFactory.getInstance().generateIdentifier(), Object::new);
         currentUnitOfWork.commit();
@@ -131,7 +131,7 @@ class AnnotatedSagaRepositoryTest {
     }
 
     @Test
-    void testSagaAssociationsVisibleInOtherThreadsBeforeSagaIsCommitted() throws Exception {
+    void sagaAssociationsVisibleInOtherThreadsBeforeSagaIsCommitted() throws Exception {
         String sagaId = "sagaId";
         AssociationValue associationValue = new AssociationValue("test", "value");
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/AssociationValueMapTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/AssociationValueMapTest.java
@@ -41,7 +41,7 @@ class AssociationValueMapTest {
     }
 
     @Test
-    void testStoreVarietyOfItems() {
+    void storeVarietyOfItems() {
         assertTrue(testSubject.isEmpty());
 
         Object anObject = new Object();
@@ -63,8 +63,8 @@ class AssociationValueMapTest {
     }
 
     @Test
-    void testRemoveItems() {
-        testStoreVarietyOfItems();
+    void removeItems() {
+        storeVarietyOfItems();
         assertEquals(6, testSubject.size(), "Wrong initial item count");
         testSubject.remove(av("a"), "T", "1");
         assertEquals(5, testSubject.size(), "Wrong item count");
@@ -81,7 +81,7 @@ class AssociationValueMapTest {
     }
 
     @Test
-    void testFindAssociations() {
+    void findAssociations() {
         List<AssociationValue> usedAssociations = new ArrayList<>(1000);
         for (int t = 0; t < 1000; t++) {
             String key = UUID.randomUUID().toString();

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
@@ -67,7 +67,7 @@ class CachingSagaStoreTest {
     }
 
     @Test
-    void testSagaAddedToCacheOnAdd() {
+    void sagaAddedToCacheOnAdd() {
 
         testSubject.insertSaga(StubSaga.class, "123", new StubSaga(), singleton(new AssociationValue("key", "value")));
 
@@ -76,7 +76,7 @@ class CachingSagaStoreTest {
     }
 
     @Test
-    void testAssociationsAddedToCacheOnLoad() {
+    void associationsAddedToCacheOnLoad() {
         testSubject.insertSaga(StubSaga.class, "id", new StubSaga(), singleton(new AssociationValue("key", "value")));
 
         verify(associationsCache, never()).put(any(), any());
@@ -94,7 +94,7 @@ class CachingSagaStoreTest {
     }
 
     @Test
-    void testSagaAddedToCacheOnLoad() {
+    void sagaAddedToCacheOnLoad() {
         StubSaga saga = new StubSaga();
         testSubject.insertSaga(StubSaga.class, "id", saga, singleton(new AssociationValue("key", "value")));
 
@@ -110,7 +110,7 @@ class CachingSagaStoreTest {
     }
 
     @Test
-    void testSagaNotAddedToCacheWhenLoadReturnsNull() {
+    void sagaNotAddedToCacheWhenLoadReturnsNull() {
 
         ehCache.removeAll();
         reset(sagaCache, associationsCache);
@@ -125,7 +125,7 @@ class CachingSagaStoreTest {
 
 
     @Test
-    void testCommitDelegatedAfterAddingToCache() {
+    void commitDelegatedAfterAddingToCache() {
         StubSaga saga = new StubSaga();
         AssociationValue associationValue = new AssociationValue("key", "value");
         testSubject.insertSaga(StubSaga.class, "123", saga, singleton(associationValue));

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/LockingSagaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/LockingSagaRepositoryTest.java
@@ -57,7 +57,7 @@ class LockingSagaRepositoryTest {
     }
 
     @Test
-    void testLockReleasedOnUnitOfWorkCleanUpAfterCreate() {
+    void lockReleasedOnUnitOfWorkCleanUpAfterCreate() {
         subject.createInstance("id", Object::new);
         verify(lockFactory).obtainLock("id");
         verify(subject).doCreateInstance(eq("id"), any());
@@ -67,7 +67,7 @@ class LockingSagaRepositoryTest {
     }
 
     @Test
-    void testLockReleasedOnUnitOfWorkCleanUpAfterLoad() {
+    void lockReleasedOnUnitOfWorkCleanUpAfterLoad() {
         subject.load("id");
         verify(lockFactory).obtainLock("id");
         verify(subject).doLoad("id");

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStoreTest.java
@@ -69,7 +69,7 @@ class JdbcSagaStoreTest {
     }
 
     @Test
-    void testInsertUpdateAndLoadSaga() {
+    void insertUpdateAndLoadSaga() {
         StubSaga saga = new StubSaga();
         Set<AssociationValue> associationValues = singleton(new AssociationValue("key", "value"));
         testSubject.insertSaga(StubSaga.class, "123", saga, associationValues);
@@ -82,12 +82,12 @@ class JdbcSagaStoreTest {
     }
 
     @Test
-    void testLoadSaga_NotFound() {
+    void loadSaga_NotFound() {
         assertNull(testSubject.loadSaga(StubSaga.class, "123456"));
     }
 
     @Test
-    void testLoadSagaByAssociationValue() {
+    void loadSagaByAssociationValue() {
         AssociationValues associationsValues =
                 new AssociationValuesImpl(singleton(new AssociationValue("key", "value")));
         testSubject.insertSaga(StubSaga.class, "123", new StubSaga(), associationsValues.asSet());
@@ -106,7 +106,7 @@ class JdbcSagaStoreTest {
     }
 
     @Test
-    void testUpdateSagaWhenDeleted() {
+    void updateSagaWhenDeleted() {
         AssociationValues associationsValues = new AssociationValuesImpl(singleton(new AssociationValue("key", "value")));
         testSubject.updateSaga(StubSaga.class, "123456", new StubSaga(), associationsValues);
         assertNull(testSubject.loadSaga(StubSaga.class, "123456"));

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStoreTest.java
@@ -95,7 +95,7 @@ class JpaSagaStoreTest {
     }
 
     @Test
-    void testAddingAnInactiveSagaDoesntStoreIt() {
+    void addingAnInactiveSagaDoesntStoreIt() {
         unitOfWork.executeWithResult(() -> {
             Saga<StubSaga> saga = repository.createInstance(IdentifierFactory.getInstance().generateIdentifier(),
                                                             StubSaga::new);
@@ -114,7 +114,7 @@ class JpaSagaStoreTest {
 
 
     @Test
-    void testAddAndLoadSaga_ByIdentifier() {
+    void addAndLoadSaga_ByIdentifier() {
         String identifier = unitOfWork.executeWithResult(() -> repository.createInstance(
                 IdentifierFactory.getInstance().generateIdentifier(), StubSaga::new).getSagaIdentifier())
                                       .getPayload();
@@ -128,7 +128,7 @@ class JpaSagaStoreTest {
     }
 
     @Test
-    void testAddAndLoadSaga_ByAssociationValue() {
+    void addAndLoadSaga_ByAssociationValue() {
         String identifier = unitOfWork.executeWithResult(() -> {
             Saga<StubSaga> saga = repository.createInstance(IdentifierFactory.getInstance().generateIdentifier(),
                                                             StubSaga::new);
@@ -147,13 +147,13 @@ class JpaSagaStoreTest {
     }
 
     @Test
-    void testLoadSaga_NotFound() {
+    void loadSaga_NotFound() {
         unitOfWork.execute(() -> assertNull(repository.load("123456")));
     }
 
 
     @Test
-    void testLoadSaga_AssociationValueRemoved() {
+    void loadSaga_AssociationValueRemoved() {
         String identifier = unitOfWork.executeWithResult(() -> {
             Saga<StubSaga> saga = repository.createInstance(IdentifierFactory.getInstance().generateIdentifier(),
                                                             StubSaga::new);
@@ -174,7 +174,7 @@ class JpaSagaStoreTest {
     }
 
     @Test
-    void testEndSaga() {
+    void endSaga() {
         String identifier = unitOfWork.executeWithResult(() -> {
             Saga<StubSaga> saga = repository.createInstance(IdentifierFactory.getInstance().generateIdentifier(),
                                                             StubSaga::new);
@@ -197,7 +197,7 @@ class JpaSagaStoreTest {
     }
 
     @Test
-    void testStoreSagaWithCustomEntity() {
+    void storeSagaWithCustomEntity() {
         JpaSagaStore sagaStore = new JpaSagaStore(
                 JpaSagaStore.builder()
                             .serializer(xStreamSerializer())

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/actuator/axonserver/AxonServerHealthIndicatorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/actuator/axonserver/AxonServerHealthIndicatorTest.java
@@ -46,7 +46,7 @@ class AxonServerHealthIndicatorTest {
     }
 
     @Test
-    void testDoHealthCheckStatusReturnsUp() {
+    void doHealthCheckStatusReturnsUp() {
         String testContextOne = "context-one";
         String testContextTwo = "context-two";
         String expectedDetailsContextOne = testContextOne + ".connection.active";
@@ -76,7 +76,7 @@ class AxonServerHealthIndicatorTest {
     }
 
     @Test
-    void testDoHealthCheckStatusReturnsWarning() {
+    void doHealthCheckStatusReturnsWarning() {
         String testContextOne = "context-one";
         String testContextTwo = "context-two";
         String expectedDetailsContextOne = testContextOne + ".connection.active";
@@ -106,7 +106,7 @@ class AxonServerHealthIndicatorTest {
     }
 
     @Test
-    void testDoHealthCheckStatusReturnsDown() {
+    void doHealthCheckStatusReturnsDown() {
         String testContextOne = "context-one";
         String testContextTwo = "context-two";
         String expectedDetailsContextOne = testContextOne + ".connection.active";

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -69,7 +69,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AxonAutoConfigurationTest {
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         new ApplicationContextRunner()
                 .withUserConfiguration(AxonAutoConfigurationTest.Context.class)
                 .withPropertyValues("axon.axonserver.enabled=false")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class AxonAutoConfigurationWithDisruptorTest {
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         new ApplicationContextRunner()
                 .withUserConfiguration(AxonAutoConfigurationWithDisruptorTest.Context.class)
                 .withPropertyValues("axon.axonserver.enabled=false")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
@@ -73,7 +73,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     private EntityManager entityManager;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(CommandBus.class));
@@ -99,7 +99,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     }
 
     @Test
-    void testEventStorageEngineUsesSerializerBean() {
+    void eventStorageEngineUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final Serializer messageSerializer = applicationContext.getBean("messageSerializer", Serializer.class);
@@ -111,7 +111,7 @@ public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
     }
 
     @Test
-    void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefinedObjectMapperBean() {
+    void eventSerializerIsOfTypeJacksonSerializerAndUsesDefinedObjectMapperBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final ObjectMapper objectMapper = applicationContext.getBean("testObjectMapper", ObjectMapper.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
@@ -72,7 +72,7 @@ public class AxonAutoConfigurationWithEventSerializerTest {
     private EntityManager entityManager;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(CommandBus.class));
@@ -94,7 +94,7 @@ public class AxonAutoConfigurationWithEventSerializerTest {
     }
 
     @Test
-    void testEventStorageEngineUsesSerializerBean() {
+    void eventStorageEngineUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("myEventSerializer", Serializer.class);
         final JpaEventStorageEngine engine = applicationContext.getBean(JpaEventStorageEngine.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
@@ -84,7 +84,7 @@ public class AxonAutoConfigurationWithHibernateTest {
     private Snapshotter snapshotter;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
         assertNotNull(snapshotter);
 
@@ -104,7 +104,7 @@ public class AxonAutoConfigurationWithHibernateTest {
 
     @Transactional
     @Test
-    public void testEventStorageEngingeUsesSerializerBean() {
+    public void eventStorageEngingeUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final JpaEventStorageEngine engine = applicationContext.getBean(JpaEventStorageEngine.class);
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsTest.java
@@ -74,7 +74,7 @@ class AxonAutoConfigurationWithMetricsTest {
     private MetricsConfigurerModule metricsConfigurerModule;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.containsBean("metricRegistry"));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
@@ -65,7 +65,7 @@ public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
     private GlobalMetricRegistry globalMetricRegistry;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertTrue(applicationContext.containsBean("metricRegistry"));
@@ -80,7 +80,7 @@ public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
     }
 
     @Test
-    void testAxonServerEventStoreRequestedMonitor() {
+    void axonServerEventStoreRequestedMonitor() {
         assertNotNull(applicationContext.getBean(AxonServerEventStore.class));
 
         MessageMonitorFactory monitor = applicationContext.getBean("mockMessageMonitorFactory", MessageMonitorFactory.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsTest.java
@@ -64,7 +64,7 @@ class AxonAutoConfigurationWithMicrometerMetricsTest {
     private org.axonframework.metrics.MetricsConfigurerModule metricsModuleMetricsConfigurerModule;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(applicationContext.getBean(MeterRegistry.class));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest.java
@@ -62,7 +62,7 @@ class AxonAutoConfigurationWithMicrometerMetricsWithoutConfigurerTest {
     private org.axonframework.metrics.MetricsConfigurerModule metricsModuleMetricsConfigurerModule;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertNotNull(applicationContext);
 
         assertNotNull(meterRegistry);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOnlyEventSerializerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOnlyEventSerializerTest.java
@@ -56,7 +56,7 @@ public class AxonAutoConfigurationWithOnlyEventSerializerTest {
     private Serializer messageSerializer;
 
     @Test
-    void testRevertsToDefaultSerializer() {
+    void revertsToDefaultSerializer() {
         assertNotNull(serializer);
         assertNotNull(eventSerializer);
         assertNotNull(messageSerializer);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTagsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTagsTest.java
@@ -57,7 +57,7 @@ class AxonAutoConfigurationWithTagsTest {
     private ApplicationContext applicationContext;
 
     @Test
-    void testConfig() {
+    void config() {
         TagsConfiguration tagsConfiguration = applicationContext.getBean(TagsConfiguration.class);
         assertNotNull(tagsConfiguration);
         Map<String, String> tags = tagsConfiguration.getTags();

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithoutObjectMapperTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithoutObjectMapperTest.java
@@ -67,7 +67,7 @@ class AxonAutoConfigurationWithoutObjectMapperTest {
     private ApplicationContext applicationContext;
 
     @Test
-    void testNoObjectMapperBeanIsCreatedIfNoJacksonSerializerIsSpecified() {
+    void noObjectMapperBeanIsCreatedIfNoJacksonSerializerIsSpecified() {
         assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean(ObjectMapper.class));
 
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonHandlerConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonHandlerConfigurationTest.java
@@ -61,7 +61,7 @@ public class AxonHandlerConfigurationTest {
     private CommandGateway commandGateway;
 
     @Test
-    void testMessageRoutedToCorrectMethod() throws Exception {
+    void messageRoutedToCorrectMethod() throws Exception {
         assertEquals("Command: info", commandGateway.send("info").get());
         assertEquals("Query: info", queryGateway.query("info", String.class).get());
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class EventProcessorConfigurationTest {
 
     @Test
-    void testProcessorConfigurationWithCustomPolicy() {
+    void processorConfigurationWithCustomPolicy() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .withPropertyValues(
@@ -93,7 +93,7 @@ class EventProcessorConfigurationTest {
     }
 
     @Test
-    void testTokenClaimIntervalCanBeSetViaSpringConfiguration() {
+    void tokenClaimIntervalCanBeSetViaSpringConfiguration() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .withPropertyValues(
@@ -123,7 +123,7 @@ class EventProcessorConfigurationTest {
     }
 
     @Test
-    void testConfigurePooledStreamingEventProcessor() {
+    void configurePooledStreamingEventProcessor() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .withPropertyValues(

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
@@ -52,7 +52,7 @@ class HandlerEnhancerDefinitionConfigurationTest {
     }
 
     @Test
-    void testHandlerEnhancerDefinitionWrapsEventHandler() {
+    void handlerEnhancerDefinitionWrapsEventHandler() {
         new ApplicationContextRunner()
                 .withUserConfiguration(ContextWithHandlers.class)
                 .withPropertyValues("axon.axonserver.enabled=false")
@@ -65,7 +65,7 @@ class HandlerEnhancerDefinitionConfigurationTest {
     }
 
     @Test
-    void testHandlerEnhancerDefinitionDoesNotWrapInAbsenceOfMessageHandlers() {
+    void handlerEnhancerDefinitionDoesNotWrapInAbsenceOfMessageHandlers() {
         new ApplicationContextRunner()
                 .withUserConfiguration(ContextWithoutHandlers.class)
                 .withPropertyValues("axon.axonserver.enabled=false")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JdbcAutoConfigurationTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.*;
 public class JdbcAutoConfigurationTest {
 
     @Test
-    void testAllJdbcComponentsAutoConfigured() {
+    void allJdbcComponentsAutoConfigured() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .run(context -> {
@@ -78,7 +78,7 @@ public class JdbcAutoConfigurationTest {
     }
 
     @Test
-    void testCustomTokenSchema() {
+    void customTokenSchema() {
         TokenSchema tokenSchema = TokenSchema.builder().setTokenTable("TEST123").build();
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
@@ -90,7 +90,7 @@ public class JdbcAutoConfigurationTest {
     }
 
     @Test
-    void testConfigurationOfEventBusPreventsEventStoreDefinition() {
+    void configurationOfEventBusPreventsEventStoreDefinition() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class, ExplicitEventBusContext.class)
                 .run(context -> assertThat(context).doesNotHaveBean(EventStorageEngine.class)

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationLazySagaStoreTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationLazySagaStoreTest.java
@@ -58,7 +58,7 @@ class JpaAutoConfigurationLazySagaStoreTest {
      * being initialized.
      */
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         EntityManagerProvider entityManagerProvider = applicationContext.getBean(EntityManagerProvider.class);
         EntityManager entityManager = entityManagerProvider.getEntityManager();
         verifyNoInteractions(entityManager);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaAutoConfigurationTest.java
@@ -56,7 +56,7 @@ class JpaAutoConfigurationTest {
     private PersistenceExceptionResolver persistenceExceptionResolver;
 
     @Test
-    void testContextInitialization() {
+    void contextInitialization() {
         assertTrue(entityManagerProvider instanceof ContainerManagedEntityManagerProvider);
         assertTrue(tokenStore instanceof JpaTokenStore);
         assertTrue(sagaStore instanceof JpaSagaStore);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
@@ -44,7 +44,7 @@ class JpaEventStoreAutoConfigurationWithAxonServerTest {
     private EventStore eventStore;
 
     @Test
-    void testEventStore() {
+    void eventStore() {
         assertTrue(eventStore instanceof AxonServerEventStore);
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithSnapshottingTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithSnapshottingTest.java
@@ -85,7 +85,7 @@ class JpaEventStoreAutoConfigurationWithSnapshottingTest {
     }
 
     @Test
-    void testSnapshotterAndSnapshotTriggerDefinitionAreInvoked() {
+    void snapshotterAndSnapshotTriggerDefinitionAreInvoked() {
         SnapshotTriggerDefinition snapshotTriggerDefinition =
                 applicationContext.getBean(SnapshotTriggerDefinition.class);
         assertNotNull(snapshotTriggerDefinition);
@@ -101,7 +101,7 @@ class JpaEventStoreAutoConfigurationWithSnapshottingTest {
     }
 
     @Test
-    void testSnapshotFilterIsInvoked() {
+    void snapshotFilterIsInvoked() {
         SnapshotFilter snapshotFilter = applicationContext.getBean(SnapshotFilter.class);
         assertNotNull(snapshotFilter);
         assertNotNull(applicationContext.getBean(JpaEventStorageEngine.class));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithoutAxonServerTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
 
     @Test
-    void testEventStore() {
+    void eventStore() {
         new ApplicationContextRunner()
                 .withPropertyValues("axon.axonserver.enabled=false")
                 .withUserConfiguration(TestContext.class)
@@ -53,7 +53,7 @@ class JpaEventStoreAutoConfigurationWithoutAxonServerTest {
     }
 
     @Test
-    void testEventBusOverridesEventStoreDefinition() {
+    void eventBusOverridesEventStoreDefinition() {
         new ApplicationContextRunner()
                 .withPropertyValues("axon.axonserver.enabled=false")
                 .withUserConfiguration(EventBusContext.class, TestContext.class)

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIntegrationTest.java
@@ -77,7 +77,7 @@ class PooledStreamingEventProcessorIntegrationTest {
     }
 
     @Test
-    void testAllEventsFromMultiUpcasterAreHandled() {
+    void allEventsFromMultiUpcasterAreHandled() {
         testApplicationContext.withPropertyValues("upcaster-test=true").run(context -> {
             EventProcessingConfiguration processingConfig = context.getBean(EventProcessingConfiguration.class);
             Optional<PooledStreamingEventProcessor> optionalProcessor =
@@ -104,7 +104,7 @@ class PooledStreamingEventProcessorIntegrationTest {
     }
 
     @Test
-    void testLastEventIsNotHandledTwice() {
+    void lastEventIsNotHandledTwice() {
         int numberOfEvents = 100;
 
         testApplicationContext.withPropertyValues("once-test=true", "errorCount=2").run(context -> {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
@@ -89,7 +89,7 @@ public class SagaCustomizeIntegrationTest {
     private EventProcessingModule eventProcessingModule;
 
     @Test
-    public void testPublishSomeEvents() throws InterruptedException {
+    public void publishSomeEvents() throws InterruptedException {
         publishEvent(new EchoEvent(UUID.randomUUID().toString()));
         eventProcessingModule.eventProcessors()
                              .forEach((name, ep) -> assertTrue(ep.isRunning()));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
@@ -131,7 +131,7 @@ public class TrackingEventProcessorIntegrationTest {
 
     @DirtiesContext
     @Test
-    public void testPublishSomeEvents() throws InterruptedException {
+    public void publishSomeEvents() throws InterruptedException {
         publishEvent(UsedEvent.INSTANCE, UsedEvent.INSTANCE);
         transactionManager.executeInTransaction(() -> {
             entityManager.createQuery("DELETE FROM TokenEntry t").executeUpdate();
@@ -157,7 +157,7 @@ public class TrackingEventProcessorIntegrationTest {
 
     @DirtiesContext
     @Test
-    void testResetHandlerIsCalledOnResetTokens() {
+    void resetHandlerIsCalledOnResetTokens() {
         String resetContext = "reset-context";
 
         Optional<TrackingEventProcessor> optionalFirstTep =
@@ -185,7 +185,7 @@ public class TrackingEventProcessorIntegrationTest {
 
     @DirtiesContext
     @Test
-    void testUnhandledEventsAreFilteredOutOfTheBlockingStream() throws InterruptedException {
+    void unhandledEventsAreFilteredOutOfTheBlockingStream() throws InterruptedException {
         publishEvent(UsedEvent.INSTANCE, UnusedEvent.INSTANCE, UsedEvent.INSTANCE, UsedEvent.INSTANCE);
 
         assertTrue(countDownLatch1.await(10, TimeUnit.SECONDS));

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
@@ -78,7 +78,7 @@ class AggregateStereotypeAutoConfigurationTest {
     }
 
     @Test
-    void testAggregateStereotypeConfiguration() {
+    void aggregateStereotypeConfiguration() {
         testApplicationContext.run(context -> {
             // Publish the first command to create the TestAggregate
             CommandGateway commandGateway = context.getBean(DefaultCommandGateway.class);
@@ -111,7 +111,7 @@ class AggregateStereotypeAutoConfigurationTest {
      * the {@code Repository}.
      */
     @Test
-    void testAggregateStereotypeWithCustomizedRepository() {
+    void aggregateStereotypeWithCustomizedRepository() {
         testApplicationContext.run(context -> {
             // Publish the first command to create the TestAggregate
             CommandGateway commandGateway = context.getBean(DefaultCommandGateway.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerActuatorAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerActuatorAutoConfigurationTest.java
@@ -44,7 +44,7 @@ class AxonServerActuatorAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerHealthIndicatorIsNotCreatedForAxonServerDisabled() {
+    void axonServerHealthIndicatorIsNotCreatedForAxonServerDisabled() {
         testApplicationContext.withUserConfiguration(TestContext.class)
                               .withPropertyValues("axon.axonserver.enabled:false")
                               .run(context -> {
@@ -54,7 +54,7 @@ class AxonServerActuatorAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerHealthIndicatorIsCreated() {
+    void axonServerHealthIndicatorIsCreated() {
         testApplicationContext.withUserConfiguration(TestContext.class)
                               .withPropertyValues("axon.axonserver.enabled:true")
                               .run(context -> {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationLoadFactorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationLoadFactorTest.java
@@ -29,7 +29,7 @@ public class AxonServerAutoConfigurationLoadFactorTest {
     private CommandLoadFactorProvider commandLoadFactorProvider;
 
     @Test
-    public void testLoadFactor() {
+    public void loadFactor() {
         int loadFactor = commandLoadFactorProvider.getFor("anything");
         assertEquals(36, loadFactor);
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -84,19 +84,19 @@ class AxonServerAutoConfigurationTest {
     private QueryUpdateEmitter updateEmitter;
 
     @Test
-    void testAxonServerQueryBusConfiguration() {
+    void axonServerQueryBusConfiguration() {
         assertTrue(queryBus instanceof AxonServerQueryBus);
         assertSame(updateEmitter, queryBus.queryUpdateEmitter());
     }
 
     @Test
-    void testAxonServerCommandBusBeanTypesConfiguration() {
+    void axonServerCommandBusBeanTypesConfiguration() {
         assertTrue(commandBus instanceof AxonServerCommandBus);
         assertTrue(localSegment instanceof SimpleCommandBus);
     }
 
     @Test
-    void testAxonServerDefaultCommandBusConfiguration() {
+    void axonServerDefaultCommandBusConfiguration() {
         this.contextRunner
                 .withConfiguration(AutoConfigurations.of(AxonServerBusAutoConfiguration.class))
                 .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
@@ -111,7 +111,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerDefaultConfiguration_AxonServerDisabled() {
+    void axonServerDefaultConfiguration_AxonServerDisabled() {
         this.contextRunner.withPropertyValues("axon.axonserver.enabled=false")
                           .withConfiguration(AutoConfigurations.of(AxonServerBusAutoConfiguration.class))
                           .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
@@ -126,7 +126,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerUserDefinedCommandBusConfiguration() {
+    void axonServerUserDefinedCommandBusConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ExplicitUserCommandBusConfiguration.class)
                           .run(context -> {
@@ -138,7 +138,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerUserDefinedLocalSegmentConfiguration() {
+    void axonServerUserDefinedLocalSegmentConfiguration() {
         this.contextRunner
                 .withConfiguration(AutoConfigurations.of(AxonServerBusAutoConfiguration.class))
                 .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
@@ -154,7 +154,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerWrongUserDefinedLocalSegmentConfiguration() {
+    void axonServerWrongUserDefinedLocalSegmentConfiguration() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ExplicitWrongUserLocalSegmentConfiguration.class)
                           .run(context -> {
@@ -166,7 +166,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testNonAxonServerCommandBusConfiguration() {
+    void nonAxonServerCommandBusConfiguration() {
         this.contextRunner.run(context -> {
             assertThat(context).getBeanNames(CommandBus.class)
                                .hasSize(1);
@@ -176,7 +176,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testDefaultTargetContextResolverIsNoOp() {
+    void defaultTargetContextResolverIsNoOp() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .run(context -> {
                               assertThat(context).getBeanNames(TargetContextResolver.class)
@@ -187,7 +187,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testCustomTargetContextResolverIsConfigured() {
+    void customTargetContextResolverIsConfigured() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(TargetContextResolverConfiguration.class)
                           .run(context -> {
@@ -199,7 +199,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testAxonServerEventSchedulerIsConfigured() {
+    void axonServerEventSchedulerIsConfigured() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .run(context -> {
                               assertThat(context).getBeanNames(EventScheduler.class)
@@ -210,7 +210,7 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
-    void testCustomManagedChannelCustomizerIsConfigured() {
+    void customManagedChannelCustomizerIsConfigured() {
         this.contextRunner.withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
                           .withUserConfiguration(ManagedChannelCustomizerConfiguration.class)
                           .run(context -> {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
@@ -68,7 +68,7 @@ class ObjectMapperAutoConfigurationTest {
     private ApplicationContext applicationContext;
 
     @Test
-    void testEventSerializerIsOfTypeJacksonSerializerAndUsesDefaultAxonObjectMapperBean() {
+    void eventSerializerIsOfTypeJacksonSerializerAndUsesDefaultAxonObjectMapperBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final Serializer eventSerializer = applicationContext.getBean("eventSerializer", Serializer.class);
         final ObjectMapper objectMapper = applicationContext.getBean("defaultAxonObjectMapper", ObjectMapper.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/XStreamAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/XStreamAutoConfigurationTest.java
@@ -43,7 +43,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationConstructsXStreamInstanceWhenGeneralSerializerPropertyIsXStream() {
+    void xStreamAutoConfigurationConstructsXStreamInstanceWhenGeneralSerializerPropertyIsXStream() {
         testApplicationContext.withUserConfiguration(DefaultContext.class)
                               .withPropertyValues("axon.serializer.general:xstream")
                               .run(context -> {
@@ -54,7 +54,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationConstructsXStreamInstanceWhenGeneralSerializerPropertyIsDefault() {
+    void xStreamAutoConfigurationConstructsXStreamInstanceWhenGeneralSerializerPropertyIsDefault() {
         testApplicationContext.withUserConfiguration(DefaultContext.class)
                               .withPropertyValues("axon.serializer.general:default")
                               .run(context -> {
@@ -65,7 +65,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationConstructsXStreamInstanceWhenMessagesSerializerPropertyIsXStream() {
+    void xStreamAutoConfigurationConstructsXStreamInstanceWhenMessagesSerializerPropertyIsXStream() {
         testApplicationContext.withUserConfiguration(DefaultContext.class)
                               .withPropertyValues("axon.serializer.messages:xstream")
                               .run(context -> {
@@ -76,7 +76,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationConstructsXStreamInstanceWhenEventsSerializerPropertyIsXStream() {
+    void xStreamAutoConfigurationConstructsXStreamInstanceWhenEventsSerializerPropertyIsXStream() {
         testApplicationContext.withUserConfiguration(DefaultContext.class)
                               .withPropertyValues("axon.serializer.events:xstream")
                               .run(context -> {
@@ -87,7 +87,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationDoesNotConstructXStreamInstanceWhenNoPropertyIsXStream() {
+    void xStreamAutoConfigurationDoesNotConstructXStreamInstanceWhenNoPropertyIsXStream() {
         testApplicationContext.withUserConfiguration(DefaultContext.class)
                               .withPropertyValues(
                                       "axon.serializer.general:jackson",
@@ -98,7 +98,7 @@ class XStreamAutoConfigurationTest {
     }
 
     @Test
-    void testXStreamAutoConfigurationDoesNotConstructXStreamInstanceForExistingBean() {
+    void xStreamAutoConfigurationDoesNotConstructXStreamInstanceForExistingBean() {
         testApplicationContext.withUserConfiguration(ContextWithXStreamInstance.class)
                               .run(context -> {
                                   assertThat(context).hasSingleBean(XStream.class);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/util/XStreamSecurityTypeUtilityTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class XStreamSecurityTypeUtilityTest {
 
     @Test
-    void testAutoConfigBasePackages() {
+    void autoConfigBasePackagesTest() {
         // Axon packages are added through the default ApplicationContextRunner that adds Axon's DefaultEntityRegistrar.
         String[] expected = new String[]{
                 "org.axonframework.springboot.util.**",

--- a/spring/src/test/java/org/axonframework/spring/AggregatePolymorphismTest.java
+++ b/spring/src/test/java/org/axonframework/spring/AggregatePolymorphismTest.java
@@ -58,7 +58,7 @@ public class AggregatePolymorphismTest {
     private CommandGateway commandGateway;
 
     @Test
-    void testConfig() {
+    void config() {
         List<AggregateConfigurer> configurers = configuration.findModules(AggregateConfigurer.class);
         assertEquals(3, configurers.size());
 

--- a/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_CustomValues.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_CustomValues.java
@@ -49,7 +49,7 @@ public class AnnotationDrivenConfigurationTest_CustomValues {
     private DefaultListableBeanFactory beanFactory;
 
     @Test
-    void testCommandHandlerPostProcessorBeanDefinitionContainCustomValues() {
+    void commandHandlerPostProcessorBeanDefinitionContainCustomValues() {
         BeanDefinition beanDefinition =  beanFactory.getBeanDefinition(
                 "__axon-annotation-command-handler-bean-post-processor");
         assertEquals(AnnotationCommandHandlerBeanPostProcessor.class.getName(), beanDefinition.getBeanClassName());

--- a/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_DefaultValues.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AnnotationDrivenConfigurationTest_DefaultValues.java
@@ -47,7 +47,7 @@ public class AnnotationDrivenConfigurationTest_DefaultValues {
     private ApplicationContext applicationContext;
 
     @Test
-    void testAnnotationConfigurationAnnotationWrapsBeans() {
+    void annotationConfigurationAnnotationWrapsBeans() {
         Object eventHandler = applicationContext.getBean("eventHandler");
         Object commandHandler = applicationContext.getBean("commandHandler");
 

--- a/spring/src/test/java/org/axonframework/spring/config/AutoWiredEventSourcedAggregateTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AutoWiredEventSourcedAggregateTest.java
@@ -52,7 +52,7 @@ public class AutoWiredEventSourcedAggregateTest {
     private Repository<Context.MyAggregate> myAggregateRepository;
 
     @Test
-    void testAggregateIsWiredUsingStateStorage() {
+    void aggregateIsWiredUsingStateStorage() {
         assertEquals(EventSourcingRepository.class, myAggregateRepository.getClass());
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/AutoWiredStateStoredAggregateTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/AutoWiredStateStoredAggregateTest.java
@@ -53,7 +53,7 @@ public class AutoWiredStateStoredAggregateTest {
     private Repository<Context.MyAggregate> myAggregateRepository;
 
     @Test
-    void testAggregateIsWiredUsingStateStorage() {
+    void aggregateIsWiredUsingStateStorage() {
         assertEquals(GenericJpaRepository.class, myAggregateRepository.getClass());
     }
 

--- a/spring/src/test/java/org/axonframework/spring/config/EventHandlerRegistrarTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventHandlerRegistrarTest.java
@@ -45,7 +45,7 @@ class EventHandlerRegistrarTest {
     }
 
     @Test
-    void testBeansRegisteredInOrder() {
+    void beansRegisteredInOrder() {
         testSubject.setEventHandlers(Arrays.asList(new OrderedBean(), new LateOrderedBean(), new UnorderedBean()));
 
         InOrder inOrder = Mockito.inOrder(eventConfigurer);

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleConfigTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleConfigTest.java
@@ -53,7 +53,7 @@ public class EventProcessingModuleConfigTest {
     private EventProcessingModule eventProcessingConfiguration;
 
     @Test
-    void testEventProcessingConfiguration() {
+    void eventProcessingConfiguration() {
         assertEquals(3, eventProcessingConfiguration.eventProcessors().size());
         assertTrue(eventProcessingConfiguration.eventProcessor("processor2").isPresent());
         assertTrue(eventProcessingConfiguration.eventProcessor("subscribingProcessor").isPresent());

--- a/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleWithInterceptorsTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/EventProcessingModuleWithInterceptorsTest.java
@@ -56,7 +56,7 @@ public class EventProcessingModuleWithInterceptorsTest {
     private Context.MyEventHandler myEventHandler;
 
     @Test
-    void testInterceptorRegistration() {
+    void interceptorRegistration() {
         eventBus.publish(GenericEventMessage.asEventMessage("myEvent"));
         assertEquals("myMetaDataValue", myEventHandler.getMetaDataValue());
     }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -241,7 +241,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void eventHandlerIsRegistered() {
+    void testEventHandlerIsRegistered() {
         eventBus.publish(asEventMessage("Testing 123"));
 
         assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");
@@ -250,7 +250,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void sagaIsConfigured() {
+    void testSagaIsConfigured() {
         AtomicInteger counter = new AtomicInteger();
         eventProcessingConfigurer.registerHandlerInterceptor("MySagaProcessor", config -> (uow, chain) -> {
             counter.incrementAndGet();
@@ -265,7 +265,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void wiresCommandHandler() {
+    void testWiresCommandHandler() {
         FutureCallback<Object, Object> callback = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage("test"), callback);
         callback.getResult(1, TimeUnit.SECONDS);
@@ -281,7 +281,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void customCommandTargetResolverWiring() {
+    void testCustomCommandTargetResolverWiring() {
         FutureCallback<Object, Object> callback1 = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage(new Context.CreateMyOtherAggregateCommand("id")), callback1);
         callback1.getResult();
@@ -296,7 +296,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void listenerInvocationErrorHandler() {
+    void testListenerInvocationErrorHandler() {
         eventBus.publish(asEventMessage("Testing 123"));
 
         assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");
@@ -304,7 +304,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void sagaInvocationErrorHandler() {
+    void testSagaInvocationErrorHandler() {
         eventBus.publish(asEventMessage(new SomeEvent("id")));
         eventBus.publish(asEventMessage(new SomeEventWhichHandlingFails("id")));
 
@@ -314,7 +314,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void wiringOfQueryHandlerAndQueryUpdateEmitter() {
+    void testWiringOfQueryHandlerAndQueryUpdateEmitter() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "axonCR",
                 ResponseTypes.multipleInstancesOf(String.class),
@@ -333,7 +333,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void handlerDefinitionAndHandlerEnhancerBeansRegistered() {
+    void testHandlerDefinitionAndHandlerEnhancerBeansRegistered() {
         MultiHandlerDefinition handlerDefinition = (MultiHandlerDefinition) axonConfig.handlerDefinition(getClass());
         MultiHandlerEnhancerDefinition handlerEnhancerDefinition =
                 (MultiHandlerEnhancerDefinition) handlerDefinition.getHandlerEnhancerDefinition();
@@ -373,14 +373,14 @@ public class SpringAxonAutoConfigurerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void eventUpcasterBeanPickedUp() {
+    void testEventUpcasterBeanPickedUp() {
         Stream<IntermediateEventRepresentation> representationStream = mock(Stream.class);
         axonConfig.upcasterChain().upcast(representationStream);
         verify(eventUpcaster).upcast(representationStream);
     }
 
     @Test
-    void aggregateCaching() {
+    void testAggregateCaching() {
         FutureCallback<Object, Object> callback1 = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage(new Context.CreateMyCachedAggregateCommand("id")), callback1);
         callback1.getResult();
@@ -391,7 +391,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void aggregateLockFactory() {
+    void testAggregateLockFactory() {
         String expectedAggregateId = "someIdentifier";
 
         FutureCallback<Object, Object> commandCallback = new FutureCallback<>();
@@ -404,7 +404,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void eventSchedulerUsesEventSerializer() {
+    void testEventSchedulerUsesEventSerializer() {
         when(eventSerializer.serialize(any(), eq(byte[].class))).thenReturn(new SimpleSerializedObject<>(new byte[1], byte[].class, SerializedType.emptyType()));
         quartzEventScheduler.schedule(Instant.now(), "deadline");
         //The below check shows we have serialized both the payload and metadata using this serializer

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest.java
@@ -241,7 +241,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testEventHandlerIsRegistered() {
+    void eventHandlerIsRegistered() {
         eventBus.publish(asEventMessage("Testing 123"));
 
         assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");
@@ -250,7 +250,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testSagaIsConfigured() {
+    void sagaIsConfigured() {
         AtomicInteger counter = new AtomicInteger();
         eventProcessingConfigurer.registerHandlerInterceptor("MySagaProcessor", config -> (uow, chain) -> {
             counter.incrementAndGet();
@@ -265,7 +265,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testWiresCommandHandler() {
+    void wiresCommandHandler() {
         FutureCallback<Object, Object> callback = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage("test"), callback);
         callback.getResult(1, TimeUnit.SECONDS);
@@ -281,7 +281,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testCustomCommandTargetResolverWiring() {
+    void customCommandTargetResolverWiring() {
         FutureCallback<Object, Object> callback1 = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage(new Context.CreateMyOtherAggregateCommand("id")), callback1);
         callback1.getResult();
@@ -296,7 +296,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testListenerInvocationErrorHandler() {
+    void listenerInvocationErrorHandler() {
         eventBus.publish(asEventMessage("Testing 123"));
 
         assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");
@@ -304,7 +304,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testSagaInvocationErrorHandler() {
+    void sagaInvocationErrorHandler() {
         eventBus.publish(asEventMessage(new SomeEvent("id")));
         eventBus.publish(asEventMessage(new SomeEventWhichHandlingFails("id")));
 
@@ -314,7 +314,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testWiringOfQueryHandlerAndQueryUpdateEmitter() {
+    void wiringOfQueryHandlerAndQueryUpdateEmitter() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "axonCR",
                 ResponseTypes.multipleInstancesOf(String.class),
@@ -333,7 +333,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testHandlerDefinitionAndHandlerEnhancerBeansRegistered() {
+    void handlerDefinitionAndHandlerEnhancerBeansRegistered() {
         MultiHandlerDefinition handlerDefinition = (MultiHandlerDefinition) axonConfig.handlerDefinition(getClass());
         MultiHandlerEnhancerDefinition handlerEnhancerDefinition =
                 (MultiHandlerEnhancerDefinition) handlerDefinition.getHandlerEnhancerDefinition();
@@ -373,14 +373,14 @@ public class SpringAxonAutoConfigurerTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testEventUpcasterBeanPickedUp() {
+    void eventUpcasterBeanPickedUp() {
         Stream<IntermediateEventRepresentation> representationStream = mock(Stream.class);
         axonConfig.upcasterChain().upcast(representationStream);
         verify(eventUpcaster).upcast(representationStream);
     }
 
     @Test
-    void testAggregateCaching() {
+    void aggregateCaching() {
         FutureCallback<Object, Object> callback1 = new FutureCallback<>();
         commandBus.dispatch(asCommandMessage(new Context.CreateMyCachedAggregateCommand("id")), callback1);
         callback1.getResult();
@@ -391,7 +391,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testAggregateLockFactory() {
+    void aggregateLockFactory() {
         String expectedAggregateId = "someIdentifier";
 
         FutureCallback<Object, Object> commandCallback = new FutureCallback<>();
@@ -404,7 +404,7 @@ public class SpringAxonAutoConfigurerTest {
     }
 
     @Test
-    void testEventSchedulerUsesEventSerializer() {
+    void eventSchedulerUsesEventSerializer() {
         when(eventSerializer.serialize(any(), eq(byte[].class))).thenReturn(new SimpleSerializedObject<>(new byte[1], byte[].class, SerializedType.emptyType()));
         quartzEventScheduler.schedule(Instant.now(), "deadline");
         //The below check shows we have serialized both the payload and metadata using this serializer

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration.java
@@ -71,7 +71,7 @@ public class SpringAxonAutoConfigurerTest_CustomEventHandlerConfiguration {
     private Context.MyOtherEventHandler myOtherEventHandler;
 
     @Test
-    void testEventHandlerIsRegisteredWithCustomProcessor() {
+    void eventHandlerIsRegisteredWithCustomProcessor() {
         eventBus.publish(asEventMessage("Testing 123"));
 
         assertNotNull(myEventHandler.eventBus, "Expected EventBus to be wired");

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 class SpringAxonConfigurationTest {
 
     @Test
-    void testAxonStartedEventIsPublished() {
+    void axonStartedEventIsPublished() {
         Configurer configurer = mock(Configurer.class);
         ApplicationContext context = mock(ApplicationContext.class);
         Configuration configuration = mock(Configuration.class);

--- a/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/UpcasterOrderingTest.java
@@ -54,7 +54,7 @@ class UpcasterOrderingTest {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    void testUpcastersAreRegisteredInOrder() {
+    void upcastersAreRegisteredInOrder() {
         //noinspection unchecked
         Stream<IntermediateEventRepresentation> mockStream = mock(Stream.class);
 

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationCommandHandlerBeanPostProcessorTest.java
@@ -47,7 +47,7 @@ class AnnotationCommandHandlerBeanPostProcessorTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testCommandHandlerCallsRedirectToAdapter() throws Exception {
+    void commandHandlerCallsRedirectToAdapter() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new AnnotatedCommandHandler(), "beanName");
@@ -65,7 +65,7 @@ class AnnotationCommandHandlerBeanPostProcessorTest {
     }
 
     @Test
-    void testCommandHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
+    void commandHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new CustomAnnotatedCommandHandler(), "beanName");
@@ -83,7 +83,7 @@ class AnnotationCommandHandlerBeanPostProcessorTest {
     }
 
     @Test
-    void testProcessorIgnoresFactoryBeans() {
+    void processorIgnoresFactoryBeans() {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         when(mockBeanFactory.containsBean("beanName")).thenReturn(true);
         FactoryBean mockFactoryBean = mock(FactoryBean.class);

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/AnnotationQueryHandlerBeanPostProcessorTest.java
@@ -45,7 +45,7 @@ class AnnotationQueryHandlerBeanPostProcessorTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testQueryHandlerCallsRedirectToAdapter() throws Exception {
+    void queryHandlerCallsRedirectToAdapter() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new AnnotatedQueryHandler(), "beanName");
@@ -64,7 +64,7 @@ class AnnotationQueryHandlerBeanPostProcessorTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testQueryHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
+    void queryHandlerCallsRedirectToAdapterWhenUsingCustomAnnotation() throws Exception {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         testSubject.setBeanFactory(mockBeanFactory);
         Object result1 = testSubject.postProcessBeforeInitialization(new CustomAnnotatedQueryHandler(), "beanName");
@@ -82,7 +82,7 @@ class AnnotationQueryHandlerBeanPostProcessorTest {
     }
 
     @Test
-    void testProcessorIgnoresFactoryBeans() {
+    void processorIgnoresFactoryBeans() {
         BeanFactory mockBeanFactory = mock(BeanFactory.class);
         when(mockBeanFactory.containsBean("beanName")).thenReturn(true);
         FactoryBean mockFactoryBean = mock(FactoryBean.class);

--- a/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanResolverFactoryTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/annotation/SpringBeanResolverFactoryTest.java
@@ -85,7 +85,7 @@ public class SpringBeanResolverFactoryTest {
     }
 
     @Test
-    void testMethodsAreProperlyInjected() throws Exception {
+    void methodsAreProperlyInjected() throws Exception {
         assertNotNull(annotatedHandler);
         new AnnotationEventHandlerAdapter(annotatedHandler, parameterResolver).handle(asEventMessage("Hello"));
         // make sure the invocation actually happened
@@ -93,7 +93,7 @@ public class SpringBeanResolverFactoryTest {
     }
 
     @Test
-    void testNewInstanceIsCreatedEachTimePrototypeResourceIsInjected() throws Exception {
+    void newInstanceIsCreatedEachTimePrototypeResourceIsInjected() throws Exception {
         Object handler = applicationContext.getBean("prototypeResourceHandler");
         AnnotationEventHandlerAdapter adapter = new AnnotationEventHandlerAdapter(
                 handler, applicationContext.getBean(ParameterResolverFactory.class)
@@ -104,7 +104,7 @@ public class SpringBeanResolverFactoryTest {
     }
 
     @Test
-    void testMethodsAreProperlyInjected_ErrorOnMissingParameterType() {
+    void methodsAreProperlyInjected_ErrorOnMissingParameterType() {
         // this should generate an error
         Object bean = applicationContext.getBean("missingResourceHandler");
         assertThrows(
@@ -113,7 +113,7 @@ public class SpringBeanResolverFactoryTest {
     }
 
     @Test
-    void testMethodsAreProperlyInjected_NullableParameterType() throws Exception {
+    void methodsAreProperlyInjected_NullableParameterType() throws Exception {
         new AnnotationEventHandlerAdapter(applicationContext.getBean("nullableResourceHandler"),
                                           parameterResolver).handle(asEventMessage("Hi there"));
 
@@ -121,7 +121,7 @@ public class SpringBeanResolverFactoryTest {
     }
 
     @Test
-    void testMethodsAreProperlyInjected_ErrorOnDuplicateParameterType() {
+    void methodsAreProperlyInjected_ErrorOnDuplicateParameterType() {
         // this should generate an error
         Object bean = applicationContext.getBean("duplicateResourceHandler");
         assertThrows(
@@ -131,7 +131,7 @@ public class SpringBeanResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    void testMethodsAreProperlyInjected_DuplicateParameterTypeWithPrimary() throws Exception {
+    void methodsAreProperlyInjected_DuplicateParameterTypeWithPrimary() throws Exception {
         // this should generate an error
         new AnnotationEventHandlerAdapter(applicationContext.getBean("duplicateResourceHandlerWithPrimary"),
                                           parameterResolver).handle(asEventMessage("Hi there"));
@@ -141,7 +141,7 @@ public class SpringBeanResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    void testMethodsAreProperlyInjected_DuplicateParameterTypeWithQualifier() throws Exception {
+    void methodsAreProperlyInjected_DuplicateParameterTypeWithQualifier() throws Exception {
         new AnnotationEventHandlerAdapter(applicationContext.getBean("duplicateResourceHandlerWithQualifier"),
                                           parameterResolver).handle(asEventMessage("Hi there"));
 
@@ -150,7 +150,7 @@ public class SpringBeanResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    void testMethodsAreProperlyInjected_QualifierPrecedesPrimary() throws Exception {
+    void methodsAreProperlyInjected_QualifierPrecedesPrimary() throws Exception {
         new AnnotationEventHandlerAdapter(
                 applicationContext.getBean("duplicateResourceHandlerWithQualifierAndPrimary"),
                 parameterResolver
@@ -161,7 +161,7 @@ public class SpringBeanResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    void testMethodsAreProperlyInjected_DuplicateParameterWithAutowired() {
+    void methodsAreProperlyInjected_DuplicateParameterWithAutowired() {
         Object handler = applicationContext.getBean("duplicateResourceHandlerWithAutowired");
         AnnotationEventHandlerAdapter adapter = new AnnotationEventHandlerAdapter(
                 handler, applicationContext.getBean(ParameterResolverFactory.class)
@@ -172,7 +172,7 @@ public class SpringBeanResolverFactoryTest {
 
     @Test
     @DirtiesContext
-    void testMethodsAreProperlyInjectedForDuplicateResourceHandlerWithAutowiredAndQualifier() throws Exception {
+    void methodsAreProperlyInjectedForDuplicateResourceHandlerWithAutowiredAndQualifier() throws Exception {
         new AnnotationEventHandlerAdapter(
                 applicationContext.getBean("duplicateResourceHandlerWithAutowiredAndQualifier"),
                 parameterResolver).handle(asEventMessage("Hi there")

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -77,7 +77,7 @@ class JpaTokenStoreTest {
 
     @Transactional
     @Test
-    void testStealingFromOtherThreadFailsWithRowLock() throws Exception {
+    void stealingFromOtherThreadFailsWithRowLock() throws Exception {
         jpaTokenStore.initializeTokenSegments("processor", 1);
 
         ExecutorService executor1 = Executors.newSingleThreadExecutor();

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBeanTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBeanTest.java
@@ -85,7 +85,7 @@ class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    void testSnapshotCreatedNoTransaction() {
+    void snapshotCreatedNoTransaction() {
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         snapshotter.scheduleSnapshot(StubAggregate.class, aggregateIdentifier);
 
@@ -94,7 +94,7 @@ class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    void testRetrieveAggregateFactoryFromRepositoryIfNotExplicitlyAvailable() {
+    void retrieveAggregateFactoryFromRepositoryIfNotExplicitlyAvailable() {
         testSubject.setEventStore(null);
         reset(mockApplicationContext);
         when(mockApplicationContext.getBean(EventStore.class)).thenReturn(mockEventStore);
@@ -106,11 +106,11 @@ class SpringAggregateSnapshotterFactoryBeanTest {
                                                                             .repositoryProvider(mockRepositoryProvider)
                                                                             .build()
                 ));
-        testSnapshotCreatedNoTransaction();
+        snapshotCreatedNoTransaction();
     }
 
     @Test
-    void testSnapshotCreatedNewlyCreatedTransactionCommitted() {
+    void snapshotCreatedNewlyCreatedTransactionCommitted() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus newlyCreatedTransaction = new SimpleTransactionStatus(true);
@@ -124,7 +124,7 @@ class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    void testSnapshotCreatedExistingTransactionNotCommitted() {
+    void snapshotCreatedExistingTransactionNotCommitted() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(false);
@@ -137,7 +137,7 @@ class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    void testSnapshotCreatedExistingTransactionNotRolledBack() {
+    void snapshotCreatedExistingTransactionNotRolledBack() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(false);
@@ -152,7 +152,7 @@ class SpringAggregateSnapshotterFactoryBeanTest {
     }
 
     @Test
-    void testSnapshotCreatedNewTransactionRolledBack() {
+    void snapshotCreatedNewTransactionRolledBack() {
         testSubject.setTransactionManager(mockTransactionManager);
         SpringAggregateSnapshotter snapshotter = testSubject.getObject();
         SimpleTransactionStatus existingTransaction = new SimpleTransactionStatus(true);

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactoryTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactoryTest.java
@@ -40,12 +40,12 @@ class SpringPrototypeAggregateFactoryTest {
     private SpringPrototypeAggregateFactory<SpringWiredAggregate> testSubject;
 
     @Test
-    void testContextStarts() {
+    void contextStarts() {
         assertNotNull(testSubject);
     }
 
     @Test
-    void testCreateNewAggregateInstance() {
+    void createNewAggregateInstance() {
         SpringWiredAggregate aggregate = testSubject.createAggregateRoot("id2", new GenericDomainEventMessage<>("SpringWiredAggregate", "id2", 0,
                                                                                                                 "FirstEvent"));
         assertTrue(aggregate.isInitialized(), "Aggregate's init method not invoked");
@@ -54,7 +54,7 @@ class SpringPrototypeAggregateFactoryTest {
     }
 
     @Test
-    void testProcessSnapshotAggregateInstance() {
+    void processSnapshotAggregateInstance() {
         SpringWiredAggregate aggregate = testSubject.createAggregateRoot("id2",
                                                                      new GenericDomainEventMessage<>("SpringWiredAggregate", "id2", 5,
                                                                                                      new SpringWiredAggregate()));

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/benchmark/JpaStorageEngineInsertionReadOrderTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/benchmark/JpaStorageEngineInsertionReadOrderTest.java
@@ -103,7 +103,7 @@ class JpaStorageEngineInsertionReadOrderTest {
 
     @Test
     @Timeout(value = 30)
-    void testInsertConcurrentlyAndCheckReadOrder() throws Exception {
+    void insertConcurrentlyAndCheckReadOrder() throws Exception {
         int threadCount = 10;
         int eventsPerThread = 100;
         int inverseRollbackRate = 7;
@@ -122,7 +122,7 @@ class JpaStorageEngineInsertionReadOrderTest {
 
     @Test
     @Timeout(value = 10)
-    void testInsertConcurrentlyAndReadUsingBlockingStreams() throws Exception {
+    void insertConcurrentlyAndReadUsingBlockingStreams() throws Exception {
         int threadCount = 10;
         int eventsPerThread = 100;
         int inverseRollbackRate = 2;
@@ -149,7 +149,7 @@ class JpaStorageEngineInsertionReadOrderTest {
 
     @Test
     @Timeout(value = 30)
-    void testInsertConcurrentlyAndReadUsingBlockingStreams_SlowConsumer() throws Exception {
+    void insertConcurrentlyAndReadUsingBlockingStreams_SlowConsumer() throws Exception {
         int threadCount = 4;
         int eventsPerThread = 100;
         int inverseRollbackRate = 2;

--- a/spring/src/test/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProviderTest.java
+++ b/spring/src/test/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProviderTest.java
@@ -66,7 +66,7 @@ class SpringDataSourceConnectionProviderTest {
     @DirtiesContext
     @Transactional
     @Test
-    void testConnectionNotCommittedWhenTransactionScopeOutsideUnitOfWork() throws Exception {
+    void connectionNotCommittedWhenTransactionScopeOutsideUnitOfWork() throws Exception {
         when(dataSource.getConnection()).thenAnswer(invocation -> {
             fail("Should be using an already existing connection.");
             return null;
@@ -81,7 +81,7 @@ class SpringDataSourceConnectionProviderTest {
     }
 
     @Test
-    void testConnectionCommittedWhenTransactionScopeInsideUnitOfWork() throws Exception {
+    void connectionCommittedWhenTransactionScopeInsideUnitOfWork() throws Exception {
         doAnswer(invocation -> {
             final Object spy = spy(invocation.callRealMethod());
             mockConnection = (Connection) spy;

--- a/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
@@ -32,7 +32,7 @@ public class ApplicationContextEventPublisherTest {
     private EventBus eventBus;
 
     @Test
-    void testEventsForwardedToListenerBean() {
+    void eventsForwardedToListenerBean() {
         eventBus.publish(asEventMessage("test"));
 
         assertEquals("test", listenerBean.getEvents().get(0));

--- a/spring/src/test/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapterTest.java
@@ -40,7 +40,7 @@ class InboundEventMessageChannelAdapterTest {
     }
 
     @Test
-    void testMessagePayloadIsPublished() {
+    void messagePayloadIsPublished() {
         testSubject = new InboundEventMessageChannelAdapter();
         StubDomainEvent event = new StubDomainEvent();
         testSubject.handleMessage(new GenericMessage<Object>(event));

--- a/spring/src/test/java/org/axonframework/spring/messaging/OutboundEventMessageChannelAdapterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/OutboundEventMessageChannelAdapterTest.java
@@ -46,7 +46,7 @@ class OutboundEventMessageChannelAdapterTest {
     }
 
     @Test
-    void testMessageForwardedToChannel() {
+    void messageForwardedToChannel() {
         StubDomainEvent event = new StubDomainEvent();
         testSubject.handle(singletonList(new GenericEventMessage<>(event)));
 
@@ -54,7 +54,7 @@ class OutboundEventMessageChannelAdapterTest {
     }
 
     @Test
-    void testEventListenerRegisteredOnInit() {
+    void eventListenerRegisteredOnInit() {
         verify(mockEventBus, never()).subscribe(any());
         testSubject.afterPropertiesSet();
         verify(mockEventBus).subscribe(any());
@@ -62,7 +62,7 @@ class OutboundEventMessageChannelAdapterTest {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testFilterBlocksEvents() {
+    void filterBlocksEvents() {
         testSubject = new OutboundEventMessageChannelAdapter(mockEventBus, mockChannel, m -> !m.getPayloadType().isAssignableFrom(Class.class));
         testSubject.handle(singletonList(newDomainEvent()));
         verify(mockEventBus, never()).publish(isA(EventMessage.class));

--- a/spring/src/test/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManagerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManagerTest.java
@@ -45,7 +45,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testManageTransaction_CustomTransactionStatus() {
+    void manageTransaction_CustomTransactionStatus() {
         testSubject = new SpringTransactionManager(transactionManager, mock(TransactionDefinition.class));
         testSubject.startTransaction().commit();
 
@@ -54,7 +54,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testManageTransaction_DefaultTransactionStatus() {
+    void manageTransaction_DefaultTransactionStatus() {
         testSubject.startTransaction().commit();
 
         verify(transactionManager).getTransaction(isA(DefaultTransactionDefinition.class));
@@ -62,7 +62,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testCommitTransaction_NoCommitOnInactiveTransaction() {
+    void commitTransaction_NoCommitOnInactiveTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isCompleted()).thenReturn(true);
         transaction.commit();
@@ -71,7 +71,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testCommitTransaction_NoRollbackOnInactiveTransaction() {
+    void commitTransaction_NoRollbackOnInactiveTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isCompleted()).thenReturn(true);
         transaction.rollback();
@@ -80,7 +80,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testCommitTransaction_NoCommitOnNestedTransaction() {
+    void commitTransaction_NoCommitOnNestedTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isNewTransaction()).thenReturn(false);
         transaction.commit();
@@ -89,7 +89,7 @@ class SpringTransactionManagerTest {
     }
 
     @Test
-    void testCommitTransaction_NoRollbackOnNestedTransaction() {
+    void commitTransaction_NoRollbackOnNestedTransaction() {
         Transaction transaction = testSubject.startTransaction();
         when(underlyingTransactionStatus.isNewTransaction()).thenReturn(false);
         transaction.rollback();

--- a/spring/src/test/java/org/axonframework/spring/modeling/command/GenericJpaRepositoryIntegrationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/modeling/command/GenericJpaRepositoryIntegrationTest.java
@@ -100,7 +100,7 @@ class GenericJpaRepositoryIntegrationTest implements EventMessageHandler {
 
     @SuppressWarnings({"unchecked"})
     @Test
-    void testStoreAndLoadNewAggregate() throws Exception {
+    void storeAndLoadNewAggregate() throws Exception {
         UnitOfWork<?> uow = startAndGetUnitOfWork();
         String originalId = repository.newInstance(() -> new JpaAggregate("Hello")).invoke(JpaAggregate::getIdentifier);
         uow.commit();
@@ -120,7 +120,7 @@ class GenericJpaRepositoryIntegrationTest implements EventMessageHandler {
     }
 
     @Test
-    void testUpdateAnAggregate() {
+    void updateAnAggregate() {
         JpaAggregate agg = new JpaAggregate("First message");
         entityManager.persist(agg);
         entityManager.flush();
@@ -138,7 +138,7 @@ class GenericJpaRepositoryIntegrationTest implements EventMessageHandler {
     }
 
     @Test
-    void testDeleteAnAggregate() {
+    void deleteAnAggregate() {
         JpaAggregate agg = new JpaAggregate("First message");
         entityManager.persist(agg);
         entityManager.flush();

--- a/spring/src/test/java/org/axonframework/spring/saga/SpringResourceInjectorTest.java
+++ b/spring/src/test/java/org/axonframework/spring/saga/SpringResourceInjectorTest.java
@@ -44,7 +44,7 @@ public class SpringResourceInjectorTest {
     }
 
     @Test
-    void testInjectSaga() {
+    void injectSaga() {
         InjectableSaga injectableSaga = new InjectableSaga();
         testSubject.injectResources(injectableSaga);
         assertNotNull(injectableSaga.getCommandBus());
@@ -53,7 +53,7 @@ public class SpringResourceInjectorTest {
     }
 
     @Test
-    void testResourcesNotAvailable() {
+    void resourcesNotAvailable() {
         ProblematicInjectableSaga injectableSaga = new ProblematicInjectableSaga();
         assertThrows(BeanCreationException.class, () -> testSubject.injectResources(injectableSaga));
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
@@ -62,7 +62,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testNullIdentifierIsRejected() {
+    void nullIdentifierIsRejected() {
         AxonAssertionError error = assertThrows(AxonAssertionError.class, () ->
                 fixture.given(new MyEvent(null, 0))
                        .when(new TestCommand("test"))
@@ -77,7 +77,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testEventsCarryCorrectTimestamp() {
+    void eventsCarryCorrectTimestamp() {
         fixture.givenCurrentTime(Instant.EPOCH)
                .andGiven(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .andGivenCommands(new TestCommand("AggregateId"))
@@ -107,7 +107,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testClockStandsStillDuringExecution() {
+    void clockStandsStillDuringExecution() {
         fixture.given(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .when(new TestCommand("AggregateId"));
 
@@ -119,7 +119,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAggregateCommandHandlersOverwrittenByCustomHandlers() {
+    void aggregateCommandHandlersOverwrittenByCustomHandlers() {
         final AtomicBoolean invoked = new AtomicBoolean(false);
         fixture.registerCommandHandler(CreateAggregateCommand.class, commandMessage -> {
             invoked.set(true);
@@ -131,20 +131,20 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAggregateIdentifier_ServerGeneratedIdentifier() {
+    void aggregateIdentifier_ServerGeneratedIdentifier() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.given()
                .when(new CreateAggregateCommand());
     }
 
     @Test
-    void testUnavailableResourcesCausesFailure() {
+    void unavailableResourcesCausesFailure() {
         TestExecutor<AnnotatedAggregate> given = fixture.given();
         assertThrows(FixtureExecutionException.class, () -> given.when(new CreateAggregateCommand()));
     }
 
     @Test
-    void testAggregateIdentifier_IdentifierAutomaticallyDeducted() {
+    void aggregateIdentifier_IdentifierAutomaticallyDeducted() {
         fixture.given(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
                .when(new TestCommand("AggregateId"))
                .expectEvents(new MyEvent("AggregateId", 3))
@@ -160,14 +160,14 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testFixtureGivenCommands_ResourcesNotAvailable() {
+    void fixtureGivenCommands_ResourcesNotAvailable() {
         assertThrows(
                 FixtureExecutionException.class, () -> fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
         );
     }
 
     @Test
-    void testFixtureGivenCommands_ResourcesAvailable() {
+    void fixtureGivenCommands_ResourcesAvailable() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID),
                               new TestCommand(AGGREGATE_ID),
@@ -178,7 +178,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAggregateIdentifier_CustomTargetResolver() {
+    void aggregateIdentifier_CustomTargetResolver() {
         CommandTargetResolver mockCommandTargetResolver = mock(CommandTargetResolver.class);
         when(mockCommandTargetResolver.resolveTarget(any()))
                 .thenReturn(new VersionedAggregateIdentifier(AGGREGATE_ID, 0L));
@@ -193,7 +193,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAggregate_InjectCustomResourceAfterCreatingAnnotatedHandler() {
+    void aggregate_InjectCustomResourceAfterCreatingAnnotatedHandler() {
         // a 'when' will cause command handlers to be registered.
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.given()
@@ -203,7 +203,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testFixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
+    void fixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
         assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()),
@@ -212,7 +212,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testFixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
+    void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
         assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(
@@ -222,14 +222,14 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testFixture_AggregateDeleted() {
+    void fixture_AggregateDeleted() {
         fixture.given(new MyEvent(AGGREGATE_ID, 5))
                .when(new DeleteCommand(AGGREGATE_ID, false))
                .expectEvents(new MyAggregateDeletedEvent(false));
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
+    void fixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
         TestExecutor<AnnotatedAggregate> exec = fixture.given(new MyEvent(AGGREGATE_ID, 5));
         AssertionError error =
                 assertThrows(AssertionError.class, () -> exec.when(new DeleteCommand(AGGREGATE_ID, true)));
@@ -237,7 +237,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAndGiven() {
+    void andGiven() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
                .andGiven(new MyEvent(AGGREGATE_ID, 1))
@@ -246,7 +246,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testAndGivenCommands() {
+    void andGivenCommands() {
         fixture.given(new MyEvent(AGGREGATE_ID, 1))
                .andGivenCommands(new TestCommand(AGGREGATE_ID))
                .when(new TestCommand(AGGREGATE_ID))
@@ -254,7 +254,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testMultipleAndGivenCommands() {
+    void multipleAndGivenCommands() {
         fixture.given(new MyEvent(AGGREGATE_ID, 1))
                .andGivenCommands(new TestCommand(AGGREGATE_ID))
                .andGivenCommands(new TestCommand(AGGREGATE_ID))
@@ -263,7 +263,7 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void testGivenNoPriorActivityAndPublishingNoEvents() {
+    void givenNoPriorActivityAndPublishingNoEvents() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenNoPriorActivity()
                .when(new CreateAggregateCommand(AGGREGATE_ID, CreateAggregateCommand.SHOULD_NOT_PUBLISH))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -78,7 +78,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandDispatchInterceptorsAreInvoked() {
+    void registeredCommandDispatchInterceptorsAreInvoked() {
         when(firstMockCommandDispatchInterceptor.handle(any(CommandMessage.class)))
                 .thenAnswer(it -> it.getArguments()[0]);
         fixture.registerCommandDispatchInterceptor(firstMockCommandDispatchInterceptor);
@@ -106,7 +106,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandDispatchInterceptorIsInvokedAndAltersAppliedEvent() {
+    void registeredCommandDispatchInterceptorIsInvokedAndAltersAppliedEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
@@ -122,7 +122,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandDispatchInterceptorIsInvokedForFixtureMethodsGivenCommands() {
+    void registeredCommandDispatchInterceptorIsInvokedForFixtureMethodsGivenCommands() {
         fixture.registerCommandDispatchInterceptor(new TestCommandDispatchInterceptor());
 
         MetaData expectedValues =
@@ -134,7 +134,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandHandlerInterceptorsAreInvoked() throws Exception {
+    void registeredCommandHandlerInterceptorsAreInvoked() throws Exception {
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
         //noinspection unchecked
         when(mockCommandHandlerInterceptor.handle(any(UnitOfWork.class), any(InterceptorChain.class)))
@@ -160,7 +160,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandHandlerInterceptorIsInvokedAndAltersEvent() {
+    void registeredCommandHandlerInterceptorIsInvokedAndAltersEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
@@ -176,7 +176,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandHandlerInterceptorIsInvokedForFixtureMethodsGivenCommands() {
+    void registeredCommandHandlerInterceptorIsInvokedForFixtureMethodsGivenCommands() {
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
 
         Map<String, Object> expectedMetaDataMap = new HashMap<>();
@@ -188,7 +188,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredCommandDispatchAndHandlerInterceptorAreBothInvokedAndAlterEvent() {
+    void registeredCommandDispatchAndHandlerInterceptorAreBothInvokedAndAlterEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
                .when(new TestCommand(AGGREGATE_IDENTIFIER))
                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
@@ -208,7 +208,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredHandlerInterceptorIsInvokedOnceOnGivenCommandsTestExecution() {
+    void registeredHandlerInterceptorIsInvokedOnceOnGivenCommandsTestExecution() {
         AtomicInteger invocations = new AtomicInteger(0);
         fixture.registerCommandHandlerInterceptor((unitOfWork, interceptorChain) -> {
             invocations.incrementAndGet();
@@ -225,7 +225,7 @@ class FixtureTest_CommandInterceptors {
     }
 
     @Test
-    void testRegisteredDispatchInterceptorIsInvokedOnceOnGivenCommandsTestExecution() {
+    void registeredDispatchInterceptorIsInvokedOnceOnGivenCommandsTestExecution() {
         AtomicInteger invocations = new AtomicInteger(0);
         fixture.registerCommandDispatchInterceptor(messages -> (i, command) -> {
             invocations.incrementAndGet();

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
@@ -56,7 +56,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testCreateOrUpdatePolicyForNewInstance() {
+    void createOrUpdatePolicyForNewInstance() {
         fixture.givenNoPriorActivity()
                .when(new CreateOrUpdateCommand(AGGREGATE_ID, PUBLISH_EVENTS))
                .expectEvents(new CreatedOrUpdatedEvent(AGGREGATE_ID))
@@ -65,7 +65,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testCreateOrUpdatePolicyForExistingInstance() {
+    void createOrUpdatePolicyForExistingInstance() {
         fixture.given(new CreatedEvent(AGGREGATE_ID))
                .when(new CreateOrUpdateCommand(AGGREGATE_ID, PUBLISH_EVENTS))
                .expectEvents(new CreatedOrUpdatedEvent(AGGREGATE_ID))
@@ -74,7 +74,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testAlwaysCreatePolicyWithoutResultReturnsAggregateId() {
+    void alwaysCreatePolicyWithoutResultReturnsAggregateId() {
         fixture.givenNoPriorActivity()
                .when(new AlwaysCreateWithoutResultCommand(AGGREGATE_ID, PUBLISH_EVENTS))
                .expectEvents(new AlwaysCreatedEvent(AGGREGATE_ID))
@@ -84,7 +84,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testAlwaysCreatePolicyWithResultReturnsCommandHandlingResult() {
+    void alwaysCreatePolicyWithResultReturnsCommandHandlingResult() {
         Object testResult = "some-result";
         fixture.givenNoPriorActivity()
                .when(new AlwaysCreateWithResultCommand(AGGREGATE_ID, testResult))
@@ -95,7 +95,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testAlwaysCreatePolicyWithResultReturnsNullCommandHandlingResult() {
+    void alwaysCreatePolicyWithResultReturnsNullCommandHandlingResult() {
         fixture.givenNoPriorActivity()
                .when(new AlwaysCreateWithResultCommand(AGGREGATE_ID, null))
                .expectEvents(new AlwaysCreatedEvent(AGGREGATE_ID))
@@ -105,7 +105,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testNeverCreatePolicy() {
+    void neverCreatePolicy() {
         fixture.given(new CreatedEvent(AGGREGATE_ID))
                .when(new ExecuteOnExistingCommand(AGGREGATE_ID))
                .expectEvents(new ExecutedOnExistingEvent(AGGREGATE_ID))
@@ -114,7 +114,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testAlwaysCreatePolicyWithStateReturnsStateInCommandHandlingResult() {
+    void alwaysCreatePolicyWithStateReturnsStateInCommandHandlingResult() {
         fixture.givenNoPriorActivity()
                .when(new AlwaysCreateWithEventSourcedResultCommand(AGGREGATE_ID))
                .expectEvents(new AlwaysCreatedEvent(AGGREGATE_ID))
@@ -124,7 +124,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testAlwaysCreateExceptionsArePropagates() {
+    void alwaysCreateExceptionsArePropagates() {
         fixture.givenNoPriorActivity()
                .when(new AlwaysCreateWithEventSourcedResultCommand(AGGREGATE_ID, PUBLISH_NO_EVENTS))
                .expectNoEvents()
@@ -133,7 +133,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @Test
-    void testCreateOrUpdatePolicyDoesNotPublishAnyEvents() {
+    void createOrUpdatePolicyDoesNotPublishAnyEvents() {
         fixture.givenNoPriorActivity()
                .when(new CreateOrUpdateCommand(AGGREGATE_ID, PUBLISH_NO_EVENTS))
                .expectNoEvents()

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Deadlines.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Deadlines.java
@@ -54,49 +54,49 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectScheduledDeadline() {
+    void expectScheduledDeadline() {
         fixture.givenNoPriorActivity()
                .when(CREATE_COMMAND)
                .expectScheduledDeadline(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), DEADLINE_PAYLOAD);
     }
 
     @Test
-    void testExpectScheduledDeadlineOfType() {
+    void expectScheduledDeadlineOfType() {
         fixture.givenNoPriorActivity()
                .when(CREATE_COMMAND)
                .expectScheduledDeadlineOfType(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), String.class);
     }
 
     @Test
-    void testExpectScheduledDeadlineWithName() {
+    void expectScheduledDeadlineWithName() {
         fixture.given(new MyAggregateCreatedEvent(AGGREGATE_ID, DEADLINE_NAME, "deadlineId"))
                .when(new SetPayloadlessDeadlineCommand(AGGREGATE_ID))
                .expectScheduledDeadlineWithName(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), "payloadless-deadline");
     }
 
     @Test
-    void testExpectNoScheduledDeadline() {
+    void expectNoScheduledDeadline() {
         fixture.givenCommands(CREATE_COMMAND)
                .when(new ResetTriggerCommand(AGGREGATE_ID))
                .expectNoScheduledDeadline(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), DEADLINE_PAYLOAD);
     }
 
     @Test
-    void testExpectNoScheduledDeadlineOfType() {
+    void expectNoScheduledDeadlineOfType() {
         fixture.givenCommands(CREATE_COMMAND)
                .when(new ResetTriggerCommand(AGGREGATE_ID))
                .expectNoScheduledDeadlineOfType(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), String.class);
     }
 
     @Test
-    void testExpectNoScheduledDeadlineWithName() {
+    void expectNoScheduledDeadlineWithName() {
         fixture.givenCommands(CREATE_COMMAND)
                .when(new ResetTriggerCommand(AGGREGATE_ID))
                .expectNoScheduledDeadlineWithName(Duration.ofMinutes(TRIGGER_DURATION_MINUTES), DEADLINE_NAME);
     }
 
     @Test
-    void testDeadlineMetMatching() {
+    void deadlineMetMatching() {
         //noinspection deprecation
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
@@ -105,7 +105,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesMatching() {
+    void triggeredDeadlinesMatching() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -113,7 +113,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlinesMet() {
+    void deadlinesMet() {
         //noinspection deprecation
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
@@ -122,7 +122,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlines() {
+    void triggeredDeadlines() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -130,7 +130,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesFailsForIncorrectDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -147,7 +147,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesFailsForIncorrectNumberOfDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -162,7 +162,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithName() {
+    void triggeredDeadlinesWithName() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -170,7 +170,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithNameFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesWithNameFailsForIncorrectDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -187,7 +187,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithNameFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesWithNameFailsForIncorrectNumberOfDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -202,7 +202,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfType() {
+    void triggeredDeadlinesOfType() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -210,7 +210,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfTypeFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesOfTypeFailsForIncorrectDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -227,7 +227,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfTypeFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesOfTypeFailsForIncorrectNumberOfDeadlines() {
         ResultValidator<MyAggregate> given =
                 fixture.givenNoPriorActivity()
                        .andGivenCommands(CREATE_COMMAND)
@@ -242,7 +242,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineWhichCancelsSchedule() {
+    void deadlineWhichCancelsSchedule() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .when(new ResetTriggerCommand(AGGREGATE_ID))
@@ -250,7 +250,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineWhichCancelsAll() {
+    void deadlineWhichCancelsAll() {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .when(new ResetAllTriggerCommand(AGGREGATE_ID))
@@ -258,7 +258,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineDispatcherInterceptor() {
+    void deadlineDispatcherInterceptor() {
         fixture.registerDeadlineDispatchInterceptor(
                 messages -> (i, m) -> asDeadlineMessage(m.getDeadlineName(), "fakeDeadlineDetails", m.getTimestamp()))
                .givenNoPriorActivity()
@@ -268,7 +268,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineHandlerInterceptor() {
+    void deadlineHandlerInterceptor() {
         fixture.registerDeadlineHandlerInterceptor((uow, chain) -> {
             uow.transformMessage(deadlineMessage -> asDeadlineMessage(
                     deadlineMessage.getDeadlineName(), "fakeDeadlineDetails", deadlineMessage.getTimestamp())

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ExceptionHandling.java
@@ -43,7 +43,7 @@ class FixtureTest_ExceptionHandling {
     private final FixtureConfiguration<MyAggregate> fixture = new AggregateTestFixture<>(MyAggregate.class);
 
     @Test
-    void testCreateAggregate() {
+    void createAggregate() {
         fixture.givenCommands()
                .when(new CreateMyAggregateCommand("14"))
                .expectEvents(new MyAggregateCreatedEvent("14"));
@@ -61,14 +61,14 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testWhenExceptionTriggeringCommand() {
+    void whenExceptionTriggeringCommand() {
         fixture.givenCommands(new CreateMyAggregateCommand("14"))
                .when(new ExceptionTriggeringCommand("14"))
                .expectException(RuntimeException.class);
     }
 
     @Test
-    void testGivenExceptionTriggeringCommand() {
+    void givenExceptionTriggeringCommand() {
         assertThrows(RuntimeException.class, () ->
                 fixture.givenCommands(
                         new CreateMyAggregateCommand("14"),
@@ -78,14 +78,14 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testGivenCommandWithInvalidIdentifier() {
+    void givenCommandWithInvalidIdentifier() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                .when(new ValidMyAggregateCommand("2"))
                .expectException(EventStoreException.class);
     }
 
     @Test
-    void testExceptionMessageCheck() {
+    void exceptionMessageCheck() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                .when(new ValidMyAggregateCommand("2"))
                .expectException(EventStoreException.class)
@@ -97,7 +97,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testExceptionMessageCheckWithMatcher() {
+    void exceptionMessageCheckWithMatcher() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                .when(new ValidMyAggregateCommand("2"))
                .expectException(EventStoreException.class)
@@ -105,7 +105,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testExceptionDetailsCheckWithEquality() {
+    void exceptionDetailsCheckWithEquality() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                 .when(new ExceptionWithDetailsTriggeringCommand("1"))
                 .expectException(CommandExecutionException.class)
@@ -113,7 +113,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testExceptionDetailsCheckWithType() {
+    void exceptionDetailsCheckWithType() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                .when(new ExceptionWithDetailsTriggeringCommand("1"))
                .expectException(CommandExecutionException.class)
@@ -121,7 +121,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testExceptionDetailsCheckWithMatcher() {
+    void exceptionDetailsCheckWithMatcher() {
         fixture.givenCommands(new CreateMyAggregateCommand("1"))
                .when(new ExceptionWithDetailsTriggeringCommand("1"))
                .expectException(CommandExecutionException.class)
@@ -129,7 +129,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testWhenCommandWithInvalidIdentifier() {
+    void whenCommandWithInvalidIdentifier() {
         assertThrows(FixtureExecutionException.class, () ->
                 fixture.givenCommands(
                         new CreateMyAggregateCommand("1"),
@@ -139,7 +139,7 @@ class FixtureTest_ExceptionHandling {
     }
 
     @Test
-    void testExpectExceptionMessageThrowsFixtureExecutionExceptionWhenNoExceptionIsThrown() {
+    void expectExceptionMessageThrowsFixtureExecutionExceptionWhenNoExceptionIsThrown() {
         assertThrows(
                 AxonAssertionError.class,
                 () -> fixture.given(new MyAggregateCreatedEvent(AGGREGATE_ID))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
@@ -60,7 +60,7 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testConfigureCustomAggregateFactory() {
+    void configureCustomAggregateFactory() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
 
@@ -71,17 +71,17 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testConfigurationOfRequiredCustomAggregateFactoryNotProvided_FailureOnGiven() {
+    void configurationOfRequiredCustomAggregateFactoryNotProvided_FailureOnGiven() {
         assertThrows(IncompatibleAggregateException.class, () -> fixture.given(new MyEvent("id1", 1)));
     }
 
     @Test
-    void testConfigurationOfRequiredCustomAggregateFactoryNotProvided_FailureOnGetRepository() {
+    void configurationOfRequiredCustomAggregateFactoryNotProvided_FailureOnGetRepository() {
         assertThrows(IncompatibleAggregateException.class, fixture::getRepository);
     }
 
     @Test
-    void testAggregateIdentifier_ServerGeneratedIdentifier() {
+    void aggregateIdentifier_ServerGeneratedIdentifier() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
         fixture.givenNoPriorActivity()
@@ -89,7 +89,7 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testStoringExistingAggregateGeneratesException() {
+    void storingExistingAggregateGeneratesException() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
         fixture.given(new MyEvent("aggregateId", 1))
@@ -98,14 +98,14 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testInjectResources_CommandHandlerAlreadyRegistered() {
+    void injectResources_CommandHandlerAlreadyRegistered() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
         assertThrows(FixtureExecutionException.class, () -> fixture.registerInjectableResource("I am injectable"));
     }
 
     @Test
-    void testAggregateIdentifier_IdentifierAutomaticallyDeducted() {
+    void aggregateIdentifier_IdentifierAutomaticallyDeducted() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
         fixture.given(new MyEvent("AggregateId", 1), new MyEvent("AggregateId", 2))
@@ -122,7 +122,7 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testReadAggregate_WrongIdentifier() {
+    void readAggregate_WrongIdentifier() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
         TestExecutor exec = fixture.given(new MyEvent("AggregateId", 1));
@@ -133,7 +133,7 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testFixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
+    void fixtureGeneratesExceptionOnWrongEvents_DifferentAggregateIdentifiers() {
         assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", UUID.randomUUID().toString(), 0, new StubDomainEvent()),
@@ -142,7 +142,7 @@ class FixtureTest_Generic {
     }
 
     @Test
-    void testFixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
+    void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
         assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
@@ -31,7 +31,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 class FixtureTest_Hierarchy {
 
     @Test
-    void testFixtureSetupWithAggregateHierarchy() {
+    void fixtureSetupWithAggregateHierarchy() {
         new AggregateTestFixture<>(AbstractAggregate.class)
                 .registerAggregateFactory(new AggregateFactory<AbstractAggregate>() {
                     @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MarkDeleted.java
@@ -46,7 +46,7 @@ class FixtureTest_MarkDeleted {
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
-    void testCreateAggregateYieldsLiveAggregate() {
+    void createAggregateYieldsLiveAggregate() {
         fixture.registerInjectableResource(new HardToCreateResource());
         fixture.givenNoPriorActivity()
                .when(new CreateAggregateCommand("id"))
@@ -55,7 +55,7 @@ class FixtureTest_MarkDeleted {
     }
 
     @Test
-    void testCreateAggregateYieldsLiveAggregateInverted() {
+    void createAggregateYieldsLiveAggregateInverted() {
         fixture.registerInjectableResource(new HardToCreateResource());
 
         assertThrows(AxonAssertionError.class, () ->
@@ -67,7 +67,7 @@ class FixtureTest_MarkDeleted {
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // Test succeeds when no Error is thrown
-    void testDeletedAggregateYieldsAggregateMarkedDeleted() {
+    void deletedAggregateYieldsAggregateMarkedDeleted() {
         fixture.given(new MyEvent("id", 0))
                .when(new DeleteCommand("id", false))
                .expectEvents(new MyAggregateDeletedEvent(false))
@@ -75,7 +75,7 @@ class FixtureTest_MarkDeleted {
     }
 
     @Test
-    void testDeletedAggregateYieldsAggregateMarkedDeletedInverted() {
+    void deletedAggregateYieldsAggregateMarkedDeletedInverted() {
         assertThrows(AxonAssertionError.class, () ->
                 fixture.given(new MyEvent("id", 0))
                         .when(new DeleteCommand("id", false))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
@@ -49,7 +49,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFirstFixture() {
+    void firstFixture() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -58,7 +58,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testPayloadsMatch() {
+    void payloadsMatch() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -67,7 +67,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testPayloadsMatchExact() {
+    void payloadsMatchExact() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -76,7 +76,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testPayloadsMatchPredicate() {
+    void payloadsMatchPredicate() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 1))
                 .when(new TestCommand("aggregateId"))
@@ -85,7 +85,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_UnexpectedException() {
+    void fixture_UnexpectedException() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -103,7 +103,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_UnexpectedReturnValue() {
+    void fixture_UnexpectedReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -121,7 +121,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_WrongReturnValue() {
+    void fixture_WrongReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -137,7 +137,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_WrongExceptionType() {
+    void fixture_WrongExceptionType() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -154,7 +154,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_ExpectedPublishedSameAsStored() {
+    void fixture_ExpectedPublishedSameAsStored() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -175,7 +175,7 @@ class FixtureTest_MatcherParams {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testFixture_DispatchMetaDataInCommand() throws Exception {
+    void fixture_DispatchMetaDataInCommand() throws Exception {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -194,7 +194,7 @@ class FixtureTest_MatcherParams {
     }
 
     @Test
-    void testFixture_EventDoesNotMatch() {
+    void fixture_EventDoesNotMatch() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Polymorphism.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Polymorphism.java
@@ -57,7 +57,7 @@ class FixtureTest_Polymorphism {
 
     @ParameterizedTest(name = "[{index}] {1}")
     @MethodSource("provideForCreationalTest")
-    void testCreationOfAggregate(Function<String, Object> commandBuilder, String aggregateType) {
+    void creationOfAggregate(Function<String, Object> commandBuilder, String aggregateType) {
         String id = "id";
         fixture.givenNoPriorActivity()
                .when(commandBuilder.apply(id))
@@ -71,7 +71,7 @@ class FixtureTest_Polymorphism {
 
     @ParameterizedTest
     @ValueSource(strings = {"AggregateB", "AggregateC"})
-    void testCommonCommandOnAggregate(String aggregateType) {
+    void commonCommandOnAggregate(String aggregateType) {
         String id = "id";
         DomainEventMessage<CreatedEvent> creationalEvent = new GenericDomainEventMessage<>(aggregateType,
                                                                                            id,
@@ -83,7 +83,7 @@ class FixtureTest_Polymorphism {
     }
 
     @Test
-    void testCreatingNewPolymorphicAggregate() {
+    void creatingNewPolymorphicAggregate() {
         AggregateTestFixture<AggregateD> fixture = new AggregateTestFixture<>(AggregateD.class);
         String id = "id";
         fixture.givenNoPriorActivity()

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
@@ -53,7 +53,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testRegisterParameterResolverFactory() {
+    void registerParameterResolverFactory() {
         testSubject.registerParameterResolverFactory(new TestParameterResolverFactory(new AtomicBoolean(false)))
                    .given(new MyEvent(TEST_AGGREGATE_IDENTIFIER, 42))
                    .when(new ResolveParameterCommand(TEST_AGGREGATE_IDENTIFIER))
@@ -66,7 +66,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testCreateHandlerMethodIsCalledForRegisteredCustomHandlerDefinition() {
+    void createHandlerMethodIsCalledForRegisteredCustomHandlerDefinition() {
         AtomicBoolean handlerDefinitionReached = new AtomicBoolean(false);
 
         testSubject.registerHandlerDefinition(new TestHandlerDefinition(handlerDefinitionReached))
@@ -80,7 +80,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testWrapHandlerMethodIsCalledForRegisteredCustomHandlerEnhancerDefinition() {
+    void wrapHandlerMethodIsCalledForRegisteredCustomHandlerEnhancerDefinition() {
         AtomicBoolean handlerEnhancerReached = new AtomicBoolean(false);
 
         testSubject.registerHandlerEnhancerDefinition(new TestHandlerEnhancerDefinition(handlerEnhancerReached))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
@@ -44,7 +44,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_NoEventsInStore() {
+    void fixture_NoEventsInStore() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                      fixture.getEventBus()))
                 .given()
@@ -53,7 +53,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFirstFixture() {
+    void firstFixture() {
         ResultValidator<StandardAggregate> validator = fixture
                 .registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                       fixture.getEventBus()))
@@ -64,7 +64,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFirstFixtureMatchingCommandResultMessage() {
+    void firstFixtureMatchingCommandResultMessage() {
         ResultValidator<StandardAggregate> validator = fixture
                 .registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                       fixture.getEventBus()))
@@ -75,7 +75,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testExpectEventsIgnoresFilteredField() {
+    void expectEventsIgnoresFilteredField() {
         ResultValidator<StandardAggregate> validator = fixture
                 .registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                       fixture.getEventBus()))
@@ -87,7 +87,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_SetterInjection() {
+    void fixture_SetterInjection() {
         MyCommandHandler commandHandler = new MyCommandHandler();
         commandHandler.setRepository(fixture.getRepository());
         fixture.registerAnnotatedCommandHandler(commandHandler)
@@ -99,7 +99,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_GivenAList() {
+    void fixture_GivenAList() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -113,7 +113,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_ExplicitValue() {
+    void fixtureDetectsStateChangeOutsideOfHandler_ExplicitValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -129,7 +129,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureIgnoredStateChangeInFilteredField() {
+    void fixtureIgnoredStateChangeInFilteredField() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -141,7 +141,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_NullValue() {
+    void fixtureDetectsStateChangeOutsideOfHandler_NullValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -156,7 +156,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_Ignored() {
+    void fixtureDetectsStateChangeOutsideOfHandler_Ignored() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -168,7 +168,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_AggregateGeneratesIdentifier() {
+    void fixtureDetectsStateChangeOutsideOfHandler_AggregateGeneratesIdentifier() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                      fixture.getEventBus()))
                 .given()
@@ -176,7 +176,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
+    void fixtureDetectsStateChangeOutsideOfHandler_AggregateDeleted() {
         TestExecutor<StandardAggregate> exec = fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                                          fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 5));
@@ -187,7 +187,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_AggregateDeleted() {
+    void fixture_AggregateDeleted() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                      fixture.getEventBus()))
                 .given(new MyEvent("aggregateId", 5))
@@ -196,7 +196,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixtureGivenCommands() {
+    void fixtureGivenCommands() {
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(),
                                                                      fixture.getEventBus()))
                 .givenCommands(new CreateAggregateCommand("aggregateId"),
@@ -208,7 +208,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_CommandHandlerDispatchesNonDomainEvents() {
+    void fixture_CommandHandlerDispatchesNonDomainEvents() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -224,7 +224,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_ReportWrongNumberOfEvents() {
+    void fixture_ReportWrongNumberOfEvents() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -241,7 +241,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_ReportWrongEvents() {
+    void fixture_ReportWrongEvents() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -259,7 +259,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_UnexpectedException() {
+    void fixture_UnexpectedException() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -276,7 +276,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_UnexpectedReturnValue() {
+    void fixture_UnexpectedReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -295,7 +295,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_WrongReturnValue() {
+    void fixture_WrongReturnValue() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -310,7 +310,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_WrongExceptionType() {
+    void fixture_WrongExceptionType() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -327,7 +327,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_WrongEventContents() {
+    void fixture_WrongEventContents() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -348,7 +348,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_WrongEventContents_WithNullValues() {
+    void fixture_WrongEventContents_WithNullValues() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));
@@ -368,7 +368,7 @@ class FixtureTest_RegularParams {
     }
 
     @Test
-    void testFixture_ExpectedPublishedSameAsStored() {
+    void fixture_ExpectedPublishedSameAsStored() {
         List<?> givenEvents = Arrays.asList(new MyEvent("aggregateId", 1),
                                             new MyEvent("aggregateId", 2),
                                             new MyEvent("aggregateId", 3));

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Resources.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Resources.java
@@ -43,7 +43,7 @@ class FixtureTest_Resources {
     }
 
     @Test
-    void testResourcesAreScopedToSingleTest_ConstructorPartOne() {
+    void resourcesAreScopedToSingleTest_ConstructorPartOne() {
         // executing the same test should pass, as resources are scoped to a single test only
         final Executor resource = mock(Executor.class);
         fixture.registerInjectableResource(resource)
@@ -55,12 +55,12 @@ class FixtureTest_Resources {
     }
 
     @Test
-    void testResourcesAreScopedToSingleTest_ConstructorPartTwo() {
-        testResourcesAreScopedToSingleTest_ConstructorPartOne();
+    void resourcesAreScopedToSingleTest_ConstructorPartTwo() {
+        resourcesAreScopedToSingleTest_ConstructorPartOne();
     }
 
     @Test
-    void testResourcesAreScopedToSingleTest_MethodPartOne() {
+    void resourcesAreScopedToSingleTest_MethodPartOne() {
         // executing the same test should pass, as resources are scoped to a single test only
         final Executor resource = mock(Executor.class);
         fixture.registerInjectableResource(resource)
@@ -73,8 +73,8 @@ class FixtureTest_Resources {
     }
 
     @Test
-    void testResourcesAreScopedToSingleTest_MethodPartTwo() {
-        testResourcesAreScopedToSingleTest_MethodPartOne();
+    void resourcesAreScopedToSingleTest_MethodPartTwo() {
+        resourcesAreScopedToSingleTest_MethodPartOne();
     }
 
     public static class AggregateWithResources {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ScopeDescriptor.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_ScopeDescriptor.java
@@ -27,7 +27,7 @@ class FixtureTest_ScopeDescriptor {
     }
 
     @Test
-    void testResolvesScopeDescriptor() {
+    void resolvesScopeDescriptor() {
         fixture.givenNoPriorActivity()
                .when("some-identifier")
                .expectEventsMatching(payloadsMatching(sequenceOf(matches(

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_SpawningNewAggregate.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_SpawningNewAggregate.java
@@ -52,7 +52,7 @@ class FixtureTest_SpawningNewAggregate {
     }
 
     @Test
-    void testFixtureWithoutRepositoryProviderInjected() {
+    void fixtureWithoutRepositoryProviderInjected() {
         fixture.givenNoPriorActivity()
                .when(new CreateAggregate1Command("id", "aggregate2Id"))
                .expectEvents(new Aggregate2CreatedEvent("aggregate2Id"), new Aggregate1CreatedEvent("id"))
@@ -61,7 +61,7 @@ class FixtureTest_SpawningNewAggregate {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testFixtureWithRepositoryProviderInjected() throws Exception {
+    void fixtureWithRepositoryProviderInjected() throws Exception {
         RepositoryProvider repositoryProvider = mock(RepositoryProvider.class);
         Repository<Aggregate2> aggregate2Repository = mock(Repository.class);
         AggregateModel<Aggregate2> aggregate2Model = AnnotatedAggregateMetaModelFactory

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -56,7 +56,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testCreateStateStoredAggregate() {
+    void createStateStoredAggregate() {
         fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                .expectEvents(new StubDomainEvent())
@@ -64,7 +64,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testGivenCommandsForStateStoredAggregate() {
+    void givenCommandsForStateStoredAggregate() {
         fixture.useStateStorage()
                .givenCommands(new InitializeCommand(AGGREGATE_ID, "message"))
                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
@@ -74,7 +74,7 @@ class FixtureTest_StateStorage {
 
 
     @Test
-    void testCreateStateStoredAggregateWithCommand() {
+    void createStateStoredAggregateWithCommand() {
         fixture.useStateStorage()
                .givenNoPriorActivity()
                .when(new InitializeCommand(AGGREGATE_ID, "message"))
@@ -83,7 +83,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testEmittedEventsFromExpectStateAreNotStored() {
+    void emittedEventsFromExpectStateAreNotStored() {
         fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
                .when(new SetMessageCommand(AGGREGATE_ID, "message2"))
                .expectEvents(new StubDomainEvent())
@@ -96,7 +96,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testCreateStateStoredAggregate_ErrorInChanges() {
+    void createStateStoredAggregate_ErrorInChanges() {
         ResultValidator<StateStoredAggregate> result =
                 fixture.givenState(() -> new StateStoredAggregate(AGGREGATE_ID, "message"))
                        .when(new ErrorCommand(AGGREGATE_ID, "message2"))
@@ -114,7 +114,7 @@ class FixtureTest_StateStorage {
      * Follow up on GitHub issue https://github.com/AxonFramework/AxonFramework/issues/1219
      */
     @Test
-    void testStateStoredAggregateCanAttachRegisteredResource() {
+    void stateStoredAggregateCanAttachRegisteredResource() {
         String expectedMessage = "state stored resource injection works";
         HardToCreateResource testResource = spy(new HardToCreateResource());
 
@@ -127,7 +127,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testGivenWithStateStorageException() {
+    void givenWithStateStorageException() {
         fixture.useStateStorage();
 
         assertThrows(
@@ -137,7 +137,7 @@ class FixtureTest_StateStorage {
     }
 
     @Test
-    void testGivenWithEventListAndStateStorageExpectException() {
+    void givenWithEventListAndStateStorageExpectException() {
         fixture.useStateStorage();
 
         assertThrows(

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -43,7 +43,7 @@ class StubAggregateLifecycleExtensionTest {
     }
 
     @Test
-    void markDeletedIsRegisteredWithActiveLifecycle() {
+    void testMarkDeletedIsRegisteredWithActiveLifecycle() {
         markDeleted();
 
         assertEquals(0, TEST_SUBJECT.getAppliedEvents().size());

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -34,7 +34,7 @@ class StubAggregateLifecycleExtensionTest {
     static final StubAggregateLifecycleExtension TEST_SUBJECT = new StubAggregateLifecycleExtension();
 
     @Test
-    void testAppliedEventsArePassedToActiveLifecycle() {
+    void appliedEventsArePassedToActiveLifecycle() {
         apply("test");
 
         assertEquals(1, TEST_SUBJECT.getAppliedEvents().size());
@@ -43,7 +43,7 @@ class StubAggregateLifecycleExtensionTest {
     }
 
     @Test
-    void testMarkDeletedIsRegisteredWithActiveLifecycle() {
+    void markDeletedIsRegisteredWithActiveLifecycle() {
         markDeleted();
 
         assertEquals(0, TEST_SUBJECT.getAppliedEvents().size());

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
@@ -40,12 +40,12 @@ class StubAggregateLifecycleTest {
     }
 
     @Test
-    void testLifecycleIsNotRegisteredAutomatically() {
+    void lifecycleIsNotRegisteredAutomatically() {
         assertThrows(IllegalStateException.class, () -> apply("test"));
     }
 
     @Test
-    void testApplyingEventsAfterDeactivationFails() {
+    void applyingEventsAfterDeactivationFails() {
         testSubject.activate();
         testSubject.close();
 
@@ -53,7 +53,7 @@ class StubAggregateLifecycleTest {
     }
 
     @Test
-    void testAppliedEventsArePassedToActiveLifecycle() {
+    void appliedEventsArePassedToActiveLifecycle() {
         testSubject.activate();
         apply("test");
 
@@ -63,7 +63,7 @@ class StubAggregateLifecycleTest {
     }
 
     @Test
-    void testMarkDeletedIsRegisteredWithActiveLifecycle() {
+    void markDeletedIsRegisteredWithActiveLifecycle() {
         testSubject.activate();
         markDeleted();
 

--- a/test/src/test/java/org/axonframework/test/deadline/StubDeadlineManagerTest.java
+++ b/test/src/test/java/org/axonframework/test/deadline/StubDeadlineManagerTest.java
@@ -38,7 +38,7 @@ class StubDeadlineManagerTest {
     }
 
     @Test
-    void testMessagesCarryTriggerTimestamp() throws Exception {
+    void messagesCarryTriggerTimestamp() throws Exception {
         Instant triggerTime = Instant.now().plusSeconds(60);
         MockScope.execute(() ->
                                   testSubject.schedule(triggerTime, "gone")

--- a/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
+++ b/test/src/test/java/org/axonframework/test/eventscheduler/StubEventSchedulerTest.java
@@ -41,13 +41,13 @@ class StubEventSchedulerTest {
     }
 
     @Test
-    void testScheduleEvent() {
+    void scheduleEvent() {
         testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
         assertEquals(1, testSubject.getScheduledItems().size());
     }
 
     @Test
-    void testEventContainsTimestampOfScheduledTime() {
+    void eventContainsTimestampOfScheduledTime() {
         Instant triggerTime = Instant.now().plusSeconds(60);
         testSubject.schedule(triggerTime, "gone");
         List<EventMessage<?>> triggered = new ArrayList<>();
@@ -58,7 +58,7 @@ class StubEventSchedulerTest {
     }
 
     @Test
-    void testInitializeAtDateTimeAfterSchedulingEvent() {
+    void initializeAtDateTimeAfterSchedulingEvent() {
         testSubject.schedule(Instant.now().plus(Duration.ofDays(1)), event(new MockEvent()));
 
         assertThrows(IllegalStateException.class, () ->

--- a/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/DeepEqualsMatcherTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class DeepEqualsMatcherTest {
 
     @Test
-    void testMatchesReturnsFalseForNoneMatchingTypes() {
+    void matchesReturnsFalseForNoneMatchingTypes() {
         Description description = new StringDescription();
 
         DeepEqualsMatcher<String> testSubject = new DeepEqualsMatcher<>("foo");
@@ -47,7 +47,7 @@ class DeepEqualsMatcherTest {
     }
 
     @Test
-    void testMatchesReturnsFalseForNoneMatchingEquals() {
+    void matchesReturnsFalseForNoneMatchingEquals() {
         Description description = new StringDescription();
 
         DeepEqualsMatcher<String> testSubject = new DeepEqualsMatcher<>("foo");
@@ -60,7 +60,7 @@ class DeepEqualsMatcherTest {
     }
 
     @Test
-    void testMatchesReturnsFalseForNoneMatchingFields() {
+    void matchesReturnsFalseForNoneMatchingFields() {
         Description description = new StringDescription();
 
         DeepEqualsMatcher<ObjectNotOverridingEquals> testSubject =
@@ -74,18 +74,18 @@ class DeepEqualsMatcherTest {
     }
 
     @Test
-    void testMatchesReturnsTrue() {
+    void matchesReturnsTrue() {
         assertTrue(new DeepEqualsMatcher<>("foo").matches("foo"));
     }
 
     @Test
-    void testMatchesIsNullSafe() {
+    void matchesIsNullSafe() {
         assertFalse(new DeepEqualsMatcher<>("foo").matches(null));
         assertThrows(AxonConfigurationException.class, () -> new DeepEqualsMatcher<>(null).matches("foo"));
     }
 
     @Test
-    void testIgnoredFieldOnEvent() {
+    void ignoredFieldOnEvent() {
         DeepEqualsMatcher<SomeEvent> testSubject = new DeepEqualsMatcher<>(
                 new SomeEvent("someField"),
                 new MatchAllFieldFilter(Collections.singletonList((new IgnoreField(SomeEvent.class, "someField"))))

--- a/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
@@ -41,40 +41,40 @@ class EqualFieldsMatcherTest {
     }
 
     @Test
-    void testMatches_SameInstance() {
+    void matches_SameInstance() {
         assertTrue(testSubject.matches(expectedEvent));
     }
 
     @Test
-    void testMatches_EqualInstance() {
+    void matches_EqualInstance() {
         assertTrue(testSubject.matches(new MyEvent(aggregateId, 1)));
     }
 
     @Test
-    void testMatches_WrongEventType() {
+    void matches_WrongEventType() {
         assertFalse(testSubject.matches(new MyOtherEvent()));
     }
 
     @Test
-    void testMatches_WrongFieldValue() {
+    void matches_WrongFieldValue() {
         assertFalse(testSubject.matches(new MyEvent(aggregateId, 2)));
         assertEquals("someValue", testSubject.getFailedField().getName());
     }
 
     @Test
-    void testMatches_WrongFieldValueInIgnoredField() {
+    void matches_WrongFieldValueInIgnoredField() {
         testSubject = Matchers.equalTo(expectedEvent, field -> !field.getName().equals("someValue"));
         assertTrue(testSubject.matches(new MyEvent(aggregateId, 2)));
     }
 
     @Test
-    void testMatches_WrongFieldValueInArray() {
+    void matches_WrongFieldValueInArray() {
         assertFalse(testSubject.matches(new MyEvent(aggregateId, 1, new byte[]{1, 2})));
         assertEquals("someBytes", testSubject.getFailedField().getName());
     }
 
     @Test
-    void testDescription_AfterSuccess() {
+    void description_AfterSuccess() {
         testSubject.matches(expectedEvent);
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
@@ -82,7 +82,7 @@ class EqualFieldsMatcherTest {
     }
 
     @Test
-    void testDescription_AfterMatchWithWrongType() {
+    void description_AfterMatchWithWrongType() {
         testSubject.matches(new MyOtherEvent());
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);
@@ -90,7 +90,7 @@ class EqualFieldsMatcherTest {
     }
 
     @Test
-    void testDescription_AfterMatchWithWrongFieldValue() {
+    void description_AfterMatchWithWrongFieldValue() {
         testSubject.matches(new MyEvent(aggregateId, 2));
         StringDescription description = new StringDescription();
         testSubject.describeTo(description);

--- a/test/src/test/java/org/axonframework/test/matchers/ExactSequenceOfEventsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ExactSequenceOfEventsMatcherTest.java
@@ -61,7 +61,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatch() {
+    void match_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -78,7 +78,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatchAndNoMore() {
+    void match_FullMatchAndNoMore() {
         testSubject = exactSequenceOf(mockMatcher1, mockMatcher2, mockMatcher3, andNoMore());
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3)));
 
@@ -96,7 +96,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_ExcessIsRefused() {
+    void match_ExcessIsRefused() {
         testSubject = exactSequenceOf(mockMatcher1, mockMatcher2, mockMatcher3, andNoMore());
         assertFalse(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3, new StubEvent())));
 
@@ -114,7 +114,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatchWithGaps() {
+    void match_FullMatchWithGaps() {
         reset(mockMatcher2);
         when(mockMatcher2.matches(any())).thenReturn(false);
 
@@ -132,7 +132,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_MoreMatchersThanEvents() {
+    void match_MoreMatchersThanEvents() {
         when(mockMatcher3.matches(null)).thenReturn(false);
         assertFalse(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
@@ -146,7 +146,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_ExcessEventsIgnored() {
+    void match_ExcessEventsIgnored() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3, new StubEvent())));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -159,7 +159,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testDescribe() {
+    void describe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -172,7 +172,7 @@ class ExactSequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testDescribe_OneMatcherFailed() {
+    void describe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(true);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);

--- a/test/src/test/java/org/axonframework/test/matchers/IgnoreFieldTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/IgnoreFieldTest.java
@@ -30,21 +30,21 @@ class IgnoreFieldTest {
     @SuppressWarnings("unused") private String ignoredField;
 
     @Test
-    void testAcceptOtherFields_ClassStringConstructor() throws Exception {
+    void acceptOtherFields_ClassStringConstructor() throws Exception {
         IgnoreField testSubject = new IgnoreField(IgnoreFieldTest.class, "ignoredField");
         assertTrue(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("field")));
         assertFalse(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("ignoredField")));
     }
 
     @Test
-    void testAcceptOtherFields_FieldConstructor() throws Exception {
+    void acceptOtherFields_FieldConstructor() throws Exception {
         IgnoreField testSubject = new IgnoreField(IgnoreFieldTest.class.getDeclaredField("ignoredField"));
         assertTrue(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("field")));
         assertFalse(testSubject.accept(IgnoreFieldTest.class.getDeclaredField("ignoredField")));
     }
 
     @Test
-    void testRejectNonExistentField() {
+    void rejectNonExistentField() {
         assertThrows(FixtureExecutionException.class, () -> new IgnoreField(IgnoreFieldTest.class, "nonExistent"));
     }
 }

--- a/test/src/test/java/org/axonframework/test/matchers/ListWithAllOfMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ListWithAllOfMatcherTest.java
@@ -58,7 +58,7 @@ class ListWithAllOfMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatch() {
+    void match_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -70,7 +70,7 @@ class ListWithAllOfMatcherTest {
     }
 
     @Test
-    void testMatch_OnlyOneEventMatches() {
+    void match_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -86,7 +86,7 @@ class ListWithAllOfMatcherTest {
     }
 
     @Test
-    void testMatch_OneMatcherDoesNotMatch() {
+    void match_OneMatcherDoesNotMatch() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -98,7 +98,7 @@ class ListWithAllOfMatcherTest {
     }
 
     @Test
-    void testDescribe() {
+    void describe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -111,7 +111,7 @@ class ListWithAllOfMatcherTest {
     }
 
     @Test
-    void testDescribe_OneMatcherFailed() {
+    void describe_OneMatcherFailed() {
         when(mockMatcher2.matches(any())).thenReturn(false);
 
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));

--- a/test/src/test/java/org/axonframework/test/matchers/ListWithAnyOfMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/ListWithAnyOfMatcherTest.java
@@ -58,7 +58,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatch() {
+    void match_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2)));
 
         verify(mockMatcher1).matches(stubEvent1);
@@ -70,7 +70,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testMatch_OnlyOneEventMatches() {
+    void match_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -86,7 +86,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testMatch_NoMatches() {
+    void match_NoMatches() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);
@@ -102,7 +102,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testMatch_OneMatcherDoesNotMatch() {
+    void match_OneMatcherDoesNotMatch() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -118,7 +118,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testDescribe() {
+    void describe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -131,7 +131,7 @@ class ListWithAnyOfMatcherTest {
     }
 
     @Test
-    void testDescribe_OneMatcherFailed() {
+    void describe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);

--- a/test/src/test/java/org/axonframework/test/matchers/MapEntryMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/MapEntryMatcherTest.java
@@ -31,14 +31,14 @@ class MapEntryMatcherTest {
     }
 
     @Test
-    void testExpectedEntriesNotPresent() {
+    void expectedEntriesNotPresent() {
         assertFalse(matcher.matches(singletonMap("a", new ValueItem("a"))));
 
         assertThat(matcher.getMissingEntries(), equalTo(newHashMap("b", new ValueItem("b"), "c", new ValueItem("c"))));
     }
 
     @Test
-    void testTooManyEntries() {
+    void tooManyEntries() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "c", new ValueItem("c"),
                                                "d", new ValueItem("d"), "e", new ValueItem("e"))));
 
@@ -46,7 +46,7 @@ class MapEntryMatcherTest {
     }
 
     @Test
-    void testIncorrectValue() {
+    void incorrectValue() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "c", new ValueItem("CCCC"))));
 
         assertThat(matcher.getAdditionalEntries(), equalTo(newHashMap("c", new ValueItem("CCCC"))));
@@ -58,7 +58,7 @@ class MapEntryMatcherTest {
     }
 
     @Test
-    void testIncorrectKey() {
+    void incorrectKey() {
         assertFalse(matcher.matches(newHashMap("a", new ValueItem("a"), "b", new ValueItem("b"), "CCCC", new ValueItem("c"))));
 
         assertThat(matcher.getAdditionalEntries(), equalTo(newHashMap("CCCC", new ValueItem("c"))));
@@ -70,7 +70,7 @@ class MapEntryMatcherTest {
     }
 
     @Test
-    void testAnyOrder() {
+    void anyOrder() {
         TreeMap<String, Object> sortedMap = new TreeMap<>();
         sortedMap.putAll(EXPECTED);
 
@@ -89,7 +89,7 @@ class MapEntryMatcherTest {
     }
 
     @Test
-    void testNonMapType() {
+    void nonMapType() {
         assertFalse(new MapEntryMatcher(emptyMap()).matches(new Object()));
         assertFalse(new MapEntryMatcher(emptyMap()).matches(emptySet()));
     }

--- a/test/src/test/java/org/axonframework/test/matchers/MatchAllFieldFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/MatchAllFieldFilterTest.java
@@ -32,20 +32,20 @@ class MatchAllFieldFilterTest {
     private String field;
 
     @Test
-    void testAcceptWhenEmpty() throws Exception {
+    void acceptWhenEmpty() throws Exception {
         assertTrue(new MatchAllFieldFilter(Collections.emptyList())
                            .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));
     }
 
     @Test
-    void testAcceptWhenAllAccept() throws Exception {
+    void acceptWhenAllAccept() throws Exception {
         assertTrue(new MatchAllFieldFilter(Arrays.asList(AllFieldsFilter.instance(),
                                                          AllFieldsFilter.instance()))
                            .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));
     }
 
     @Test
-    void testRejectWhenOneRejects() throws Exception {
+    void rejectWhenOneRejects() throws Exception {
         assertFalse(new MatchAllFieldFilter(Arrays.asList(AllFieldsFilter.instance(),
                                                           field -> false))
                             .accept(MatchAllFieldFilterTest.class.getDeclaredField("field")));

--- a/test/src/test/java/org/axonframework/test/matchers/NonStaticFieldsFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NonStaticFieldsFilterTest.java
@@ -13,13 +13,13 @@ class NonStaticFieldsFilterTest {
     private String nonStaticField;
 
     @Test
-    void testAcceptNonTransientField() throws Exception {
+    void acceptNonTransientField() throws Exception {
         assertTrue(NonStaticFieldsFilter.instance()
                            .accept(getClass().getDeclaredField("nonStaticField")));
     }
 
     @Test
-    void testRejectTransientField() throws Exception {
+    void rejectTransientField() throws Exception {
         assertFalse(NonStaticFieldsFilter.instance()
                             .accept(getClass().getDeclaredField("staticField")));
     }

--- a/test/src/test/java/org/axonframework/test/matchers/NonTransientFieldsFilterTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NonTransientFieldsFilterTest.java
@@ -31,13 +31,13 @@ class NonTransientFieldsFilterTest {
     private String nonTransientField;
 
     @Test
-    void testAcceptNonTransientField() throws Exception {
+    void acceptNonTransientField() throws Exception {
         assertTrue(NonTransientFieldsFilter.instance()
                                            .accept(getClass().getDeclaredField("nonTransientField")));
     }
 
     @Test
-    void testRejectTransientField() throws Exception {
+    void rejectTransientField() throws Exception {
         assertFalse(NonTransientFieldsFilter.instance()
                                             .accept(getClass().getDeclaredField("transientField")));
     }

--- a/test/src/test/java/org/axonframework/test/matchers/NullOrVoidMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/NullOrVoidMatcherTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class NullOrVoidMatcherTest {
 
     @Test
-    void testMatcherMatchesVoidAndNull() {
+    void matcherMatchesVoidAndNull() {
         assertTrue(nothing().matches(Void.class));
         assertTrue(nothing().matches(null));
         assertFalse(nothing().matches(new Object()));

--- a/test/src/test/java/org/axonframework/test/matchers/SequenceOfEventsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/SequenceOfEventsMatcherTest.java
@@ -63,7 +63,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatch() {
+    void match_FullMatch() {
         assertTrue(testSubject.matches(Arrays.asList(stubEvent1, stubEvent2, stubEvent3,
                                                      stubEvent4, stubEvent5)));
 
@@ -87,7 +87,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_FullMatchWithGaps() {
+    void match_FullMatchWithGaps() {
         reset(mockMatcher2);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(stubEvent5)).thenReturn(true);
@@ -116,7 +116,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_OnlyOneEventMatches() {
+    void match_OnlyOneEventMatches() {
         when(mockMatcher1.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher2.matches(stubEvent1)).thenReturn(false);
         when(mockMatcher3.matches(stubEvent1)).thenReturn(false);
@@ -135,7 +135,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testMatch_NoMatches() {
+    void match_NoMatches() {
         when(mockMatcher1.matches(any())).thenReturn(false);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);
@@ -151,7 +151,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testDescribe() {
+    void describe() {
         testSubject.matches(Arrays.asList(stubEvent1, stubEvent2));
 
         doAnswer(new DescribingAnswer("A")).when(mockMatcher1).describeTo(isA(Description.class));
@@ -164,7 +164,7 @@ public class SequenceOfEventsMatcherTest {
     }
 
     @Test
-    void testDescribe_OneMatcherFailed() {
+    void describe_OneMatcherFailed() {
         when(mockMatcher1.matches(any())).thenReturn(true);
         when(mockMatcher2.matches(any())).thenReturn(false);
         when(mockMatcher3.matches(any())).thenReturn(false);

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
 class AnnotatedSagaTest {
 
     @Test
-    void testFixtureApi_WhenEventOccurs() {
+    void fixtureApi_WhenEventOccurs() {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -74,7 +74,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_AggregatePublishedEvent_NoHistoricActivity() {
+    void fixtureApi_AggregatePublishedEvent_NoHistoricActivity() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenAggregate("id").publishes(new TriggerSagaStartEvent("id"))
@@ -84,7 +84,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_AggregatePublishedEventWithMetaData_NoHistoricActivity() {
+    void fixtureApi_AggregatePublishedEventWithMetaData_NoHistoricActivity() {
         String extraIdentifier = UUID.randomUUID().toString();
         Map<String, String> metaData = new HashMap<>();
         metaData.put("extraIdentifier", extraIdentifier);
@@ -99,7 +99,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_NonTransientResourceInjected() {
+    void fixtureApi_NonTransientResourceInjected() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerResource(new NonTransientResource());
         fixture.givenNoPriorActivity();
@@ -113,7 +113,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_NonTransientResourceInjected_CheckDisabled() {
+    void fixtureApi_NonTransientResourceInjected_CheckDisabled() {
         FixtureConfiguration fixture = new SagaTestFixture<>(StubSaga.class)
                 .withTransienceCheckDisabled();
         fixture.registerResource(new NonTransientResource());
@@ -124,7 +124,7 @@ class AnnotatedSagaTest {
     }
 
     @Test// testing issue AXON-279
-    void testFixtureApi_PublishedEvent_NoHistoricActivity() {
+    void fixtureApi_PublishedEvent_NoHistoricActivity() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.givenNoPriorActivity()
                .whenPublishingA(new GenericEventMessage<>(new TriggerSagaStartEvent("id")))
@@ -134,7 +134,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_PublishedEventWithMetaData_NoHistoricActivity() {
+    void fixtureApi_PublishedEventWithMetaData_NoHistoricActivity() {
         String extraIdentifier = UUID.randomUUID().toString();
         Map<String, String> metaData = new HashMap<>();
         metaData.put("extraIdentifier", extraIdentifier);
@@ -149,7 +149,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_WithApplicationEvents() {
+    void fixtureApi_WithApplicationEvents() {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -168,7 +168,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_WhenEventIsPublishedToEventBus() {
+    void fixtureApi_WhenEventIsPublishedToEventBus() {
         String aggregate1 = UUID.randomUUID().toString();
         String aggregate2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -188,7 +188,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() throws Exception {
+    void fixtureApi_ElapsedTimeBetweenEventsHasEffectOnScheduler() throws Exception {
         String aggregate1 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         FixtureExecutionResult validator = fixture
@@ -214,7 +214,7 @@ class AnnotatedSagaTest {
 
 
     @Test
-    void testFixtureApi_WhenTimeElapses_UsingMockGateway() {
+    void fixtureApi_WhenTimeElapses_UsingMockGateway() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -238,7 +238,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_givenCurrentTime() {
+    void fixtureApi_givenCurrentTime() {
         String identifier = UUID.randomUUID().toString();
         Instant fourDaysAgo = Instant.now().minus(4, ChronoUnit.DAYS);
         Instant fourDaysMinusTenMinutesAgo = fourDaysAgo.plus(10, ChronoUnit.MINUTES);
@@ -251,7 +251,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_WhenTimeElapses_UsingDefaults() {
+    void fixtureApi_WhenTimeElapses_UsingDefaults() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -271,7 +271,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_WhenTimeElapses_UsingCallbackBehavior() throws Exception {
+    void fixtureApi_WhenTimeElapses_UsingCallbackBehavior() throws Exception {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -295,7 +295,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testFixtureApi_WhenTimeAdvances() {
+    void fixtureApi_WhenTimeAdvances() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -314,7 +314,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testLastResourceEvaluatedFirst() {
+    void lastResourceEvaluatedFirst() {
         String identifier = UUID.randomUUID().toString();
         String identifier2 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
@@ -336,7 +336,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testPublishEventFromSecondFixtureCall() {
+    void publishEventFromSecondFixtureCall() {
         String identifier = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.whenAggregate(identifier).publishes(new TriggerSagaStartEvent(identifier))
@@ -352,7 +352,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testNoExceptionThrownInHandlerMethod() {
+    void noExceptionThrownInHandlerMethod() {
         String identifier = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
 
@@ -362,7 +362,7 @@ class AnnotatedSagaTest {
     }
 
     @Test
-    void testExceptionThrownInHandlerMethod() {
+    void exceptionThrownInHandlerMethod() {
         String identifier = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
 

--- a/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/CommandValidatorTest.java
@@ -49,28 +49,28 @@ class CommandValidatorTest {
     }
 
     @Test
-    void testAssertEmptyDispatchedEqualTo() {
+    void assertEmptyDispatchedEqualTo() {
         when(commandBus.getDispatchedCommands()).thenReturn(emptyCommandMessageList());
 
         testSubject.assertDispatchedEqualTo();
     }
 
     @Test
-    void testAssertNonEmptyDispatchedEqualTo() {
+    void assertNonEmptyDispatchedEqualTo() {
         when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage("command"));
 
         testSubject.assertDispatchedEqualTo("command");
     }
 
     @Test
-    void testMatchWithUnexpectedNullValue() {
+    void matchWithUnexpectedNullValue() {
         when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage(new SomeCommand(null)));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.assertDispatchedEqualTo(new SomeCommand("test")));
     }
 
     @Test
-    void testMatchPrimitiveTypedCommands() {
+    void matchPrimitiveTypedCommands() {
         when(commandBus.getDispatchedCommands()).thenReturn(listOfOneCommandMessage("some-string"));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.assertDispatchedEqualTo("some-other-string"));

--- a/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -20,31 +20,31 @@ class EventValidatorTest {
     }
 
     @Test
-    void testAssertPublishedEventsWithNoEventsMatcherIfNoEventWasPublished() {
+    void assertPublishedEventsWithNoEventsMatcherIfNoEventWasPublished() {
         testSubject.assertPublishedEventsMatching(Matchers.noEvents());
     }
 
     @Test
-    void testAssertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() {
+    void assertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() {
         testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.assertPublishedEventsMatching(Matchers.noEvents()));
     }
 
     @Test
-    void testAssertPublishedEventsIfNoEventWasPublished() {
+    void assertPublishedEventsIfNoEventWasPublished() {
         testSubject.assertPublishedEvents();
     }
 
     @Test
-    void testAssertPublishedEventsThrowsAssertionErrorIfEventWasPublished() {
+    void assertPublishedEventsThrowsAssertionErrorIfEventWasPublished() {
         testSubject.handle(GenericEventMessage.asEventMessage(new MyOtherEvent()));
 
         assertThrows(AxonAssertionError.class, testSubject::assertPublishedEvents);
     }
 
     @Test
-    void testAssertPublishedEventsForEventMessages() {
+    void assertPublishedEventsForEventMessages() {
         EventMessage<MyOtherEvent> testEventMessage = GenericEventMessage.asEventMessage(new MyOtherEvent());
         testSubject.handle(testEventMessage);
 

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -90,7 +90,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testStartRecording() throws Exception {
+    void startRecording() throws Exception {
         RecordingListenerInvocationErrorHandler errorHandler = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
         EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
         doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
@@ -121,7 +121,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testStartRecording_ClearsEventsAndCommands() throws Exception {
+    void startRecording_ClearsEventsAndCommands() throws Exception {
         RecordingListenerInvocationErrorHandler errorHandler = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
         EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
         doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
@@ -140,7 +140,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectPublishedEvents_WrongCount() {
+    void expectPublishedEvents_WrongCount() {
         eventBus.publish(new GenericEventMessage<>(new TriggerSagaEndEvent(identifier)));
 
         assertThrows(
@@ -152,7 +152,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectPublishedEvents_WrongType() {
+    void expectPublishedEvents_WrongType() {
         eventBus.publish(new GenericEventMessage<>(new TriggerSagaEndEvent(identifier)));
 
         assertThrows(
@@ -162,7 +162,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectPublishedEvents_FailedMatcher() {
+    void expectPublishedEvents_FailedMatcher() {
         eventBus.publish(new GenericEventMessage<>(new TriggerSagaEndEvent(identifier)));
 
         assertThrows(
@@ -171,7 +171,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands_FailedCount() {
+    void expectDispatchedCommands_FailedCount() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("First"));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("Second"));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("Third"));
@@ -181,7 +181,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands_FailedType() {
+    void expectDispatchedCommands_FailedType() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("First"));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("Second"));
 
@@ -189,7 +189,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands() {
+    void expectDispatchedCommands() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("First"));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("Second"));
 
@@ -197,7 +197,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands_ObjectsNotImplementingEquals() {
+    void expectDispatchedCommands_ObjectsNotImplementingEquals() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("First")));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("Second")));
 
@@ -205,7 +205,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands_ObjectsNotImplementingEquals_FailedField() {
+    void expectDispatchedCommands_ObjectsNotImplementingEquals_FailedField() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("First")));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("Second")));
 
@@ -217,7 +217,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectDispatchedCommands_ObjectsNotImplementingEquals_WrongType() {
+    void expectDispatchedCommands_ObjectsNotImplementingEquals_WrongType() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("First")));
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(new SimpleCommand("Second")));
 
@@ -229,43 +229,43 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectNoDispatchedCommands_Failed() {
+    void expectNoDispatchedCommands_Failed() {
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("First"));
         assertThrows(AxonAssertionError.class, testSubject::expectNoDispatchedCommands);
     }
 
     @Test
-    void testExpectNoDispatchedCommands() {
+    void expectNoDispatchedCommands() {
         testSubject.expectNoDispatchedCommands();
     }
 
     @Test
-    void testExpectDispatchedCommands_FailedMatcher() {
+    void expectDispatchedCommands_FailedMatcher() {
         assertThrows(
                 AxonAssertionError.class, () -> testSubject.expectDispatchedCommands(new FailingMatcher<String>())
         );
     }
 
     @Test
-    void testExpectNoScheduledEvents_EventIsScheduled() {
+    void expectNoScheduledEvents_EventIsScheduled() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         assertThrows(AxonAssertionError.class, testSubject::expectNoScheduledEvents);
     }
 
     @Test
-    void testExpectNoScheduledEvents_NoEventScheduled() {
+    void expectNoScheduledEvents_NoEventScheduled() {
         testSubject.expectNoScheduledEvents();
     }
 
     @Test
-    void testExpectNoScheduledEvents_ScheduledEventIsTriggered() {
+    void expectNoScheduledEvents_ScheduledEventIsTriggered() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceToNextTrigger();
         testSubject.expectNoScheduledEvents();
     }
 
     @Test
-    void testExpectScheduledEvent_WrongDateTime() {
+    void expectScheduledEvent_WrongDateTime() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTimeBy(Duration.ofMillis(500), i -> {
         });
@@ -276,7 +276,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectScheduledEvent_WrongClass() {
+    void expectScheduledEvent_WrongClass() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTimeBy(Duration.ofMillis(500), i -> {
         });
@@ -287,7 +287,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectScheduledEvent_WrongEvent() {
+    void expectScheduledEvent_WrongEvent() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTimeBy(Duration.ofMillis(500), i -> {
         });
@@ -300,7 +300,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectScheduledEvent_FailedMatcher() {
+    void expectScheduledEvent_FailedMatcher() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTimeBy(Duration.ofMillis(500), i -> {
         });
@@ -311,7 +311,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectScheduledEvent_Found() {
+    void expectScheduledEvent_Found() {
         eventScheduler.schedule(Duration.ofSeconds(1), new GenericEventMessage<>(applicationEvent));
         eventScheduler.advanceTimeBy(Duration.ofMillis(500), i -> {
         });
@@ -319,7 +319,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectScheduledEvent_FoundInMultipleCandidates() {
+    void expectScheduledEvent_FoundInMultipleCandidates() {
         eventScheduler.schedule(
                 Duration.ofSeconds(1), new GenericEventMessage<>(new TimerTriggeredEvent("unexpected1"))
         );
@@ -331,7 +331,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testAssociationWith_WrongValue() {
+    void associationWith_WrongValue() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -340,7 +340,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testAssociationWith_WrongKey() {
+    void associationWith_WrongKey() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -349,7 +349,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testAssociationWith_Present() {
+    void associationWith_Present() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -358,7 +358,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testNoAssociationWith_WrongValue() {
+    void noAssociationWith_WrongValue() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -367,7 +367,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testNoAssociationWith_WrongKey() {
+    void noAssociationWith_WrongKey() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -376,7 +376,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testNoAssociationWith_Present() {
+    void noAssociationWith_Present() {
         sagaStore.insertSaga(
                 StubSaga.class, "test", new StubSaga(), Collections.singleton(new AssociationValue("key", "value"))
         );
@@ -385,14 +385,14 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testExpectActiveSagas_WrongCount() {
+    void expectActiveSagas_WrongCount() {
         sagaStore.insertSaga(StubSaga.class, "test", new StubSaga(), Collections.emptySet());
 
         assertThrows(AxonAssertionError.class, () -> testSubject.expectActiveSagas(2));
     }
 
     @Test
-    void testExpectActiveSagas_CorrectCount() {
+    void expectActiveSagas_CorrectCount() {
         sagaStore.insertSaga(StubSaga.class, "test", new StubSaga(), Collections.emptySet());
         sagaStore.deleteSaga(StubSaga.class, "test", Collections.emptySet());
         sagaStore.insertSaga(StubSaga.class, "test2", new StubSaga(), Collections.emptySet());
@@ -401,7 +401,7 @@ class FixtureExecutionResultImplTest {
     }
 
     @Test
-    void testStartRecordingCallback() {
+    void startRecordingCallback() {
         AtomicInteger startRecordingCallbackInvocations = new AtomicInteger();
         testSubject.registerStartRecordingCallback(startRecordingCallbackInvocations::incrementAndGet);
         testSubject.startRecording();

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_Deadlines.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_Deadlines.java
@@ -55,7 +55,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectScheduledDeadline() {
+    void expectScheduledDeadline() {
         fixture.givenNoPriorActivity()
                .whenAggregate(AGGREGATE_ID)
                .publishes(START_SAGA_EVENT)
@@ -65,7 +65,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectScheduledDeadlineOfType() {
+    void expectScheduledDeadlineOfType() {
         fixture.givenNoPriorActivity()
                .whenAggregate(AGGREGATE_ID)
                .publishes(START_SAGA_EVENT)
@@ -75,7 +75,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectScheduledDeadlineWithName() {
+    void expectScheduledDeadlineWithName() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenAggregate(AGGREGATE_ID)
@@ -84,7 +84,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectNoScheduledDeadline() {
+    void expectNoScheduledDeadline() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenPublishingA(new ResetTriggerEvent(AGGREGATE_ID))
@@ -94,7 +94,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectNoScheduledDeadlineOfType() {
+    void expectNoScheduledDeadlineOfType() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenPublishingA(new ResetTriggerEvent(AGGREGATE_ID))
@@ -104,7 +104,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testExpectNoScheduledDeadlineWithName() {
+    void expectNoScheduledDeadlineWithName() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenPublishingA(new ResetTriggerEvent(AGGREGATE_ID))
@@ -114,7 +114,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineMetMatching() {
+    void deadlineMetMatching() {
         //noinspection deprecation
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
@@ -125,7 +125,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesMatching() {
+    void triggeredDeadlinesMatching() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -135,7 +135,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineMet() {
+    void deadlineMet() {
         //noinspection deprecation
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
@@ -146,7 +146,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlines() {
+    void triggeredDeadlines() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -156,7 +156,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesFailsForIncorrectDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -172,7 +172,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesFailsForIncorrectNumberOfDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -186,7 +186,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithName() {
+    void triggeredDeadlinesWithName() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -196,7 +196,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithNameFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesWithNameFailsForIncorrectDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -211,7 +211,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesWithNameFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesWithNameFailsForIncorrectNumberOfDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -225,7 +225,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfType() {
+    void triggeredDeadlinesOfType() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
@@ -235,7 +235,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfTypeFailsForIncorrectDeadlines() {
+    void triggeredDeadlinesOfTypeFailsForIncorrectDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -251,7 +251,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testTriggeredDeadlinesOfTypeFailsForIncorrectNumberOfDeadlines() {
+    void triggeredDeadlinesOfTypeFailsForIncorrectNumberOfDeadlines() {
         FixtureExecutionResult given = fixture.givenAggregate(AGGREGATE_ID)
                                               .published(START_SAGA_EVENT)
                                               .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1));
@@ -265,7 +265,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineCancelled() {
+    void deadlineCancelled() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenPublishingA(new ResetTriggerEvent(AGGREGATE_ID))
@@ -275,7 +275,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineWhichCancelsAll() {
+    void deadlineWhichCancelsAll() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(START_SAGA_EVENT)
                .whenPublishingA(new ResetAllTriggeredEvent(AGGREGATE_ID))
@@ -285,7 +285,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineDispatchInterceptor() {
+    void deadlineDispatchInterceptor() {
         fixture.registerDeadlineDispatchInterceptor(
                 messages -> (i, m) -> asDeadlineMessage(m.getDeadlineName(), "fakeDeadlineDetails", m.getTimestamp())
         )
@@ -298,7 +298,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineHandlerInterceptor() {
+    void deadlineHandlerInterceptor() {
         fixture.registerDeadlineHandlerInterceptor((uow, chain) -> {
             uow.transformMessage(deadlineMessage -> asDeadlineMessage(
                     deadlineMessage.getDeadlineName(), "fakeDeadlineDetails", deadlineMessage.getTimestamp())
@@ -314,7 +314,7 @@ class FixtureTest_Deadlines {
     }
 
     @Test
-    void testDeadlineHandlerEndsSagaLifecycle() {
+    void deadlineHandlerEndsSagaLifecycle() {
         fixture.givenAggregate(AGGREGATE_ID)
                .published(new TriggerSagaStartEvent(AGGREGATE_ID, "sagaEndingDeadline"))
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -53,7 +53,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testRegisterParameterResolverFactory() {
+    void registerParameterResolverFactory() {
         testSubject.registerParameterResolverFactory(new TestParameterResolverFactory(new AtomicBoolean(false)))
                    .givenAggregate(TEST_AGGREGATE_IDENTIFIER)
                    .published(new TriggerSagaStartEvent(TEST_AGGREGATE_IDENTIFIER))
@@ -67,7 +67,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testCreateHandlerMethodIsCalledForRegisteredCustomHandlerDefinition() {
+    void createHandlerMethodIsCalledForRegisteredCustomHandlerDefinition() {
         AtomicBoolean handlerDefinitionReached = new AtomicBoolean(false);
 
         testSubject.registerHandlerDefinition(new TestHandlerDefinition(handlerDefinitionReached))
@@ -79,7 +79,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
     }
 
     @Test
-    void testWrapHandlerMethodIsCalledForRegisteredCustomHandlerEnhancerDefinition() {
+    void wrapHandlerMethodIsCalledForRegisteredCustomHandlerEnhancerDefinition() {
         AtomicBoolean handlerEnhancerReached = new AtomicBoolean(false);
 
         testSubject.registerHandlerEnhancerDefinition(new TestHandlerEnhancerDefinition(handlerEnhancerReached))

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringSagaEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringSagaEnhancements.java
@@ -33,7 +33,7 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void testStartRecordingCallbackIsInvokedOnWhenPublishingAnEvent() {
+    void startRecordingCallbackIsInvokedOnWhenPublishingAnEvent() {
         testSubject.registerStartRecordingCallback(startRecordingCount::getAndIncrement)
                    .givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
@@ -43,7 +43,7 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void testStartRecordingCallbackIsInvokedOnWhenTimeAdvances() {
+    void startRecordingCallbackIsInvokedOnWhenTimeAdvances() {
         testSubject.registerStartRecordingCallback(startRecordingCount::getAndIncrement)
                    .givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
@@ -53,7 +53,7 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void testStartRecordingCallbackIsInvokedOnWhenTimeElapses() {
+    void startRecordingCallbackIsInvokedOnWhenTimeElapses() {
         testSubject.registerStartRecordingCallback(startRecordingCount::getAndIncrement)
                    .givenAPublished(new SomeTestSaga.SomeEvent());
         assertThat(startRecordingCount.get(), equalTo(0));
@@ -63,7 +63,7 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void testCustomListenerInvocationErrorHandlerIsUsed() {
+    void customListenerInvocationErrorHandlerIsUsed() {
         SomeTestSaga.SomeEvent testEvent = new SomeTestSaga.SomeEvent("some-id", true);
 
         ListenerInvocationErrorHandler testSubject = (exception, event, eventHandler) ->
@@ -75,7 +75,7 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void testRegisteredResourceInjectorIsCalledUponFirstEventPublication() {
+    void registeredResourceInjectorIsCalledUponFirstEventPublication() {
         AtomicBoolean assertion = new AtomicBoolean(false);
         testSubject.registerResourceInjector(saga -> assertion.set(true))
                    // Publishing a single event should trigger the creation and injection of resources

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScheduledEvents.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScheduledEvents.java
@@ -48,21 +48,21 @@ class FixtureTest_ScheduledEvents {
     }
 
     @Test
-    void testExpectScheduledEvent() {
+    void expectScheduledEvent() {
         testSubject.givenNoPriorActivity()
                    .whenPublishingA(new TriggerSagaStartEvent(IDENTIFIER))
                    .expectScheduledEvent(TRIGGER_DURATION_MINUTES, EVENT_TO_SCHEDULE);
     }
 
     @Test
-    void testExpectScheduledEventOfType() {
+    void expectScheduledEventOfType() {
         testSubject.givenNoPriorActivity()
                    .whenPublishingA(new TriggerSagaStartEvent(IDENTIFIER))
                    .expectScheduledEventOfType(TRIGGER_DURATION_MINUTES, String.class);
     }
 
     @Test
-    void testExpectScheduledEventDurationAdjustedByElapsedTime() {
+    void expectScheduledEventDurationAdjustedByElapsedTime() {
         Duration elapsedTime = Duration.ofMinutes(1);
 
         testSubject.givenAggregate(IDENTIFIER)
@@ -73,7 +73,7 @@ class FixtureTest_ScheduledEvents {
     }
 
     @Test
-    void testNoExpectScheduledEvent() {
+    void noExpectScheduledEvent() {
         testSubject.givenAggregate(IDENTIFIER)
                    .published(new TriggerSagaStartEvent(IDENTIFIER))
                    .whenAggregate(IDENTIFIER)
@@ -82,7 +82,7 @@ class FixtureTest_ScheduledEvents {
     }
 
     @Test
-    void testNoExpectScheduledEventOfType() {
+    void noExpectScheduledEventOfType() {
         testSubject.givenAggregate(IDENTIFIER)
                    .published(new TriggerSagaStartEvent(IDENTIFIER))
                    .whenAggregate(IDENTIFIER)

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScopeDescriptor.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_ScopeDescriptor.java
@@ -26,7 +26,7 @@ class FixtureTest_ScopeDescriptor {
     }
 
     @Test
-    void testResolvesScopeDescriptor() {
+    void resolvesScopeDescriptor() {
         fixture.givenNoPriorActivity()
                .whenPublishingA(new SagaStartEvent("some-identifier"))
                .expectDispatchedCommandsMatching(payloadsMatching(sequenceOf(matches(

--- a/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
@@ -27,26 +27,26 @@ import static org.mockito.Mockito.*;
 class RecordingListenerInvocationErrorHandlerTest {
 
     @Test
-    void testEmptyOnCreation() {
+    void emptyOnCreation() {
         RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
 
         assertFalse(testSubject.getException().isPresent());
     }
 
     @Test
-    void testWrappedHandlerCannotBeNull() {
+    void wrappedHandlerCannotBeNull() {
         assertThrows(IllegalArgumentException.class, () -> new RecordingListenerInvocationErrorHandler(null));
     }
 
     @Test
-    void testCannotSetWrappedHanlderToNull() {
+    void cannotSetWrappedHanlderToNull() {
         RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
 
         assertThrows(IllegalArgumentException.class, () -> testSubject.setListenerInvocationErrorHandler(null));
     }
 
     @Test
-    void testLogExceptionOnError() throws Exception {
+    void logExceptionOnError() throws Exception {
         RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
         EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
         doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
@@ -59,7 +59,7 @@ class RecordingListenerInvocationErrorHandlerTest {
     }
 
     @Test
-    void testClearExceptionOnStartRecording() throws Exception {
+    void clearExceptionOnStartRecording() throws Exception {
         RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
         EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
         doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();

--- a/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
+++ b/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
@@ -38,7 +38,7 @@ class RecordingCommandBusTest {
     }
 
     @Test
-    void testPublishCommand() {
+    void publishCommand() {
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("First"));
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("Second"),
                              (commandMessage, commandResultMessage) -> {
@@ -55,7 +55,7 @@ class RecordingCommandBusTest {
     }
 
     @Test
-    void testPublishCommandWithCallbackBehavior() {
+    void publishCommandWithCallbackBehavior() {
         testSubject.setCallbackBehavior((commandPayload, commandMetaData) -> "callbackResult");
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("First"));
         testSubject.dispatch(GenericCommandMessage.asCommandMessage("Second"),
@@ -72,7 +72,7 @@ class RecordingCommandBusTest {
     }
 
     @Test
-    void testRegisterHandler() {
+    void registerHandler() {
         MessageHandler<? super CommandMessage<?>> handler = command -> {
             fail("Did not expect handler to be invoked");
             return null;


### PR DESCRIPTION
Applied using `./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:4.31.3:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:1.26.1 -DactiveRecipes=org.openrewrite.java.testing.cleanup.RemoveTestPrefix`.
Inspired by https://twitter.com/maciejwalkowiak/status/1549332873219657730

Nearly all changes made automatically; only had to adjust some tests calling other test methods such as the super calls in `org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngineTest`.