### PR TITLE
[#2514] Fix naming of registered `Repository` and `AggregateFactory` beans

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/StringUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/StringUtils.java
@@ -67,5 +67,15 @@ public abstract class StringUtils {
     public static boolean nonEmpty(String s) {
         return !EMPTY_STRING.equals(s);
     }
+
+    /**
+     * Return the given {@code s}, with its first character lowercase.
+     *
+     * @param s The input string to adjust to a version with the first character as a lowercase.
+     * @return The input string, with first character lowercase.
+     */
+    public static String lowerCaseFirstCharacterOf(String s) {
+        return s.substring(0, 1).toLowerCase() + s.substring(1);
+    }
 }
 

--- a/messaging/src/test/java/org/axonframework/common/StringUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/StringUtilsTest.java
@@ -18,6 +18,7 @@ package org.axonframework.common;
 
 import org.junit.jupiter.api.*;
 
+import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -55,5 +56,18 @@ class StringUtilsTest {
     @Test
     void emptyOrNullReturnsFalseForNonEmptyString() {
         assertFalse(StringUtils.emptyOrNull("some-string"));
+    }
+
+    @Test
+    void lowerCaseFirstCharacterOfAdjustsFirstCharacterToLowerCase() {
+        String fullUppercase = "FOO";
+        String lowerCasedOutputOfFullUppercase = "fOO";
+        assertEquals(lowerCasedOutputOfFullUppercase, lowerCaseFirstCharacterOf(fullUppercase));
+        assertEquals(lowerCasedOutputOfFullUppercase, lowerCaseFirstCharacterOf(lowerCasedOutputOfFullUppercase));
+
+        String partialUppercase = "FOo";
+        String partialLowercase = "fOo";
+        assertEquals(partialLowercase, lowerCaseFirstCharacterOf(partialUppercase));
+        assertEquals(partialLowercase, lowerCaseFirstCharacterOf(partialLowercase));
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregatePolymorphismAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregatePolymorphismAutoConfigurationTest.java
@@ -105,14 +105,22 @@ class AggregatePolymorphismAutoConfigurationTest {
 
     @Test
     void polymorphicAggregateWiringConstructsSingleRepository() {
+        String animalRepositoryBeanName = repositoryBeanName(PolymorphicAggregateContext.Animal.class);
+
         testApplicationContext.withUserConfiguration(PolymorphicAggregateContext.class)
                               .run(context -> {
                                   assertThat(context).hasSingleBean(Repository.class);
                                   assertThat(context).getBean(Repository.class)
                                                      .isInstanceOf(EventSourcingRepository.class);
-                                  assertThat(context).getBean("animalRepository", Repository.class)
-                                                     .isNotNull();
+                                  String[] namesForRepositoryBeans = context.getBeanNamesForType(Repository.class);
+                                  assertThat(namesForRepositoryBeans.length).isEqualTo(1);
+
+                                  assertThat(namesForRepositoryBeans[0]).isEqualTo(animalRepositoryBeanName);
                               });
+    }
+
+    private static String repositoryBeanName(@SuppressWarnings("SameParameterValue") Class<?> aggregateClass) {
+        return lowerCaseFirstCharacterOf(aggregateClass.getSimpleName()) + "Repository";
     }
 
     @ContextConfiguration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AggregateStereotypeAutoConfigurationTest.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.UnaryOperator;
 
+import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -61,7 +62,7 @@ import static org.mockito.Mockito.*;
  */
 class AggregateStereotypeAutoConfigurationTest {
 
-    private static final String AGGREGATE_IDENTIFIER = "aggregateIdentifier";
+    private static final Object AGGREGATE_IDENTIFIER = "aggregateIdentifier";
 
     private static AtomicBoolean snapshotFilterInvoked;
     private static AtomicBoolean commandTargetResolverInvoked;
@@ -152,18 +153,22 @@ class AggregateStereotypeAutoConfigurationTest {
 
     @Test
     void aggregateWithEntityManagerAnnotationIsAutoconfiguredWitDefaultJpaRepository() {
+        String expectedRepositoryBeanName = repositoryBeanName(TestContext.SimpleStateStoredAggregate.class);
         testApplicationContext.run(context -> {
-            String beanName = context.getBeanNamesForType(TestContext.SimpleStateStoredAggregate.class)[0];
-            assertTrue(context.containsBean(beanName + "Repository"));
-            Object actual = context.getBean(beanName + "Repository");
+            assertTrue(context.containsBean(expectedRepositoryBeanName));
+            Object actual = context.getBean(expectedRepositoryBeanName);
             assertTrue(actual instanceof GenericJpaRepository, "Expected Jpa repository to have been configured");
         });
+    }
+
+    private static String repositoryBeanName(@SuppressWarnings("SameParameterValue") Class<?> aggregateClass) {
+        return lowerCaseFirstCharacterOf(aggregateClass.getSimpleName()) + "Repository";
     }
 
     @Test
     void aggregateWithEntityManagerAnnotationIsAutoconfiguredWitExistingJpaRepository() {
         String beanName = "org.axonframework.springboot.autoconfig.AggregateStereotypeAutoConfigurationTest$TestContext$SimpleStateStoredAggregate";
-        Repository mockRepo = mock(Repository.class);
+        Repository<?> mockRepo = mock(Repository.class);
         testApplicationContext.withBean(beanName + "Repository", Repository.class, () -> mockRepo)
                               .run(context -> {
                                   assertTrue(context.containsBean(beanName + "Repository"));
@@ -253,6 +258,7 @@ class AggregateStereotypeAutoConfigurationTest {
             }
         }
 
+        @SuppressWarnings("unused")
         @Entity(name = "simpleAggregate")
         @Aggregate
         private static class SimpleStateStoredAggregate {
@@ -380,7 +386,7 @@ class AggregateStereotypeAutoConfigurationTest {
         private final String aggregateId;
 
         CreateTestAggregate() {
-            this(AGGREGATE_IDENTIFIER);
+            this(AGGREGATE_IDENTIFIER.toString());
         }
 
         CreateTestAggregate(String aggregateId) {
@@ -412,7 +418,7 @@ class AggregateStereotypeAutoConfigurationTest {
         private final String aggregateId;
 
         UpdateTestAggregate() {
-            this(AGGREGATE_IDENTIFIER);
+            this(AGGREGATE_IDENTIFIER.toString());
         }
 
         UpdateTestAggregate(String aggregateId) {
@@ -443,7 +449,7 @@ class AggregateStereotypeAutoConfigurationTest {
         private final String aggregateId;
 
         CreateCustomRepoTestAggregate() {
-            this(AGGREGATE_IDENTIFIER);
+            this(AGGREGATE_IDENTIFIER.toString());
         }
 
         CreateCustomRepoTestAggregate(String aggregateId) {
@@ -475,7 +481,7 @@ class AggregateStereotypeAutoConfigurationTest {
         private final String aggregateId;
 
         UpdateCustomRepoTestAggregate() {
-            this(AGGREGATE_IDENTIFIER);
+            this(AGGREGATE_IDENTIFIER.toString());
         }
 
         UpdateCustomRepoTestAggregate(String aggregateId) {

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 
 import static java.lang.String.format;
+import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
 import static org.axonframework.common.StringUtils.nonEmptyOrNull;
 
 /**
@@ -187,15 +188,15 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
         if (nonEmptyOrNull((String) props.get(REPOSITORY))) {
             beanDefinitionBuilder.addPropertyValue(REPOSITORY, props.get(REPOSITORY));
         } else {
-            String repositoryBeanName = aggregateBeanName + REPOSITORY_BEAN;
-            if (registry.containsBean(repositoryBeanName)) {
-                Class<?> type = registry.getType(repositoryBeanName);
+            String repositoryName = lowerCaseFirstCharacterOf(aggregateType.getSimpleName()) + REPOSITORY_BEAN;
+            if (registry.containsBean(repositoryName)) {
+                Class<?> type = registry.getType(repositoryName);
                 if (type == null || Repository.class.isAssignableFrom(type)) {
-                    beanDefinitionBuilder.addPropertyValue(REPOSITORY, repositoryBeanName);
+                    beanDefinitionBuilder.addPropertyValue(REPOSITORY, repositoryName);
                 }
             } else {
                 ((BeanDefinitionRegistry) registry).registerBeanDefinition(
-                        repositoryBeanName,
+                        repositoryName,
                         BeanDefinitionBuilder.genericBeanDefinition(SpringRepositoryFactoryBean.class)
                                              .addConstructorArgValue(aggregateType)
                                              .addAutowiredProperty("configuration")
@@ -203,7 +204,7 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
                 );
             }
         }
-        String aggregateFactory = aggregateBeanName + "AggregateFactory";
+        String aggregateFactory = lowerCaseFirstCharacterOf(aggregateType.getSimpleName()) + "AggregateFactory";
         if (!registry.containsBeanDefinition(aggregateFactory)) {
             ((BeanDefinitionRegistry) registry).registerBeanDefinition(
                     aggregateFactory,


### PR DESCRIPTION
With the recent switch to a newer Spring integration, the naming of the `Repository` and `AggregateFactory` beans.
More specifically, the fully qualified class name of the `@Aggregate` annotated class, combined with `"Repository"` and `"AggregateFactory"` was the bean.
Instead, as in pre-AxonFramework-4.6, the name should be the **simple** name of the `@Aggregate` annotated class, combined with `"Repository"` and `"AggregateFactory"` was the bean.
This pull request rectifies this, by registering the `Repository` and `AggregateFactory` beans through the aforementioned naming scheme.

Doing so, this pull request resolves #2514.