### PR TITLE
Adjust dependabot behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-# Updates for GitHub Actions, 'master' only.
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -15,14 +14,10 @@ updates:
     - "gklijs"
     - "Morlack"
     - "smcvb" # Main
-# Updates for `master`.
 - package-ecosystem: maven
   directory: "/"
   schedule:
     interval: daily
-  ignore:
-    - dependency-name: "*"
-      update-types: [ "version-update:semver-patch" ]
   open-pull-requests-limit: 5
   labels:
     - "Type: Dependency Upgrade"
@@ -33,22 +28,3 @@ updates:
     - "gklijs"
     - "Morlack"
     - "smcvb" # Main
-# Patch and security updates for patch branch.
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  ignore:
-    - dependency-name: "*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  labels:
-    - "Type: Dependency Upgrade"
-    - "Priority 1: Must"
-    - "Status: In Progress"
-  milestone: 81
-  open-pull-requests-limit: 5
-  reviewers:
-    - "gklijs"
-    - "Morlack"
-    - "smcvb" # Main
-  target-branch: "axon-4.6.x"

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -13,4 +13,4 @@ changelog:
       labels: [ "Type: Incorrect Repository", "Type: Question" ]
   contributors:
     exclude:
-      names: [ "dependabot" ]
+      names: [ "dependabot", "dependabot[bot]" ]


### PR DESCRIPTION
Instead of pushing patch upgrades to Axon Framework's patch branch only, this PR adjusts the behavior towards making all adjustments to `master`.
The intent of the patch version to the patch branch was to (1) deal with security fixes quicker and (2) to tag along quicker until a new minor release was made.
The security fixes are something we've decided to be diligent about ourselves.
The fact the last minor release (4.6) took so long is something we're not planning to reiterate anytime soon.
Hence, argument two should be covered as well.
Next to this minor dependabot adjustment, I've added the `dependabot[bot]` user the the ignore list when constructing the release notes.