### PR TITLE
Saga Caching Enhancements

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachedSaga.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachedSaga.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,9 @@ public class CachedSaga {
     public void on(SagaCreatedEvent event) {
         this.name = event.name;
         this.state = new ArrayList<>();
+        for (int i = 0; i < event.numberOfAssociations; i++) {
+            SagaLifecycle.associateWith(event.id + i, i);
+        }
     }
 
     @SagaEventHandler(associationProperty = "id")
@@ -65,10 +68,12 @@ public class CachedSaga {
 
         private final String id;
         private final String name;
+        private final int numberOfAssociations;
 
-        public SagaCreatedEvent(String id, String name) {
+        public SagaCreatedEvent(String id, String name, int numberOfAssociations) {
             this.id = id;
             this.name = name;
+            this.numberOfAssociations = numberOfAssociations;
         }
 
         public String getId() {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachedSaga.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachedSaga.java
@@ -22,6 +22,7 @@ import org.axonframework.modelling.saga.StartSaga;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Test saga used by the {@link CachingIntegrationTestSuite}.
@@ -32,13 +33,19 @@ public class CachedSaga {
 
     private String name;
     private List<Object> state;
+    private int numberOfAssociations;
+    private Random random;
+    private Integer associationToRemove;
 
     @StartSaga
     @SagaEventHandler(associationProperty = "id")
     public void on(SagaCreatedEvent event) {
         this.name = event.name;
         this.state = new ArrayList<>();
-        for (int i = 0; i < event.numberOfAssociations; i++) {
+        this.numberOfAssociations = event.numberOfAssociations;
+        this.random = new Random();
+
+        for (int i = 0; i < numberOfAssociations; i++) {
             SagaLifecycle.associateWith(event.id + i, i);
         }
     }
@@ -46,6 +53,13 @@ public class CachedSaga {
     @SagaEventHandler(associationProperty = "id")
     public void on(VeryImportantEvent event) {
         state.add(event.stateEntry);
+        if (associationToRemove == null) {
+            associationToRemove = random.nextInt(numberOfAssociations);
+            SagaLifecycle.removeAssociationWith(event.id + associationToRemove, associationToRemove);
+        } else {
+            SagaLifecycle.associateWith(event.id + associationToRemove, associationToRemove);
+            associationToRemove = null;
+        }
     }
 
     @SagaEventHandler(associationProperty = "id")

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -75,6 +75,8 @@ public abstract class CachingIntegrationTestSuite {
     private static final Duration TWO_SECONDS = Duration.ofSeconds(2);
     private static final Duration FOUR_SECONDS = Duration.ofSeconds(4);
     private static final Duration EIGHT_SECONDS = Duration.ofSeconds(8);
+    private static final Duration SIXTEEN_SECONDS = Duration.ofSeconds(16);
+    private static final Duration THIRTY_TWO_SECONDS = Duration.ofSeconds(32);
 
     protected Configuration config;
     private StreamingEventProcessor sagaProcessor;
@@ -158,7 +160,7 @@ public abstract class CachingIntegrationTestSuite {
         // Bulk update the saga...
         publishBulkUpdatesTo(associationValue, NUMBER_OF_UPDATES);
         await().pollDelay(DEFAULT_DELAY)
-               .atMost(TWO_SECONDS)
+               .atMost(FOUR_SECONDS)
                .until(() -> handledEventsUpTo(createEvents + NUMBER_OF_UPDATES));
 
         // Validate caches again
@@ -217,7 +219,7 @@ public abstract class CachingIntegrationTestSuite {
                  .orElse(CompletableFuture.completedFuture(null))
                  .get(15, TimeUnit.SECONDS);
         await().pollDelay(DEFAULT_DELAY)
-               .atMost(EIGHT_SECONDS)
+               .atMost(SIXTEEN_SECONDS)
                .until(() -> handledEventsUpTo(createEvents + (NUMBER_OF_UPDATES * NUMBER_OF_CONCURRENT_PUBLISHERS)));
 
         // Validate caches again
@@ -363,7 +365,7 @@ public abstract class CachingIntegrationTestSuite {
                  .orElse(CompletableFuture.completedFuture(null))
                  .get(15, TimeUnit.SECONDS);
         await().pollDelay(DEFAULT_DELAY)
-               .atMost(Duration.ofSeconds(20))
+               .atMost(THIRTY_TWO_SECONDS)
                .until(() -> handledEventsUpTo(
                        createEvents + (NUMBER_OF_UPDATES * (SAGA_NAMES.length * NUMBER_OF_CONCURRENT_PUBLISHERS))
                ));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -156,7 +156,7 @@ public abstract class CachingIntegrationTestSuite {
         // Bulk update the saga...
         publishBulkUpdatesTo(associationValue, NUMBER_OF_UPDATES);
         await().pollDelay(DEFAULT_DELAY)
-               .atMost(EIGHT_SECONDS)
+               .atMost(TWO_SECONDS)
                .until(() -> handledEventsUpTo(createEvents + NUMBER_OF_UPDATES));
 
         // Validate caches again
@@ -215,7 +215,7 @@ public abstract class CachingIntegrationTestSuite {
                  .orElse(CompletableFuture.completedFuture(null))
                  .get(15, TimeUnit.SECONDS);
         await().pollDelay(DEFAULT_DELAY)
-               .atMost(Duration.ofSeconds(20))
+               .atMost(EIGHT_SECONDS)
                .until(() -> handledEventsUpTo(createEvents + (NUMBER_OF_UPDATES * NUMBER_OF_CONCURRENT_PUBLISHERS)));
 
         // Validate caches again

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -451,23 +451,23 @@ public abstract class CachingIntegrationTestSuite {
 
         @SuppressWarnings({"FieldCanBeLocal", "unused"})
         private final ListenerType type;
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
         private final Set<String> created = new ConcurrentSkipListSet<>();
-        private final Set<String> removed = new ConcurrentSkipListSet<>();
-        private final Set<String> expired = new ConcurrentSkipListSet<>();
         private final Map<String, V> updates = new ConcurrentHashMap<>();
+        private final Set<String> removed = new ConcurrentSkipListSet<>();
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+        private final Set<String> expired = new ConcurrentSkipListSet<>();
 
         private EntryListenerValidator(ListenerType type) {
             this.type = type;
         }
 
         @Override
-        public void onEntryExpired(Object key) {
-            expired.add(key.toString());
-        }
-
-        @Override
-        public void onEntryRemoved(Object key) {
-            removed.add(key.toString());
+        public void onEntryCreated(Object key, Object value) {
+            String keyAsString = key.toString();
+            created.add(keyAsString);
+            //noinspection unchecked
+            updates.put(keyAsString, (V) value);
         }
 
         @Override
@@ -477,15 +477,13 @@ public abstract class CachingIntegrationTestSuite {
         }
 
         @Override
-        public void onEntryCreated(Object key, Object value) {
-            String keyAsString = key.toString();
-            //noinspection unchecked
-            updates.put(keyAsString, (V) value);
-            boolean added = created.add(keyAsString);
-            if (!added) {
-                removed.remove(keyAsString);
-                expired.remove(keyAsString);
-            }
+        public void onEntryRemoved(Object key) {
+            removed.add(key.toString());
+        }
+
+        @Override
+        public void onEntryExpired(Object key) {
+            expired.add(key.toString());
         }
 
         @Override

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -400,9 +400,7 @@ public abstract class CachingIntegrationTestSuite {
 
         // Validate association cache is empty
         for (String sagaName : SAGA_NAMES) {
-            await().pollDelay(DEFAULT_DELAY)
-                   .atMost(FOUR_SECONDS)
-                   .until(() -> associationsCacheListener.isRemoved(sagaAssociationCacheKey(sagaName + "-id")));
+            assertTrue(associationsCacheListener.isRemoved(sagaAssociationCacheKey(sagaName + "-id")));
         }
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -23,7 +23,6 @@ import org.axonframework.config.SagaConfigurer;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.StreamingEventProcessor;
-import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.modelling.saga.repository.CachingSagaStore;
@@ -108,13 +107,16 @@ public abstract class CachingIntegrationTestSuite {
         config = DefaultConfigurer.defaultConfiguration(DO_NOT_AUTO_LOCATE_CONFIGURER_MODULES)
                                   .configureEmbeddedEventStore(c -> new InMemoryEventStorageEngine())
                                   .eventProcessing(
-                                          procConfig -> procConfig.usingTrackingEventProcessors()
-                                                                  .registerTrackingEventProcessorConfiguration(c -> tepConfig)
-                                                                  .registerSaga(CachedSaga.class, sagaConfigurer)
+                                          procConfig -> procConfig
+                                                  .usingTrackingEventProcessors()
+                                                  .registerTrackingEventProcessorConfiguration(
+                                                          "CachedSagaProcessor", c -> tepConfig
+                                                  )
+                                                  .registerSaga(CachedSaga.class, sagaConfigurer)
                                   )
                                   .start();
         sagaProcessor = config.eventProcessingConfiguration()
-                              .eventProcessor("CachedSagaProcessor", TrackingEventProcessor.class)
+                              .eventProcessor("CachedSagaProcessor", StreamingEventProcessor.class)
                               .orElseThrow(() -> new IllegalStateException("CachedSagaProcessor is not present"));
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -23,6 +23,7 @@ import org.axonframework.modelling.saga.AssociationValues;
 import org.axonframework.modelling.saga.SagaRepository;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -76,7 +77,9 @@ public class CachingSagaStore<T> implements SagaStore<T> {
     @Override
     public Set<String> findSagas(Class<? extends T> sagaType, AssociationValue associationValue) {
         final String key = cacheKey(associationValue, sagaType);
-        return associationsCache.computeIfAbsent(key, () -> delegate.findSagas(sagaType, associationValue));
+        return new HashSet<>(associationsCache.computeIfAbsent(
+                key, () -> delegate.findSagas(sagaType, associationValue))
+        );
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -83,7 +83,8 @@ public class CachingSagaStore<T> implements SagaStore<T> {
                     // Wrap the original collection in a synchronized implementation, since it might be changed while
                     // the SagaManager is reading it using the insertSaga/deleteSaga methods.
                     return Collections.synchronizedSet(delegate.findSagas(sagaType, associationValue));
-                });
+                }
+        );
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -76,7 +76,6 @@ public class CachingSagaStore<T> implements SagaStore<T> {
 
     @Override
     public Set<String> findSagas(Class<? extends T> sagaType, AssociationValue associationValue) {
-
         final String key = cacheKey(associationValue, sagaType);
         return associationsCache.computeIfAbsent(
                 key,
@@ -154,7 +153,6 @@ public class CachingSagaStore<T> implements SagaStore<T> {
                            T saga,
                            AssociationValues associationValues) {
         sagaCache.put(sagaIdentifier, new CacheEntry<>(saga, associationValues.asSet()));
-
         delegate.updateSaga(sagaType, sagaIdentifier, saga, associationValues);
         associationValues.removedAssociations()
                          .forEach(av -> removeAssociationValueFromCache(sagaType, sagaIdentifier, av));


### PR DESCRIPTION
This pull request does a couple of things:

1. It enhances the `CachedSaga` instance to construct N associations. This is done, as the number of associations may impact the cache invocations
2. It adjusts the `CachingIntegrationTestSuite` to use a `TrackingEventProcessor` instead of a `SubscribingEventProcessor`. This adjustments lets the IT mirror Saga Caching use cases more closely, as we recommend the use of a `StreamingEventProcessor` (like the `TrackingEventProcessor`) to our users. Furthermore, as this makes event handling asynchronous, the validation process is adjusted to wait for the expected amount of events to be handled.
3. It adjusts the `CachingIntegrationTestSuite` to use a custom `Cache.EntryListener` to validate the `Cache` is accessed as expected.
4. It ensures the `WeakReferenceCachce#computeIfPresent` invokes the `Cache.EntryListener`. 
5. The outcome of the `Cache#computeIfAbsent` lambda invocation in the `CachingSagaStore` to retrieve associations is wrapped into a `Collections#synchronizedSet`. This resolves any `ConcurrentModificationExceptions` that may occur upon invocation of the `CachingSagaStore#findSagas` method, as the set within the `Cache` is replaced by a thread-safe variant.
6. It adds a harsher concurrency test to the `CachingSagaStoreTest`, validating the `ConcurrentModificationException` does not occur anymore.