### PR TITLE
[#2383] Add `ConditionalOnMissingBean` to `SpringAxonConfiguration` and `SpringConfigurer`

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
@@ -84,11 +84,13 @@ public class InfraConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringAxonConfiguration springAxonConfiguration(Configurer configurer) {
         return new SpringAxonConfiguration(configurer);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringConfigurer springAxonConfigurer(ConfigurableListableBeanFactory beanFactory,
                                                  List<ConfigurerModule> configurerModules,
                                                  List<ModuleConfiguration> moduleConfigurations) {
@@ -101,7 +103,9 @@ public class InfraConfiguration {
     @Bean
     public InitializingBean lifecycleInitializer(Configurer configurer,
                                                  List<Lifecycle> lifecycleBeans) {
-        return () -> configurer.onInitialize(configuration -> lifecycleBeans.forEach(bean -> bean.registerLifecycleHandlers(configuration.lifecycleRegistry())));
+        return () -> configurer.onInitialize(
+                config -> lifecycleBeans.forEach(bean -> bean.registerLifecycleHandlers(config.lifecycleRegistry()))
+        );
     }
 
     @Primary
@@ -139,4 +143,3 @@ public class InfraConfiguration {
         return new SpringResourceInjector();
     }
 }
-


### PR DESCRIPTION
This pull request adds `ConditionalOnMissingBean` to the `SpringAxonConfiguration` and `SpringConfigurer` bean creation methods of the `InfraConfiguration` class. 
This will allow users to provide a custom implementation of both beans to override Axon's default behavior.

Doing so, this PR resolves #2383.