### PR TITLE
Proposed changes to caching saga fix

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.integrationtests.cache;
 
+import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.caching.Cache;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
@@ -26,6 +27,7 @@ import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.modelling.saga.AssociationValue;
 import org.axonframework.modelling.saga.repository.CachingSagaStore;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.*;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,6 +128,45 @@ public abstract class CachingIntegrationTestSuite {
      * @return The constructed {@link Cache} instance.
      */
     public abstract Cache buildCache(String name);
+
+    @Test
+    void canHandleConcurrentReadsAndWrites() throws ExecutionException, InterruptedException, TimeoutException {
+        String sagaName = SAGA_NAMES[0];
+        AssociationValue associationValue = new AssociationValue(sagaName + "-id", "value");
+
+        ExecutorService executor = Executors.newFixedThreadPool(32);
+
+        SagaStore store = CachingSagaStore.builder()
+                                          .delegateSagaStore(new InMemorySagaStore())
+                                          .sagaCache(buildCache("saga2"))
+                                          .associationsCache(buildCache("associations2"))
+                                          .build();
+
+        IntStream.range(0, 256)
+                 .mapToObj(i -> CompletableFuture.runAsync(
+                         () -> {
+                             try {
+                                 String id = IdentifierFactory.getInstance()
+                                                              .generateIdentifier();
+                                 store.insertSaga(CachedSaga.class,
+                                                  id,
+                                                  id,
+                                                  Collections.singleton(
+                                                          associationValue));
+                                 store.findSagas(CachedSaga.class, associationValue);
+                                 store.deleteSaga(CachedSaga.class,
+                                                  id,
+                                                  Collections.singleton(
+                                                          associationValue));
+                             } catch (Exception e) {
+                                 throw new RuntimeException(e);
+                             }
+                         }, executor
+                 )).reduce(CompletableFuture::allOf)
+                 .orElse(CompletableFuture.completedFuture(null))
+                 .get(30, TimeUnit.SECONDS);
+
+    }
 
     @Test
     void publishingBigEventTransactionTowardsCachedSagaWorksWithoutException() {

--- a/messaging/src/main/java/org/axonframework/common/caching/WeakReferenceCache.java
+++ b/messaging/src/main/java/org/axonframework/common/caching/WeakReferenceCache.java
@@ -174,18 +174,23 @@ public class WeakReferenceCache implements Cache {
     public <V> void computeIfPresent(Object key, UnaryOperator<V> update) {
         purgeItems();
         cache.computeIfPresent(key, (k, v) -> {
+            Object currentValue = v.get();
+            if (currentValue == null) {
+                return null;
+            }
             //noinspection unchecked
-            V value = update.apply((V) v.get());
+            V value = update.apply((V) currentValue);
             if (value != null) {
                 for (EntryListener adapter : adapters) {
                     adapter.onEntryUpdated(key, value);
                 }
+                return new Entry(k, value);
             } else {
                 for (EntryListener adapter : adapters) {
                     adapter.onEntryRemoved(key);
                 }
+                return null;
             }
-            return new Entry(k, value);
         });
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -23,7 +23,7 @@ import org.axonframework.modelling.saga.AssociationValues;
 import org.axonframework.modelling.saga.SagaRepository;
 
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -78,11 +78,13 @@ public class CachingSagaStore<T> implements SagaStore<T> {
     public Set<String> findSagas(Class<? extends T> sagaType, AssociationValue associationValue) {
 
         final String key = cacheKey(associationValue, sagaType);
-        synchronized (associationsCache) {
-            return new HashSet<>(associationsCache.computeIfAbsent(
-                    key, () -> delegate.findSagas(sagaType, associationValue))
-            );
-        }
+        return associationsCache.computeIfAbsent(
+                key,
+                () -> {
+                    // Wrap the original collection in a synchronized implementation, since it might be changed while
+                    // the SagaManager is reading it using the insertSaga/deleteSaga methods.
+                    return Collections.synchronizedSet(delegate.findSagas(sagaType, associationValue));
+                });
     }
 
     @Override
@@ -117,14 +119,12 @@ public class CachingSagaStore<T> implements SagaStore<T> {
                                                  String sagaIdentifier,
                                                  AssociationValue associationValue) {
         String key = cacheKey(associationValue, sagaType);
-        synchronized (associationsCache) {
-            associationsCache.computeIfPresent(key, associations -> {
-                //noinspection unchecked
-                ((Set<String>) associations).remove(sagaIdentifier);
-                //noinspection unchecked
-                return ((Set<String>) associations).isEmpty() ? null : associations;
-            });
-        }
+        associationsCache.computeIfPresent(key, associations -> {
+            //noinspection unchecked
+            ((Set<String>) associations).remove(sagaIdentifier);
+            //noinspection unchecked
+            return ((Set<String>) associations).isEmpty() ? null : associations;
+        });
     }
 
     /**
@@ -138,15 +138,13 @@ public class CachingSagaStore<T> implements SagaStore<T> {
     protected void addCachedAssociations(Iterable<AssociationValue> associationValues,
                                          String sagaIdentifier,
                                          Class<?> sagaType) {
-        synchronized (associationsCache) {
-            for (AssociationValue associationValue : associationValues) {
-                String key = cacheKey(associationValue, sagaType);
-                associationsCache.computeIfPresent(key, identifiers -> {
-                    //noinspection unchecked
-                    ((Set<String>) identifiers).add(sagaIdentifier);
-                    return identifiers;
-                });
-            }
+        for (AssociationValue associationValue : associationValues) {
+            String key = cacheKey(associationValue, sagaType);
+            associationsCache.computeIfPresent(key, identifiers -> {
+                //noinspection unchecked
+                ((Set<String>) identifiers).add(sagaIdentifier);
+                return identifiers;
+            });
         }
     }
 
@@ -155,7 +153,7 @@ public class CachingSagaStore<T> implements SagaStore<T> {
                            String sagaIdentifier,
                            T saga,
                            AssociationValues associationValues) {
-            sagaCache.put(sagaIdentifier, new CacheEntry<>(saga, associationValues.asSet()));
+        sagaCache.put(sagaIdentifier, new CacheEntry<>(saga, associationValues.asSet()));
 
         delegate.updateSaga(sagaType, sagaIdentifier, saga, associationValues);
         associationValues.removedAssociations()


### PR DESCRIPTION
The current fix can still trigger the ConcurrentModificationException.
This PR contains a testcase that will reliably create an exception by using the CachingSagaStore directly without modelling intervention. It does so by ending/creating saga's and querying saga's from multiple threads, causing the exception.
It also contains a fix which should be discussed. It introduces locking on the associationsCache. 