### PR TITLE
Cancel of direct query

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -266,6 +266,15 @@ class AxonServerQueryBusTest {
     }
 
     @Test
+    void queryCloseConnectionOnCompletableFutureCancel() {
+        ResultStream<QueryResponse> resultStream = mock(ResultStream.class);
+        when(mockQueryChannel.query(any())).thenReturn(resultStream);
+        QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class));
+        testSubject.query(testQuery).cancel(true);
+        verify(resultStream).close();
+    }
+
+    @Test
     void subscribeHandler() {
         when(mockQueryChannel.registerQueryHandler(any(), any()))
                 .thenReturn(() -> CompletableFuture.completedFuture(null));

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -83,6 +83,11 @@ public class DefaultQueryGateway implements QueryGateway {
         CompletableFuture<QueryResponseMessage<R>> queryResponse = queryBus
                 .query(processInterceptors(new GenericQueryMessage<>(asMessage(query), queryName, responseType)));
         CompletableFuture<R> result = new CompletableFuture<>();
+        result.whenComplete((r, e) -> {
+            if (!queryResponse.isDone()) {
+                queryResponse.cancel(true);
+            }
+        });
         queryResponse.exceptionally(cause -> asResponseMessage(responseType.responseMessagePayloadType(), cause))
                      .thenAccept(queryResponseMessage -> {
                          try {

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -150,6 +150,20 @@ class DefaultQueryGatewayTest {
     }
 
     @Test
+    void pointToPointQueryWhenClientCancelQuery() {
+        CompletableFuture<QueryResponseMessage<String>> queryBusFutureResult = new CompletableFuture<>();
+        when(mockBus.query(anyMessage(String.class, String.class)))
+                .thenReturn(queryBusFutureResult);
+
+        CompletableFuture<String> result = testSubject.query("query", String.class);
+        assertFalse(queryBusFutureResult.isDone());
+        result.cancel(true);
+
+        assertTrue(queryBusFutureResult.isDone());
+        assertTrue(queryBusFutureResult.isCancelled());
+    }
+
+    @Test
     void pointToPointQueryWhenQueryBusThrowsException() throws Exception {
         Throwable expected = new Throwable("oops");
         CompletableFuture<QueryResponseMessage<String>> queryResponseCompletableFuture = new CompletableFuture<>();


### PR DESCRIPTION
The canceling of the completable future result of a direct query should cause the canceling of the query to be propagated to AxonServer too.