### PR TITLE
[#2449] Adhere to Spring's `@Order` annotation for Message Handling Component registration

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -128,7 +128,7 @@ class InfraConfigurationTest {
                                .isNotNull();
             EventProcessingModule eventProcessingModule =
                     context.getBean("eventProcessingModule", EventProcessingModule.class);
-            assertThat(eventProcessingModule.eventProcessor("test").isPresent()).isTrue();
+            assertThat(eventProcessingModule.eventProcessor("test")).isPresent();
 
             assertThat(context).getBean("eventHandlerInvocations", CountDownLatch.class)
                                .isNotNull();

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -201,7 +201,6 @@ class InfraConfigurationTest {
         }
 
         @Bean
-        @Order(0)
         public EarlyEventHandler earlyEventHandler(CountDownLatch eventHandlerInvocations,
                                                    Set<String> handlingOutcome) {
             return new EarlyEventHandler(eventHandlerInvocations, handlingOutcome);
@@ -231,6 +230,7 @@ class InfraConfigurationTest {
             }
         }
 
+        @Order(0)
         @ProcessingGroup("test")
         static class EarlyEventHandler {
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -17,7 +17,10 @@
 package org.axonframework.springboot.autoconfig;
 
 import org.axonframework.config.Configuration;
-import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.config.EventProcessingModule;
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.spring.config.MessageHandlerLookup;
@@ -31,12 +34,18 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.core.annotation.Order;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 
@@ -104,6 +113,44 @@ class InfraConfigurationTest {
         });
     }
 
+    /**
+     * This form of integration test is added in the {@link InfraConfiguration} test class, as it is in charge of
+     * constructing the {@link MessageHandlerLookup} bean. It's this bean that finds all the message handlers and should
+     * provide them in a sorted fashion.
+     */
+    @Test
+    void eventHandlingComponentsAreRegisteredAccordingToOrderAnnotation() {
+        testApplicationContext.withUserConfiguration(EventHandlerOrderingContext.class).run(context -> {
+            // Validate existence of Event Processor "test"
+            assertThat(context).getBean("eventProcessingModule")
+                               .isNotNull();
+            EventProcessingModule eventProcessingModule =
+                    context.getBean("eventProcessingModule", EventProcessingModule.class);
+            assertThat(eventProcessingModule.eventProcessor("test").isPresent()).isTrue();
+
+            assertThat(context).getBean("eventHandlerInvocations", CountDownLatch.class)
+                               .isNotNull();
+            CountDownLatch eventHandlerInvocations =
+                    context.getBean("eventHandlerInvocations", CountDownLatch.class);
+
+            String testEvent = "some-event-payload";
+            context.getBean(EventGateway.class)
+                   .publish(testEvent);
+
+            // Wait for all the event handlers to had their chance.
+            assertThat(eventHandlerInvocations.await(1, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(context).getBean("handlingOutcome", Set.class)
+                               .isNotNull();
+            //noinspection unchecked
+            Set<String> handlingOrder = context.getBean("handlingOutcome", Set.class);
+            InOrder order = inOrder(handlingOrder);
+            order.verify(handlingOrder).add("early-[" + testEvent + "]");
+            order.verify(handlingOrder).add("late-[" + testEvent + "]");
+            order.verify(handlingOrder).add("unordered-[" + testEvent + "]");
+        });
+    }
+
     @ContextConfiguration
     @EnableAutoConfiguration
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
@@ -132,6 +179,92 @@ class InfraConfigurationTest {
                 rep.sorted();
                 return rep;
             });
+        }
+    }
+
+    static class EventHandlerOrderingContext {
+
+        @Bean
+        public CountDownLatch eventHandlerInvocations() {
+            return new CountDownLatch(3);
+        }
+
+        @Bean
+        public Set<String> handlingOutcome() {
+            return spy(new HashSet<>());
+        }
+
+        @Bean
+        @Order(100)
+        public LateEventHandler lateEventHandler(CountDownLatch eventHandlerInvocations, Set<String> handlingOutcome) {
+            return new LateEventHandler(eventHandlerInvocations, handlingOutcome);
+        }
+
+        @Bean
+        @Order(0)
+        public EarlyEventHandler earlyEventHandler(CountDownLatch eventHandlerInvocations,
+                                                   Set<String> handlingOutcome) {
+            return new EarlyEventHandler(eventHandlerInvocations, handlingOutcome);
+        }
+
+        @Bean
+        public UnorderedEventHandler unorderedEventHandler(CountDownLatch eventHandlerInvocations,
+                                                           Set<String> handlingOutcome) {
+            return new UnorderedEventHandler(eventHandlerInvocations, handlingOutcome);
+        }
+
+        @ProcessingGroup("test")
+        static class UnorderedEventHandler {
+
+            private final CountDownLatch invocation;
+            private final Set<String> handlingOutcome;
+
+            public UnorderedEventHandler(CountDownLatch invocation, Set<String> handlingOutcome) {
+                this.invocation = invocation;
+                this.handlingOutcome = handlingOutcome;
+            }
+
+            @EventHandler
+            public void on(String event) {
+                handlingOutcome.add("unordered-[" + event + "]");
+                invocation.countDown();
+            }
+        }
+
+        @ProcessingGroup("test")
+        static class EarlyEventHandler {
+
+            private final CountDownLatch invocation;
+            private final Set<String> handlingOutcome;
+
+            public EarlyEventHandler(CountDownLatch invocation, Set<String> handlingOutcome) {
+                this.invocation = invocation;
+                this.handlingOutcome = handlingOutcome;
+            }
+
+            @EventHandler
+            public void on(String event) {
+                handlingOutcome.add("early-[" + event + "]");
+                invocation.countDown();
+            }
+        }
+
+        @ProcessingGroup("test")
+        static class LateEventHandler {
+
+            private final CountDownLatch invocation;
+            private final Set<String> handlingOutcome;
+
+            public LateEventHandler(CountDownLatch invocation, Set<String> handlingOutcome) {
+                this.invocation = invocation;
+                this.handlingOutcome = handlingOutcome;
+            }
+
+            @EventHandler
+            public void on(String event) {
+                handlingOutcome.add("late-[" + event + "]");
+                invocation.countDown();
+            }
         }
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import com.thoughtworks.xstream.XStream;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingModule;
 import org.axonframework.config.ProcessingGroup;
@@ -28,6 +29,7 @@ import org.axonframework.spring.config.SpringAggregateLookup;
 import org.axonframework.spring.config.SpringAxonConfiguration;
 import org.axonframework.spring.config.SpringConfigurer;
 import org.axonframework.spring.config.SpringSagaLookup;
+import org.axonframework.springboot.utils.TestSerializer;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -156,6 +158,10 @@ class InfraConfigurationTest {
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
     static class DefaultContext {
 
+        @Bean
+        public XStream xStream() {
+            return TestSerializer.xStreamSerializer().getXStream();
+        }
     }
 
     // We're not returning the result of invoking the stream operations as a simplification for adjusting the mock.

--- a/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.annotation.OrderUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -144,9 +145,9 @@ public class MessageHandlerLookup implements BeanDefinitionRegistryPostProcessor
         return found.stream()
                     .collect(Collectors.toMap(
                             beanRef -> beanRef,
-                            beanRef -> ObjectUtils.getOrDefault(
-                                    beanFactory.findAnnotationOnBean(beanRef, Order.class),
-                                    Order::value, Ordered.LOWEST_PRECEDENCE
+                            beanRef -> OrderUtils.getOrder(
+                                    ObjectUtils.getOrDefault(beanFactory.getType(beanRef), Object.class),
+                                    Ordered.LOWEST_PRECEDENCE
                             )
                     ))
                     .entrySet()

--- a/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.spring.config;
 
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.Message;
@@ -29,18 +30,21 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 /**
  * A {@link BeanDefinitionRegistryPostProcessor} implementation that detects beans with Axon Message handlers and
- * registers an {@link MessageHandlerConfigurer} to have these handlers registered in the Axon {@link
- * org.axonframework.config.Configuration}.
+ * registers an {@link MessageHandlerConfigurer} to have these handlers registered in the Axon
+ * {@link org.axonframework.config.Configuration}.
  *
  * @author Allard Buijze
  * @since 4.6.0
@@ -50,8 +54,8 @@ public class MessageHandlerLookup implements BeanDefinitionRegistryPostProcessor
     private static final Logger logger = LoggerFactory.getLogger(MessageHandlerLookup.class);
 
     /**
-     * Returns a list of beans found in the given {@code register} that contain a handler for the given {@code
-     * messageType}. The search will not consider prototype beans (or any other non-singleton or abstract bean
+     * Returns a list of beans found in the given {@code register} that contain a handler for the given
+     * {@code messageType}. The search will not consider prototype beans (or any other non-singleton or abstract bean
      * definitions).
      *
      * @param messageType The type of message to find handlers for.
@@ -64,8 +68,8 @@ public class MessageHandlerLookup implements BeanDefinitionRegistryPostProcessor
     }
 
     /**
-     * Returns a list of beans found in the given {@code register} that contain a handler for the given {@code
-     * messageType}. The search will only consider prototype beans (or any other non-singleton or abstract bean
+     * Returns a list of beans found in the given {@code register} that contain a handler for the given
+     * {@code messageType}. The search will only consider prototype beans (or any other non-singleton or abstract bean
      * definitions) when {@code includePrototypeBeans} is {@code true}.
      *
      * @param messageType The type of message to find handlers for.
@@ -114,15 +118,42 @@ public class MessageHandlerLookup implements BeanDefinitionRegistryPostProcessor
 
             List<String> found = messageHandlerBeans(value.getMessageType(), beanFactory);
             if (!found.isEmpty()) {
+                List<String> sortedFound = sortByOrder(found, beanFactory);
                 AbstractBeanDefinition beanDefinition =
                         BeanDefinitionBuilder.genericBeanDefinition(MessageHandlerConfigurer.class)
                                              .addConstructorArgValue(value.name())
-                                             .addConstructorArgValue(found)
+                                             .addConstructorArgValue(sortedFound)
                                              .getBeanDefinition();
-
                 ((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(configurerBeanName, beanDefinition);
             }
         }
+    }
+
+    /**
+     * Sorts the given {@code found} bean references based on the value in the {@link Order} annotation on these beans.
+     * <p>
+     * This method uses the given {@code beanFactory} to find the value of the {@code Order} annotation. In absence of
+     * this annotation, the order defaults to {@link Ordered#LOWEST_PRECEDENCE}.
+     *
+     * @param found       The bean references of components containing message handling functions.
+     * @param beanFactory The bean factory used to find the {@link Order} annotation value.
+     * @return A new {@link List} of sorted bean references, according to the value of the {@link Order} annotation
+     * value on the beans.
+     */
+    private List<String> sortByOrder(List<String> found, @Nonnull ConfigurableListableBeanFactory beanFactory) {
+        return found.stream()
+                    .collect(Collectors.toMap(
+                            beanRef -> beanRef,
+                            beanRef -> ObjectUtils.getOrDefault(
+                                    beanFactory.findAnnotationOnBean(beanRef, Order.class),
+                                    Order::value, Ordered.LOWEST_PRECEDENCE
+                            )
+                    ))
+                    .entrySet()
+                    .stream()
+                    .sorted(java.util.Map.Entry.comparingByValue())
+                    .map(java.util.Map.Entry::getKey)
+                    .collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Message Handling Components should adhere to the presence of the `@Order` annotation when in a Spring environment. 
This allows users to impose an ordering on their event handling classes within a given Event Processor.

With the Spring auto wiring changes introduced in 4.6.0, the support around this got lost.
This pull request introduces a similar behavior as present in the (deprecated) `SpringAxonAutoConfigurer` for upcaster beans.

This solution uses an implementation of the `ListableBeanFactory` to check for the existence of the `@Order` annotation.
If present, the value is retrieved. 
Otherwise, we default to `Ordered.LOWEST_PRECEDENCE` to sort the bean on.
We then use these values to sort the bean references in the `MessageHandlerLookup` class, before they're given to the constructor of the `MessageHandlerConfigurer`.

The test case for the desired behavior is added to the `InfraConfigurationTest` class, since this component constructs the `MessageHandlerLookup`.
On top of that, we provide a form of integration test that starts the Application Context.

In doing the above, this pull request resolves #2449.