### PR TITLE
Improve mismatch messages for Hamcrest Matchers #2400

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -69,7 +69,11 @@ public class Reporter {
      * @param actualEvents  The events that were found
      * @param expectation   A Description of what was expected
      * @param probableCause An optional exception that might be the reason for wrong events
+     * @deprecated This method has been previously used to report non-matching {@link org.hamcrest.Matcher} results.
+     *             Has been replaced by {@link #reportWrongEvent(Collection, Description, Description, Throwable)}.
+     *             The method is kept for api backwards compatibility only and my be removed in a future release.
      */
+    @Deprecated
     public void reportWrongEvent(Collection<?> actualEvents, StringDescription expectation, Throwable probableCause) {
         StringBuilder sb = new StringBuilder(
                 "The published events do not match the expected events.");
@@ -94,6 +98,45 @@ public class Reporter {
         throw new AxonAssertionError(sb.toString());
     }
 
+    /**
+     * Report an error of events not matching expectations defined by {@link org.hamcrest.Matcher}s. This method will
+     * receive two different {@link Description}s:
+     * <ul>
+     *   <li><code>expectation</code>: textual description of the complete matcher (chain) that has been used</li>
+     *   <li><code>mismatch</code>: detailed description of the mismatch.</li>
+     * </ul>
+     *
+     * @param actualEvents  The events that were found
+     * @param expectation   A Description of what was expected
+     * @param mismatch      detailed description of the actual mismatch.
+     * @param probableCause An optional exception that might be the reason for wrong events
+     */
+    public void reportWrongEvent(Collection<?> actualEvents, Description expectation, Description mismatch, Throwable probableCause) {
+        StringBuilder sb = new StringBuilder("The published events do not match the expected events.");
+        sb.append("Expected :");
+        sb.append(NEWLINE);
+        sb.append(expectation);
+        sb.append(NEWLINE);
+        sb.append("Did not match:");
+        sb.append(NEWLINE);
+        sb.append(mismatch);
+        sb.append(NEWLINE);
+        sb.append("Actual Sequence of events:");
+        if (actualEvents.isEmpty()) { 
+            sb.append(" no events emitted");
+        }
+        for (Object publishedEvent : actualEvents) {
+            sb.append(NEWLINE);
+            sb.append(publishedEvent.getClass().getSimpleName());
+            sb.append(": ");
+            sb.append(publishedEvent);
+        }
+        appendProbableCause(probableCause, sb);
+
+        throw new AxonAssertionError(sb.toString());
+
+    }
+        
     /**
      * Reports an error due to an unexpected exception. This means a return value was expected, but an exception was
      * thrown by the command handler

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -32,6 +32,7 @@ import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.matchers.MapEntryMatcher;
 import org.axonframework.test.matchers.PayloadMatcher;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
@@ -117,15 +118,15 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     @Override
     public ResultValidator<T> expectEventsMatching(Matcher<? extends List<? super EventMessage<?>>> matcher) {
         if (!matcher.matches(publishedEvents)) {
-            reporter.reportWrongEvent(publishedEvents, descriptionOf(matcher), actualException);
+            final Description expectation = new StringDescription();
+            matcher.describeTo(expectation);
+            
+            final Description mismatch = new StringDescription();
+            matcher.describeMismatch(publishedEvents, mismatch);
+            
+            reporter.reportWrongEvent(publishedEvents, expectation, mismatch, actualException);
         }
         return this;
-    }
-
-    private StringDescription descriptionOf(Matcher<?> matcher) {
-        StringDescription description = new StringDescription();
-        matcher.describeTo(description);
-        return description;
     }
 
     @Override


### PR DESCRIPTION
This is the first pull request related to issue #2400, improving the mismatch reporting. This is done by using the describeMismatch Method to identify the actual difference.