### PR TITLE
Introduce LoggingSpanFactory and MultiSpanFactory

### DIFF
--- a/messaging/src/main/java/org/axonframework/tracing/LoggingSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/LoggingSpanFactory.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.common.IdentifierFactory;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementation of a {@link SpanFactory} that requires no java agent or APM system, only logging. Will log tracing
+ * information to info level, with the following identifying prefix: {@code {spanId}{spanName}}.
+ * <p>
+ * When traces are related to a message, the message type and identifier is logged as well. If a message is dispatched
+ * while currently handling a message in the {@link org.axonframework.messaging.unitofwork.UnitOfWork}, it will log the
+ * information regarding the message being handled as well.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6.0
+ */
+public class LoggingSpanFactory implements SpanFactory {
+    /**
+     * Singleton instance of the {@link LoggingSpanFactory}.
+     */
+    public static final LoggingSpanFactory INSTANCE = new LoggingSpanFactory();
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingSpanFactory.class);
+
+    private LoggingSpanFactory() {
+    }
+
+    @Override
+    public Span createRootTrace(Supplier<String> operationNameSupplier) {
+        return new Slf4jSpan(operationNameSupplier.get()) {
+            @Override
+            public void doStart() {
+                logger.info("[{}][{}] Root trace starting", identifier, name);
+            }
+        };
+    }
+
+    @Override
+    public Span createHandlerSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                  boolean isChildTrace, Message<?>... linkedParents) {
+        return new Slf4jSpan(operationNameSupplier.get()) {
+            @Override
+            public void doStart() {
+                logger.info("[{}][{}] Handler span starting for message of type [{}] and identifier [{}]",
+                            identifier,
+                            name,
+                            parentMessage.getClass().getSimpleName(),
+                            parentMessage.getIdentifier());
+            }
+        };
+    }
+
+    @Override
+    public Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                   Message<?>... linkedSiblings) {
+        return new Slf4jSpan(operationNameSupplier.get()) {
+            @Override
+            public void doStart() {
+                if (CurrentUnitOfWork.isStarted()) {
+                    Message<?> handlingMessage = CurrentUnitOfWork.get().getMessage();
+                    logger.info(
+                            "[{}][{}] Dispatch span started for message of type [{}] and identifier [{}] while handling message of type [{}] and identifier [{}]",
+                            identifier,
+                            name,
+                            parentMessage.getClass().getSimpleName(),
+                            parentMessage.getIdentifier(),
+                            handlingMessage.getClass().getSimpleName(),
+                            handlingMessage.getIdentifier());
+                } else {
+                    logger.info("[{}][{}] Dispatch span started for message of type [{}] and identifier [{}]",
+                                identifier,
+                                name,
+                                parentMessage.getClass().getSimpleName(),
+                                parentMessage.getIdentifier());
+                }
+            }
+        };
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier) {
+        return new Slf4jSpan(operationNameSupplier.get()) {
+            @Override
+            public void doStart() {
+                if (CurrentUnitOfWork.isStarted()) {
+                    Message<?> handlingMessage = CurrentUnitOfWork.get().getMessage();
+                    logger.info(
+                            "[{}][{}] Internal span starting while handling message of type [{}] and identifier [{}]",
+                            identifier,
+                            name,
+                            handlingMessage.getClass().getSimpleName(),
+                            handlingMessage.getIdentifier());
+                } else {
+                    logger.info("[{}][{}] Internal span starting", identifier, name);
+                }
+            }
+        };
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier, Message<?> message) {
+        return new Slf4jSpan(operationNameSupplier.get()) {
+            @Override
+            public void doStart() {
+                if (CurrentUnitOfWork.isStarted() && CurrentUnitOfWork.get().getMessage() != message) {
+                    Message<?> handlingMessage = CurrentUnitOfWork.get().getMessage();
+                    logger.info(
+                            "[{}][{}] Internal span starting for message of type [{}] and identifier [{}] while handling message of type [{}] and identifier [{}]",
+                            identifier,
+                            name,
+                            handlingMessage.getClass().getSimpleName(),
+                            handlingMessage.getIdentifier(),
+                            message.getClass().getSimpleName(),
+                            message.getIdentifier());
+                } else {
+                    logger.info("[{}][{}] Internal span starting for message of type [{}] and identifier [{}]",
+                                identifier,
+                                name,
+                                message.getClass().getSimpleName(),
+                                message.getIdentifier());
+                }
+            }
+        };
+    }
+
+    @Override
+    public void registerSpanAttributeProvider(SpanAttributesProvider provider) {
+        // No-op for now
+    }
+
+    @Override
+    public <M extends Message<?>> M propagateContext(M message) {
+        return message;
+    }
+
+    private abstract static class Slf4jSpan implements Span {
+
+        protected final String identifier;
+        protected final String name;
+
+        private Slf4jSpan(String name) {
+            this.identifier = IdentifierFactory.getInstance().generateIdentifier();
+            this.name = name;
+        }
+
+        abstract void doStart();
+
+        @Override
+        public Span start() {
+            doStart();
+            return this;
+        }
+
+        @Override
+        public void end() {
+            logger.info("[{}][{}] Span ended", identifier, name);
+        }
+
+        @Override
+        public Span recordException(Throwable t) {
+            logger.info("[{}][{}] Span recorded exception", identifier, name, t);
+            return this;
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/tracing/MultiSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/MultiSpanFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.messaging.Message;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of a {@link SpanFactory} that can delegates calls to multiple other factories. This can be useful if
+ * you want the {@link LoggingSpanFactory} to be used in conjunction with another.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6.0
+ */
+public class MultiSpanFactory implements SpanFactory {
+
+    private final List<SpanFactory> spanFactories;
+
+    /**
+     * Creates the {@link MultiSpanFactory} with the delegate factory implementations that it should use.
+     *
+     * @param spanFactories The delegate {@link SpanFactory} implementations it should use.
+     */
+    public MultiSpanFactory(List<SpanFactory> spanFactories) {
+        this.spanFactories = spanFactories;
+    }
+
+    @Override
+    public Span createRootTrace(Supplier<String> operationNameSupplier) {
+        return new MultiSpan(
+                spanFactories.stream()
+                             .map(sf -> sf.createRootTrace(operationNameSupplier))
+                             .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Span createHandlerSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                  boolean isChildTrace, Message<?>... linkedParents) {
+        return new MultiSpan(
+                spanFactories.stream()
+                             .map(sf -> sf.createHandlerSpan(operationNameSupplier,
+                                                             parentMessage,
+                                                             isChildTrace,
+                                                             linkedParents))
+                             .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                   Message<?>... linkedSiblings) {
+        return new MultiSpan(
+                spanFactories.stream()
+                             .map(sf -> sf.createDispatchSpan(operationNameSupplier,
+                                                              parentMessage,
+                                                              linkedSiblings))
+                             .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier) {
+        return new MultiSpan(
+                spanFactories.stream()
+                             .map(sf -> sf.createInternalSpan(operationNameSupplier))
+                             .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier, Message<?> message) {
+        return new MultiSpan(
+                spanFactories.stream()
+                             .map(sf -> sf.createInternalSpan(operationNameSupplier, message))
+                             .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public void registerSpanAttributeProvider(SpanAttributesProvider provider) {
+        spanFactories.forEach(sf -> sf.registerSpanAttributeProvider(provider));
+    }
+
+    @Override
+    public <M extends Message<?>> M propagateContext(M message) {
+        M adjustedMessage = message;
+        for (SpanFactory spanFactory : spanFactories) {
+            adjustedMessage = spanFactory.propagateContext(adjustedMessage);
+        }
+
+        return adjustedMessage;
+    }
+
+    private static class MultiSpan implements Span {
+
+        private final List<Span> spans;
+
+        public MultiSpan(List<Span> spans) {
+            this.spans = spans;
+        }
+
+        @Override
+        public Span start() {
+            spans.forEach(Span::start);
+            return this;
+        }
+
+        @Override
+        public void end() {
+            spans.forEach(Span::end);
+        }
+
+        @Override
+        public Span recordException(Throwable t) {
+            spans.forEach(s -> s.recordException(t));
+            return this;
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/tracing/LoggingSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/LoggingSpanFactoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The {@link LoggingSpanFactory} only logs statement, but should still provide basic requirements such as returning a
+ * non-null span, and the span returning itself in certain situations.
+ */
+class LoggingSpanFactoryTest {
+
+    @Test
+    void createRootTraceReturnsNoOpSpan() {
+        Span trace = LoggingSpanFactory.INSTANCE.createRootTrace(() -> "Trace");
+        assertNotNull(trace);
+    }
+
+    @Test
+    void createHandlerSpanReturnsNoOpSpan() {
+        Span trace = LoggingSpanFactory.INSTANCE.createHandlerSpan(() -> "Trace",
+                                                                   new GenericEventMessage<>("payload"),
+                                                                   true);
+        assertNotNull(trace);
+    }
+
+    @Test
+    void createDispatchSpanReturnsNoOpSpan() {
+        Span trace = LoggingSpanFactory.INSTANCE.createDispatchSpan(() -> "Trace",
+                                                                    new GenericEventMessage<>("payload"));
+        assertNotNull(trace);
+    }
+
+    @Test
+    void createInternalSpanWithMessageReturnsNoOpSpan() {
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace",
+                                                                    new GenericEventMessage<>("payload"));
+        assertNotNull(trace);
+    }
+
+    @Test
+    void createInternalSpanWithoutMessageReturnsNoOpSpan() {
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace");
+        assertNotNull(trace);
+    }
+
+    @Test
+    void propagateContextReturnsOriginal() {
+        GenericEventMessage<String> message = new GenericEventMessage<>("payload");
+        GenericEventMessage<String> result = NoOpSpanFactory.INSTANCE.propagateContext(message);
+        assertSame(message, result);
+    }
+
+    @Test
+    void internalSpanCanBeStartedAndEnded() {
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace");
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+    }
+
+    @Test
+    void internalSpanCanBeStartedAndEndedWithUnitOfWorkActive() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("My command");
+        DefaultUnitOfWork<CommandMessage<Object>> uow = new DefaultUnitOfWork<>(command);
+        uow.start();
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace");
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+        uow.commit();
+    }
+
+    @Test
+    void handlingSpanCanBeStartedAndEnded() {
+        GenericEventMessage message = new GenericEventMessage("payload");
+        Span trace = LoggingSpanFactory.INSTANCE.createHandlerSpan(() -> "Trace", message, true);
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+    }
+
+    @Test
+    void rootSpanCanBeStartedAndEnded() {
+        Span trace = LoggingSpanFactory.INSTANCE.createRootTrace(() -> "Trace");
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+    }
+
+    @Test
+    void dispatchSpanCanBeStartedAndEnded() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("My command");
+        Span trace = LoggingSpanFactory.INSTANCE.createDispatchSpan(() -> "Trace", command);
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+    }
+
+    @Test
+    void dispatchSpanCanBeStartedAndEndedWhileUnitOfWorkActive() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("My command");
+        DefaultUnitOfWork<CommandMessage<Object>> uow = new DefaultUnitOfWork<>(command);
+        uow.start();
+        GenericEventMessage message = new GenericEventMessage("payload");
+        Span trace = LoggingSpanFactory.INSTANCE.createDispatchSpan(() -> "Trace", message);
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+        uow.commit();
+    }
+
+    @Test
+    void internalSpanWithMessageCanBeStartedAndEnded() {
+        GenericEventMessage message = new GenericEventMessage("payload");
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace", message);
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+    }
+
+    @Test
+    void internalSpanWithMessageCanBeStartedAndEndedWhileUnitOfWorkActive() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("My command");
+        DefaultUnitOfWork<CommandMessage<Object>> uow = new DefaultUnitOfWork<>(command);
+        uow.start();
+        GenericEventMessage message = new GenericEventMessage("payload");
+        Span trace = LoggingSpanFactory.INSTANCE.createInternalSpan(() -> "Trace", message);
+        trace.start()
+             .recordException(new RuntimeException("My test exception"))
+             .end();
+        uow.commit();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/tracing/MultiSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/MultiSpanFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.Message;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MultiSpanFactoryTest {
+
+    SpanFactory spanFactory1 = mock(SpanFactory.class);
+    Span mockSpan1 = mock(Span.class);
+    SpanFactory spanFactory2 = mock(SpanFactory.class);
+    Span mockSpan2 = mock(Span.class);
+    SpanFactory multiSpanFactory = new MultiSpanFactory(Arrays.asList(spanFactory1, spanFactory2));
+    GenericEventMessage<?> message = new GenericEventMessage<>("payload");
+    Supplier<String> stringSupplier = () -> "Trace";
+
+    @Test
+    void rootTracesCreatedWillDelegateToBothFactories() {
+        when(spanFactory1.createRootTrace(any())).thenReturn(mockSpan1);
+        when(spanFactory2.createRootTrace(any())).thenReturn(mockSpan2);
+
+        Span span = multiSpanFactory.createRootTrace(() -> "Trace").start();
+
+        Mockito.verify(mockSpan1).start();
+        Mockito.verify(mockSpan2).start();
+
+        Mockito.verify(mockSpan1, never()).end();
+        Mockito.verify(mockSpan2, never()).end();
+
+        RuntimeException exception = new RuntimeException("My Exception");
+        span.recordException(exception).end();
+
+        Mockito.verify(mockSpan1).end();
+        Mockito.verify(mockSpan2).end();
+        Mockito.verify(mockSpan1).recordException(exception);
+        Mockito.verify(mockSpan2).recordException(exception);
+    }
+
+    @Test
+    void handlerSpansCreatedWillDelegateToBothFactories() {
+        multiSpanFactory.createHandlerSpan(stringSupplier, message, false);
+
+        Mockito.verify(spanFactory1).createHandlerSpan(stringSupplier, message, false);
+        Mockito.verify(spanFactory2).createHandlerSpan(stringSupplier, message, false);
+    }
+
+    @Test
+    void dispatchSpansCreatedWillDelegateToBothFactories() {
+        multiSpanFactory.createDispatchSpan(stringSupplier, message);
+
+        Mockito.verify(spanFactory1).createDispatchSpan(stringSupplier, message);
+        Mockito.verify(spanFactory2).createDispatchSpan(stringSupplier, message);
+    }
+
+    @Test
+    void internalSpansCreatedWillDelegateToBothFactories() {
+        multiSpanFactory.createInternalSpan(stringSupplier);
+
+        Mockito.verify(spanFactory1).createInternalSpan(stringSupplier);
+        Mockito.verify(spanFactory2).createInternalSpan(stringSupplier);
+    }
+
+    @Test
+    void internalSpansWithMessageCreatedWillDelegateToBothFactories() {
+        multiSpanFactory.createInternalSpan(stringSupplier, message);
+
+        Mockito.verify(spanFactory1).createInternalSpan(stringSupplier, message);
+        Mockito.verify(spanFactory2).createInternalSpan(stringSupplier, message);
+    }
+
+    @Test
+    void registerSpanAttributeProviderWillDelegate() {
+        SpanAttributesProvider provider = mock(SpanAttributesProvider.class);
+        multiSpanFactory.registerSpanAttributeProvider(provider);
+
+        Mockito.verify(spanFactory1).registerSpanAttributeProvider(provider);
+        Mockito.verify(spanFactory2).registerSpanAttributeProvider(provider);
+    }
+
+    @Test
+    void propagateContextCallsBoth() {
+        Message original = mock(Message.class);
+        Message modifiedFirst = mock(Message.class);
+        Message modifiedSecond = mock(Message.class);
+
+        when(spanFactory1.propagateContext(original)).thenReturn(modifiedFirst);
+        when(spanFactory2.propagateContext(modifiedFirst)).thenReturn(modifiedSecond);
+
+        Message result = multiSpanFactory.propagateContext(original);
+        assertSame(result, modifiedSecond);
+    }
+}


### PR DESCRIPTION
These SpanFactory implementations will allow the user to easily log tracing without needing an APM system. This can also be used during testing. A MultiSpanFactory allows the user to do both APM and logging tracing, if they want to.