### PR TITLE
[#2431] Use `XStreamSerializer#defaultSerializer` to mitigate XStream exclusion issues

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -312,14 +312,7 @@ public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
 
         protected void validate() throws AxonConfigurationException {
             if (serializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                + " the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used, without specifying the security context"
-                        )
-                );
-                serializer = () -> XStreamSerializer.builder().build();
+                serializer = () -> XStreamSerializer.defaultSerializer();
             }
             assertNonNull(axonServerConnectionManager,
                           "The AxonServerConnectionManager is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -17,7 +17,6 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import com.google.protobuf.ByteString;
-import com.thoughtworks.xstream.XStream;
 import io.axoniq.axonserver.connector.event.EventChannel;
 import io.axoniq.axonserver.grpc.InstructionAck;
 import io.axoniq.axonserver.grpc.event.Event;
@@ -37,7 +36,6 @@ import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -321,9 +319,7 @@ public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = () -> XStreamSerializer.builder()
-                                                    .xStream(new XStream(new CompactDriver()))
-                                                    .build();
+                serializer = () -> XStreamSerializer.builder().build();
             }
             assertNonNull(axonServerConnectionManager,
                           "The AxonServerConnectionManager is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -37,10 +37,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutionException;
@@ -60,8 +57,6 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @since 4.4
  */
 public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
-
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final long requestTimeout;
     private final Serializer serializer;
@@ -312,7 +307,7 @@ public class AxonServerEventScheduler implements EventScheduler, Lifecycle {
 
         protected void validate() throws AxonConfigurationException {
             if (serializer == null) {
-                serializer = () -> XStreamSerializer.defaultSerializer();
+                serializer = XStreamSerializer::defaultSerializer;
             }
             assertNonNull(axonServerConnectionManager,
                           "The AxonServerConnectionManager is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -17,7 +17,6 @@
 package org.axonframework.axonserver.connector.event.axon;
 
 import com.google.protobuf.ByteString;
-import com.thoughtworks.xstream.XStream;
 import io.axoniq.axonserver.connector.event.AggregateEventStream;
 import io.axoniq.axonserver.connector.event.AppendEventsTransaction;
 import io.axoniq.axonserver.connector.event.EventChannel;
@@ -55,7 +54,6 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.tracing.SpanFactory;
 import org.slf4j.Logger;
@@ -362,9 +360,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                                         + " without specifying the security context"
                         )
                 );
-                snapshotSerializer = () -> XStreamSerializer.builder()
-                                                            .xStream(new XStream(new CompactDriver()))
-                                                            .build();
+                snapshotSerializer = () -> XStreamSerializer.builder().build();
             }
             if (eventSerializer == null) {
                 logger.warn(
@@ -375,9 +371,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                                         + " without specifying the security context"
                         )
                 );
-                eventSerializer = () -> XStreamSerializer.builder()
-                                                         .xStream(new XStream(new CompactDriver()))
-                                                         .build();
+                eventSerializer = () -> XStreamSerializer.builder().build();
             }
 
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -352,10 +352,10 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private void buildStorageEngine() {
             if (snapshotSerializer == null) {
-                snapshotSerializer = () -> XStreamSerializer.defaultSerializer();
+                snapshotSerializer = XStreamSerializer::defaultSerializer;
             }
             if (eventSerializer == null) {
-                eventSerializer = () -> XStreamSerializer.defaultSerializer();
+                eventSerializer = XStreamSerializer::defaultSerializer;
             }
 
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -352,26 +352,10 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private void buildStorageEngine() {
             if (snapshotSerializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used for events, whereas it is strongly recommended to"
-                                + " configure the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used for events,"
-                                        + " without specifying the security context"
-                        )
-                );
-                snapshotSerializer = () -> XStreamSerializer.builder().build();
+                snapshotSerializer = () -> XStreamSerializer.defaultSerializer();
             }
             if (eventSerializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used for snapshots, whereas it is strongly recommended to "
-                                + "configure the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used for snapshots,"
-                                        + " without specifying the security context"
-                        )
-                );
-                eventSerializer = () -> XStreamSerializer.builder().build();
+                eventSerializer = () -> XStreamSerializer.defaultSerializer();
             }
 
             assertNonNull(configuration, "The AxonServerConfiguration is a hard requirement and should be provided");

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -31,10 +31,7 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -54,8 +51,6 @@ import static org.axonframework.eventsourcing.EventStreamUtils.upcastAndDeserial
  * @since 3.0
  */
 public abstract class AbstractEventStorageEngine implements EventStorageEngine {
-
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Serializer snapshotSerializer;
     protected final EventUpcaster upcasterChain;
@@ -356,10 +351,10 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
          */
         protected void validate() throws AxonConfigurationException {
             if (snapshotSerializer == null) {
-                snapshotSerializer = () -> XStreamSerializer.defaultSerializer();
+                snapshotSerializer = XStreamSerializer::defaultSerializer;
             }
             if (eventSerializer == null) {
-                eventSerializer = () -> XStreamSerializer.defaultSerializer();
+                eventSerializer = XStreamSerializer::defaultSerializer;
             }
         }
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngine.java
@@ -356,26 +356,10 @@ public abstract class AbstractEventStorageEngine implements EventStorageEngine {
          */
         protected void validate() throws AxonConfigurationException {
             if (snapshotSerializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used for events, whereas it is strongly recommended to"
-                                + " configure the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used for events,"
-                                        + " without specifying the security context"
-                        )
-                );
-                snapshotSerializer = () -> XStreamSerializer.builder().build();
+                snapshotSerializer = () -> XStreamSerializer.defaultSerializer();
             }
             if (eventSerializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used for snapshots, whereas it is strongly recommended to "
-                                + "configure the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used for snapshots,"
-                                        + " without specifying the security context"
-                        )
-                );
-                eventSerializer = () -> XStreamSerializer.builder().build();
+                eventSerializer = () -> XStreamSerializer.defaultSerializer();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -363,14 +363,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager implements Li
             assertNonNull(scheduler, "The Scheduler is a hard requirement and should be provided");
             assertNonNull(scopeAwareProvider, "The ScopeAwareProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                + " the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used, without specifying the security context"
-                        )
-                );
-                serializer = () -> XStreamSerializer.builder().build();
+                serializer = () -> XStreamSerializer.defaultSerializer();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.deadline.quartz;
 
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonNonTransientException;
 import org.axonframework.common.transaction.NoTransactionManager;
@@ -30,7 +29,6 @@ import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.Span;
@@ -372,9 +370,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager implements Li
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = () -> XStreamSerializer.builder()
-                                                    .xStream(new XStream(new CompactDriver()))
-                                                    .build();
+                serializer = () -> XStreamSerializer.builder().build();
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -363,7 +363,7 @@ public class QuartzDeadlineManager extends AbstractDeadlineManager implements Li
             assertNonNull(scheduler, "The Scheduler is a hard requirement and should be provided");
             assertNonNull(scopeAwareProvider, "The ScopeAwareProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                serializer = () -> XStreamSerializer.defaultSerializer();
+                serializer = XStreamSerializer::defaultSerializer;
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -252,13 +252,6 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
         @Deprecated
         public DirectEventJobDataBinder() {
             this(XStreamSerializer.defaultSerializer());
-            logger.warn(
-                    "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                            + " the security context of the XStream instance.",
-                    new AxonConfigurationException(
-                            "A default XStreamSerializer is used, without specifying the security context"
-                    )
-            );
         }
 
         /**
@@ -453,14 +446,7 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
             assertNonNull(eventBus, "The EventBus is a hard requirement and should be provided");
             if (jobDataBinderSupplier == null) {
                 if (serializer == null) {
-                    logger.warn(
-                            "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                    + " the security context of the XStream instance.",
-                            new AxonConfigurationException(
-                                    "A default XStreamSerializer is used, without specifying the security context"
-                            )
-                    );
-                    serializer = () -> XStreamSerializer.builder().build();
+                    serializer = () -> XStreamSerializer.defaultSerializer();
                 }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.eventhandling.scheduling.quartz;
 
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.transaction.NoTransactionManager;
@@ -33,7 +32,6 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
@@ -462,9 +460,7 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
                                     "A default XStreamSerializer is used, without specifying the security context"
                             )
                     );
-                    serializer = () -> XStreamSerializer.builder()
-                                                        .xStream(new XStream(new CompactDriver()))
-                                                        .build();
+                    serializer = () -> XStreamSerializer.builder().build();
                 }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -446,7 +446,7 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
             assertNonNull(eventBus, "The EventBus is a hard requirement and should be provided");
             if (jobDataBinderSupplier == null) {
                 if (serializer == null) {
-                    serializer = () -> XStreamSerializer.defaultSerializer();
+                    serializer = XStreamSerializer::defaultSerializer;
                 }
                 jobDataBinderSupplier = () -> new DirectEventJobDataBinder(serializer.get());
             }

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
 import com.thoughtworks.xstream.io.xml.Dom4JReader;
 import com.thoughtworks.xstream.io.xml.XomReader;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.serialization.AbstractXStreamSerializer;
 import org.axonframework.serialization.AnnotationRevisionResolver;
@@ -104,7 +105,11 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
     @Deprecated
     public static XStreamSerializer defaultSerializer() {
         logger.warn("An unsecured XStream instance allowing all types is used. "
-                            + "It is strongly recommended to set the security context yourself instead!");
+                            + "It is strongly recommended to set the security context yourself instead!",
+                    new AxonConfigurationException(
+                            "An unsecured XStream instance allowing all types is used. "
+                                    + "It is strongly recommended to set the security context yourself instead!"
+                    ));
         XStream xStream = new XStream(new CompactDriver());
         xStream.allowTypeHierarchy(Object.class);
         return builder().xStream(xStream)

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -229,7 +229,11 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
         public XStreamSerializer build() {
             if (xStream == null) {
                 logger.warn("An unsecured XStream instance allowing all types is used. "
-                                    + "It is strongly recommended to set the security context yourself instead!");
+                                    + "It is strongly recommended to set the security context yourself instead!",
+                            new AxonConfigurationException(
+                                    "An unsecured XStream instance allowing all types is used. "
+                                            + "It is strongly recommended to set the security context yourself instead!"
+                            ));
                 xStream = new XStream(new CompactDriver());
             }
             return new XStreamSerializer(this);

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -223,6 +223,8 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
          */
         public XStreamSerializer build() {
             if (xStream == null) {
+                logger.warn("An unsecured XStream instance allowing all types is used. "
+                                    + "It is strongly recommended to set the security context yourself instead!");
                 xStream = new XStream(new CompactDriver());
             }
             return new XStreamSerializer(this);

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -393,14 +393,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
         protected void validate() throws AxonConfigurationException {
             assertNonNull(connectionProvider, "The ConnectionProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                + " the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used, without specifying the security context"
-                        )
-                );
-                serializer = () -> XStreamSerializer.builder().build();
+                serializer = () -> XStreamSerializer.defaultSerializer();
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -393,7 +393,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
         protected void validate() throws AxonConfigurationException {
             assertNonNull(connectionProvider, "The ConnectionProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                serializer = () -> XStreamSerializer.defaultSerializer();
+                serializer = XStreamSerializer::defaultSerializer;
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jdbc/JdbcSagaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.axonframework.modelling.saga.repository.jdbc;
 
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.DataSourceConnectionProvider;
@@ -28,7 +27,6 @@ import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.SagaEntry;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -402,9 +400,7 @@ public class JdbcSagaStore implements SagaStore<Object> {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = () -> XStreamSerializer.builder()
-                                                    .xStream(new XStream(new CompactDriver()))
-                                                    .build();
+                serializer = () -> XStreamSerializer.builder().build();
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.axonframework.modelling.saga.repository.jpa;
 
-import com.thoughtworks.xstream.XStream;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.modelling.saga.AssociationValue;
@@ -24,7 +23,6 @@ import org.axonframework.modelling.saga.AssociationValues;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
-import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -414,9 +412,7 @@ public class JpaSagaStore implements SagaStore<Object> {
                                 "A default XStreamSerializer is used, without specifying the security context"
                         )
                 );
-                serializer = () -> XStreamSerializer.builder()
-                                                    .xStream(new XStream(new CompactDriver()))
-                                                    .build();
+                serializer = () -> XStreamSerializer.builder().build();
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -55,7 +55,6 @@ public class JpaSagaStore implements SagaStore<Object> {
 
     private static final Logger logger = LoggerFactory.getLogger(JpaSagaStore.class);
 
-
     // Saga Queries, non-final to inject the return type and table name.
     private final String LOAD_SAGA_QUERY =
             "SELECT new " + serializedObjectType().getName() + "(" +
@@ -405,7 +404,7 @@ public class JpaSagaStore implements SagaStore<Object> {
             assertNonNull(entityManagerProvider,
                           "The EntityManagerProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                serializer = () -> XStreamSerializer.defaultSerializer();
+                serializer = XStreamSerializer::defaultSerializer;
             }
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStore.java
@@ -405,14 +405,7 @@ public class JpaSagaStore implements SagaStore<Object> {
             assertNonNull(entityManagerProvider,
                           "The EntityManagerProvider is a hard requirement and should be provided");
             if (serializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
-                                + " the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used, without specifying the security context"
-                        )
-                );
-                serializer = () -> XStreamSerializer.builder().build();
+                serializer = () -> XStreamSerializer.defaultSerializer();
             }
         }
     }


### PR DESCRIPTION
This pull request replaces the local construction of the `XStreamSerializer` through it's builder in several of Axon Framework's infrastructure components.
Doing so, ensure an end user can safely exclude the XStream dependency, without the component in question failing with `NoClassDefFoundError`.

Instead, we reintroduce the use of `XStreamSerializer#defaultSerializer`, as this moves the statements to the `XStreamSerializer` instance.
To maintain the logged exception trace, the warning *with* the `AxonConfigurationException` is completely moved to the `XStreamSerializer`.
Previously, every infrastructure component logged this warning itself.

Through this fix, we resolve bug #2431.