### PR TITLE
[#2389] Make constructors accessible in `NoArgumentConstructorCreationPolicyAggregateFactory` 

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.modelling.command;
 
+import org.axonframework.common.ReflectionUtils;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -51,7 +53,7 @@ public class NoArgumentConstructorCreationPolicyAggregateFactory<A> implements C
     @Override
     public A create(@Nullable Object identifier) {
         try {
-            return aggregateClass.getDeclaredConstructor().newInstance();
+            return ReflectionUtils.ensureAccessible(aggregateClass.getDeclaredConstructor()).newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This PR introduces changes to the `NoArgumentConstructorCreationPolicyAggregateFactory`.
More specifically, it ensures that `@CreationPolicy` annotated methods using `CREATE_IF_MISSING` or `ALWAYS` may still have a `private` or `protected` method.
This is done by using the `ReflectionUtils` to make the `private`/`protected` accessible.
For validation, four test cases have been introduced:

1. A `private` constructor with `CREATE_IF_MISSING` policy,
2. a `protected` constructor with `CREATE_IF_MISSING` policy,
3. a `private` constructor with `ALWAYS` policy, and
4. a `protected` constructor with `ALWAYS` policy.

Doing so, this pull request resolves #2389.