### PR TITLE
[#2456] Replace use of unregister for deregister

### DIFF
--- a/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/DisruptorUnitOfWork.java
+++ b/disruptor/src/main/java/org/axonframework/disruptor/commandhandling/DisruptorUnitOfWork.java
@@ -62,7 +62,7 @@ public abstract class DisruptorUnitOfWork<T extends Message<?>> extends Abstract
     }
 
     /**
-     * Pause this Unit of Work by unregistering it with the {@link CurrentUnitOfWork}. This will detach it from the
+     * Pause this Unit of Work by deregistering it with the {@link CurrentUnitOfWork}. This will detach it from the
      * current thread.
      */
     public void pause() {

--- a/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
@@ -226,7 +226,7 @@ public class SimpleCommandBus implements CommandBus {
      * interceptors at the given order before the command is passed to the handler for processing.
      *
      * @param handlerInterceptor The interceptor to invoke when commands are handled
-     * @return handle to unregister the interceptor
+     * @return handle to deregister the interceptor
      */
     @Override
     public Registration registerHandlerInterceptor(
@@ -241,7 +241,7 @@ public class SimpleCommandBus implements CommandBus {
      * interceptors at the given order before the command is dispatched toward the command handler.
      *
      * @param dispatchInterceptor The interceptors to invoke when commands are dispatched
-     * @return handle to unregister the interceptor
+     * @return handle to deregister the interceptor
      */
     @Override
     public Registration registerDispatchInterceptor(

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -268,7 +268,7 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
      * interceptors at the given order before the command is dispatched toward the command handler.
      *
      * @param dispatchInterceptor The interceptors to invoke when commands are dispatched
-     * @return handle to unregister the interceptor
+     * @return handle to deregister the interceptor
      */
     public Registration registerDispatchInterceptor(
             @Nonnull MessageDispatchInterceptor<? super CommandMessage<?>> dispatchInterceptor) {

--- a/messaging/src/main/java/org/axonframework/common/Registration.java
+++ b/messaging/src/main/java/org/axonframework/common/Registration.java
@@ -38,7 +38,7 @@ public interface Registration extends AutoCloseable {
     /**
      * Cancels this Registration. If the Registration was already cancelled, no action is taken.
      *
-     * @return {@code true} if this handler is successfully unregistered, {@code false} if this handler
+     * @return {@code true} if this handler is successfully deregistered, {@code false} if this handler
      * was not currently registered.
      */
     boolean cancel();

--- a/messaging/src/main/java/org/axonframework/common/caching/AbstractCacheAdapter.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/AbstractCacheAdapter.java
@@ -63,7 +63,7 @@ public abstract class AbstractCacheAdapter<L> implements Cache {
      * Registers the given listener with the cache implementation
      *
      * @param listenerAdapter the listener to register
-     * @return a handle to unregister the listener
+     * @return a handle to deregister the listener
      */
     protected abstract Registration doRegisterListener(L listenerAdapter);
 }

--- a/messaging/src/main/java/org/axonframework/common/caching/Cache.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/Cache.java
@@ -86,7 +86,7 @@ public interface Cache {
      * Registers the given {@code cacheEntryListener} to listen for Cache changes.
      *
      * @param cacheEntryListener The listener to register
-     * @return a handle to unregister the listener
+     * @return a handle to deregister the listener
      */
     Registration registerCacheEntryListener(EntryListener cacheEntryListener);
 

--- a/messaging/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
@@ -68,7 +68,7 @@ public abstract class PropertyAccessStrategy implements Comparable<PropertyAcces
     /**
      * Removes all strategies registered using the {@link #register(PropertyAccessStrategy)} method.
      *
-     * @param strategy The strategy instance to unregister
+     * @param strategy The strategy instance to deregister.
      */
     public static void unregister(PropertyAccessStrategy strategy) {
         STRATEGIES.remove(strategy);

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptorSupport.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptorSupport.java
@@ -38,7 +38,7 @@ public interface MessageDispatchInterceptorSupport<T extends Message<?>> {
      * dispatched on the messaging component that it was registered to.
      *
      * @param dispatchInterceptor The interceptor to register
-     * @return a Registration, which may be used to remove the unregister the interceptor
+     * @return A Registration, which may be used to deregister the interceptor.
      */
     Registration registerDispatchInterceptor(@Nonnull MessageDispatchInterceptor<? super T> dispatchInterceptor);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptorSupport.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptorSupport.java
@@ -37,7 +37,7 @@ public interface MessageHandlerInterceptorSupport<T extends Message<?>> {
      * handled Message on the messaging component that it was registered to, prior to invoking the message's handler.
      *
      * @param handlerInterceptor The interceptor to register
-     * @return a Registration, which may be used to remove the unregister the interceptor
+     * @return A Registration, which may be used to deregister the interceptor.
      */
     Registration registerHandlerInterceptor(@Nonnull MessageHandlerInterceptor<? super T> handlerInterceptor);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
@@ -34,7 +34,7 @@ import javax.annotation.Nonnull;
  * This class represents a Unit of Work that monitors the processing of a {@link Message}.
  * <p/>
  * Before processing begins a Unit of Work is bound to the active thread by registering it with the {@link
- * CurrentUnitOfWork}. After processing, the Unit of Work is unregistered from the {@link CurrentUnitOfWork}.
+ * CurrentUnitOfWork}. After processing, the Unit of Work is deregistered from the {@link CurrentUnitOfWork}.
  * <p/>
  * Handlers can be notified about the state of the processing of the Message by registering with this Unit of Work.
  *
@@ -53,7 +53,7 @@ public interface UnitOfWork<T extends Message<?>> {
      * registered to the Unit of Work will be notified.
      * <p/>
      * After the commit (successful or not), any registered clean-up handlers ({@link #onCleanup(Consumer)}}) will be
-     * invoked and the Unit of Work is unregistered from the {@link CurrentUnitOfWork}.
+     * invoked and the Unit of Work is deregistered from the {@link CurrentUnitOfWork}.
      * <p/>
      * If the Unit of Work fails to commit, e.g. because an exception is raised by one of its handlers, the Unit of Work
      * is rolled back.
@@ -65,7 +65,7 @@ public interface UnitOfWork<T extends Message<?>> {
 
     /**
      * Initiates the rollback of this Unit of Work, invoking all registered rollback ({@link #onRollback(Consumer) and
-     * clean-up handlers {@link #onCleanup(Consumer)}} respectively. Finally, the Unit of Work is unregistered from the
+     * clean-up handlers {@link #onCleanup(Consumer)}} respectively. Finally, the Unit of Work is deregistered from the
      * {@link CurrentUnitOfWork}.
      * <p/>
      * If the rollback is a result of an exception, consider using {@link #rollback(Throwable)} instead.
@@ -78,7 +78,7 @@ public interface UnitOfWork<T extends Message<?>> {
 
     /**
      * Initiates the rollback of this Unit of Work, invoking all registered rollback ({@link #onRollback(Consumer) and
-     * clean-up handlers {@link #onCleanup(Consumer)}} respectively. Finally, the Unit of Work is unregistered from the
+     * clean-up handlers {@link #onCleanup(Consumer)}} respectively. Finally, the Unit of Work is deregistered from the
      * {@link CurrentUnitOfWork}.
      *
      * @param cause The cause of the rollback. May be {@code null}.

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -504,7 +504,7 @@ public class SimpleQueryBus implements QueryBus {
      * The interceptor is invoked separately for each handler instance (in a separate unit of work).
      *
      * @param interceptor the interceptor to invoke before passing a Query to the handler
-     * @return handle to unregister the interceptor
+     * @return handle to deregister the interceptor
      */
     @Override
     public Registration registerHandlerInterceptor(
@@ -518,7 +518,7 @@ public class SimpleQueryBus implements QueryBus {
      * the type of query (point-to-point or scatter-gather) executed.
      *
      * @param interceptor the interceptor to invoke when sending a Query
-     * @return handle to unregister the interceptor
+     * @return handle to deregister the interceptor
      */
     @Override
     public @Nonnull

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtension.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.*;
 /**
  * Implementation of {@link StubAggregateLifecycle} that can be used as an {@link org.junit.jupiter.api.extension.RegisterExtension}
  * annotated method or field in a test class. In that case, the JUnit lifecycle will automatically register and
- * unregister the {@code StubAggregateLifecycle}.
+ * deregister the {@code StubAggregateLifecycle}.
  * <p>
  * Usage example:
  * <pre>

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleRule.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycleRule.java
@@ -22,7 +22,7 @@ import org.junit.runners.model.*;
 
 /**
  * Implementation of StubAggregateLifecycle that can be used as an {@link org.junit.Rule} annotated method or field in a
- * test class. In that case, the JUnit lifecycle will automatically register and unregister the {@link
+ * test class. In that case, the JUnit lifecycle will automatically register and deregister the {@link
  * StubAggregateLifecycle}.
  * <p>
  * Usage example:


### PR DESCRIPTION
As mentioned in #2456, the use of unregister is incorrect use of the English language. 
Unregister may only be used if something was never registered to begin with. 
All occurrences are, however, describing the removal of an existing registration, which should be called deregister instead.

This pull request adjusts that and in doing so resolves #2456.