### PR TITLE
Add test scope to `mysql-connector-java` dependency

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -209,12 +209,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
This pull request adds the `test` scope to the `mysql-connector-java` dependency in the `axon-spring` module.
Without the `test` scope, users may accidentally retrieve an additional and undesired data source.