### PR TITLE
[#2393] Move retrieval of Command Handler to the end of the InterceptorChain

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
@@ -421,12 +421,18 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
             throw new NoHandlerForCommandException(commandMessage);
         }
 
-        //noinspection unchecked
-        return new DefaultInterceptorChain<>(
-                (UnitOfWork<CommandMessage<?>>) CurrentUnitOfWork.get(),
-                interceptors,
-                m -> suitableHandler(commandMessage, potentialHandlers).handle(commandMessage, aggregateRoot)
-        ).proceed();
+        Object result;
+        if (interceptors.isEmpty()) {
+            result = suitableHandler(commandMessage, potentialHandlers).handle(commandMessage, aggregateRoot);
+        } else {
+            //noinspection unchecked
+            result = new DefaultInterceptorChain<>(
+                    (UnitOfWork<CommandMessage<?>>) CurrentUnitOfWork.get(),
+                    interceptors,
+                    m -> suitableHandler(commandMessage, potentialHandlers).handle(commandMessage, aggregateRoot)
+            ).proceed();
+        }
+        return result;
     }
 
     private MessageHandlingMember<? super T> suitableHandler(CommandMessage<?> command,

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ForwardingCommandMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ForwardingCommandMessageHandlingMember.java
@@ -20,11 +20,13 @@ import org.axonframework.commandhandling.CommandMessageHandlingMember;
 
 /**
  * Interface describing a message handler capable of forwarding a specific command.
+ *
+ * @param <T> The type of entity to which the message handler will delegate the actual handling of the command
  * @author Somrak Monpengpinij
  * @since 4.6.0
- * @param <T> The type of entity to which the message handler will delegate the actual handling of the command
  */
 public interface ForwardingCommandMessageHandlingMember<T> extends CommandMessageHandlingMember<T> {
+
     /**
      * Check if this handler is in a state where it can currently accept the command.
      *


### PR DESCRIPTION
With the introduction of #2093, the `AnnotatedAggregate` started validating whether there's an entity inside the Aggregate that's eligible to handle the command in question.
This validation will check for the existence of a concrete instance of an entity.

As described in issue #2393, this breaks the support for an `@CommandHandlerInterceptor` annotated method that handles a command targeted towards an Entity / Aggregate Member.
More specifically, `@CommandHandlerInterceptor` annotated methods having an `InterceptorChain` parameter, as those specifically give power to the user to decide whether to move into the command handler, yes or no.

By moving the retrieval of a suitable command handler inside the `InterceptChain`, we ensure the chain is invoked _before_ we actually enter the command handler.
Doing so, the aforementioned scenario is applicable, but we keep support for entity validation as described in #2093.

This pull request resolves #2393.