### PR TITLE
Throw exception on ambiguous dependencies

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -18,7 +18,10 @@ package org.axonframework.springboot;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.EventProcessingConfigurer;
@@ -47,6 +50,7 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
 import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -107,6 +111,57 @@ class AxonAutoConfigurationTest {
                                applicationContext.getBean("messageSerializer"));
                     assertSame(applicationContext.getBean("serializer"),
                                applicationContext.getBean("messageSerializer"));
+                });
+    }
+
+    @Test
+    void ambiguousComponentsThrowExceptionWhenRequestedFromConfiguration() {
+        ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean("gatewayOne", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build())
+                .withBean("gatewayTwo", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build())
+                .withPropertyValues("axon.axonserver.enabled=false");
+
+        AxonConfigurationException actual = assertThrows(AxonConfigurationException.class, () -> {
+            applicationContextRunner
+                    .run(ctx -> ctx.getBean(org.axonframework.config.Configuration.class).commandGateway());
+        });
+        assertTrue(actual.getMessage().contains("CommandGateway"));
+        assertTrue(actual.getMessage().contains("gatewayOne"));
+        assertTrue(actual.getMessage().contains("gatewayTwo"));
+
+    }
+
+    @Test
+    void ambiguousPrimaryComponentsThrowExceptionWhenRequestedFromConfiguration() {
+        ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean("gatewayOne", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(), beanDefinition -> beanDefinition.setPrimary(true))
+                .withBean("gatewayTwo", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(), beanDefinition -> beanDefinition.setPrimary(true))
+                .withPropertyValues("axon.axonserver.enabled=false");
+
+        AxonConfigurationException actual = assertThrows(AxonConfigurationException.class, () -> {
+            applicationContextRunner
+                    .run(ctx -> ctx.getBean(org.axonframework.config.Configuration.class).commandGateway());
+        });
+        assertTrue(actual.getMessage().contains("CommandGateway"));
+        assertTrue(actual.getMessage().contains("gatewayOne"));
+        assertTrue(actual.getMessage().contains("gatewayTwo"));
+    }
+
+    @Test
+    void ambiguousBeanDependenciesThrowException() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean("gatewayOne", CommandBus.class, () -> SimpleCommandBus.builder().build())
+                .withBean("gatewayTwo", CommandBus.class, () -> SimpleCommandBus.builder().build())
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .run(ctx -> {
+                    Throwable startupFailure = ctx.getStartupFailure();
+                    assertTrue(startupFailure instanceof UnsatisfiedDependencyException);
+                    assertTrue(startupFailure.getMessage().contains("CommandBus"), "Expected mention of 'CommandBus' in: " + startupFailure.getMessage());
+                    assertTrue(startupFailure.getMessage().contains("gatewayOne"), "Expected mention of 'gatewayOne' in: " + startupFailure.getMessage());
+                    assertTrue(startupFailure.getMessage().contains("gatewayTwo"), "Expected mention of 'gatewayTwo' in: " + startupFailure.getMessage());
                 });
     }
 

--- a/spring/src/main/java/org/axonframework/spring/config/SpringConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringConfigurer.java
@@ -16,10 +16,12 @@
 
 package org.axonframework.spring.config;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -64,7 +66,11 @@ public class SpringConfigurer extends DefaultConfigurer {
             } else if (candidates.length == 1) {
                 return Optional.of(beanFactory.getBean(candidates[0], componentType));
             } else {
-                return findPrimary(componentType, candidates);
+                Optional<T> primary = findPrimary(componentType, candidates);
+                if (!primary.isPresent()) {
+                    throw new AxonConfigurationException("Expected single candidate for component [" + componentType.getSimpleName() + "]. Found candidates: " + Arrays.deepToString(candidates));
+                }
+                return primary;
             }
         }
 

--- a/spring/src/test/java/org/axonframework/spring/config/SpringConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringConfigurerTest.java
@@ -1,0 +1,108 @@
+package org.axonframework.spring.config;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.config.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SpringConfigurerTest {
+
+    private ConfigurableListableBeanFactory context;
+
+    @BeforeEach
+    void setUp() {
+        context = mock(ConfigurableListableBeanFactory.class);
+        when(context.getBeanNamesForType(any(Class.class))).thenReturn(new String[]{});
+    }
+
+    @Test
+    void springComponentLoadedWhenNoComponentConfigured() {
+        when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus"});
+
+        SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
+        when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
+
+        SpringConfigurer configurer = new SpringConfigurer(context);
+
+        assertSame(commandBus, configurer.buildConfiguration().commandBus());
+    }
+
+    @Test
+    void springPrimaryBeanUsedWhenMultipleCandidates() {
+        when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
+        when(context.getBeanDefinition(any())).thenReturn(new GenericBeanDefinition());
+        GenericBeanDefinition primary = new GenericBeanDefinition();
+        primary.setPrimary(true);
+        when(context.getBeanDefinition("commandBus")).thenReturn(primary);
+        SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
+        when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
+
+        SpringConfigurer configurer = new SpringConfigurer(context);
+
+        assertSame(commandBus, configurer.buildConfiguration().commandBus());
+
+        //noinspection unchecked
+        verify(context, never()).getBean(eq("alternative"), any(Class.class));
+    }
+
+    @Test
+    void failsWhenMultiplePrimaryCandidates() {
+        when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
+        GenericBeanDefinition primary = new GenericBeanDefinition();
+        primary.setPrimary(true);
+        when(context.getBeanDefinition(any())).thenReturn(primary);
+        SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
+        when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
+
+        SpringConfigurer configurer = new SpringConfigurer(context);
+
+        Configuration configuration = configurer.buildConfiguration();
+        assertThrows(AxonConfigurationException.class, configuration::commandBus);
+
+        //noinspection unchecked
+        verify(context, never()).getBean(anyString(), any(Class.class));
+    }
+
+    @Test
+    void failsWhenMultipleNonPrimaryCandidates() {
+        when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
+        GenericBeanDefinition nonPrimary = new GenericBeanDefinition();
+        when(context.getBeanDefinition(any())).thenReturn(nonPrimary);
+        SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
+        when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
+
+        SpringConfigurer configurer = new SpringConfigurer(context);
+
+        Configuration configuration = configurer.buildConfiguration();
+        assertThrows(AxonConfigurationException.class, configuration::commandBus);
+
+        //noinspection unchecked
+        verify(context, never()).getBean(anyString(), any(Class.class));
+    }
+
+    @Test
+    void usesConfigurerDefaultsWhenNoBeansDefined() {
+        SpringConfigurer configurer = new SpringConfigurer(context);
+
+        assertNotNull(configurer.buildConfiguration().commandBus());
+
+        //noinspection unchecked
+        verify(context, never()).getBean(anyString(), any(Class.class));
+    }
+
+}


### PR DESCRIPTION
When multiple candidates exist for a certain component, the Axon Configurer should throw an exception if not exactly one of these is marked as a Primary bean.