### PR TITLE
Improve deadline span name.

### DIFF
--- a/messaging/src/main/java/org/axonframework/tracing/SpanUtils.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanUtils.java
@@ -56,9 +56,10 @@ public class SpanUtils {
                 messageName = queryName;
             }
         }
-        if(message instanceof DeadlineMessage) {
-            if(message.getPayload() != null) {
-                return ((DeadlineMessage<?>) message).getDeadlineName() + "," +message.getPayloadType().getSimpleName();
+        if (message instanceof DeadlineMessage) {
+            if (message.getPayload() != null) {
+                return ((DeadlineMessage<?>) message).getDeadlineName() + "," + message.getPayloadType()
+                                                                                       .getSimpleName();
             }
             return ((DeadlineMessage<?>) message).getDeadlineName();
         }

--- a/messaging/src/main/java/org/axonframework/tracing/SpanUtils.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanUtils.java
@@ -17,6 +17,7 @@
 package org.axonframework.tracing;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.QueryMessage;
 
@@ -54,6 +55,12 @@ public class SpanUtils {
             if (!Objects.equals(queryName, message.getPayloadType().getName())) {
                 messageName = queryName;
             }
+        }
+        if(message instanceof DeadlineMessage) {
+            if(message.getPayload() != null) {
+                return ((DeadlineMessage<?>) message).getDeadlineName() + "," +message.getPayloadType().getSimpleName();
+            }
+            return ((DeadlineMessage<?>) message).getDeadlineName();
         }
         return messageName;
     }

--- a/messaging/src/test/java/org/axonframework/tracing/SpanUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/SpanUtilsTest.java
@@ -74,6 +74,7 @@ class SpanUtilsTest {
         GenericDeadlineMessage<String> message = new GenericDeadlineMessage<>("myDeadlineName");
         assertEquals("myDeadlineName", SpanUtils.determineMessageName(message));
     }
+
     @Test
     void determineMessageNameForDeadlineWithPayload() {
         GenericDeadlineMessage<String> message = new GenericDeadlineMessage<>("myDeadlineName", "MyPayload");

--- a/messaging/src/test/java/org/axonframework/tracing/SpanUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/SpanUtilsTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.tracing;
 
 import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.deadline.GenericDeadlineMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.axonframework.queryhandling.GenericQueryMessage;
@@ -66,5 +67,16 @@ class SpanUtilsTest {
         GenericCommandMessage<String> message = new GenericCommandMessage<>(new GenericCommandMessage<>("MyPayload"),
                                                                             "SuperCommand");
         assertEquals("SuperCommand", SpanUtils.determineMessageName(message));
+    }
+
+    @Test
+    void determineMessageNameForDeadlineWithoutPayload() {
+        GenericDeadlineMessage<String> message = new GenericDeadlineMessage<>("myDeadlineName");
+        assertEquals("myDeadlineName", SpanUtils.determineMessageName(message));
+    }
+    @Test
+    void determineMessageNameForDeadlineWithPayload() {
+        GenericDeadlineMessage<String> message = new GenericDeadlineMessage<>("myDeadlineName", "MyPayload");
+        assertEquals("myDeadlineName,String", SpanUtils.determineMessageName(message));
     }
 }


### PR DESCRIPTION
Currently, the deadline only contains the payload type in the trace name. However, it's useful to know the deadlineName and the payload class.