### PR TITLE
Added Spring Resource Injector to Application Context

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
+import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.spring.config.MessageHandlerLookup;
 import org.axonframework.spring.config.SpringAggregateLookup;
@@ -31,10 +32,12 @@ import org.axonframework.spring.config.SpringConfigurer;
 import org.axonframework.spring.config.SpringSagaLookup;
 import org.axonframework.spring.config.annotation.HandlerDefinitionFactoryBean;
 import org.axonframework.spring.config.annotation.SpringParameterResolverFactoryBean;
+import org.axonframework.spring.saga.SpringResourceInjector;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -120,6 +123,12 @@ public class InfraConfiguration {
     @Bean
     public ConfigurerModule eventUpcastersConfigurer(List<EventUpcaster> upcasters) {
         return configurer -> upcasters.forEach(u -> configurer.registerEventUpcaster(c -> u));
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public ResourceInjector resourceInjector() {
+        return new SpringResourceInjector();
     }
 }
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -28,15 +28,18 @@ import org.axonframework.disruptor.commandhandling.DisruptorCommandBus;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.messaging.Message;
+import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.queryhandling.QueryBus;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.*;
+import org.axonframework.spring.saga.SpringResourceInjector;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
@@ -44,7 +47,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -84,6 +89,9 @@ class AxonServerAutoConfigurationTest {
     @Autowired
     private QueryUpdateEmitter updateEmitter;
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Test
     void axonServerQueryBusConfiguration() {
         assertTrue(queryBus instanceof AxonServerQueryBus);
@@ -94,6 +102,12 @@ class AxonServerAutoConfigurationTest {
     void axonServerCommandBusBeanTypesConfiguration() {
         assertTrue(commandBus instanceof AxonServerCommandBus);
         assertTrue(localSegment instanceof SimpleCommandBus);
+    }
+
+    @Test
+    void springResourceInjectorConfigured() {
+        assertFalse(applicationContext.getBeansOfType(ResourceInjector.class).isEmpty(), "Expected an autoconfigured ResourceInjector");
+        assertTrue(applicationContext.getBean(ResourceInjector.class) instanceof SpringResourceInjector);
     }
 
     @Test


### PR DESCRIPTION
There is a regression in the Spring Autoconfiguration since 4.6, causing the Resource Injector to not be available as a bean in the application context. As a result, the Resource Injector used by default is the one taking resources from the Configuration, rather than using Spring to autowire dependencies. In most cases, this will behave the same way. Only when using Qualifiers or spring-specific dependency injection options, this may lead to issues.

This commit will enforce the same behavior as 4.5, where a user-defined resource injector takes precedence, while defaulting to the SpringResourceInjector.