### PR TITLE
Update slf4j version to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         </sonar.coverage.jacoco.xmlReportPaths>
 
         <!-- dependency versions -->
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.0</slf4j.version>
         <log4j.version>2.18.0</log4j.version>
         <spring.version>5.3.22</spring.version>
         <spring-security.version>5.7.3</spring-security.version>
@@ -160,7 +160,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/reactorless-test/pom.xml
+++ b/reactorless-test/pom.xml
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,6 +47,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <version>${spring.boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Needed some additional fixes. It does give a warning currently, as there was a breaking change in the `org.slf4j.spi.SLF4JServiceProvider` interface `getRequesteApiVersion` -> `getRequestedApiVersion`. We might want to wait till the new impl versions are available, likely 2.18.0 -> 3.0.0? See [tags](https://github.com/apache/logging-log4j2/tags). But we already moved to 2.0.0 for some extensions.