### PR TITLE
Implement the JobRunr implementation of the event scheduler.

### DIFF
--- a/messaging-jakarta/pom.xml
+++ b/messaging-jakarta/pom.xml
@@ -229,6 +229,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -223,6 +223,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>

--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
@@ -119,7 +119,9 @@ public class JobRunrDeadlineManager extends AbstractDeadlineManager {
                                                                 deadlineScope,
                                                                 interceptedDeadlineMessage,
                                                                 serializer);
-            jobScheduler.<JobRunrDeadlineManager>schedule(deadlineId, triggerDateTime, x -> x.execute(deadlineDetails));
+            jobScheduler.<JobRunrDeadlineManager>schedule(deadlineId,
+                                                          triggerDateTime,
+                                                          deadlineManager -> deadlineManager.execute(deadlineDetails));
         }));
         return deadlineId.toString();
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.scheduling.jobrunr;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.scheduling.EventScheduler;
+import org.axonframework.eventhandling.scheduling.ScheduleToken;
+import org.axonframework.eventhandling.scheduling.SchedulingException;
+import org.axonframework.lifecycle.Lifecycle;
+import org.axonframework.lifecycle.Phase;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.jobrunr.scheduling.JobScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+
+/**
+ * EventScheduler implementation that delegates scheduling and triggering to a JobRunr JobScheduler.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class JobRunrEventScheduler implements EventScheduler, Lifecycle {
+
+    private static final Logger logger = LoggerFactory.getLogger(JobRunrEventScheduler.class);
+    private final JobScheduler jobScheduler;
+    private final Serializer serializer;
+    private final TransactionManager transactionManager;
+    private final EventBus eventBus;
+
+    /**
+     * Instantiate a {@link JobRunrEventScheduler} based on the fields contained in the
+     * {@link JobRunrEventScheduler.Builder}.
+     * <p>
+     * Will assert that the {@link JobScheduler}, {@link Serializer} and {@link EventBus} are not {@code null}, and will
+     * throw an {@link AxonConfigurationException} if any of them is {@code null}.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link JobRunrEventScheduler} instance
+     */
+    protected JobRunrEventScheduler(Builder builder) {
+        builder.validate();
+        jobScheduler = builder.jobScheduler;
+        serializer = builder.serializer;
+        transactionManager = builder.transactionManager;
+        eventBus = builder.eventBus;
+    }
+
+    /**
+     * Instantiate a Builder to be able to create a {@link JobRunrEventScheduler}.
+     * <p>
+     * The {@link TransactionManager} is defaulted to a {@link NoTransactionManager}.
+     * <p>
+     * The {@link JobScheduler}, {@link Serializer} and {@link EventBus} are <b>hard requirements</b> and as such should
+     * be provided.
+     *
+     * @return a Builder to be able to create a {@link JobRunrEventScheduler}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public ScheduleToken schedule(Instant triggerDateTime, Object event) {
+        UUID jobIdentifier = UUID.randomUUID();
+        try {
+            if (event instanceof EventMessage) {
+                schedulePayloadAndMetadata(jobIdentifier, triggerDateTime, (EventMessage) event);
+            } else {
+                schedulePayload(jobIdentifier, triggerDateTime, event);
+            }
+        } catch (Exception e) {
+            throw new SchedulingException("An error occurred while setting a timer.", e);
+        }
+        return new JobRunrScheduleToken(jobIdentifier);
+    }
+
+    private void schedulePayload(UUID jobIdentifier, Instant triggerDateTime, Object event) {
+        String serializedPayload = serializer.serialize(event, String.class).getData();
+        String payloadClass = event.getClass().getName();
+        jobScheduler.<JobRunrEventScheduler>schedule(
+                jobIdentifier,
+                triggerDateTime,
+                x -> x.publish(serializedPayload, payloadClass)
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void schedulePayloadAndMetadata(UUID jobIdentifier, Instant triggerDateTime, EventMessage eventMessage) {
+        String serializedPayload = serializer.serialize(eventMessage.getPayload(), String.class).getData();
+        String payloadClass = eventMessage.getPayloadType().getName();
+        String serializedMetadata = serializer.serialize(eventMessage.getMetaData(), String.class).getData();
+        jobScheduler.<JobRunrEventScheduler>schedule(
+                jobIdentifier,
+                triggerDateTime,
+                x -> x.publish(serializedPayload, payloadClass, serializedMetadata)
+        );
+    }
+
+    @Override
+    public ScheduleToken schedule(Duration triggerDuration, Object event) {
+        return schedule(Instant.now().plus(triggerDuration), event);
+    }
+
+    @Override
+    public void cancelSchedule(ScheduleToken scheduleToken) {
+        if (!(scheduleToken instanceof JobRunrScheduleToken)) {
+            throw new IllegalArgumentException("The given ScheduleToken was not provided by this scheduler.");
+        }
+        JobRunrScheduleToken reference = (JobRunrScheduleToken) scheduleToken;
+        jobScheduler.delete(reference.getJobIdentifier(), "Deleted via EventScheduler API");
+    }
+
+    @Override
+    public void shutdown() {
+        jobScheduler.shutdown();
+    }
+
+    @Override
+    public void registerLifecycleHandlers(@Nonnull LifecycleRegistry lifecycle) {
+        lifecycle.onShutdown(Phase.INBOUND_EVENT_CONNECTORS, this::shutdown);
+    }
+
+    /**
+     * This function should only be called via Jobrunr when a scheduled event was triggered. It will create an
+     * {@link EventMessage} and publish it using the {@link EventBus}.
+     *
+     * @param serializedPayload The {@link String} with the serialized payload.
+     * @param payloadClass      The {@link String} with the name of the class ot the payload.
+     */
+    @SuppressWarnings("rawtypes")
+    public void publish(String serializedPayload, String payloadClass) {
+        logger.debug("Invoked by JobRunr to publish a scheduled event without metadata.");
+        EventMessage eventMessage = createMessage(serializedPayload, payloadClass);
+        publishEventMessage(eventMessage);
+    }
+
+    /**
+     * This function should only be called via Jobrunr when a scheduled event was triggered. It will create an
+     * {@link EventMessage} and publish it using the {@link EventBus}.
+     *
+     * @param serializedPayload  The {@link String} with the serialized payload.
+     * @param payloadClass       The {@link String} with the name of the class ot the payload.
+     * @param serializedMetadata The {@link String} with the serialized metadata.
+     */
+    @SuppressWarnings("rawtypes")
+    public void publish(String serializedPayload, String payloadClass, String serializedMetadata) {
+        logger.debug("Invoked by JobRunr to publish a scheduled event with metadata");
+        EventMessage eventMessage = createMessage(serializedPayload, payloadClass, serializedMetadata);
+        publishEventMessage(eventMessage);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private EventMessage createMessage(String serializedPayload, String payloadClass) {
+        SimpleSerializedObject<String> serializedObject = new SimpleSerializedObject<>(
+                serializedPayload, String.class, payloadClass, null
+        );
+        Object deserializedPayload = serializer.deserialize(serializedObject);
+        return GenericEventMessage.asEventMessage(deserializedPayload);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private EventMessage createMessage(String serializedPayload, String payloadClass, String serializedMetadata) {
+        EventMessage eventMessage = createMessage(serializedPayload, payloadClass);
+        SimpleSerializedObject<String> serializedMetaData = new SimpleSerializedObject<>(
+                serializedMetadata, String.class, MetaData.class.getName(), null
+        );
+        return eventMessage.andMetaData(serializer.deserialize(serializedMetaData));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void publishEventMessage(EventMessage eventMessage) {
+        UnitOfWork<EventMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(null);
+        unitOfWork.attachTransaction(transactionManager);
+        unitOfWork.execute(() -> eventBus.publish(eventMessage));
+    }
+
+    /**
+     * Builder class to instantiate a {@link JobRunrEventScheduler}.
+     * <p>
+     * The {@link TransactionManager} is defaulted to a {@link NoTransactionManager}.
+     * <p>
+     * The {@link JobScheduler}, {@link Serializer} and {@link EventBus} are <b>hard requirements</b> and as such should
+     * be provided.
+     */
+    public static class Builder {
+
+        private JobScheduler jobScheduler;
+        private Serializer serializer;
+        private TransactionManager transactionManager = NoTransactionManager.INSTANCE;
+        private EventBus eventBus;
+
+        /**
+         * Sets the {@link JobScheduler} used for scheduling and triggering purposes of the events.
+         *
+         * @param jobScheduler a {@link JobScheduler} used for scheduling and triggering purposes of the events
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder jobScheduler(JobScheduler jobScheduler) {
+            assertNonNull(jobScheduler, "JobScheduler may not be null");
+            this.jobScheduler = jobScheduler;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} used to de-/serialize the {@code payload} and the
+         * {@link org.axonframework.messaging.MetaData}.
+         *
+         * @param serializer a {@link Serializer} used to de-/serialize the {@code payload}, and
+         *                   {@link org.axonframework.messaging.MetaData}.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder serializer(Serializer serializer) {
+            assertNonNull(serializer, "Serializer may not be null");
+            this.serializer = serializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link TransactionManager} used to build transactions and ties them on event publication. Defaults
+         * to a {@link NoTransactionManager}.
+         *
+         * @param transactionManager a {@link TransactionManager} used to build transactions and ties them on event
+         *                           publication
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder transactionManager(TransactionManager transactionManager) {
+            assertNonNull(transactionManager, "TransactionManager may not be null");
+            this.transactionManager = transactionManager;
+            return this;
+        }
+
+        /**
+         * Sets the {@link EventBus} used to publish events on once the schedule has been met.
+         *
+         * @param eventBus a {@link EventBus} used to publish events on once the schedule has been met
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder eventBus(EventBus eventBus) {
+            assertNonNull(eventBus, "EventBus may not be null");
+            this.eventBus = eventBus;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link JobRunrEventScheduler} as specified through this Builder.
+         *
+         * @return a {@link JobRunrEventScheduler} as specified through this Builder
+         */
+        public JobRunrEventScheduler build() {
+            return new JobRunrEventScheduler(this);
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        protected void validate() throws AxonConfigurationException {
+            assertNonNull(jobScheduler, "The JobScheduler is a hard requirement and should be provided.");
+            assertNonNull(serializer, "The Serializer is a hard requirement and should be provided.");
+            assertNonNull(eventBus, "The EventBus is a hard requirement and should be provided.");
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleToken.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.scheduling.jobrunr;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.axonframework.eventhandling.scheduling.ScheduleToken;
+
+import java.beans.ConstructorProperties;
+import java.util.UUID;
+
+import static java.lang.String.format;
+
+/**
+ * ScheduleToken implementation representing a scheduled JobRunr Job.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class JobRunrScheduleToken implements ScheduleToken {
+
+    private static final long serialVersionUID = 7798276124742534225L;
+
+    private final UUID jobIdentifier;
+
+    /**
+     * Initialize a token for the given {@code jobIdentifier}.
+     *
+     * @param jobIdentifier The identifier used when registering the job with JobRunr.
+     */
+    @JsonCreator
+    @ConstructorProperties({"jobIdentifier", "groupIdentifier"})
+    public JobRunrScheduleToken(@JsonProperty("jobIdentifier") UUID jobIdentifier) {
+        this.jobIdentifier = jobIdentifier;
+    }
+
+    /**
+     * Returns the JobRunr job identifier.
+     *
+     * @return the JobRunr job identifier
+     */
+    public UUID getJobIdentifier() {
+        return jobIdentifier;
+    }
+
+    @Override
+    public String toString() {
+        return format("JobRunr Schedule token for job [%s]", jobIdentifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return jobIdentifier.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final JobRunrScheduleToken other = (JobRunrScheduleToken) obj;
+        return this.jobIdentifier.equals(other.jobIdentifier);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -52,6 +52,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.eventhandling.GenericEventMessage.clock;
 import static org.axonframework.eventhandling.scheduling.quartz.FireEventJob.*;
 import static org.axonframework.messaging.Headers.*;
 import static org.quartz.JobKey.jobKey;
@@ -135,7 +136,7 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
             JobDetail jobDetail = buildJobDetail(eventMessage, new JobKey(jobIdentifier, groupIdentifier));
             scheduler.scheduleJob(jobDetail, buildTrigger(triggerDateTime, jobDetail.getKey()));
         } catch (SchedulerException e) {
-            throw new SchedulingException("An error occurred while setting a timer for a saga", e);
+            throw new SchedulingException("An error occurred while scheduling an event.", e);
         }
         return tr;
     }
@@ -179,7 +180,7 @@ public class QuartzEventScheduler implements EventScheduler, Lifecycle {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(Instant.now().plus(triggerDuration), event);
+        return schedule(clock.instant().plus(triggerDuration), event);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerBuilderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.scheduling.jobrunr;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.serialization.TestSerializer;
+import org.jobrunr.scheduling.JobScheduler;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JobRunrEventSchedulerBuilderTest {
+
+    private JobRunrEventScheduler.Builder builder;
+    private final JobScheduler jobScheduler = mock(JobScheduler.class);
+    private final TransactionManager transactionManager = mock(TransactionManager.class);
+    private final EventBus eventBus = mock(EventBus.class);
+
+    @BeforeEach
+    void newBuilder() {
+        builder = JobRunrEventScheduler.builder();
+    }
+
+    @Test
+    void whenAllPropertiesAreSetCreatesManager() {
+        JobRunrEventScheduler scheduler = builder.transactionManager(transactionManager)
+                                                 .jobScheduler(jobScheduler)
+                                                 .serializer(TestSerializer.JACKSON.getSerializer())
+                                                 .eventBus(eventBus)
+                                                 .build();
+
+        assertNotNull(scheduler);
+    }
+
+    @Test
+    void validateNeedsAllPropertiesSet() {
+        builder.jobScheduler(jobScheduler)
+               .transactionManager(transactionManager);
+        assertThrows(AxonConfigurationException.class, () -> builder.build());
+    }
+
+    @Test
+    void whenSettingSchedulerWithNullThrowError() {
+        assertThrows(AxonConfigurationException.class, () -> builder.jobScheduler(null));
+    }
+
+    @Test
+    void whenSettingTransactionManagerWithNullThrowError() {
+        assertThrows(AxonConfigurationException.class, () -> builder.transactionManager(null));
+    }
+
+    @Test
+    void whenSettingSerializerWithNullThrowError() {
+        assertThrows(AxonConfigurationException.class, () -> builder.serializer(null));
+    }
+
+    @Test
+    void whenSettingEventBusWithNullThrowError() {
+        assertThrows(AxonConfigurationException.class, () -> builder.eventBus(null));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.scheduling.jobrunr;
+
+import org.axonframework.common.Registration;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.scheduling.ScheduleToken;
+import org.axonframework.eventhandling.scheduling.java.SimpleScheduleToken;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.serialization.TestSerializer;
+import org.jobrunr.configuration.JobRunr;
+import org.jobrunr.scheduling.JobScheduler;
+import org.jobrunr.server.BackgroundJobServer;
+import org.jobrunr.server.JobActivator;
+import org.jobrunr.storage.InMemoryStorageProvider;
+import org.jobrunr.storage.StorageProvider;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+
+import static org.awaitility.Awaitility.await;
+import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobRunrEventSchedulerTest {
+
+    private List<EventMessage<?>> publishedMessages;
+    private JobRunrEventScheduler eventScheduler;
+    private BackgroundJobServer backgroundJobServer;
+
+    @AfterEach
+    void cleanUp() {
+        if (eventScheduler != null) {
+            eventScheduler.shutdown();
+        }
+        if (!Objects.isNull(backgroundJobServer)) {
+            backgroundJobServer.stop();
+            backgroundJobServer = null;
+        }
+    }
+
+
+    @BeforeEach
+    void prepare() {
+        publishedMessages = new ArrayList<>();
+        EventBus eventBus = new InMemoryEventBus(publishedMessages);
+        StorageProvider storageProvider = new InMemoryStorageProvider();
+        JobScheduler scheduler = new JobScheduler(storageProvider);
+        eventScheduler = JobRunrEventScheduler
+                .builder()
+                .jobScheduler(scheduler)
+                .serializer(TestSerializer.JACKSON.getSerializer())
+                .eventBus(eventBus)
+                .build();
+        JobRunr.configure()
+               .useJobActivator(new SimpleActivator(eventScheduler))
+               .useStorageProvider(storageProvider)
+               .useBackgroundJobServer(usingStandardBackgroundJobServerConfiguration().andPollIntervalInSeconds(5))
+               .initialize();
+        backgroundJobServer = JobRunr.getBackgroundJobServer();
+    }
+
+    @Test
+    void whenScheduleIsCalledThanShouldPublishEvent() {
+        eventScheduler.schedule(Duration.ZERO, 1);
+        Instant rightAfterSchedule = Instant.now();
+
+        await().atMost(Duration.ofSeconds(2)).until(() -> !publishedMessages.isEmpty());
+        assertEquals(1, publishedMessages.size());
+
+        EventMessage<?> publishedMessage = publishedMessages.get(0);
+
+        assertEquals(1, publishedMessage.getPayload());
+        assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
+        assertTrue(publishedMessage.getMetaData().isEmpty());
+    }
+
+    @Test
+    void whenScheduleIsCalledWithEventMessageMetadataShouldBePreserved() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("foo", "bar");
+        EventMessage<?> originalMessage = new GenericEventMessage<>(2, metadata);
+        eventScheduler.schedule(Instant.now(), originalMessage);
+        Instant rightAfterSchedule = Instant.now();
+
+        await().atMost(Duration.ofSeconds(2)).until(() -> !publishedMessages.isEmpty());
+        assertEquals(1, publishedMessages.size());
+
+        EventMessage<?> publishedMessage = publishedMessages.get(0);
+
+        assertEquals(2, publishedMessage.getPayload());
+        assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
+        assertEquals(metadata, publishedMessage.getMetaData());
+    }
+
+    @Test
+    void rescheduleWithDurationShouldWork() {
+        ScheduleToken token = eventScheduler.schedule(Duration.ofMillis(100L), 3);
+        eventScheduler.reschedule(token, Duration.ofMillis(100L), 4);
+
+        await().atMost(Duration.ofSeconds(2)).until(() -> !publishedMessages.isEmpty());
+        assertEquals(1, publishedMessages.size());
+
+        EventMessage<?> publishedMessage = publishedMessages.get(0);
+        assertEquals(4, publishedMessage.getPayload());
+    }
+
+    @Test
+    void rescheduleWithInstantShouldWork() {
+        ScheduleToken token = eventScheduler.schedule(Instant.now().plusMillis(100L), 5);
+        eventScheduler.reschedule(token, Instant.now().plusMillis(100L), 6);
+
+        await().atMost(Duration.ofSeconds(2)).until(() -> !publishedMessages.isEmpty());
+        assertEquals(1, publishedMessages.size());
+
+        EventMessage<?> publishedMessage = publishedMessages.get(0);
+        assertEquals(6, publishedMessage.getPayload());
+    }
+
+    @Test
+    void incorrectTokenClassShouldThrow() {
+        ScheduleToken token = new SimpleScheduleToken("ff");
+        assertThrows(IllegalArgumentException.class, () -> eventScheduler.cancelSchedule(token));
+    }
+
+    private static class InMemoryEventBus implements EventBus {
+
+        private final List<EventMessage<?>> publishedMessages;
+
+        private InMemoryEventBus(List<EventMessage<?>> publishedMessages) {
+            this.publishedMessages = publishedMessages;
+        }
+
+        @Override
+        public void publish(@Nonnull List<? extends EventMessage<?>> events) {
+            publishedMessages.addAll(events);
+        }
+
+        @Override
+        public Registration subscribe(@Nonnull Consumer<List<? extends EventMessage<?>>> eventProcessor) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Registration registerDispatchInterceptor(
+                @Nonnull MessageDispatchInterceptor<? super EventMessage<?>> dispatchInterceptor) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class SimpleActivator implements JobActivator {
+
+        private final JobRunrEventScheduler eventScheduler;
+
+        SimpleActivator(JobRunrEventScheduler eventScheduler) {
+            this.eventScheduler = eventScheduler;
+        }
+
+        @Override
+        public <T> T activateJob(Class<T> type) {
+            if (type.isAssignableFrom(JobRunrEventScheduler.class)) {
+                return type.cast(eventScheduler);
+            }
+            return null;
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleTokenTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.scheduling.jobrunr;
+
+import org.axonframework.eventhandling.scheduling.ScheduleToken;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobRunrScheduleTokenTest {
+
+    @Test
+    void equalsIfSameUuidIsUsed() {
+        UUID uuid = UUID.randomUUID();
+        ScheduleToken one = new JobRunrScheduleToken(uuid);
+        ScheduleToken other = new JobRunrScheduleToken(uuid);
+
+        assertEquals(one, other);
+        assertEquals(one.toString(), other.toString());
+        assertEquals(one.hashCode(), other.hashCode());
+    }
+
+    @Test
+    void notEqualsIfDifferentUuidIsUsed() {
+        ScheduleToken one = new JobRunrScheduleToken(UUID.randomUUID());
+        ScheduleToken other = new JobRunrScheduleToken(UUID.randomUUID());
+
+        assertNotEquals(one, other);
+        assertNotEquals(one.toString(), other.toString());
+        assertNotEquals(one.hashCode(), other.hashCode());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrScheduleTokenTest.java
@@ -17,8 +17,12 @@
 package org.axonframework.eventhandling.scheduling.jobrunr;
 
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
+import org.axonframework.serialization.TestSerializer;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
+import java.util.Collection;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,5 +48,16 @@ class JobRunrScheduleTokenTest {
         assertNotEquals(one, other);
         assertNotEquals(one.toString(), other.toString());
         assertNotEquals(one.hashCode(), other.hashCode());
+    }
+
+    @MethodSource("serializers")
+    @ParameterizedTest
+    void tokenShouldBeSerializable(TestSerializer serializer) {
+        ScheduleToken tokenToTest = new JobRunrScheduleToken(UUID.randomUUID());
+        assertEquals(tokenToTest, serializer.serializeDeserialize(tokenToTest));
+    }
+
+    public static Collection<TestSerializer> serializers() {
+        return TestSerializer.all();
     }
 }


### PR DESCRIPTION
Last issue to fix https://github.com/AxonFramework/AxonFramework/issues/1106.
Will encapsulate the uuid from Jobrunr for the token and will call one of the `publish` methods, depending on whether there was metadata, to publish the event from JobRunr.