### PR TITLE
Replace `IdentifierMissingException` in `AnnotationCommandTargetResolver` for `IllegalArgumentException`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -505,10 +505,17 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
     private VersionedAggregateIdentifier resolveNullableAggregateId(CommandMessage<?> command) {
         try {
             return commandTargetResolver.resolveTarget(command);
-        } catch (IdentifierMissingException exception) {
+        } catch (IdentifierMissingException e) {
             // Couldn't find identifier in given command, so defaulting to null.
             // Assuming it will be set in the command handler.
             return null;
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("It does not identify the target aggregate.")) {
+                // Couldn't find identifier in given command, so defaulting to null.
+                // Assuming it will be set in the command handler.
+                return null;
+            }
+            throw e;
         }
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
@@ -101,7 +101,7 @@ public class AnnotationCommandTargetResolver implements CommandTargetResolver {
             throw new IllegalArgumentException("The value provided for the version is not a number.", e);
         }
         if (aggregateIdentifier == null) {
-            throw new IdentifierMissingException(format(
+            throw new IllegalArgumentException(format(
                     "Invalid command. It does not identify the target aggregate. "
                             + "Make sure at least one of the fields or methods in the [%s] class contains the "
                             + "@TargetAggregateIdentifier annotation and that it returns a non-null value.",

--- a/modelling/src/test/java/org/axonframework/modelling/command/AnnotationCommandTargetResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AnnotationCommandTargetResolverTest.java
@@ -46,7 +46,7 @@ class AnnotationCommandTargetResolverTest {
 
     @Test
     void resolveTarget_CommandWithoutAnnotations() {
-        assertThrows(IdentifierMissingException.class,
+        assertThrows(IllegalArgumentException.class,
                      () -> testSubject.resolveTarget(asCommandMessage("That won't work")));
     }
 
@@ -109,7 +109,7 @@ class AnnotationCommandTargetResolverTest {
             private void getIdentifier() {
             }
         });
-        assertThrows(IdentifierMissingException.class, () -> testSubject.resolveTarget(command));
+        assertThrows(IllegalArgumentException.class, () -> testSubject.resolveTarget(command));
     }
 
     @Test


### PR DESCRIPTION
This PR replaces the `IdentifierMissingException` in the `AnnotationCommandTargetResolver` for the `IllegalArgumentException`. 
This is a revert compared to 4.6.0, which introduced the `IdentifierMissingException`.

We need to revert this as users may anticipate an `IllegalArgumentException` to be thrown. 
Hence, the introduction of the `IdentifierMissingException` is a breaking change. 

A revert also requires another catch-case on the `AggregateAnnotationCommandHandler` to check the type of `IllegalArgumentException`, to correctly react to the missing identifier scenario.