### PR TITLE
Enable heartbeats to Axon Server by default

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -622,9 +622,9 @@ public class AxonServerConfiguration {
 
         /**
          * Enables heartbeat messages between a client and Axon Server. When enabled, the connection will be abandoned
-         * if a heartbeat message response <b>is not</b> returned in a timely manor. Defaults to {@code false}.
+         * if a heartbeat message response <b>is not</b> returned in a timely manner. Defaults to {@code true}.
          */
-        private boolean enabled = false;
+        private boolean enabled = true;
 
         /**
          * Interval between consecutive heartbeat message sent in milliseconds. Defaults to {@code 10_000}


### PR DESCRIPTION
Until now, heartbeats have been disabled when using the default Axon Server configuration. However, we see many connection problems resolves after enabling this. In order to reduce support calls and customer problems preemptively, this PR enables them by default