### PR TITLE
[#2364] Fix framework failing to start due to a `ClassNotFoundException`

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.eventhandling.DomainEventData;
@@ -31,7 +30,6 @@ import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -366,9 +364,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
                                         + " without specifying the security context"
                         )
                 );
-                snapshotSerializer = () -> XStreamSerializer.builder()
-                                                            .xStream(new XStream(new CompactDriver()))
-                                                            .build();
+                snapshotSerializer = () -> XStreamSerializer.builder().build();
             }
             if (eventSerializer == null) {
                 logger.warn(
@@ -379,9 +375,7 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
                                         + " without specifying the security context"
                         )
                 );
-                eventSerializer = () -> XStreamSerializer.builder()
-                                                         .xStream(new XStream(new CompactDriver()))
-                                                         .build();
+                eventSerializer = () -> XStreamSerializer.builder().build();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -279,7 +279,7 @@ public abstract class AbstractXStreamSerializer implements Serializer {
      */
     public abstract static class Builder {
 
-        private XStream xStream;
+        protected XStream xStream;
         private Charset charset = StandardCharsets.UTF_8;
         private RevisionResolver revisionResolver = new AnnotationRevisionResolver();
         private Converter converter = new ChainingConverter();

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -222,6 +222,9 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
          * @return a {@link XStreamSerializer} as specified through this Builder
          */
         public XStreamSerializer build() {
+            if (xStream == null) {
+                xStream = new XStream(new CompactDriver());
+            }
             return new XStreamSerializer(this);
         }
     }


### PR DESCRIPTION
In later JDK versions, and earlier on Windows (it seems), Axon Framework 4.6.0 fails to boot due to a ClassNotFoundException.
This happens when XStream is not included on the classpath.

It seems like the JDK can handle not being able to find a class unless it's called. However, it can not handle being able to find a class but not the interface it implements (like the case in `CompactDriver`, implementing an XStream class). 

The `XStreamSerializer` now defaults to a `new XStream(new CompactDriver())`, instead of relying on the caller to do this. This allows the JDK to happily boot Axon Framework again. 