### PR TITLE
[#2454] Reintroduce changes from PR #1905

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,9 @@ import org.axonframework.messaging.RemoteHandlingException;
 
 /**
  * Exception indicating a problem that was reported by the remote end of a connection.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
+ * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 4.0
@@ -38,7 +41,19 @@ public class AxonServerRemoteCommandHandlingException extends RemoteHandlingExce
      * @param errorMessage the message describing the exception on the remote end
      */
     public AxonServerRemoteCommandHandlingException(String errorCode, ErrorMessage errorMessage) {
-        super(new RemoteExceptionDescription(errorMessage.getDetailsList()));
+        this(errorCode, errorMessage, false);
+    }
+
+    /**
+     * Initialize the exception with given {@code errorCode}, {@code errorMessage} and {@code writableStackTrace}.
+     *
+     * @param errorCode          the code reported by the server
+     * @param errorMessage       the message describing the exception on the remote end
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public AxonServerRemoteCommandHandlingException(String errorCode, ErrorMessage errorMessage,
+                                                    boolean writableStackTrace) {
+        super(new RemoteExceptionDescription(errorMessage.getDetailsList()), writableStackTrace);
         this.errorCode = errorCode;
         this.server = errorMessage.getLocation();
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerRemoteCommandHandlingException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
@@ -22,6 +22,9 @@ import org.axonframework.messaging.RemoteHandlingException;
 
 /**
  * An AxonServer Exception which is thrown on a Query Handling exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
+ * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 4.0
@@ -40,7 +43,18 @@ public class AxonServerRemoteQueryHandlingException extends RemoteHandlingExcept
      * @param message   an {@link ErrorMessage} describing the exception
      */
     public AxonServerRemoteQueryHandlingException(String errorCode, ErrorMessage message) {
-        super(new RemoteExceptionDescription(message.getDetailsList()));
+        this(errorCode, message, false);
+    }
+
+    /**
+     * Initialize a Query Handling exception from a remote source.
+     *
+     * @param errorCode          a {@link String} defining the error code of this exception
+     * @param message            an {@link ErrorMessage} describing the exception
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false}
+     */
+    public AxonServerRemoteQueryHandlingException(String errorCode, ErrorMessage message, boolean writableStackTrace) {
+        super(new RemoteExceptionDescription(message.getDetailsList()), writableStackTrace);
         this.errorCode = errorCode;
         this.server = message.getLocation();
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerRemoteQueryHandlingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,9 @@ import org.axonframework.messaging.HandlerExecutionException;
 /**
  * Indicates that an exception has occurred while handling a command. Typically, this class is used to wrap checked
  * exceptions that have been thrown from a Command Handler while processing an incoming command.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Allard Buijze
  * @since 1.3
@@ -50,5 +53,18 @@ public class CommandExecutionException extends HandlerExecutionException {
      */
     public CommandExecutionException(String message, Throwable cause, Object details) {
         super(message, cause, details);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, an object providing application-specific
+     * {@code details}, and {@code writableStackTrace}
+     *
+     * @param message            The message describing the exception
+     * @param cause              The cause of the exception
+     * @param details            An object providing more error details (may be {@code null})
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public CommandExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, details, writableStackTrace);
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/messaging/src/main/java/org/axonframework/common/AxonException.java
+++ b/messaging/src/main/java/org/axonframework/common/AxonException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/messaging/src/main/java/org/axonframework/common/AxonException.java
+++ b/messaging/src/main/java/org/axonframework/common/AxonException.java
@@ -17,7 +17,7 @@
 package org.axonframework.common;
 
 /**
- * Base exception of all Axon Framework related exceptions.
+ * Base exception for all Axon Framework related exceptions.
  *
  * @author Allard Buijze
  * @since 0.6
@@ -43,5 +43,16 @@ public abstract class AxonException extends RuntimeException {
      */
     public AxonException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    /**
+     * Initializes the exception using the given {@code message}, {@code cause} and {@code writableStackTrace}.
+     *
+     * @param message            The message describing the exception
+     * @param cause              The underlying cause of the exception
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public AxonException(String message, Throwable cause, boolean writableStackTrace) {
+        super(message, cause, true, writableStackTrace);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,9 @@ import java.util.Optional;
  * Base exception for exceptions raised by Handler methods. Besides standard exception information (such as message and
  * cause), these exception may optionally carry an object with additional application-specific details about the
  * exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
+ * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Allard Buize
  * @since 4.2
@@ -34,8 +37,8 @@ public abstract class HandlerExecutionException extends AxonException {
     private final Object details;
 
     /**
-     * Initializes an execution exception with given {@code message}. The cause and application-specific details are
-     * set to {@code null}.
+     * Initializes an execution exception with given {@code message}. The cause and application-specific details are set
+     * to {@code null}.
      *
      * @param message A message describing the exception
      */
@@ -63,13 +66,26 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param details An object providing application-specific details of the exception
      */
     public HandlerExecutionException(String message, Throwable cause, Object details) {
-        super(message, cause);
+        this(message, cause, details, false);
+    }
+
+    /**
+     * Initializes an execution exception with given {@code message}, {@code cause}, application-specific
+     * {@code details}, and {@code writableStackTrace}
+     *
+     * @param message            A message describing the exception
+     * @param cause              The cause of the execution exception
+     * @param details            An object providing application-specific details of the exception
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public HandlerExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, writableStackTrace);
         this.details = details;
     }
 
     /**
-     * Resolve details from the given {@code throwable}, taking into account that the details may be available in any
-     * of the {@code HandlerExecutionException}s is the "cause" chain.
+     * Resolve details from the given {@code throwable}, taking into account that the details may be available in any of
+     * the {@code HandlerExecutionException}s is the "cause" chain.
      *
      * @param throwable The exception to resolve the details from
      * @param <R>       The type of details expected
@@ -85,9 +101,9 @@ public abstract class HandlerExecutionException extends AxonException {
     }
 
     /**
-     * Returns an Optional containing application-specific details of the exception, if any were provided. These
-     * details are implicitly cast to the expected type. A mismatch in type may lead to a {@link ClassCastException}
-     * further downstream, when accessing the Optional's enclosed value.
+     * Returns an Optional containing application-specific details of the exception, if any were provided. These details
+     * are implicitly cast to the expected type. A mismatch in type may lead to a {@link ClassCastException} further
+     * downstream, when accessing the Optional's enclosed value.
      *
      * @param <R> The type of details expected
      * @return an Optional containing the details, if provided

--- a/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/HandlerExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2018. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,9 @@ import java.util.List;
 
 /**
  * Exception indicating that an error has occurred while remotely handling a message.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
+ * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  * <p/>
  * The sender of the message <strong>cannot</strong> assume that the message has not been handled. It may, if the type
  * of message or the infrastructure allows it, try to dispatch the message again.
@@ -41,7 +44,18 @@ public class RemoteHandlingException extends AxonException {
      * @param exceptionDescription a {@link String} describing the remote exceptions
      */
     public RemoteHandlingException(RemoteExceptionDescription exceptionDescription) {
-        super("An exception was thrown by the remote message handling component: " + exceptionDescription.toString());
+        this(exceptionDescription, false);
+    }
+
+    /**
+     * Initializes the exception using the given {@code exceptionDescription} and {@code writableStackTrace}.
+     *
+     * @param exceptionDescription a {@link String} describing the remote exceptions
+     * @param writableStackTrace   whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public RemoteHandlingException(RemoteExceptionDescription exceptionDescription, boolean writableStackTrace) {
+        super("An exception was thrown by the remote message handling component: " + exceptionDescription.toString(),
+              null, writableStackTrace);
         this.exceptionDescriptions = exceptionDescription.getDescriptions();
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/RemoteHandlingException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,10 @@ package org.axonframework.queryhandling;
 import org.axonframework.messaging.HandlerExecutionException;
 
 /**
- * Exception indicating that the execution of a Query Handler has resulted in an exception
+ * Exception indicating that the execution of a Query Handler has resulted in an exception.
+ * <p/>
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
+ * via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
  * @since 3.1
@@ -38,13 +41,26 @@ public class QueryExecutionException extends HandlerExecutionException {
     }
 
     /**
-     * Initializes the exception with given {@code message} and {@code cause} and {@code details}.
+     * Initializes the exception with given {@code message}, {@code cause} and {@code details}.
      *
      * @param message Message explaining the context of the error
      * @param cause   The underlying cause of the invocation failure
-     * @param details An object providing more error details (may be {@code null}
+     * @param details An object providing more error details (may be {@code null})
      */
     public QueryExecutionException(String message, Throwable cause, Object details) {
         super(message, cause, details);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, {@code details} and
+     * {@code writableStackTrace}
+     *
+     * @param message            Message explaining the context of the error
+     * @param cause              The underlying cause of the invocation failure
+     * @param details            An object providing more error details (may be {@code null})
+     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    public QueryExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+        super(message, cause, details, writableStackTrace);
     }
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryExecutionException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating the {@link HandlerExecutionException}.
+ */
 class HandlerExecutionExceptionTest {
 
     @Test
@@ -46,6 +49,24 @@ class HandlerExecutionExceptionTest {
         assertFalse(HandlerExecutionException.resolveDetails(new RuntimeException()).isPresent());
     }
 
+    @Test
+    void validatePresenceOfStackTraceWithWritableStackTraceSetting() {
+        Exception exception = new StubHandlerExecutionException("Some message");
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException());
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details");
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details", false);
+        assertEquals(0, exception.getStackTrace().length);
+
+        exception = new StubHandlerExecutionException("Some message", new RuntimeException(), "Some details", true);
+        assertTrue(exception.getStackTrace().length > 0);
+    }
+
     private static class StubHandlerExecutionException extends HandlerExecutionException {
 
         public StubHandlerExecutionException(String message) {
@@ -58,6 +79,13 @@ class HandlerExecutionExceptionTest {
 
         public StubHandlerExecutionException(String message, Throwable cause, Object details) {
             super(message, cause, details);
+        }
+
+        public StubHandlerExecutionException(String message,
+                                             Throwable cause,
+                                             Object details,
+                                             boolean writableStackTrace) {
+            super(message, cause, details, writableStackTrace);
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HandlerExecutionExceptionTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This pull request reintroduces the changes @dmurat provided in pull request #1905.
Due to an unintentional (force) push to the `master` branch, those changes were overwritten.

As they weren't retrievable directly by commit referral, I  downloaded the source as a zip based on the merge operation within #1905.
More specifically, the status of Axon Framework as depicted [here](https://github.com/AxonFramework/AxonFramework/tree/7fc435b5624ae83ccebbb6df07b937d444617660).
With this in hand, I was able to reintroduce the changes made by @dmurat.

Although this sadly means his user tag is not attached to the commit, I've been careful in naming the commit such that the credentials still point back to @dmurat.

In doing so, this pull request resolves #2454.