### PR TITLE
Fix `Cache#computeIfPresent` return value in `CachingSagaStore`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ package org.axonframework.modelling.saga.repository;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.CollectionUtils;
 import org.axonframework.common.lock.LockFactory;
+import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.saga.AnnotatedSaga;
 import org.axonframework.modelling.saga.AssociationValue;
 import org.axonframework.modelling.saga.ResourceInjector;
@@ -26,10 +30,6 @@ import org.axonframework.modelling.saga.Saga;
 import org.axonframework.modelling.saga.SagaRepository;
 import org.axonframework.modelling.saga.metamodel.AnnotationSagaMetaModelFactory;
 import org.axonframework.modelling.saga.metamodel.SagaModel;
-import org.axonframework.messaging.annotation.HandlerDefinition;
-import org.axonframework.messaging.annotation.ParameterResolverFactory;
-import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-import org.axonframework.messaging.unitofwork.UnitOfWork;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -187,15 +187,17 @@ public class AnnotatedSagaRepository<T> extends LockingSagaRepository<T> {
     }
 
     /**
-     * Remove the given saga as well as all known association values pointing to it from the repository. If no such
-     * saga exists, nothing happens.
+     * Remove the given saga as well as all known association values pointing to it from the repository. If no such saga
+     * exists, nothing happens.
      *
      * @param saga The saga instance to remove from the repository
      */
     protected void deleteSaga(AnnotatedSaga<T> saga) {
-        Set<AssociationValue> associationValues = CollectionUtils
-                .merge(saga.getAssociationValues().asSet(), saga.getAssociationValues().removedAssociations(),
-                       HashSet::new);
+        Set<AssociationValue> associationValues = CollectionUtils.merge(
+                saga.getAssociationValues().asSet(),
+                saga.getAssociationValues().removedAssociations(),
+                HashSet::new
+        );
         sagaStore.deleteSaga(sagaType, saga.getSagaIdentifier(), associationValues);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -108,13 +108,15 @@ public class CachingSagaStore<T> implements SagaStore<T> {
         delegate.deleteSaga(sagaType, sagaIdentifier, associationValues);
     }
 
-    private void removeAssociationValueFromCache(Class<?> sagaType, String sagaIdentifier,
+    private void removeAssociationValueFromCache(Class<?> sagaType,
+                                                 String sagaIdentifier,
                                                  AssociationValue associationValue) {
         String key = cacheKey(associationValue, sagaType);
         associationsCache.computeIfPresent(key, associations -> {
             //noinspection unchecked
             ((Set<String>) associations).remove(sagaIdentifier);
-            return ((Set<?>) associations).isEmpty() ? null : associations;
+            //noinspection unchecked
+            return ((Set<String>) associations).isEmpty() ? null : associations;
         });
     }
 
@@ -131,8 +133,11 @@ public class CachingSagaStore<T> implements SagaStore<T> {
                                          Class<?> sagaType) {
         for (AssociationValue associationValue : associationValues) {
             String key = cacheKey(associationValue, sagaType);
-            //noinspection unchecked
-            associationsCache.computeIfPresent(key, identifiers -> ((Set<String>) identifiers).add(sagaIdentifier));
+            associationsCache.computeIfPresent(key, identifiers -> {
+                //noinspection unchecked
+                ((Set<String>) identifiers).add(sagaIdentifier);
+                return identifiers;
+            });
         }
     }
 


### PR DESCRIPTION
When adjusting the `CachingSagaStore` in 4.6.1, I have accidentally introduced a lambda that replaced the `AssociationValue` cache entries into a `boolean`.
This was done by simply invoking `Set#add` on the association values directly, instead of returning the set.

This pull request fixes that issue, by returning the set i.o. the result of `Set#add`.
For testing, the `sagaAndAssociationsRemovedFromCacheOnDelete` now updates the saga entry.
Doing so, we impose an adjustment on the association value cache too, ensuring the right result is consistently returned from the `Cache#computeIfPresent` invocation.