### PR TITLE
Allow usage of specific serializers for the JpaDLQ

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterJpaConverter.java
@@ -33,7 +33,7 @@ public interface DeadLetterJpaConverter<M extends EventMessage<?>> {
      *
      * @param message    The message to convert.
      * @param eventSerializer The {@link Serializer} for serialization of payload and metadata.
-     * @param genericSerializer The {@link Serializer} for serialization of the token.
+     * @param genericSerializer The {@link Serializer} for serialization of the token, if present.
      * @return The created {@link DeadLetterEventEntry}
      */
     DeadLetterEventEntry convert(M message, Serializer eventSerializer, Serializer genericSerializer);
@@ -43,7 +43,7 @@ public interface DeadLetterJpaConverter<M extends EventMessage<?>> {
      *
      * @param entry      The database entry to convert to a {@link EventMessage}
      * @param eventSerializer The {@link Serializer} for deserialization of payload and metadata.
-     * @param genericSerializer The {@link Serializer} for deserialization of the token.
+     * @param genericSerializer The {@link Serializer} for deserialization of the token, if present.
      * @return The created {@link DeadLetterEventEntry}
      */
     M convert(DeadLetterEventEntry entry, Serializer eventSerializer, Serializer genericSerializer);

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterJpaConverter.java
@@ -32,19 +32,21 @@ public interface DeadLetterJpaConverter<M extends EventMessage<?>> {
      * Converts an {@link EventMessage} implementation to a {@link DeadLetterEventEntry}.
      *
      * @param message    The message to convert.
-     * @param serializer The {@link Serializer} to use for serialization of payload and metadata.
+     * @param eventSerializer The {@link Serializer} for serialization of payload and metadata.
+     * @param genericSerializer The {@link Serializer} for serialization of the token.
      * @return The created {@link DeadLetterEventEntry}
      */
-    DeadLetterEventEntry convert(M message, Serializer serializer);
+    DeadLetterEventEntry convert(M message, Serializer eventSerializer, Serializer genericSerializer);
 
     /**
      * Converts a {@link DeadLetterEventEntry} to a {@link EventMessage} implementation.
      *
      * @param entry      The database entry to convert to a {@link EventMessage}
-     * @param serializer The {@link Serializer} to use for deserialization of payload and metadata.
+     * @param eventSerializer The {@link Serializer} for deserialization of payload and metadata.
+     * @param genericSerializer The {@link Serializer} for deserialization of the token.
      * @return The created {@link DeadLetterEventEntry}
      */
-    M convert(DeadLetterEventEntry entry, Serializer serializer);
+    M convert(DeadLetterEventEntry entry, Serializer eventSerializer, Serializer genericSerializer);
 
     /**
      * Check whether this converter supports the given {@link DeadLetterEventEntry}.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
@@ -86,7 +86,8 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
     private final int maxSequences;
     private final int maxSequenceSize;
     private final int queryPageSize;
-    private final Serializer serializer;
+    private final Serializer eventSerializer;
+    private final Serializer genericSerializer;
     private final Duration claimDuration;
 
     /**
@@ -101,7 +102,8 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
         this.maxSequenceSize = builder.maxSequenceSize;
         this.entityManagerProvider = builder.entityManagerProvider;
         this.transactionManager = builder.transactionManager;
-        this.serializer = builder.serializer;
+        this.eventSerializer = builder.eventSerializer;
+        this.genericSerializer = builder.genericSerializer;
         this.converters = builder.converters;
         this.claimDuration = builder.claimDuration;
         this.queryPageSize = builder.queryPageSize;
@@ -143,7 +145,7 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
                 .stream()
                 .filter(c -> c.canConvert(letter.message()))
                 .findFirst()
-                .map(c -> c.convert(letter.message(), serializer))
+                .map(c -> c.convert(letter.message(), eventSerializer, genericSerializer))
                 .orElseThrow(() -> new NoJpaConverterFoundException(
                         String.format("No converter found for message of type: [%s]",
                                       letter.message().getClass().getName()))
@@ -159,7 +161,7 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
                                                              letter.lastTouched(),
                                                              letter.cause().orElse(null),
                                                              letter.diagnostics(),
-                                                             serializer);
+                                                             eventSerializer);
             logger.info("Storing DeadLetter (id: [{}]) for sequence [{}] with index [{}] in processing group [{}].",
                         deadLetter.getDeadLetterId(),
                         stringSequenceIdentifier,
@@ -215,7 +217,7 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
         if (letterEntity == null) {
             throw new NoSuchDeadLetterException(String.format("Can not find dead letter with id [%s] to requeue.", id));
         }
-        letterEntity.setDiagnostics(updatedLetter.diagnostics(), serializer);
+        letterEntity.setDiagnostics(updatedLetter.diagnostics(), eventSerializer);
         letterEntity.setLastTouched(updatedLetter.lastTouched());
         letterEntity.setCause(updatedLetter.cause().orElse(null));
         letterEntity.clearProcessingStarted();
@@ -296,10 +298,10 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
                 .orElseThrow(() -> new NoJpaConverterFoundException(String.format(
                         "No converter found to convert message of class [%s].",
                         entry.getMessage().getMessageType())));
-        MetaData deserializedDiagnostics = serializer.deserialize(entry.getDiagnostics());
+        MetaData deserializedDiagnostics = eventSerializer.deserialize(entry.getDiagnostics());
         return new JpaDeadLetter<>(entry,
                                    deserializedDiagnostics,
-                                   converter.convert(entry.getMessage(), serializer));
+                                   converter.convert(entry.getMessage(), eventSerializer, genericSerializer));
     }
 
     @Override
@@ -600,7 +602,8 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
         private int queryPageSize = 100;
         private EntityManagerProvider entityManagerProvider;
         private TransactionManager transactionManager;
-        private Serializer serializer;
+        private Serializer eventSerializer;
+        private Serializer genericSerializer;
         private Duration claimDuration = Duration.ofSeconds(30);
 
         public Builder() {
@@ -682,15 +685,42 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
         }
 
         /**
-         * Sets the {@link Serializer} to deserialize the events, metadata and diagnostics of the {@link DeadLetter}
-         * when storing it to a database.
+         * Sets the {@link Serializer} to (de)serialize the event payload,
+         * event metadata, tracking token, and diagnostics of the {@link DeadLetter} when storing it to the database.
          *
          * @param serializer The serializer to use
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<T> serializer(Serializer serializer) {
             assertNonNull(serializer, "The serializer may not be null");
-            this.serializer = serializer;
+            this.eventSerializer = serializer;
+            this.genericSerializer = serializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} to (de)serialize the event payload,
+         * event metadata, and diagnostics of the {@link DeadLetter} when storing it to the database.
+         *
+         * @param serializer The serializer to use
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> eventSerializer(Serializer serializer) {
+            assertNonNull(serializer, "The eventSerializer may not be null");
+            this.eventSerializer = serializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} to (de)serialize the tracking token of the event in
+         * the {@link DeadLetter} when storing it to the database.
+         *
+         * @param serializer The serializer to use
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> genericSerializer(Serializer serializer) {
+            assertNonNull(serializer, "The genericSerializer may not be null");
+            this.genericSerializer = serializer;
             return this;
         }
 
@@ -769,8 +799,10 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
                           "Must supply a TransactionManager when constructing a JpaSequencedDeadLetterQueue");
             assertNonNull(entityManagerProvider,
                           "Must supply a EntityManagerProvider when constructing a JpaSequencedDeadLetterQueue");
-            assertNonNull(serializer,
-                          "Must supply a Serializer when constructing a JpaSequencedDeadLetterQueue");
+            assertNonNull(eventSerializer,
+                          "Must supply an eventSerializer when constructing a JpaSequencedDeadLetterQueue");
+            assertNonNull(genericSerializer,
+                          "Must supply an genericSerializer when constructing a JpaSequencedDeadLetterQueue");
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueueTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueueTest.java
@@ -139,7 +139,8 @@ class JpaSequencedDeadLetterQueueTest extends SequencedDeadLetterQueueTest<Event
                 .maxSequences(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
                 .maxSequenceSize(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
                 .processingGroup("my_processing_group")
-                .serializer(TestSerializer.JACKSON.getSerializer())
+                .eventSerializer(TestSerializer.JACKSON.getSerializer())
+                .genericSerializer(TestSerializer.XSTREAM.getSerializer())
                 .build();
     }
 


### PR DESCRIPTION
In some cases, differentiation is wanted when serializing a dead letter to the database. This PR allows users to configure an event serializer, and a generic serializer.

The event serializer is used for serialization of the event payload, event metadata, and diagnostics of the Dead letter.
The generic serialize is used for the serialization of the tracking token. 

The builder still has the `serializer()` method and I have decided not to deprecate it. In a lot of cases, setting one serializer for both types is enough.

Closing #2485 