### PR TITLE
[#2331] Fix deserialization bug `GrpcBackedSubscriptionQueryMessage` and filter non-handler-matching updates

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
@@ -62,7 +62,7 @@ public class GrpcBackedSubscriptionQueryMessage<Q, I, U> implements Subscription
                 subscriptionQuery,
                 new GrpcBackedQueryMessage<>(subscriptionQuery.getQueryRequest(), messageSerializer, serializer),
                 new LazyDeserializingObject<>(
-                        new GrpcSerializedObject(subscriptionQuery.getQueryRequest().getResponseType()), serializer
+                        new GrpcSerializedObject(subscriptionQuery.getUpdateResponseType()), serializer
                 )
         );
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
@@ -120,10 +120,10 @@ class SubscriptionMessageSerializerTest {
 
     @Test
     void testSubscriptionQueryMessage() {
-        GenericSubscriptionQueryMessage<String, Integer, Integer> message = new GenericSubscriptionQueryMessage<>(
+        GenericSubscriptionQueryMessage<String, String, Integer> message = new GenericSubscriptionQueryMessage<>(
                 "query",
                 "MyQueryName",
-                instanceOf(int.class),
+                instanceOf(String.class),
                 instanceOf(int.class));
         SubscriptionQuery grpcMessage = testSubject.serialize(message);
         SubscriptionQueryMessage<Object, Object, Object> deserialized = testSubject.deserialize(grpcMessage);

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
@@ -173,6 +173,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
                             SubscriptionQueryUpdateMessage<U> update) {
         updateHandlers.keySet()
                       .stream()
+                      .filter(sqm -> sqm.getUpdateResponseType().matches(update.getPayloadType()))
                       .filter(sqm -> filter.test((SubscriptionQueryMessage<?, ?, U>) sqm))
                       .forEach(query -> Optional.ofNullable(updateHandlers.get(query))
                                                 .ifPresent(uh -> doEmit(query, uh, update)));

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -137,6 +137,30 @@ class SimpleQueryUpdateEmitterTest {
     }
 
     @Test
+    void testDifferentUpdateAreDisambiguatedAndWrongTypesAreFilteredBasedOnQueryTypes() {
+        SubscriptionQueryMessage<String, List<String>, Integer> queryMessage = new GenericSubscriptionQueryMessage<>(
+                "some-payload",
+                "chatMessages",
+                ResponseTypes.multipleInstancesOf(String.class),
+                ResponseTypes.instanceOf(Integer.class)
+        );
+
+        UpdateHandlerRegistration<Object> result = testSubject.registerUpdateHandler(
+                queryMessage,
+                1024
+        );
+
+        result.getUpdates().subscribe();
+        testSubject.emit(any -> true, "some-awesome-text");
+        testSubject.emit(any -> true, 1234);
+        result.complete();
+
+        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+                    .expectNext(1234)
+                    .verifyComplete();
+    }
+
+    @Test
     void testCancelingRegistrationDoesNotCompleteFluxOfUpdates() {
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
                 "some-payload",


### PR DESCRIPTION
See https://github.com/AxonFramework/AxonFramework/issues/2331

