### PR TITLE
[#2367] Fix Repository beans not being registered to the Spring application context

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -29,6 +29,7 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventCountSnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.SnapshotTriggerDefinition;
 import org.axonframework.eventsourcing.Snapshotter;
@@ -43,6 +44,7 @@ import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.annotation.SimpleResourceParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.SimpleCorrelationDataProvider;
+import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.serialization.Serializer;
@@ -97,6 +99,8 @@ class AxonAutoConfigurationTest {
                     assertEquals(0, applicationContext.getBeansOfType(TokenStore.class).size());
                     assertNotNull(applicationContext.getBean(Context.MySaga.class));
                     assertNotNull(applicationContext.getBean(Context.MyAggregate.class));
+                    assertNotNull(applicationContext.getBean(Repository.class));
+                    assertNotNull(applicationContext.getBean(AggregateFactory.class));
                     assertNotNull(applicationContext.getBean(EventProcessingConfiguration.class));
 
                     assertEquals(2,

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithDisruptorTest.java
@@ -25,15 +25,17 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.SimpleCorrelationDataProvider;
+import org.axonframework.modelling.command.Repository;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -43,8 +45,7 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.stereotype.Component;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AxonAutoConfigurationWithDisruptorTest {
 
@@ -66,6 +67,8 @@ class AxonAutoConfigurationWithDisruptorTest {
                     assertEquals(0, applicationContext.getBeansOfType(TokenStore.class).size());
                     assertNotNull(applicationContext.getBean(Context.MySaga.class));
                     assertNotNull(applicationContext.getBean(Context.MyAggregate.class));
+                    assertNotNull(applicationContext.getBean(Repository.class));
+                    assertNotNull(applicationContext.getBean(AggregateFactory.class));
                     org.axonframework.config.Configuration configuration = applicationContext.getBean(org.axonframework.config.Configuration.class);
                     assertEquals(2, configuration.correlationDataProviders().size());
                 });

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -20,7 +20,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.spring.eventsourcing.SpringPrototypeAggregateFactory;
-import org.axonframework.spring.eventsourcing.SpringRepositoryFactoryBean;
+import org.axonframework.spring.modelling.SpringRepositoryFactoryBean;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -20,6 +20,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.spring.eventsourcing.SpringPrototypeAggregateFactory;
+import org.axonframework.spring.eventsourcing.SpringRepositoryFactoryBean;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +42,8 @@ import static java.lang.String.format;
 import static org.axonframework.common.StringUtils.nonEmptyOrNull;
 
 /**
- * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Aggregate types and registers a {@link
- * SpringAggregateConfigurer configurer} for each Aggregate found.
+ * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Aggregate types and registers a
+ * {@link SpringAggregateConfigurer configurer} for each Aggregate found.
  *
  * @author Allard Buijze
  * @since 4.6.0
@@ -186,10 +187,21 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
         }
         if (nonEmptyOrNull((String) props.get(REPOSITORY))) {
             beanDefinitionBuilder.addPropertyValue(REPOSITORY, props.get(REPOSITORY));
-        } else if (registry.containsBean(aggregateBeanName + REPOSITORY_BEAN)) {
-            Class<?> type = registry.getType(aggregateBeanName + REPOSITORY_BEAN);
-            if (type == null || Repository.class.isAssignableFrom(type)) {
-                beanDefinitionBuilder.addPropertyReference(REPOSITORY, aggregateBeanName + REPOSITORY_BEAN);
+        } else {
+            String repositoryBeanName = aggregateBeanName + REPOSITORY_BEAN;
+            if (registry.containsBean(repositoryBeanName)) {
+                Class<?> type = registry.getType(repositoryBeanName);
+                if (type == null || Repository.class.isAssignableFrom(type)) {
+                    beanDefinitionBuilder.addPropertyReference(REPOSITORY, repositoryBeanName);
+                }
+            } else {
+                ((BeanDefinitionRegistry) registry).registerBeanDefinition(
+                        repositoryBeanName,
+                        BeanDefinitionBuilder.genericBeanDefinition(SpringRepositoryFactoryBean.class)
+                                             .addConstructorArgValue(aggregateType)
+                                             .addAutowiredProperty("configuration")
+                                             .getBeanDefinition()
+                );
             }
         }
         String aggregateFactory = aggregateBeanName + "AggregateFactory";

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringRepositoryFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringRepositoryFactoryBean.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.spring.eventsourcing;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.modelling.command.Repository;
+import org.axonframework.spring.config.SpringAggregateConfigurer;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Supplies the {@link Repository} created by the {@link SpringAggregateConfigurer} to the Spring Application Context.
+ * This will allow it to be injected as a bean.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6.1
+ * @param <T> The aggregate type
+ */
+public class SpringRepositoryFactoryBean<T> implements FactoryBean<Repository<T>> {
+
+    private final Class<T> aggregateClass;
+    private Configuration configuration;
+
+    /**
+     * Constructs the {@link SpringRepositoryFactoryBean} for the provided {@code aggregateClass}.
+     *
+     * @param aggregateClass The aggregate's class
+     */
+    public SpringRepositoryFactoryBean(Class<T> aggregateClass) {
+        this.aggregateClass = aggregateClass;
+    }
+
+    @Override
+    public Repository<T> getObject() throws Exception {
+        return configuration.aggregateConfiguration(aggregateClass).repository();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return Repository.class;
+    }
+
+    /**
+     * Sets the {@link Configuration} that the {@link Repository} will be retrieved from.
+     *
+     * @param configuration The {@link Configuration} for usage in the factory bean.
+     */
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/modelling/SpringRepositoryFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/modelling/SpringRepositoryFactoryBean.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.axonframework.spring.eventsourcing;
+package org.axonframework.spring.modelling;
 
 import org.axonframework.config.Configuration;
 import org.axonframework.modelling.command.Repository;


### PR DESCRIPTION
The revised Spring configuration classes did not include registering `Repository` beans to the application context, as pointed out in #2367.

This PR introduces a `FactoryBean` to achieve this that retrieves the `Repository` for a certain class from Axon's `Configuration`.

This pull request resolves #2367.