### PR TITLE
Make Given-phase Error Handling configurable for Saga Test Fixtures

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -210,6 +210,24 @@ public interface FixtureConfiguration {
             ListenerInvocationErrorHandler listenerInvocationErrorHandler);
 
     /**
+     * Configure whether the fixture should proceed when exceptions are thrown during the given-phase. When
+     * {@code proceed} is {@code true}, the fixture moves on to the when-phase regardless of any exceptions thrown
+     * during the given-phase.
+     * <p>
+     * Note that setting this to {@code false} means the
+     * {@link #registerListenerInvocationErrorHandler(ListenerInvocationErrorHandler) registered}
+     * {@link ListenerInvocationErrorHandler} is not invoked during exception in the given-phase. Defaults to fail
+     * during given-phase exceptions.
+     *
+     * @param proceed A {@code boolean} describing whether the fixture should proceed on failures during the
+     *                given-phase.
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    default FixtureConfiguration proceedOnGivenPhaseExceptions(boolean proceed) {
+        return this;
+    }
+
+    /**
      * Registers a {@link ResourceInjector} within this fixture. This approach can be used if a custom {@code
      * ResourceInjector} has been built for a project which the user wants to take into account when testing it's
      * sagas.

--- a/test/src/main/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandler.java
+++ b/test/src/main/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandler.java
@@ -24,8 +24,9 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 
 /**
- * A wrapper around a {@link ListenerInvocationErrorHandler} that in itself also implements {@link ListenerInvocationErrorHandler}. Any Exception encountered
- * will be stored, after which the rest of the error handling will be handed off to the wrapped ListenerInvocationErrorHandler.
+ * A wrapper around a {@link ListenerInvocationErrorHandler} that in itself also implements
+ * {@link ListenerInvocationErrorHandler}. Any Exception encountered will be stored, after which the rest of the error
+ * handling will be handed off to the wrapped ListenerInvocationErrorHandler.
  *
  * @author Christian Vermorken
  * @since 4.6.0
@@ -34,12 +35,15 @@ public class RecordingListenerInvocationErrorHandler implements ListenerInvocati
 
     private ListenerInvocationErrorHandler listenerInvocationErrorHandler;
 
+    private boolean started = false;
     private Exception exception;
+    private boolean proceed = false;
 
     /**
      * Create a new instance of this class, wrapping another {@link ListenerInvocationErrorHandler}.
      *
-     * @param listenerInvocationErrorHandler The {@link ListenerInvocationErrorHandler} to invoke for the error handling, cannot be null.
+     * @param listenerInvocationErrorHandler The {@link ListenerInvocationErrorHandler} to invoke for the error
+     *                                       handling, cannot be null.
      */
     public RecordingListenerInvocationErrorHandler(ListenerInvocationErrorHandler listenerInvocationErrorHandler) {
         if (listenerInvocationErrorHandler == null) {
@@ -51,21 +55,26 @@ public class RecordingListenerInvocationErrorHandler implements ListenerInvocati
     @Override
     public void onError(@Nonnull Exception exception, @Nonnull EventMessage<?> event,
                         @Nonnull EventMessageHandler eventHandler) throws Exception {
+        if (!started && !proceed) {
+            throw exception;
+        }
         this.exception = exception;
         listenerInvocationErrorHandler.onError(exception, event, eventHandler);
     }
 
     /**
-     * Clear any current Exception.
+     * Start recording by clearing any current {@link Exception}.
      */
     public void startRecording() {
+        started = true;
         exception = null;
     }
 
     /**
      * Sets a new wrapped {@link ListenerInvocationErrorHandler}.
      *
-     * @param listenerInvocationErrorHandler The {@link ListenerInvocationErrorHandler} to invoke for the error handling, cannot be null.
+     * @param listenerInvocationErrorHandler The {@link ListenerInvocationErrorHandler} to invoke for the error
+     *                                       handling, cannot be null.
      */
     public void setListenerInvocationErrorHandler(ListenerInvocationErrorHandler listenerInvocationErrorHandler) {
         if (listenerInvocationErrorHandler == null) {
@@ -75,11 +84,24 @@ public class RecordingListenerInvocationErrorHandler implements ListenerInvocati
     }
 
     /**
-     * Return the last encountered Exception after the startRecording method has been invoked, or an empty Optional of no Exception occurred.
+     * Return the last encountered Exception after the startRecording method has been invoked, or an empty Optional of
+     * no Exception occurred.
      *
      * @return an Optional of the last encountered Exception
      */
     public Optional<Exception> getException() {
         return Optional.ofNullable(exception);
+    }
+
+    /**
+     * Configure whether this error handler should proceed when it catches an exception while it's not started yet.
+     * <p>
+     * When set to {@code false} will rethrow the exception, regardless of the configured
+     * {@link ListenerInvocationErrorHandler}. Defaults to {@code false}.
+     *
+     * @param proceed A {@code boolean} dictating whether to proceed if this recorder is not started.
+     */
+    public void proceedWhenNotStarted(boolean proceed) {
+        this.proceed = proceed;
     }
 }

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -415,6 +415,12 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     @Override
+    public FixtureConfiguration proceedOnGivenPhaseExceptions(boolean proceed) {
+        recordingListenerInvocationErrorHandler.proceedWhenNotStarted(proceed);
+        return this;
+    }
+
+    @Override
     public FixtureConfiguration registerResourceInjector(ResourceInjector resourceInjector) {
         this.resourceInjector = resourceInjector;
         return this;

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -91,7 +91,8 @@ class FixtureExecutionResultImplTest {
 
     @Test
     void startRecording() throws Exception {
-        RecordingListenerInvocationErrorHandler errorHandler = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
+        RecordingListenerInvocationErrorHandler errorHandler =
+                new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
         EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
         doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
         testSubject = new FixtureExecutionResultImpl<>(
@@ -99,11 +100,17 @@ class FixtureExecutionResultImplTest {
                 AllFieldsFilter.instance(), errorHandler);
 
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("First"));
-        GenericEventMessage<TriggerSagaStartEvent> firstEventMessage = new GenericEventMessage<>(new TriggerSagaStartEvent(identifier));
+        GenericEventMessage<TriggerSagaStartEvent> firstEventMessage =
+                new GenericEventMessage<>(new TriggerSagaStartEvent(identifier));
         eventBus.publish(firstEventMessage);
-        errorHandler.onError(new IllegalArgumentException("First"), firstEventMessage, eventMessageHandler);
+        assertThrows(IllegalArgumentException.class, () -> errorHandler.onError(
+                new IllegalArgumentException("First"), firstEventMessage, eventMessageHandler
+        ));
+
         testSubject.startRecording();
-        GenericEventMessage<TriggerSagaEndEvent> endEventMessage = new GenericEventMessage<>(new TriggerSagaEndEvent(identifier));
+
+        GenericEventMessage<TriggerSagaEndEvent> endEventMessage =
+                new GenericEventMessage<>(new TriggerSagaEndEvent(identifier));
         eventBus.publish(endEventMessage);
         commandBus.dispatch(GenericCommandMessage.asCommandMessage("Second"));
         IllegalArgumentException secondException = new IllegalArgumentException("Second");

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringSagaEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringSagaEnhancements.java
@@ -1,8 +1,10 @@
 package org.axonframework.test.saga;
 
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
+import org.axonframework.eventhandling.LoggingErrorHandler;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
+import org.axonframework.test.FixtureExecutionException;
 import org.junit.jupiter.api.*;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -13,6 +15,7 @@ import static java.time.Instant.now;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class dedicated to validating custom, saga specific, registered components on {@link SagaTestFixture}.
@@ -63,15 +66,36 @@ class FixtureTest_RegisteringSagaEnhancements {
     }
 
     @Test
-    void customListenerInvocationErrorHandlerIsUsed() {
+    void customListenerInvocationErrorHandlerIsUsedInWhenPhase() {
         SomeTestSaga.SomeEvent testEvent = new SomeTestSaga.SomeEvent("some-id", true);
+        ListenerInvocationErrorHandler testErrorHandler = (exception, event, eventHandler) ->
+                assertEquals(testEvent.getException().getMessage(), exception.getMessage());
+        this.testSubject.registerListenerInvocationErrorHandler(testErrorHandler);
 
-        ListenerInvocationErrorHandler testSubject = (exception, event, eventHandler) ->
+        this.testSubject.givenNoPriorActivity()
+                        .whenPublishingA(testEvent);
+    }
+
+    @Test
+    void customListenerInvocationErrorHandlerIsUsedInGivenPhase() {
+        SomeTestSaga.SomeEvent testEvent = new SomeTestSaga.SomeEvent("some-id", true);
+        ListenerInvocationErrorHandler testErrorHandler = (exception, event, eventHandler) ->
                 assertEquals(testEvent.getException().getMessage(), exception.getMessage());
 
-        this.testSubject.registerListenerInvocationErrorHandler(testSubject);
-        // This will trigger the test subject due to how the event is configured
+        this.testSubject.registerListenerInvocationErrorHandler(testErrorHandler)
+                        .proceedOnGivenPhaseExceptions(true);
+
         this.testSubject.givenAPublished(testEvent);
+    }
+
+    @Test
+    void exceptionsAreRethrownAsFixtureExecutionExceptionDuringGivenPhaseWithoutInvokedCustomErrorHandler() {
+        SomeTestSaga.SomeEvent testEvent = new SomeTestSaga.SomeEvent("some-id", true);
+        ListenerInvocationErrorHandler testErrorHandler = spy(new LoggingErrorHandler());
+
+        this.testSubject.registerListenerInvocationErrorHandler(testErrorHandler);
+
+        assertThrows(FixtureExecutionException.class, () -> this.testSubject.givenAPublished(testEvent));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
@@ -18,18 +18,44 @@ package org.axonframework.test.saga;
 
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.eventhandling.LoggingErrorHandler;
 import org.junit.jupiter.api.*;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Test class validating the {@link RecordingListenerInvocationErrorHandler}.
+ *
+ * @author Christian Vermorken
+ */
 class RecordingListenerInvocationErrorHandlerTest {
+
+    private static final GenericEventMessage<String> TEST_EVENT = new GenericEventMessage<>("test");
+    public static final IllegalArgumentException TEST_EXCEPTION = new IllegalArgumentException(
+            "This argument is illegal");
+
+
+    private ListenerInvocationErrorHandler wrappedErrorHandler;
+    private EventMessageHandler eventHandler;
+
+    private RecordingListenerInvocationErrorHandler testSubject;
+
+    @BeforeEach
+    void setUp() {
+        eventHandler = mock(EventMessageHandler.class);
+        doReturn(StubSaga.class).when(eventHandler)
+                                .getTargetType();
+
+        wrappedErrorHandler = spy(new LoggingErrorHandler());
+        testSubject = new RecordingListenerInvocationErrorHandler(wrappedErrorHandler);
+    }
 
     @Test
     void emptyOnCreation() {
-        RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
-
         assertFalse(testSubject.getException().isPresent());
     }
 
@@ -39,35 +65,48 @@ class RecordingListenerInvocationErrorHandlerTest {
     }
 
     @Test
-    void cannotSetWrappedHanlderToNull() {
-        RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
-
+    void cannotSetWrappedHandlerToNull() {
         assertThrows(IllegalArgumentException.class, () -> testSubject.setListenerInvocationErrorHandler(null));
     }
 
     @Test
-    void logExceptionOnError() throws Exception {
-        RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
-        EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
-        doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
-        IllegalArgumentException expectedException = new IllegalArgumentException("This argument is illegal");
+    void delegatesExceptionToWrappedErrorHandler() throws Exception {
+        testSubject.startRecording();
 
-        testSubject.onError(expectedException, new GenericEventMessage<>("test"), eventMessageHandler);
+        testSubject.onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
 
-        assertTrue(testSubject.getException().isPresent());
-        assertEquals(expectedException, testSubject.getException().get());
+        Optional<Exception> result = testSubject.getException();
+        assertTrue(result.isPresent());
+        assertEquals(TEST_EXCEPTION, result.get());
+        verify(wrappedErrorHandler).onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
     }
 
     @Test
     void clearExceptionOnStartRecording() throws Exception {
-        RecordingListenerInvocationErrorHandler testSubject = new RecordingListenerInvocationErrorHandler(new LoggingErrorHandler());
-        EventMessageHandler eventMessageHandler = mock(EventMessageHandler.class);
-        doReturn(StubSaga.class).when(eventMessageHandler).getTargetType();
-        IllegalArgumentException expectedException = new IllegalArgumentException("This argument is illegal");
-
-        testSubject.onError(expectedException, new GenericEventMessage<>("test"), eventMessageHandler);
+        testSubject.startRecording();
+        testSubject.onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
         testSubject.startRecording();
 
         assertFalse(testSubject.getException().isPresent());
+        verify(wrappedErrorHandler).onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
+    }
+
+    @Test
+    void byDefaultRethrowsExceptionsIfRecordingHasNotStartedYet() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> testSubject.onError(TEST_EXCEPTION, TEST_EVENT, eventHandler));
+        verifyNoInteractions(wrappedErrorHandler);
+    }
+
+    @Test
+    void doesNotRethrowExceptionIfProceedDuringGivenStateIsEnabled() throws Exception {
+        testSubject.proceedWhenNotStarted(true);
+
+        testSubject.onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
+
+        Optional<Exception> result = testSubject.getException();
+        assertTrue(result.isPresent());
+        assertEquals(TEST_EXCEPTION, result.get());
+        verify(wrappedErrorHandler).onError(TEST_EXCEPTION, TEST_EVENT, eventHandler);
     }
 }


### PR DESCRIPTION
Currently, if an exception is thrown in the given-phase of the `SagaTestFixture`, the exception is caught and the fixture proceeds to the when-phase. 
This happens due to the default `ListenerInvocationErrorHandler`, which is the `LoggingErrorHandler`.
This behavior may have undesired side effects for testers, as exception in the given-phase aren't clearly shared with the end-user. 

To resolve this, it would be better to not invoke the (configurable) `ListenerInvocationErrorHandler` if the when-phase has not started yet.
If the `SagaTestFixture` does reach the when-phase, handling exception should end up in the `ListenerInvocationErrorHandler` again.

This pull request provides this exact behavior, with the introduction of the `FixtureConfiguration#proceedOnGivenPhaseExceptions(boolean)` method.
Setting this to `true` will mean the (configurable) `ListenerInvocationErrorHandler` is invoked on given-phase exceptions.

However, by default this is set to `false`, as we make the assumption that users want to validate occurrences during the when-phase. 
Setting this to `true` may be valuable still for testers who want to validate a customized `ListenerInvocationErrorHandler`, for example.