### PR TITLE
Introduce component decorators

### DIFF
--- a/config/src/main/java/org/axonframework/config/Component.java
+++ b/config/src/main/java/org/axonframework/config/Component.java
@@ -75,8 +75,9 @@ public class Component<B> {
 
     /**
      * Retrieves the object contained in this component, triggering the builder function if the component hasn't been
-     * built yet. Upon initiation of the instance the {@link LifecycleHandlerInspector#registerLifecycleHandlers(Configuration,
-     * Object)} methods will be called to resolve and register lifecycle methods.
+     * built yet. Upon initiation of the instance the
+     * {@link LifecycleHandlerInspector#registerLifecycleHandlers(Configuration, Object)} methods will be called to
+     * resolve and register lifecycle methods.
      *
      * @return the initialized component contained in this instance
      */
@@ -101,6 +102,16 @@ public class Component<B> {
         this.builderFunction = builderFunction;
     }
 
+    /**
+     * Updates the builder function for this component by creating a new builderFunction that uses the
+     * {@code decoratingFunction} to change the original component. This can wrap the original component.
+     * <p>
+     * Lifecycle handlers are scanned for both the original component and the one created by the @code
+     * decoratingFunction}.
+     *
+     * @param decoratingFunction Function that takes the original component and can wrap or change it depending on
+     *                           requirements.
+     */
     public void decorate(@Nonnull BiFunction<Configuration, B, ? extends B> decoratingFunction) {
         Assert.state(instance == null, () -> "Cannot change " + name + ": it is already in use");
         Function<Configuration, ? extends B> previous = builderFunction;

--- a/config/src/main/java/org/axonframework/config/ComponentDecorator.java
+++ b/config/src/main/java/org/axonframework/config/ComponentDecorator.java
@@ -21,10 +21,16 @@ package org.axonframework.config;
  *
  * @author Mitchell Herrijgers
  * @since 4.7.0
- * @param <T> The Component's type
  */
-@FunctionalInterface
-public interface ComponentDecorator<T> {
+public interface ComponentDecorator {
 
-    T decorate(Configuration configuration, T component);
+    /**
+     * Can decorate the given component, returning a decorated component or the original if there is no intention
+     * of decorating it.
+     *
+     * @param configuration The Axon Configuration
+     * @param component The component to be decorated
+     * @return The decorated component
+     */
+    Object decorate(Configuration configuration, Object component);
 }

--- a/config/src/main/java/org/axonframework/config/ComponentDecorator.java
+++ b/config/src/main/java/org/axonframework/config/ComponentDecorator.java
@@ -17,10 +17,11 @@
 package org.axonframework.config;
 
 /**
- * Functional interface that is able to decorate a component.
+ * Functional interface that is able to decorate a {@link Component}, wrapping the original component.
  *
  * @author Mitchell Herrijgers
  * @since 4.7.0
+ * @param <T> The Component's type
  */
 @FunctionalInterface
 public interface ComponentDecorator<T> {

--- a/config/src/main/java/org/axonframework/config/ComponentDecorator.java
+++ b/config/src/main/java/org/axonframework/config/ComponentDecorator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.config;
+
+/**
+ * Functional interface that is able to decorate a component.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.7.0
+ */
+@FunctionalInterface
+public interface ComponentDecorator<T> {
+
+    T decorate(Configuration configuration, T component);
+}

--- a/config/src/main/java/org/axonframework/config/ComponentTypeSafeDecorator.java
+++ b/config/src/main/java/org/axonframework/config/ComponentTypeSafeDecorator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.config;
+
+import java.util.function.BiFunction;
+
+/**
+ * Type-safe implementation of the {@link ComponentDecorator}. Will check whether the component matches the target type
+ * before executing the decorating function. Additionally, if wanted, it will call the lifecycle handlers on the
+ * original component.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.7.0
+ */
+public class ComponentTypeSafeDecorator<T> implements ComponentDecorator {
+
+    private final Class<T> componentClass;
+    private final boolean registerOriginalLifeCycleHandlers;
+    private final BiFunction<Configuration, T, T> decorator;
+
+    /**
+     * Creates a new {@link ComponentTypeSafeDecorator} that can decorate a component of the {@param componentClass}.
+     *
+     * @param componentClass            The component class which this decorator should decorate.
+     * @param registerOriginalLifeCycleHandlers Whether the lifecycle handlers of the wrapped component should be registered.
+     * @param decoratorFunction         The function that returns the decorated component based on the given
+     *                                  configuration and the original.
+     */
+    public ComponentTypeSafeDecorator(Class<T> componentClass,
+                                      boolean registerOriginalLifeCycleHandlers,
+                                      BiFunction<Configuration, T, T> decoratorFunction) {
+        this.componentClass = componentClass;
+        this.registerOriginalLifeCycleHandlers = registerOriginalLifeCycleHandlers;
+        this.decorator = decoratorFunction;
+    }
+
+    /**
+     * Decorates the given component using the {@link #decorator} if it matches the {@link #componentClass}, otherwise
+     * returns the original.
+     *
+     * @param configuration The Axon Configuration
+     * @param component     The component to be decorated
+     * @return The decorated component
+     */
+    public Object decorate(Configuration configuration, Object component) {
+        if (componentClass.isAssignableFrom(component.getClass())) {
+            T result = decorator.apply(configuration, (T) component);
+            if (registerOriginalLifeCycleHandlers) {
+                LifecycleHandlerInspector.registerLifecycleHandlers(configuration, component);
+            }
+            return result;
+        }
+        return component;
+    }
+}

--- a/config/src/main/java/org/axonframework/config/Configuration.java
+++ b/config/src/main/java/org/axonframework/config/Configuration.java
@@ -44,10 +44,10 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
 import org.axonframework.tracing.SpanFactory;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 /**
  * Interface describing the Global Configuration for Axon components. It provides access to the components configured,
@@ -411,6 +411,10 @@ public interface Configuration extends LifecycleOperations {
      * @return the EventUpcasterChain with all registered upcasters
      */
     EventUpcasterChain upcasterChain();
+
+    default List<ComponentDecorator> getDecorators() {
+        throw new AxonConfigurationException("The getDecorators has not been implemented by the Configuration!");
+    }
 
     /**
      * Returns the {@link SnapshotFilter} combining all defined filters per {@link AggregateConfigurer} in an {@link

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -218,15 +218,37 @@ public interface Configurer extends LifecycleOperations {
      * configuration that matches the {@code componentType}, the {@code decorator} will be called. It's up to the
      * decorator to decide to return the original component or a wrapped version of it.
      *
-     * @param componentType The declared type of the component, typically an interface
-     * @param decorator     The decorator function for this component
-     * @param <C>           The type of component
+     * @param componentType                     The declared type of the component, typically an interface
+     * @param decoratorFunction                 The decorator function for this component
+     * @param registerOriginalLifeCycleHandlers Whether the original component's lifecycle handlers should be
+     *                                          registered.
+     * @param <C>                               The deckared type of component
      * @return the current instance of the Configurer, for chaining purposes
      */
     default <C> Configurer registerComponentDecorator(@Nonnull Class<C> componentType,
-                                              @Nonnull ComponentDecorator<C> decorator) {
-        // Default implementation for backwards compatibility
-        return this;
+                                                      @Nonnull BiFunction<Configuration, C, C> decoratorFunction,
+                                                      boolean registerOriginalLifeCycleHandlers
+    ) {
+        throw new AxonConfigurationException(
+                "The registerComponentDecorator function has not been implemented by the Configurer");
+    }
+
+    /**
+     * Registers a {@link ComponentDecorator decorator} for a component type. For any component that is created by the
+     * configuration that matches the {@code componentType}, the {@code decorator} will be called. It's up to the
+     * decorator to decide to return the original component or a wrapped version of it.
+     * <p>
+     * Will register the original's lifecycle handlers.
+     *
+     * @param componentType     The declared type of the component, typically an interface
+     * @param decoratorFunction The decorator function for this component
+     * @param <C>               The deckared type of component
+     * @return the current instance of the Configurer, for chaining purposes
+     */
+    default <C> Configurer registerComponentDecorator(@Nonnull Class<C> componentType,
+                                                      @Nonnull BiFunction<Configuration, C, C> decoratorFunction
+    ) {
+        return registerComponentDecorator(componentType, decoratorFunction, true);
     }
 
     /**

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -214,9 +214,9 @@ public interface Configurer extends LifecycleOperations {
 
 
     /**
-     * Registers a decorator for a component type. For any component that is created by the configuration that matches
-     * the {@code componentType}, the {@code decorator} will be called. It's up to the decorator to decide to return the
-     * original component, a wrapped version of it or something else entirely.
+     * Registers a {@link ComponentDecorator decorator} for a component type. For any component that is created by the
+     * configuration that matches the {@code componentType}, the {@code decorator} will be called. It's up to the
+     * decorator to decide to return the original component or a wrapped version of it.
      *
      * @param componentType The declared type of the component, typically an interface
      * @param decorator     The decorator function for this component

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -212,6 +212,23 @@ public interface Configurer extends LifecycleOperations {
     <C> Configurer registerComponent(@Nonnull Class<C> componentType,
                                      @Nonnull Function<Configuration, ? extends C> componentBuilder);
 
+
+    /**
+     * Registers a decorator for a component type. For any component that is created by the configuration that matches
+     * the {@code componentType}, the {@code decorator} will be called. It's up to the decorator to decide to return the
+     * original component, a wrapped version of it or something else entirely.
+     *
+     * @param componentType The declared type of the component, typically an interface
+     * @param decorator     The decorator function for this component
+     * @param <C>           The type of component
+     * @return the current instance of the Configurer, for chaining purposes
+     */
+    default <C> Configurer registerComponentDecorator(@Nonnull Class<C> componentType,
+                                              @Nonnull ComponentDecorator<C> decorator) {
+        // Default implementation for backwards compatibility
+        return this;
+    }
+
     /**
      * Registers a command handler bean with this {@link Configurer}. The bean may be of any type. The actual command
      * handler methods will be detected based on the annotations present on the bean's methods. Message handling

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -222,7 +222,7 @@ public interface Configurer extends LifecycleOperations {
      * @param decoratorFunction                 The decorator function for this component
      * @param registerOriginalLifeCycleHandlers Whether the original component's lifecycle handlers should be
      *                                          registered.
-     * @param <C>                               The deckared type of component
+     * @param <C>                               The declared type of component
      * @return the current instance of the Configurer, for chaining purposes
      */
     default <C> Configurer registerComponentDecorator(@Nonnull Class<C> componentType,
@@ -242,7 +242,7 @@ public interface Configurer extends LifecycleOperations {
      *
      * @param componentType     The declared type of the component, typically an interface
      * @param decoratorFunction The decorator function for this component
-     * @param <C>               The deckared type of component
+     * @param <C>               The declared type of component
      * @return the current instance of the Configurer, for chaining purposes
      */
     default <C> Configurer registerComponentDecorator(@Nonnull Class<C> componentType,

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -808,8 +808,15 @@ public class DefaultConfigurer implements Configurer {
         initHandlers.forEach(h -> h.accept(config));
     }
 
+    /**
+     * Calls all registered decorators of this configuration and updates the components where appropriate. Decorating
+     * components is postponed until building to make sure all {@link Component} definitions are present and can be
+     * decorated.
+     * <p>
+     * Registration of decorates are ignore after initialization.
+     */
     protected void invokeDecoratorHandlers() {
-        decoratorHandlers.forEach(h -> h.run());
+        decoratorHandlers.forEach(Runnable::run);
     }
 
     /**

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerLifecycleOperationsTest.java
@@ -482,8 +482,8 @@ class DefaultConfigurerLifecycleOperationsTest {
                 .defaultConfiguration()
                 .registerComponent(LifeCycleComponent.class, config -> original)
                 .registerComponentDecorator(LifeCycleComponent.class, (config, o) -> decorator1)
-                .registerComponentDecorator(LifeCycleComponent.class, (config, o) -> decorator2)
-                .registerComponentDecorator(LifeCycleComponent.class, (config, o) -> decorator3)
+                .registerComponentDecorator(LifeCycleComponent.class, (config, o) -> decorator2 )
+                .registerComponentDecorator(LifeCycleComponent.class, (config, o) -> decorator3, false)
                 .buildConfiguration();
 
         testSubject.getComponent(LifeCycleComponent.class);
@@ -494,12 +494,12 @@ class DefaultConfigurerLifecycleOperationsTest {
                 inOrder(original, decorator1, decorator2, decorator3);
         lifecycleOrder.verify(original).registerLifecycleHandlers(any());
         lifecycleOrder.verify(decorator1).registerLifecycleHandlers(any());
-        lifecycleOrder.verify(decorator2).registerLifecycleHandlers(any());
+        lifecycleOrder.verify(decorator2, never()).registerLifecycleHandlers(any());
         lifecycleOrder.verify(decorator3).registerLifecycleHandlers(any());
 
         assertTrue(original.isInvoked());
         assertTrue(decorator1.isInvoked());
-        assertTrue(decorator2.isInvoked());
+        assertFalse(decorator2.isInvoked());
         assertTrue(decorator3.isInvoked());
     }
 

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -638,7 +638,7 @@ class DefaultConfigurerTest {
                                                                           (configuration, component) -> {
                                                                               assertSame(custom, component);
                                                                               return decorated;
-                                                                          })
+                                                                          }, false)
                                               .buildConfiguration()
                                               .spanFactory();
 

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -620,11 +620,29 @@ class DefaultConfigurerTest {
         SpanFactory custom = mock(SpanFactory.class);
 
         SpanFactory result = DefaultConfigurer.defaultConfiguration()
-                        .configureSpanFactory((config) -> custom)
-                                 .buildConfiguration()
-                                 .spanFactory();
+                                              .configureSpanFactory((config) -> custom)
+                                              .buildConfiguration()
+                                              .spanFactory();
 
         assertSame(custom, result);
+    }
+
+    @Test
+    void canDecorateComponentsSuchAsSpanFactory() {
+        SpanFactory custom = mock(SpanFactory.class);
+        SpanFactory decorated = mock(SpanFactory.class);
+
+        SpanFactory result = DefaultConfigurer.defaultConfiguration()
+                                              .configureSpanFactory((config) -> custom)
+                                              .registerComponentDecorator(SpanFactory.class,
+                                                                          (configuration, component) -> {
+                                                                              assertSame(custom, component);
+                                                                              return decorated;
+                                                                          })
+                                              .buildConfiguration()
+                                              .spanFactory();
+
+        assertSame(decorated, result);
     }
 
     @Test
@@ -637,8 +655,8 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void whenStubAggregateRegisteredWithRegisterMessageHandler_thenRightThingsCalled(){
-        Configurer configurer =  spy(DefaultConfigurer.defaultConfiguration());
+    void whenStubAggregateRegisteredWithRegisterMessageHandler_thenRightThingsCalled() {
+        Configurer configurer = spy(DefaultConfigurer.defaultConfiguration());
         configurer.registerMessageHandler(c -> new StubAggregate());
 
         verify(configurer, times(1)).registerCommandHandler(any());
@@ -647,8 +665,8 @@ class DefaultConfigurerTest {
     }
 
     @Test
-    void whenQueryHandlerRegisteredWithRegisterMessageHandler_thenRightThingsCalled(){
-        Configurer configurer =  spy(DefaultConfigurer.defaultConfiguration());
+    void whenQueryHandlerRegisteredWithRegisterMessageHandler_thenRightThingsCalled() {
+        Configurer configurer = spy(DefaultConfigurer.defaultConfiguration());
         configurer.registerMessageHandler(c -> new StubQueryHandler());
 
         verify(configurer, never()).registerCommandHandler(any());

--- a/messaging/src/main/java/org/axonframework/tracing/SpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanFactory.java
@@ -132,11 +132,11 @@ public interface SpanFactory {
      * {@link SpanUtils#determineMessageName(Message)}.
      *
      * @param operationNameSupplier Supplier of the operation's name.
-     * @param parentMessage  The message that is being handled.
+     * @param message  The message that is being sent.
      * @param linkedSiblings Optional parameter, providing this will link the provided messages to the current.
      * @return The created {@link Span}.
      */
-    Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage, Message<?>... linkedSiblings);
+    Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> message, Message<?>... linkedSiblings);
 
     /**
      * Creates a new {@link Span} linked to the currently active span. This is useful for tracing different parts of


### PR DESCRIPTION
You can now decorate `Component` instances by calling `Configurer.registerComponentDecorator`. Upon initialization of the component, the original component will be constructed and the decorators will be called in order. Decorators can return the existing component, a modified version of it or a completely different implementation, as long as it's the same type.