### PR TITLE
Roll back slf4j to major version 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
         <!-- dependency versions -->
 
-        <slf4j.version>2.0.3</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.18.0</log4j.version>
         <spring.version>5.3.24</spring.version>
         <spring-security.version>5.7.3</spring-security.version>


### PR DESCRIPTION
During 4.6 we upgraded `slf4j-api` to `2.x`. However, in many situations, this does not work since Spring Boot still includes `1.x`. This PR rolls back this change. 
