### PR TITLE
Catch exceptions from correlation data providers.

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/correlation/CorrelationDataProvider.java
+++ b/messaging/src/main/java/org/axonframework/messaging/correlation/CorrelationDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import org.axonframework.messaging.Message;
 import java.util.Map;
 
 /**
- * Object defining the data from a Message that should be attached as correlation data to messages generated as
- * result of the processing of that message.
+ * Object defining the data from a Message that should be attached as correlation data to messages generated as result
+ * of the processing of that message.
  *
  * @author Allard Buijze
  * @since 2.3
@@ -34,7 +34,9 @@ public interface CorrelationDataProvider {
      * Provides a map with the entries to attach as correlation data to generated messages while processing given
      * {@code message}.
      * <p/>
-     * This method should not return {@code null}.
+     * This method should not return {@code null}. Any exception thrown from this method might interfere with rolling
+     * back a transaction. Therefore, by default exceptions are caught, ignoring the correlation data that should have
+     * been added.
      *
      * @param message The message to define correlation data for
      * @return the data to attach as correlation data to generated messages

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package org.axonframework.messaging;
 
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.correlation.ThrowingCorrelationDataProvider;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.serialization.CannotConvertBetweenTypesException;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
@@ -38,10 +42,11 @@ import static org.mockito.Mockito.*;
 class GenericMessageTest {
 
     private final Map<String, ?> correlationData = MetaData.from(Collections.singletonMap("foo", "bar"));
+    private UnitOfWork<?> unitOfWork;
 
     @BeforeEach
     void setUp() {
-        UnitOfWork<?> unitOfWork = mock(UnitOfWork.class);
+        unitOfWork = mock(UnitOfWork.class);
         when(unitOfWork.getCorrelationData()).thenAnswer(invocation -> correlationData);
         CurrentUnitOfWork.set(unitOfWork);
     }
@@ -91,5 +96,17 @@ class GenericMessageTest {
 
         assertNotEquals(testPayload, result);
         assertEquals(testPayload, result.getPayload());
+    }
+
+    @Test
+    void whenCorrelationDataProviderThrowsException_thenCatchException(){
+        unitOfWork = new DefaultUnitOfWork<>(new GenericEventMessage<>("Input 1"));
+        CurrentUnitOfWork.set(unitOfWork);
+        unitOfWork.registerCorrelationDataProvider(new ThrowingCorrelationDataProvider());
+        CannotConvertBetweenTypesException exception = new CannotConvertBetweenTypesException("foo");
+
+        Message<?> result = GenericMessage.asMessage(exception);
+
+        assertNotNull(result);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/correlation/ThrowingCorrelationDataProvider.java
+++ b/messaging/src/test/java/org/axonframework/messaging/correlation/ThrowingCorrelationDataProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.correlation;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.messaging.Message;
+
+import java.util.Map;
+
+public class ThrowingCorrelationDataProvider implements CorrelationDataProvider{
+    @Override
+    public Map<String, ?> correlationDataFor(Message<?> message) {
+        throw new AxonConfigurationException("correlation is not clear");
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.axonframework.messaging.unitofwork;
 
-import org.axonframework.utils.MockException;
 import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.ResultMessage;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
+import org.axonframework.messaging.correlation.ThrowingCorrelationDataProvider;
+import org.axonframework.utils.MockException;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -192,6 +192,12 @@ class AbstractUnitOfWorkTest {
         verify(subject).rollback(isA(MockException.class));
     }
 
+    @Test
+    void whenGettingCorrelationMetaThrows_thenCatchExceptions() {
+        subject.registerCorrelationDataProvider(new ThrowingCorrelationDataProvider());
+        MetaData correlationData = subject.getCorrelationData();
+        assertNotNull(correlationData);
+    }
 
     private static class PhaseTransition {
 


### PR DESCRIPTION
Current implementation always catches exceptions from correlation providers.
Optionally we might only do this when the message is an exception or when called from the catch block in the `UnitOfWork`?
Resolves https://github.com/AxonFramework/AxonFramework/issues/2328