### PR TITLE
Ensure default `TrackingEventProcessorConfiguration` is taken into account for Sagas

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -75,7 +75,6 @@ import javax.annotation.Nonnull;
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.common.annotation.AnnotationUtils.findAnnotationAttributes;
 import static org.axonframework.config.EventProcessingConfigurer.PooledStreamingProcessorConfiguration.noOp;
 


### PR DESCRIPTION
The `EventProcessingConfigurer#registerTrackingEventProcessorConfiguration(Function<Configuration, TrackingEventProcessorConfiguration>)` did not overrule the default Saga `TrackingEventProcessorConfiguration`.
This is an unintended side effect when we introduced the default configuration for Sagas in issue #1019.

This pull request resolves that by adding the default `TrackingEventProcessorConfiguration` in the map of `TrackingEventProcessorConfigurations` when `EventProcessingConfigurer#registerTrackingEventProcessorConfiguration` is invoked.
This provides a simple location to validate this customization when constructing the `TrackingEventProcessor` and when defining the Saga configuration.