### PR TITLE
Added parameter resolver for aggregate type retrieval from domain event messages

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AggregateType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AggregateType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation indication that a parameter on a Message Handler method should be injected with the
+ * {@link org.axonframework.eventhandling.DomainEventMessage#getType() aggregate type} of a
+ * {@link org.axonframework.eventhandling.DomainEventMessage}. The parameter type must be assignable
+ * from {@link String}.
+ *
+ * @author Frank Scheffler
+ * @since 4.7.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface AggregateType {
+}

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.common.Priority;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.messaging.Message;
+
+/**
+ * An extension of the AbstractAnnotatedParameterResolverFactory that accepts parameters of a {@link String} type that
+ * are annotated with the {@link AggregateType} annotation and assigns the aggregate type of the
+ * {@link org.axonframework.eventhandling.DomainEventMessage}.
+ *
+ * @author Frank Scheffler
+ * @since 4.7.0
+ */
+@Priority(Priority.HIGH)
+public final class AggregateTypeParameterResolverFactory
+        extends AbstractAnnotatedParameterResolverFactory<AggregateType, String> {
+
+    private final ParameterResolver<String> resolver;
+
+    /**
+     * Initialize a {@link ParameterResolverFactory} for {@link MessageIdentifier} annotated parameters.
+     */
+    public AggregateTypeParameterResolverFactory() {
+        super(AggregateType.class, String.class);
+        resolver = new AggregateTypeParameterResolver();
+    }
+
+    @Override
+    protected ParameterResolver<String> getResolver() {
+        return resolver;
+    }
+
+    /**
+     * ParameterResolver to resolve {@link AggregateType} parameters
+     */
+    static class AggregateTypeParameterResolver implements ParameterResolver<String> {
+
+        @Override
+        public String resolveParameterValue(Message message) {
+            return ((DomainEventMessage) message).getType();
+        }
+
+        @Override
+        public boolean matches(Message message) {
+            return message instanceof DomainEventMessage;
+        }
+    }
+}

--- a/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
+++ b/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
@@ -27,3 +27,4 @@ org.axonframework.messaging.annotation.MessageIdentifierParameterResolverFactory
 org.axonframework.messaging.annotation.SourceIdParameterResolverFactory
 org.axonframework.messaging.annotation.ResultParameterResolverFactory
 org.axonframework.messaging.annotation.ScopeDescriptorParameterResolverFactory
+org.axonframework.messaging.annotation.AggregateTypeParameterResolverFactory

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AggregateTypeParameterResolverFactoryTest {
+
+    private AggregateTypeParameterResolverFactory testSubject;
+
+    private Method aggregateTypeMethod;
+    private Method nonAnnotatedMethod;
+    private Method integerMethod;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testSubject = new AggregateTypeParameterResolverFactory();
+
+        aggregateTypeMethod = getClass().getMethod("someAggregateTypeMethod", String.class);
+        nonAnnotatedMethod = getClass().getMethod("someNonAnnotatedMethod", String.class);
+        integerMethod = getClass().getMethod("someIntegerMethod", Integer.class);
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void someAggregateTypeMethod(@AggregateType String aggregateType) {
+        //Used in setUp()
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void someNonAnnotatedMethod(String aggregateType) {
+        //Used in setUp()
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void someIntegerMethod(@AggregateType Integer messageIdentifier) {
+        //Used in setUp()
+    }
+
+    @Test
+    void resolvesToAggregateTypeWhenAnnotatedForDomainEventMessage() {
+        ParameterResolver<String> resolver =
+                testSubject.createInstance(aggregateTypeMethod, aggregateTypeMethod.getParameters(), 0);
+        final DomainEventMessage<Object> eventMessage = new GenericDomainEventMessage("aggregateType", "id", 0L, "payload");
+        assertTrue(resolver.matches(eventMessage));
+        assertEquals(eventMessage.getType(), resolver.resolveParameterValue(eventMessage));
+    }
+
+    @Test
+    void ignoredForNonDomainEventMessage() {
+        ParameterResolver<String> resolver =
+                testSubject.createInstance(aggregateTypeMethod, aggregateTypeMethod.getParameters(), 0);
+        EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        assertFalse(resolver.matches(eventMessage));
+    }
+
+    @Test
+    void ignoredWhenNotAnnotated() {
+        ParameterResolver<String> resolver =
+                testSubject.createInstance(nonAnnotatedMethod, nonAnnotatedMethod.getParameters(), 0);
+        assertNull(resolver);
+    }
+
+    @Test
+    void ignoredWhenWrongType() {
+        ParameterResolver<String> resolver =
+                testSubject.createInstance(integerMethod, integerMethod.getParameters(), 0);
+        assertNull(resolver);
+    }
+}


### PR DESCRIPTION
@smcvb not sure if this is the proper process, but we found this parameter resolver very useful in our projects. The aggregate type may be needed, if you use aggregate polymorphism, where events are potentially shared across different types. This information might be useful for event handlers, i.e. knowing the originating aggregate type.