### PR TITLE
[#2481] Check `MessageHandlerRegistrar` registration to be non-null

### DIFF
--- a/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
+++ b/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
@@ -19,7 +19,10 @@ package org.axonframework.config;
 import org.axonframework.common.Registration;
 import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -38,6 +41,8 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @since 4.3
  */
 public class MessageHandlerRegistrar implements Lifecycle {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Supplier<Configuration> configurationSupplier;
     private final Function<Configuration, Object> messageHandlerBuilder;
@@ -90,6 +95,10 @@ public class MessageHandlerRegistrar implements Lifecycle {
      * through the {@link #start()} method.
      */
     public void shutdown() {
+        if (handlerRegistration == null) {
+            logger.info("Shutting down a message handler registrar before it was started.");
+            return;
+        }
         handlerRegistration.cancel();
     }
 }

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -705,6 +705,17 @@ class DefaultConfigurerTest {
         verifyNoInteractions(testUpcasterChain);
     }
 
+    @Test
+    void shuttingDownTheConfigurationBeforeItStartedWithConfiguredMessageHandlersDoesNotCauseAnyExceptions() {
+        Configuration configuration = DefaultConfigurer.defaultConfiguration()
+                                                       .registerCommandHandler(c -> new Object())
+                                                       .registerEventHandler(c -> new Object())
+                                                       .registerQueryHandler(c -> new Object())
+                                                       .registerMessageHandler(c -> new Object())
+                                                       .buildConfiguration();
+        assertDoesNotThrow(configuration::shutdown);
+    }
+
     @SuppressWarnings("unused")
     @Entity(name = "StubAggregate")
     private static class StubAggregate {

--- a/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
+++ b/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
@@ -65,20 +65,6 @@ class MessageHandlerRegistrarTest {
         assertTrue(isRegistered.get());
     }
 
-    /**
-     * The thrown {@link NullPointerException} will always be wrapped in a {@link org.axonframework.lifecycle.LifecycleHandlerInvocationException}
-     * since the {@link MessageHandlerRegistrar#shutdown()} will be wrapped in a {@link LifecycleHandler}.
-     */
-    @Test
-    void shutdownThrowsNullPointerExceptionIfRegistrationDidNotHappen(@Mock Configuration config) {
-        MessageHandlerRegistrar testSubject = new MessageHandlerRegistrar(
-                () -> config, c -> new SomeMessageHandler(),
-                (c, msgHandler) -> TEST_REGISTRATION_IMPLEMENTATION
-        );
-
-        assertThrows(NullPointerException.class, testSubject::shutdown);
-    }
-
     @Test
     void shutdownCancelsMessageHandlerRegistration(@Mock Configuration config) {
         AtomicBoolean isCanceled = new AtomicBoolean(false);

--- a/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
+++ b/config/src/test/java/org/axonframework/config/MessageHandlerRegistrarTest.java
@@ -97,6 +97,23 @@ class MessageHandlerRegistrarTest {
         assertTrue(isCanceled.get());
     }
 
+    @Test
+    void shutdownDoesNotThrowExceptionsIfWhenTheRegistrarHasNotStartedYet(@Mock Configuration config) {
+        AtomicBoolean isCanceled = new AtomicBoolean(false);
+
+        MessageHandlerRegistrar testSubject = new MessageHandlerRegistrar(
+                () -> config,
+                c -> new SomeMessageHandler(),
+                (c, msgHandler) -> () -> {
+                    isCanceled.set(true);
+                    return false;
+                }
+        );
+
+        assertDoesNotThrow(testSubject::shutdown);
+        assertFalse(isCanceled.get());
+    }
+
     private static class SomeMessageHandler {
 
         private SomeMessageHandler() {


### PR DESCRIPTION
The `MessageHandlerRegistrar#shutdown` operation might cause a `NullPointerException` if it wasn't started yet.
Although the chances of this are slim, it does cause noise in the shutdown procedure of a `Configuration`.

As such, we should check whether the `handlerRegistration` is not null before invoking it.
If it's null, we can log the fact it was never started to begin with.

By doing so, we resolve #2481.