### PR TITLE
Small test and code improvement for JobRunr deadline manager

### DIFF
--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/DeadlineDetails.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/DeadlineDetails.java
@@ -24,8 +24,6 @@ import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.SimpleSerializedObject;
 
-import java.time.Instant;
-import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -40,14 +38,12 @@ import javax.annotation.Nullable;
 public class DeadlineDetails {
 
     private String deadlineName;
-    private UUID deadlineId;
     private String scopeDescriptor;
     private String scopeDescriptorClass;
     private String payload;
     private String payloadClass;
     private String payloadRevision;
     private String metaData;
-    private Instant timestamp;
 
     private DeadlineDetails() {
         //private no-args constructor needed for deserialization
@@ -58,29 +54,24 @@ public class DeadlineDetails {
      * {@link org.axonframework.deadline.DeadlineMessage}.
      *
      * @param deadlineName         The {@link String} with the name of the deadline.
-     * @param deadlineId           The {@link UUID} with the deadline id.
      * @param scopeDescriptor      The {@link String} which tells what the scope is of the deadline.
      * @param scopeDescriptorClass The {@link String} which tells what the class of the scope descriptor is.
      * @param payload              The {@link String} with the payload. This can be null.
      * @param payloadClass         The {@link String} which tells what the class of the scope payload is.
      * @param payloadRevision      The {@link String} which tells what the revision of the scope payload is.
      * @param metaData             The {@link String} containing the metadata about the deadline.
-     * @param timestamp            The {@link Instant} containing the timestamp of the deadline message.
      */
     @SuppressWarnings("squid:S107")
-    public DeadlineDetails(@Nonnull String deadlineName, @Nonnull UUID deadlineId,
-                           @Nonnull String scopeDescriptor, @Nonnull String scopeDescriptorClass,
-                           @Nullable String payload, @Nullable String payloadClass, @Nullable String payloadRevision,
-                           @Nonnull String metaData, @Nonnull Instant timestamp) {
+    public DeadlineDetails(@Nonnull String deadlineName, @Nonnull String scopeDescriptor,
+                           @Nonnull String scopeDescriptorClass, @Nullable String payload,
+                           @Nullable String payloadClass, @Nullable String payloadRevision, @Nonnull String metaData) {
         this.deadlineName = deadlineName;
-        this.deadlineId = deadlineId;
         this.scopeDescriptor = scopeDescriptor;
         this.scopeDescriptorClass = scopeDescriptorClass;
         this.payload = payload;
         this.payloadClass = payloadClass;
         this.payloadRevision = payloadRevision;
         this.metaData = metaData;
-        this.timestamp = timestamp;
     }
 
     /**
@@ -89,7 +80,6 @@ public class DeadlineDetails {
      * {@link String} its easy to read the details there.
      *
      * @param deadlineName The {@link String} with the name of the deadline.
-     * @param deadlineId   The {@link UUID} with the deadline id.
      * @param descriptor   The {@link ScopeDescriptor} which tells what the scope is of the deadline.
      * @param message      The {@link DeadlineMessage} containing the payload and metadata which needs to be
      *                     serialized.
@@ -98,22 +88,20 @@ public class DeadlineDetails {
      * @return The serialized {@link String} representation of the details.
      */
     @SuppressWarnings("rawtypes")
-    static String serialized(@Nonnull String deadlineName, @Nonnull UUID deadlineId,
-                             @Nonnull ScopeDescriptor descriptor, @Nonnull DeadlineMessage message,
+    static String serialized(@Nonnull String deadlineName, @Nonnull ScopeDescriptor descriptor,
+                             @Nonnull DeadlineMessage message,
                              @Nonnull Serializer serializer) {
         SerializedObject<String> serializedDescriptor = serializer.serialize(descriptor, String.class);
         SerializedObject<String> serializedPayload = serializer.serialize(message.getPayload(), String.class);
         SerializedObject<String> serializedMetaData = serializer.serialize(message.getMetaData(), String.class);
         DeadlineDetails deadlineDetails = new DeadlineDetails(
                 deadlineName,
-                deadlineId,
                 serializedDescriptor.getData(),
                 serializedDescriptor.getType().getName(),
                 serializedPayload.getData(),
                 serializedPayload.getType().getName(),
                 serializedPayload.getType().getRevision(),
-                serializedMetaData.getData(),
-                message.getTimestamp()
+                serializedMetaData.getData()
         );
         SerializedObject<String> serializedDeadlineDetails = serializer.serialize(deadlineDetails, String.class);
         return serializedDeadlineDetails.getData();
@@ -126,15 +114,6 @@ public class DeadlineDetails {
      */
     public String getDeadlineName() {
         return deadlineName;
-    }
-
-    /**
-     * Returns The {@link UUID} with the deadline id.
-     *
-     * @return The {@link UUID} with the deadline id.
-     */
-    public UUID getDeadlineId() {
-        return deadlineId;
     }
 
     /**
@@ -192,15 +171,6 @@ public class DeadlineDetails {
     }
 
     /**
-     * Returns the {@link Instant} containing the timestamp of the deadline.
-     *
-     * @return The {@link Instant} containing the timestamp of the deadline.
-     */
-    public Instant getTimestamp() {
-        return timestamp;
-    }
-
-    /**
      * Returns the {@link DeadlineDetails} as an {@link GenericDeadlineMessage}, with the {@code} timestamp set using
      * the {@code GenericEventMessage.clock} to set to the current time.
      *
@@ -210,10 +180,8 @@ public class DeadlineDetails {
     public GenericDeadlineMessage asDeadLineMessage(Serializer serializer) {
         return new GenericDeadlineMessage<>(
                 deadlineName,
-                deadlineId.toString(),
                 getDeserializedPayload(serializer),
-                getDeserializedMetaData(serializer),
-                timestamp);
+                getDeserializedMetaData(serializer));
     }
 
     private Object getDeserializedPayload(Serializer serializer) {

--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
@@ -109,13 +109,12 @@ public class JobRunrDeadlineManager extends AbstractDeadlineManager {
                            @Nullable Object messageOrPayload,
                            @Nonnull ScopeDescriptor deadlineScope) {
         DeadlineMessage<Object> deadlineMessage = asDeadlineMessage(deadlineName, messageOrPayload, triggerDateTime);
-        UUID deadlineId = UUID.fromString(deadlineMessage.getIdentifier());
+        UUID deadlineId = UUID.randomUUID();
         Span span = spanFactory.createDispatchSpan(() -> "JobRunrDeadlineManager.schedule(" + deadlineName + ")",
                                                    deadlineMessage);
         runOnPrepareCommitOrNow(span.wrapRunnable(() -> {
             DeadlineMessage<Object> interceptedDeadlineMessage = processDispatchInterceptors(deadlineMessage);
             String deadlineDetails = DeadlineDetails.serialized(deadlineName,
-                                                                deadlineId,
                                                                 deadlineScope,
                                                                 interceptedDeadlineMessage,
                                                                 serializer);
@@ -186,8 +185,8 @@ public class JobRunrDeadlineManager extends AbstractDeadlineManager {
         ResultMessage<?> resultMessage = unitOfWork.executeWithResult(chain::proceed);
         if (resultMessage.isExceptional()) {
             Throwable e = resultMessage.exceptionResult();
-            logger.warn("An error occurred while triggering the deadline [{}] with identifier [{}]",
-                        deadlineDetails.getDeadlineName(), deadlineDetails.getDeadlineId());
+            logger.warn("An error occurred while triggering deadline with name [{}].",
+                        deadlineDetails.getDeadlineName());
             throw new DeadlineException("Failed to process", e);
         }
     }

--- a/messaging/src/test/java/org/axonframework/deadline/jobrunr/DeadlineDetailsSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/jobrunr/DeadlineDetailsSerializationTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.*;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,7 +37,6 @@ class DeadlineDetailsSerializationTest {
     private static final String TEST_DEADLINE_NAME = "deadline-name";
     private static final String TEST_DEADLINE_PAYLOAD = "deadline-payload";
     private static MetaData metaData;
-    private static UUID scheduleId;
     @SuppressWarnings("rawtypes")
     private static DeadlineMessage message;
 
@@ -48,7 +46,6 @@ class DeadlineDetailsSerializationTest {
         map.put("someStringValue", "foo");
         map.put("someIntValue", 2);
         metaData = new MetaData(map);
-        scheduleId = UUID.randomUUID();
         message = GenericDeadlineMessage.asDeadlineMessage(TEST_DEADLINE_NAME, TEST_DEADLINE_PAYLOAD, Instant.now())
                                         .withMetaData(metaData);
     }
@@ -71,20 +68,18 @@ class DeadlineDetailsSerializationTest {
         String expectedIdentifier = "identifier";
         ScopeDescriptor descriptor = new TestScopeDescriptor(expectedType, expectedIdentifier);
         String serializedDeadlineDetails = DeadlineDetails.serialized(
-                TEST_DEADLINE_NAME, scheduleId, descriptor, message, serializer);
+                TEST_DEADLINE_NAME, descriptor, message, serializer);
         SimpleSerializedObject<String> serializedDeadlineMetaData = new SimpleSerializedObject<>(
                 serializedDeadlineDetails, String.class, DeadlineDetails.class.getName(), null
         );
         DeadlineDetails result = serializer.deserialize(serializedDeadlineMetaData);
 
         assertEquals(TEST_DEADLINE_NAME, result.getDeadlineName());
-        assertEquals(scheduleId, result.getDeadlineId());
         assertEquals(descriptor, result.getDeserializedScopeDescriptor(serializer));
         DeadlineMessage resultMessage = result.asDeadLineMessage(serializer);
 
         assertNotNull(resultMessage);
         assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.getPayload());
         assertEquals(metaData, resultMessage.getMetaData());
-        assertEquals(message.getTimestamp(), resultMessage.getTimestamp());
     }
 }


### PR DESCRIPTION
Expend the test to make sure the deadline message has the correct timestamp. Improved the JobRunrDeadlineManager by creating the id, instead of taking it from the message. It also no longer stores the original id and original timestamp of the message, as it's not needed.