### PR TITLE
Introduce the NestingSpanFactory

### DIFF
--- a/messaging/src/main/java/org/axonframework/tracing/NestingSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/NestingSpanFactory.java
@@ -25,6 +25,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 
 /**
  * Implementation of {@link SpanFactory} that wraps another factory and creates nested spans when handling messages
@@ -140,7 +141,7 @@ public class NestingSpanFactory implements SpanFactory {
          * @param spanFactory The {@link SpanFactory} to configure for use.
          * @return The current Builder instance, for fluent interfacing.
          */
-        public Builder delegate(SpanFactory spanFactory) {
+        public Builder delegate(@Nonnull SpanFactory spanFactory) {
             BuilderUtils.assertNonNull(spanFactory, "The spanFactory should not be null");
             this.delegateSpanFactory = spanFactory;
             return this;
@@ -155,7 +156,7 @@ public class NestingSpanFactory implements SpanFactory {
          * @param timeLimit The amount of time before handling of an event should be considered a separate trace.
          * @return The current Builder instance, for fluent interfacing.
          */
-        public Builder timeLimit(Duration timeLimit) {
+        public Builder timeLimit(@Nonnull Duration timeLimit) {
             BuilderUtils.assertNonNull(timeLimit, "The timeLimit should not be null");
             this.timeLimit = timeLimit;
             return this;
@@ -172,7 +173,7 @@ public class NestingSpanFactory implements SpanFactory {
          *              current time.
          * @return The current Builder instance, for fluent interfacing.
          */
-        public Builder clock(Clock clock) {
+        public Builder clock(@Nonnull Clock clock) {
             BuilderUtils.assertNonNull(clock, "The clock should not be null");
             this.clock = clock;
             return this;

--- a/messaging/src/main/java/org/axonframework/tracing/NestingSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/NestingSpanFactory.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Message;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of {@link SpanFactory} that wraps another factory and creates nested spans when handling messages
+ * instead of starting a new trace.
+ * <p>
+ * This factory includes a time limit (by default 2 minutes, but is configurable on the builder) that handling an event
+ * will become part of the dispatching trace. After this time limit it is considered its own trace. The time limit
+ * prevents replays of events from being added to the original trace, even after a longer period of time.
+ * The time limit only applies for events and does not affect commands and queries. These will always be part of the
+ * same trace.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6.3
+ */
+public class NestingSpanFactory implements SpanFactory {
+
+    private final SpanFactory delegateSpanFactory;
+    private final Duration timeLimit;
+    private final Clock clock;
+
+    /**
+     * Creates the {@link NestingSpanFactory} based on the {@link Builder} provided.
+     * @param builder The {@link Builder} to use during construction.
+     */
+    protected NestingSpanFactory(Builder builder) {
+        this.delegateSpanFactory = builder.delegateSpanFactory;
+        this.timeLimit = builder.timeLimit;
+        this.clock = builder.clock;
+    }
+
+    /**
+     * Creates a new {@link Builder} that can build a {@link NestingSpanFactory}.
+     * @return The {@link Builder} in charge of creating a {@link NestingSpanFactory}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Span createRootTrace(Supplier<String> operationNameSupplier) {
+        return delegateSpanFactory.createRootTrace(operationNameSupplier);
+    }
+
+    @Override
+    public Span createHandlerSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                  boolean isChildTrace, Message<?>... linkedParents) {
+        if (!isChildTrace && messageIsWithinTimeLimit(parentMessage)) {
+            return delegateSpanFactory.createHandlerSpan(operationNameSupplier, parentMessage, true, linkedParents);
+        }
+        return delegateSpanFactory.createHandlerSpan(operationNameSupplier, parentMessage, isChildTrace, linkedParents);
+    }
+
+    private boolean messageIsWithinTimeLimit(Message<?> parentMessage) {
+        if (!(parentMessage instanceof EventMessage)) {
+            return true;
+        }
+        Instant timestamp = ((EventMessage<?>) parentMessage).getTimestamp();
+        return clock.instant().isBefore(timestamp.plus(timeLimit));
+    }
+
+    @Override
+    public Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                   Message<?>... linkedSiblings) {
+        return delegateSpanFactory.createDispatchSpan(operationNameSupplier, parentMessage, linkedSiblings);
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier) {
+        return delegateSpanFactory.createInternalSpan(operationNameSupplier);
+    }
+
+    @Override
+    public Span createInternalSpan(Supplier<String> operationNameSupplier, Message<?> message) {
+        return delegateSpanFactory.createInternalSpan(operationNameSupplier, message);
+    }
+
+    @Override
+    public void registerSpanAttributeProvider(SpanAttributesProvider provider) {
+        delegateSpanFactory.registerSpanAttributeProvider(provider);
+    }
+
+    @Override
+    public <M extends Message<?>> M propagateContext(M message) {
+        return delegateSpanFactory.propagateContext(message);
+    }
+
+
+    /**
+     * Creates a builder that will create a {@link NestingSpanFactory}.
+     * <p>
+     * Requires the delegate {@link SpanFactory} to be configured.
+     * <p>
+     * The {@link Clock} defaults to the system utc time and the timeLimit {@link Duration} defaults to two minutes.
+     */
+    public static class Builder {
+
+        private SpanFactory delegateSpanFactory;
+        private Duration timeLimit = Duration.ofMinutes(2);
+        private Clock clock = Clock.systemUTC();
+
+        /**
+         * Defines the delegate {@link SpanFactory} to use, which actually provides the spans.
+         *
+         * @param spanFactory The {@link SpanFactory} to configure for use.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder delegate(SpanFactory spanFactory) {
+            BuilderUtils.assertNonNull(spanFactory, "The spanFactory should not be null");
+            this.delegateSpanFactory = spanFactory;
+            return this;
+        }
+
+        /**
+         * Configures the {@link Duration} since original publishing of an event during which it should be considered a
+         * nested span. After that duration, it will become its own separate trace.
+         *
+         * @param timeLimit The amount of time before handling of an event should be considered a separate trace.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder timeLimit(Duration timeLimit) {
+            BuilderUtils.assertNonNull(timeLimit, "The timeLimit should not be null");
+            this.timeLimit = timeLimit;
+            return this;
+        }
+
+        /**
+         * Configures the {@link Clock} to use when determining the time passed since publication of an event and the
+         * current time.
+         *
+         * @param clock The {@link Clock} to use when determining the time passed since publication of an event and the
+         *              current time.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder clock(Clock clock) {
+            BuilderUtils.assertNonNull(clock, "The clock should not be null");
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Executes the builder's configuration, creating the {@link NestingSpanFactory}.
+         *
+         * @return The span factory.
+         */
+        public NestingSpanFactory build() {
+            BuilderUtils.assertNonNull(delegateSpanFactory, "The delegateSpanFactory should be configured");
+            return new NestingSpanFactory(this);
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
@@ -41,7 +41,7 @@ class NestingSpanFactoryTest {
                                                                      .delegate(delegate)
                                                                      .build();
     private final Supplier<String> nameSupplier = () -> "spanName";
-    EventMessage<Object> message = GenericEventMessage.asEventMessage("payload");
+    private final EventMessage<Object> message = GenericEventMessage.asEventMessage("payload");
 
     @BeforeEach
     void setUp() {
@@ -50,7 +50,6 @@ class NestingSpanFactoryTest {
 
     @Test
     void createsNestedSpanIfRecentMessage() {
-
         spanFactory.createLinkedHandlerSpan(nameSupplier, message);
 
         verify(delegate).createHandlerSpan(nameSupplier, message, true);

--- a/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.Message;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class NestingSpanFactoryTest {
+
+    private final Clock clock = Mockito.spy(Clock.class);
+    private final SpanFactory delegate = Mockito.mock(SpanFactory.class);
+    private final Span mockSpan = Mockito.mock(Span.class);
+    private final NestingSpanFactory spanFactory = NestingSpanFactory.builder()
+                                                                     .clock(clock)
+                                                                     .delegate(delegate)
+                                                                     .build();
+    private final Supplier<String> nameSupplier = () -> "spanName";
+    EventMessage<Object> message = GenericEventMessage.asEventMessage("payload");
+
+    @BeforeEach
+    void setUp() {
+        when(clock.instant()).thenReturn(Instant.now());
+    }
+
+    @Test
+    void createsNestedSpanIfRecentMessage() {
+
+        spanFactory.createLinkedHandlerSpan(nameSupplier, message);
+
+        verify(delegate).createHandlerSpan(nameSupplier, message, true);
+    }
+
+    @Test
+    void createsLinkedSpanIfOldMessage() {
+        EventMessage<Object> payload = GenericEventMessage.asEventMessage("payload");
+        when(clock.instant()).thenReturn(Instant.now().plusSeconds(121));
+
+        Supplier<String> nameSupplier = () -> "spanName";
+        spanFactory.createLinkedHandlerSpan(nameSupplier, payload);
+
+        verify(delegate).createHandlerSpan(nameSupplier, payload, false);
+    }
+
+    @Test
+    void rootTracesCreatedWillDelegate() {
+        when(delegate.createRootTrace(any())).thenReturn(mockSpan);
+
+        spanFactory.createRootTrace(nameSupplier);
+        verify(delegate).createRootTrace(nameSupplier);
+    }
+
+    @Test
+    void dispatchSpansCreatedWillDelegate() {
+        spanFactory.createDispatchSpan(nameSupplier, message);
+
+        Mockito.verify(delegate).createDispatchSpan(nameSupplier, message);
+    }
+
+    @Test
+    void internalSpansCreatedWillDelegate() {
+        spanFactory.createInternalSpan(nameSupplier);
+
+        Mockito.verify(delegate).createInternalSpan(nameSupplier);
+    }
+
+    @Test
+    void internalSpansWithMessageCreatedWillDelegate() {
+        spanFactory.createInternalSpan(nameSupplier, message);
+
+        Mockito.verify(delegate).createInternalSpan(nameSupplier, message);
+    }
+
+    @Test
+    void registerSpanAttributeProviderWillDelegate() {
+        SpanAttributesProvider provider = mock(SpanAttributesProvider.class);
+        spanFactory.registerSpanAttributeProvider(provider);
+
+        Mockito.verify(delegate).registerSpanAttributeProvider(provider);
+    }
+
+    @Test
+    void propagateContextDelegate() {
+        Message original = mock(Message.class);
+        Message modified = mock(Message.class);
+
+        when(delegate.propagateContext(original)).thenReturn(modified);
+
+        Message result = spanFactory.propagateContext(original);
+        assertSame(result, modified);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/NestingSpanFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.tracing;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.*;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Supplier;
 
@@ -111,5 +113,39 @@ class NestingSpanFactoryTest {
 
         Message result = spanFactory.propagateContext(original);
         assertSame(result, modified);
+    }
+
+    @Test
+    void builderThrowsExceptionWhenNoDelegateIsDefined() {
+        NestingSpanFactory.Builder builder = NestingSpanFactory.builder()
+                                                               .clock(clock)
+                                                               .timeLimit(Duration.ZERO);
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.build();
+        });
+    }
+
+    @Test
+    void builderThrowsExceptionWhenNullDelegateIsSet() {
+        NestingSpanFactory.Builder builder = NestingSpanFactory.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.delegate(null);
+        });
+    }
+
+    @Test
+    void builderThrowsExceptionWhenNullTimeLimitIsSet() {
+        NestingSpanFactory.Builder builder = NestingSpanFactory.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.timeLimit(null);
+        });
+    }
+
+    @Test
+    void builderThrowsExceptionWhenNullClockIsSet() {
+        NestingSpanFactory.Builder builder = NestingSpanFactory.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.clock(null);
+        });
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
@@ -18,6 +18,8 @@ package org.axonframework.springboot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * Properties describing the settings for tracing.
  *
@@ -32,6 +34,17 @@ public class TracingProperties {
      * loaded without a snapshot in place. Use with care.
      */
     private boolean showEventSourcingHandlers = false;
+
+    /**
+     * Whether to nest spans of subsequent in the same trace. This setting is disabled by default.
+     */
+    private boolean nestedHandlers = false;
+
+    /**
+     * How old an event is allowed to be when nesting a span inside the dispatching trace. Will link spans together when
+     * this time expires.
+     */
+    private Duration nestedTimeLimit = Duration.ofMinutes(2);
 
     /**
      * Defines which {@link org.axonframework.tracing.SpanAttributesProvider SpanAttributesProviders}, provided by
@@ -55,6 +68,43 @@ public class TracingProperties {
      */
     public void setShowEventSourcingHandlers(boolean showEventSourcingHandlers) {
         this.showEventSourcingHandlers = showEventSourcingHandlers;
+    }
+
+    /**
+     * Getting value for nesting handlers in dispatching traces.
+     *
+     * @return Whether handlers should be nested in dispatching traces
+     */
+    public boolean isNestedHandlers() {
+        return nestedHandlers;
+    }
+
+    /**
+     * Setting value for nesting handlers in dispatching traces.
+     *
+     * @param nestedHandlers The new value for nesting handlers in dispatching trace.
+     */
+    public void setNestedHandlers(boolean nestedHandlers) {
+        this.nestedHandlers = nestedHandlers;
+    }
+
+
+    /**
+     * Getting value for the time limit set on nested handlers inside dispatching trace. Only affects events. Commands
+     * and queries are always nested.
+     *
+     * @return For how long event messages should be nested in their dispatching trace.
+     */
+    public Duration getNestedTimeLimit() {
+        return nestedTimeLimit;
+    }
+
+    /**
+     * Sets the value for the time limit set on nested handlers inside dispatching trace. Only affects events. Commands
+     * and queries are always nested.
+     */
+    public void setNestedTimeLimit(Duration nestedTimeLimit) {
+        this.nestedTimeLimit = nestedTimeLimit;
     }
 
     /**

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
@@ -41,8 +41,9 @@ public class TracingProperties {
     private boolean nestedHandlers = false;
 
     /**
-     * How old an event is allowed to be when nesting a span inside the dispatching trace. Will link spans together when
-     * this time expires.
+     * How old a message is allowed to be when nesting a span inside the dispatching trace.
+     * Only affects events and deadlines.
+     * After the time limit, the handling spans become their own root trace, per default behavior.
      */
     private Duration nestedTimeLimit = Duration.ofMinutes(2);
 
@@ -88,10 +89,9 @@ public class TracingProperties {
         this.nestedHandlers = nestedHandlers;
     }
 
-
     /**
-     * Getting value for the time limit set on nested handlers inside dispatching trace. Only affects events. Commands
-     * and queries are always nested.
+     * The time limit set on nested handlers inside dispatching trace.
+     * Only affects events and deadlines, other messages are always nested.
      *
      * @return For how long event messages should be nested in their dispatching trace.
      */

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/OpenTelemetryAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import org.axonframework.springboot.TracingProperties;
+import org.axonframework.tracing.NestingSpanFactory;
 import org.axonframework.tracing.SpanFactory;
 import org.axonframework.tracing.opentelemetry.OpenTelemetrySpanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -38,8 +40,16 @@ public class OpenTelemetryAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SpanFactory.class)
-    public SpanFactory spanFactory() {
-        return OpenTelemetrySpanFactory.builder()
-                                       .build();
+    public SpanFactory spanFactory(TracingProperties properties) {
+
+        OpenTelemetrySpanFactory spanFactory = OpenTelemetrySpanFactory.builder()
+                                                                       .build();
+        if (properties.isNestedHandlers()) {
+            return NestingSpanFactory.builder()
+                                     .delegate(spanFactory)
+                                     .timeLimit(properties.getNestedTimeLimit())
+                                     .build();
+        }
+        return spanFactory;
     }
 }


### PR DESCRIPTION
Allows handler traces to be child traces of their dispatching trace within a certain time limit.

Can be configured using properties in Spring boot:
```properties
axon.tracing.nested-handlers=true
axon.tracing.nested-time-limit=3m
```

Default to a time limit of two minutes. Within this time limit messages will become part of the dispatching span. After this time, they will become their own span.  This prevents replays from adding activity to ancient spans. 