### PR TITLE
Fix typos in Javadoc

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
@@ -83,7 +83,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
     /**
      * Instantiates a query processing task.
      *
-     * @param localSegment    Local instance of {@link QueryBus} used to actually execute the query withing this
+     * @param localSegment    Local instance of {@link QueryBus} used to actually execute the query within this
      *                        application instance.
      * @param queryRequest    The request received from Axon Server.
      * @param responseHandler The {@link ReplyChannel} used for sending items to the Axon Server.
@@ -109,7 +109,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
     /**
      * Instantiates a query processing task.
      *
-     * @param localSegment       Local instance of {@link QueryBus} used to actually execute the query withing this
+     * @param localSegment       Local instance of {@link QueryBus} used to actually execute the query within this
      *                           application instance.
      * @param queryRequest       The request received from Axon Server.
      * @param responseHandler    The {@link ReplyChannel} used for sending items to the Axon Server.

--- a/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
@@ -74,7 +74,7 @@ public interface EventProcessingConfigurer {
      *
      * @param <T>            The type of Saga to configure
      * @param sagaType       The type of Saga to configure
-     * @param sagaConfigurer a function providing modifications on top of the defaul configuration
+     * @param sagaConfigurer a function providing modifications on top of the default configuration
      * @return the current {@link EventProcessingConfigurer} instance, for fluent interfacing
      */
     <T> EventProcessingConfigurer registerSaga(Class<T> sagaType, Consumer<SagaConfigurer<T>> sagaConfigurer);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateSnapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateSnapshotter.java
@@ -131,7 +131,7 @@ public class AggregateSnapshotter extends AbstractSnapshotter {
      * Returns the AggregateFactory registered for the given {@code aggregateType}, or {@code null} if no such
      * AggregateFactory is known.
      * <p>
-     * Sublasses may override this method to enhance how AggregateFactories are retrieved. They may choose to
+     * Subclasses may override this method to enhance how AggregateFactories are retrieved. They may choose to
      * {@link #registerAggregateFactory(AggregateFactory)} if it hasn't been found using this implementation.
      *
      * @param aggregateType The type to get the AggregateFactory for

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/PostgresEventTableFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/PostgresEventTableFactory.java
@@ -17,7 +17,7 @@
 package org.axonframework.eventsourcing.eventstore.jdbc;
 
 /**
- * Jdbc table factory for Postgress databases.
+ * Jdbc table factory for Postgresql databases.
  *
  * @author Rene de Waele
  * @since 3.0

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
@@ -55,9 +55,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p/>
  * Committing a unit of work may result in additional units of work being created -- typically as part of the 'publish
  * event' phase: <ol> <li>A Command is dispatched. <li>A UOW is created, started. <li>The command completes.
- * Aggregate(s) have been loaded and events have been applied. <li>The UOW is comitted: <ol> <li>The aggregate is
+ * Aggregate(s) have been loaded and events have been applied. <li>The UOW is committed: <ol> <li>The aggregate is
  * saved.
- * <li>Events are published on the event bus. <li>Inner UOWs are comitted. <li>AfterCommit listeners are notified.
+ * <li>Events are published on the event bus. <li>Inner UOWs are committed. <li>AfterCommit listeners are notified.
  * </ol>
  * </ol>
  * <p/>

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/ReplyMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/ReplyMessage.java
@@ -80,7 +80,7 @@ public abstract class ReplyMessage implements Serializable {
     }
 
     /**
-     * Returns a {@link CommandResultMessage} containg the result of command processing.
+     * Returns a {@link CommandResultMessage} containing the result of command processing.
      *
      * @param serializer the serializer to deserialize the result with
      * @return a {@link CommandResultMessage} containing the return value of command processing

--- a/messaging/src/main/java/org/axonframework/common/CollectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/CollectionUtils.java
@@ -111,7 +111,7 @@ public abstract class CollectionUtils {
      * @param collection1       The first collection
      * @param collection2       The second collection
      * @param collectionBuilder The factory for the returned collection instance
-     * @param <T>               The type of element contained in the resuling collection
+     * @param <T>               The type of element contained in the resulting collection
      * @param <C>               The type of collection to return
      * @return a collection containing the elements that were found in both given collections
      */

--- a/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
+++ b/messaging/src/main/java/org/axonframework/common/lock/PessimisticLockFactory.java
@@ -210,7 +210,7 @@ public class PessimisticLockFactory implements LockFactory {
          * <p>
          * Defaults to 10ms.
          *
-         * @param lockAttemptTimeout The duration of a single aqcuisition attempt of the internal lock, in milliseconds
+         * @param lockAttemptTimeout The duration of a single acquisition attempt of the internal lock, in milliseconds
          *
          * @return this Builder, for further configuration
          */

--- a/messaging/src/main/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactory.java
@@ -23,7 +23,7 @@ import org.axonframework.messaging.unitofwork.BatchingUnitOfWork;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 
 /**
- * Paramater resolver factory for boolean event handler parameters annotated with {@link ConcludesBatch}. If the event
+ * Parameter resolver factory for boolean event handler parameters annotated with {@link ConcludesBatch}. If the event
  * is processed in the context of a {@link BatchingUnitOfWork} and is the last of the batch the resolver injects a
  * value of {@code true}. If the event is processed in another unit of work it is always assumed to be the last of a
  * batch.

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
@@ -467,7 +467,7 @@ public interface UnitOfWork<T extends Message<?>> {
          * case for phases where cleanup or post-error processing is done. Exceptions in those phases should not trigger
          * exceptions, but to a best-effort attempt to clean up.
          *
-         * @return {@code true} when errors should be suppressed, otherise {@code false}
+         * @return {@code true} when errors should be suppressed, otherwise {@code false}
          */
         public boolean isSuppressHandlerErrors() {
             return suppressHandlerErrors;

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -155,7 +155,7 @@ public interface TestExecutor<T> {
      * Note: As this method is added to the interface as a replacement for the deprecated
      * {@link #whenThenTimeAdvancesTo(Instant)} method, and in case there are other implementations by 3rd party
      * libraries, this method is changed to a default method that rely on the deprecated method so that there is no
-     * breaking changes in the API in case an external implementation of this interface. Nevertheless, the recomended
+     * breaking changes in the API in case an external implementation of this interface. Nevertheless, the recommended
      * approach is to override this implementation.
      *
      * @param elapsedTime a {@link Duration} specifying the amount of time that will elapse
@@ -202,7 +202,7 @@ public interface TestExecutor<T> {
      * Note: As this method is added to the interface as a replacement for the deprecated
      * {@link #whenThenTimeAdvancesTo(Instant)} method, and in case there are other implementations by 3rd party
      * libraries, this method is changed to a default method that rely on the deprecated method so that there is no
-     * breaking changes in the API in case an external implementation of this interface. Nevertheless, the recomended
+     * breaking changes in the API in case an external implementation of this interface. Nevertheless, the recommended
      * approach is to override this implementation.
      *
      * @param newPointInTime an {@link Instant} specifying the amount of time to advance the clock to


### PR DESCRIPTION
I found some typos in the Javadocs. These have been resolved in this PR.