### PR TITLE
Parameter resolver ordering is wrong for test fixtures

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/Priority.java
+++ b/messaging/src/main/java/org/axonframework/common/Priority.java
@@ -41,11 +41,11 @@ public @interface Priority {
     /**
      * Value indicating the annotated member should be placed at the "lower quarter".
      */
-    int LOWER = Integer.MIN_VALUE / 2;
+    int LOWER = (Integer.MIN_VALUE / 2) + (Integer.MIN_VALUE / 4);
     /**
      * Value indicating the annotated member should be placed at the "lower half".
      */
-    int LOW = Integer.MIN_VALUE / 4;
+    int LOW = Integer.MIN_VALUE / 2;
     /**
      * Value indicating the annotated member should have medium priority, effectively placing it "in the middle".
      */
@@ -54,6 +54,11 @@ public @interface Priority {
      * Value indicating the annotated member should have high priority, effectively placing it "in the first half".
      */
     int HIGH = Integer.MAX_VALUE / 2;
+
+    /**
+     * Value indicating the annotated member should be placed at the "upper quarter".
+     */
+    int HIGHER = (Integer.MAX_VALUE / 2) + (Integer.MAX_VALUE / 4);
 
     /**
      * Value indicating the annotated member should be the very first

--- a/messaging/src/main/java/org/axonframework/common/Priority.java
+++ b/messaging/src/main/java/org/axonframework/common/Priority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.axonframework.common;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates the relative priority of the annotated component. Components with a higher priority are considered before
@@ -35,9 +39,13 @@ public @interface Priority {
      */
     int LAST = Integer.MIN_VALUE;
     /**
+     * Value indicating the annotated member should be placed at the "lower quarter".
+     */
+    int LOWER = Integer.MIN_VALUE / 2;
+    /**
      * Value indicating the annotated member should be placed at the "lower half".
      */
-    int LOW = Integer.MIN_VALUE / 2;
+    int LOW = Integer.MIN_VALUE / 4;
     /**
      * Value indicating the annotated member should have medium priority, effectively placing it "in the middle".
      */

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.lang.reflect.Parameter;
  * Uses the {@link FixedValueParameterResolver} to inject a resource as a fixed value
  * on message handling if the resource equals a message handling method parameter.
  */
-@Priority(Priority.LOW)
+@Priority(Priority.LAST)
 public class SimpleResourceParameterResolverFactory implements ParameterResolverFactory {
 
     private final Iterable<?> resources;

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactory.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Parameter;
  * Uses the {@link FixedValueParameterResolver} to inject a resource as a fixed value
  * on message handling if the resource equals a message handling method parameter.
  */
-@Priority(Priority.LAST)
+@Priority(Priority.LOWER)
 public class SimpleResourceParameterResolverFactory implements ParameterResolverFactory {
 
     private final Iterable<?> resources;

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.test.saga;
 
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.*;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
@@ -64,6 +66,17 @@ public class FixtureTest_RegisteringMethodEnhancements {
                        AtomicBoolean assertion = ((ResolveParameterCommand) payload).getAssertion();
                        return assertion.get();
                    })));
+    }
+
+
+    @Test
+    void testRegisterParameterResolverFactoryStillCallsMetadataValue() {
+        testSubject.registerParameterResolverFactory(new TestParameterResolverFactory(new AtomicBoolean(false)))
+                   .givenAggregate(TEST_AGGREGATE_IDENTIFIER)
+                   .published(GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(TEST_AGGREGATE_IDENTIFIER)).withMetaData(
+                           Collections.singletonMap("extraIdentifier", "myExtraIdentifier")))
+                   .whenPublishingA(new ParameterResolvedEvent(TEST_AGGREGATE_IDENTIFIER))
+                .expectAssociationWith("extraIdentifier", "myExtraIdentifier");
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/StubSaga.java
+++ b/test/src/test/java/org/axonframework/test/saga/StubSaga.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,11 +65,11 @@ public class StubSaga {
     @SagaEventHandler(associationProperty = "identifier")
     public void handleSagaStart(TriggerSagaStartEvent event,
                                 EventMessage<TriggerSagaStartEvent> message,
-                                @MetaDataValue("extraIdentifier") String extraIdentifier) {
+                                @MetaDataValue("extraIdentifier") Object extraIdentifier) {
         handledEvents.add(event);
 
         if (extraIdentifier != null) {
-            associateWith("extraIdentifier", extraIdentifier);
+            associateWith("extraIdentifier", extraIdentifier.toString());
         }
 
         timer = scheduler.schedule(message.getTimestamp().plus(TRIGGER_DURATION_MINUTES, ChronoUnit.MINUTES),


### PR DESCRIPTION
The `SimpleResourceParameterResolverFactory` had the same priority as the `DefaultParameterResolverFactory`. Because of this it was possible for both the `SagaFixture` and `AggregateFixture` to inject the wrong values into message handling methods in certain cases. This behavior in tests deviates from normal application behavior, so should be fixed. 

This was done by lowering the priority on the `SimpleResourceParameterResolverFactory`, essentially making it the last to resolve. 

A notable case where the issue occurred is when injecting an `Object` value of the `MetaDataValue` annotation, like so:

```java
 public void handleSagaStart(TriggerSagaStartEvent event, @MetaDataValue("extraIdentifier") Object extraIdentifier) {
}
```

Since Object matches any resource present in the `SimpleResourceParameterResolverFactory`, and its priority is the same, the first mock resource is injected instead of the correct metadata value. 
