### PR TITLE
Ensure lifecycle handlers for components declared as Spring beans are invoked

### DIFF
--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -44,10 +44,10 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 import org.axonframework.tracing.SpanFactory;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 /**
  * Interface describing the Global Configuration for Axon components. It provides access to the components configured,

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.HandlerDefinition;
@@ -69,6 +70,25 @@ public interface Configuration extends LifecycleOperations {
         return getComponent(EventBus.class);
     }
 
+    /**
+     * Returns the lifecycle registry for this configuration. Typically, this is just an adapter around the
+     * configuration itself to register individual handler methods.
+     *
+     * @return the lifecycle registry for this configuration
+     */
+    default Lifecycle.LifecycleRegistry lifecycleRegistry() {
+        return new Lifecycle.LifecycleRegistry() {
+            @Override
+            public void onStart(int phase, @Nonnull Lifecycle.LifecycleHandler action) {
+                Configuration.this.onStart(phase, action::run);
+            }
+
+            @Override
+            public void onShutdown(int phase, @Nonnull Lifecycle.LifecycleHandler action) {
+                Configuration.this.onShutdown(phase, action::run);
+            }
+        };
+    }
     /**
      * Returns the Event Store in this Configuration, if it is defined. If no Event Store is defined (but an Event Bus
      * instead), this method throws an {@link AxonConfigurationException}.

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
@@ -19,6 +19,7 @@ package org.axonframework.springboot.autoconfig;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.ModuleConfiguration;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
@@ -33,6 +34,7 @@ import org.axonframework.spring.config.SpringSagaLookup;
 import org.axonframework.spring.config.annotation.HandlerDefinitionFactoryBean;
 import org.axonframework.spring.config.annotation.SpringParameterResolverFactoryBean;
 import org.axonframework.spring.saga.SpringResourceInjector;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -94,6 +96,12 @@ public class InfraConfiguration {
         moduleConfigurations.forEach(configurer::registerModule);
         configurerModules.forEach(c -> c.configureModule(configurer));
         return configurer;
+    }
+
+    @Bean
+    public InitializingBean lifecycleInitializer(Configurer configurer,
+                                                 List<Lifecycle> lifecycleBeans) {
+        return () -> configurer.onInitialize(configuration -> lifecycleBeans.forEach(bean -> bean.registerLifecycleHandlers(configuration.lifecycleRegistry())));
     }
 
     @Primary

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -37,6 +37,7 @@ import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.messaging.annotation.FixedValueParameterResolver;
 import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
 import org.axonframework.messaging.annotation.ParameterResolver;
@@ -138,6 +139,17 @@ class AxonAutoConfigurationTest {
 
     }
 
+    @Test
+    void beansImplementingLifecycleHaveTheirHandlersRegistered() {
+        ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean("lifecycletest", CustomLifecycleBean.class, CustomLifecycleBean::new)
+                .withPropertyValues("axon.axonserver.enabled=false");
+
+        applicationContextRunner.run(context -> {
+            assertTrue(context.getBean("lifecycletest", CustomLifecycleBean.class).isInvoked());
+        });
+    }
     @Test
     void ambiguousPrimaryComponentsThrowExceptionWhenRequestedFromConfiguration() {
         ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
@@ -285,5 +297,18 @@ class AxonAutoConfigurationTest {
 
     public static class CustomResource {
 
+    }
+
+    private class CustomLifecycleBean implements Lifecycle {
+        private boolean invoked;
+
+        @Override
+        public void registerLifecycleHandlers(LifecycleRegistry lifecycle) {
+            this.invoked = true;
+        }
+
+        public boolean isInvoked() {
+            return invoked;
+        }
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -53,7 +53,7 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
 import org.axonframework.tracing.SpanFactory;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -72,7 +72,11 @@ import java.util.List;
 
 import static java.util.Collections.singleton;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AxonAutoConfigurationTest {
 
@@ -150,6 +154,7 @@ class AxonAutoConfigurationTest {
             assertTrue(context.getBean("lifecycletest", CustomLifecycleBean.class).isInvoked());
         });
     }
+
     @Test
     void ambiguousPrimaryComponentsThrowExceptionWhenRequestedFromConfiguration() {
         ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()


### PR DESCRIPTION
This PR ensures that Axon components declared as Spring beans will have their lifecycle handlers invoked if they implement the Lifecycle interface.

Resolves #2473 