### PR TITLE
Rename SpanFactory.registerTagProvider to registerSpanAttributeProvider

### DIFF
--- a/messaging/src/main/java/org/axonframework/tracing/NoOpSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/NoOpSpanFactory.java
@@ -64,7 +64,7 @@ public class NoOpSpanFactory implements SpanFactory {
     }
 
     @Override
-    public void registerTagProvider(SpanAttributesProvider supplier) {
+    public void registerSpanAttributeProvider(SpanAttributesProvider supplier) {
         // Do nothing
     }
 

--- a/messaging/src/main/java/org/axonframework/tracing/SpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanFactory.java
@@ -169,7 +169,7 @@ public interface SpanFactory {
      *
      * @param provider The provider to add.
      */
-    void registerTagProvider(SpanAttributesProvider provider);
+    void registerSpanAttributeProvider(SpanAttributesProvider provider);
 
     /**
      * Propagates the currently active trace and span to the message. It should do so in a way that the context can be

--- a/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
@@ -229,7 +229,7 @@ public class TestSpanFactory implements SpanFactory {
     }
 
     @Override
-    public void registerTagProvider(SpanAttributesProvider provider) {
+    public void registerSpanAttributeProvider(SpanAttributesProvider provider) {
 
     }
 

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactory.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactory.java
@@ -152,7 +152,7 @@ public class OpenTelemetrySpanFactory implements SpanFactory {
     }
 
     @Override
-    public void registerTagProvider(SpanAttributesProvider provider) {
+    public void registerSpanAttributeProvider(SpanAttributesProvider provider) {
         spanAttributesProviders.add(provider);
     }
 


### PR DESCRIPTION
There is a naming error in the `SpanFactory` interface. This PR corrects it.