### PR TITLE
Include message identifier in error message if de-serialization fails

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
@@ -75,12 +75,20 @@ public class SerializedMessage<T> extends AbstractMessage<T> {
 
     @Override
     public T getPayload() {
-        return payload.getObject();
+        try {
+            return payload.getObject();
+        } catch (SerializationException e) {
+            throw new SerializationException("Error while deserializing payload of message " + getIdentifier(), e);
+        }
     }
 
     @Override
     public MetaData getMetaData() {
-        return metaData.getObject();
+        try {
+            return metaData.getObject();
+        } catch (SerializationException e) {
+            throw new SerializationException("Error while deserializing meta data of message " + getIdentifier(), e);
+        }
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
@@ -123,4 +123,22 @@ class SerializedMessageTest {
         verify(serializer, atLeast(0)).getConverter();
         verifyNoMoreInteractions(serializer);
     }
+
+    @Test
+    void testRethrowSerializationException() {
+        SerializationException serializationException = new SerializationException("test message");
+        when(serializer.deserialize(serializedMetaData)).thenThrow(serializationException);
+        when(serializer.deserialize(serializedPayload)).thenThrow(serializationException);
+
+        SerializedMessage<Object> message = new SerializedMessage<>(eventId, serializedPayload,
+                                                                          serializedMetaData, serializer);
+
+        SerializationException thrown1 = assertThrows(SerializationException.class, message::getPayload);
+        assertEquals("Error while deserializing payload of message " + eventId, thrown1.getMessage());
+        assertSame(serializationException, thrown1.getCause());
+
+        SerializationException thrown2 = assertThrows(SerializationException.class, message::getMetaData);
+        assertEquals("Error while deserializing meta data of message " + eventId, thrown2.getMessage());
+        assertSame(serializationException, thrown2.getCause());
+    }
 }


### PR DESCRIPTION
If, while de-serializing a message payload or meta data, a SerializationException is thrown, re-throw it with a more specific error message that includes the message identifier. This makes analysis of de-serialization errors easier.