### PR TITLE
Several fixes to successfully run a JDK17 build

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.utils.InMemoryAppender;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
@@ -47,12 +48,14 @@ import static org.mockito.Mockito.*;
  */
 class AbstractSnapshotterTest {
 
-    private AbstractSnapshotter testSubject;
     private EventStore mockEventStore;
     private TestSpanFactory spanFactory;
 
+    private AbstractSnapshotter testSubject;
+
     @BeforeEach
     void setUp() throws Exception {
+        InMemoryAppender.clearLogs();
         mockEventStore = mock(EventStore.class);
         spanFactory = new TestSpanFactory();
         testSubject = TestSnapshotter.builder()
@@ -135,6 +138,8 @@ class AbstractSnapshotterTest {
 
         testSubject.scheduleSnapshot(Object.class, aggregateIdentifier);
         verify(mockEventStore, times(2)).storeSnapshot(argThat(event(aggregateIdentifier, 1)));
+
+        assertTrue(InMemoryAppender.logEvents().isEmpty());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/utils/InMemoryAppender.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/utils/InMemoryAppender.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.utils;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Custom {@link Appender} used for validating log statements.
+ *
+ * @author Steven van Beelen
+ */
+@Plugin(
+        name = "InMemoryAppender",
+        category = Core.CATEGORY_NAME,
+        elementType = Appender.ELEMENT_TYPE
+)
+public class InMemoryAppender extends AbstractAppender {
+
+    public static final boolean DO_NOT_USE_CURRENT_CONTEXT = false;
+    private final List<LogEvent> logEvents;
+
+    /**
+     * Constructs a {@link InMemoryAppender} based on the given {@code name} and {@code filter}.
+     * <p>
+     * Will default the {@link org.apache.logging.log4j.core.Layout} to {@code null}, it sets {@code ignoreExceptions}
+     * to {@code false}, and it defines the {@link Property Property array} as {@code null}.
+     *
+     * @param name   The name of this {@link Appender}.
+     * @param filter The filter used by this {@link Appender}.
+     */
+    protected InMemoryAppender(String name, Filter filter) {
+        super(name, filter, null, DO_NOT_USE_CURRENT_CONTEXT, null);
+        logEvents = new CopyOnWriteArrayList<>();
+    }
+
+    @SuppressWarnings("unused") // Suppressed since used by Log4J.
+    @PluginFactory
+    public static InMemoryAppender createAppender(@PluginAttribute("name") String name,
+                                                  @PluginElement("Filter") Filter filter) {
+        return new InMemoryAppender(name, filter);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        logEvents.add(event);
+    }
+
+    /**
+     * Return the {@link LogEvent LogEvents} this {@link Appender} has {@link Appender#append(LogEvent) added}.
+     *
+     * @return The {@link LogEvent LogEvents} this {@link Appender} has {@link Appender#append(LogEvent) added}.
+     */
+    public List<LogEvent> getLogEvents() {
+        return logEvents;
+    }
+
+    /**
+     * Clear the {@link #getLogEvents() logs} of the {@link InMemoryAppender}.
+     * <p>
+     * Use this to ensure a test starts with a clean log.
+     */
+    public static void clearLogs() {
+        LoggerContext context = LoggerContext.getContext(DO_NOT_USE_CURRENT_CONTEXT);
+        Configuration configuration = context.getConfiguration();
+        InMemoryAppender inMemoryAppender = configuration.getAppender("InMemoryAppender");
+        inMemoryAppender.getLogEvents().clear();
+    }
+
+    /**
+     * Return the {@link LogEvent LogEvents} the {@link InMemoryAppender} has
+     * {@link Appender#append(LogEvent) appended}.
+     *
+     * @return The {@link LogEvent LogEvents} the {@link InMemoryAppender} has
+     * {@link Appender#append(LogEvent) appended}.
+     */
+    public static List<LogEvent> logEvents() {
+        LoggerContext context = LoggerContext.getContext(DO_NOT_USE_CURRENT_CONTEXT);
+        Configuration configuration = context.getConfiguration();
+        InMemoryAppender inMemoryAppender = configuration.getAppender("InMemoryAppender");
+        return new ArrayList<>(inMemoryAppender.getLogEvents());
+    }
+}

--- a/eventsourcing/src/test/resources/log4j2.properties
+++ b/eventsourcing/src/test/resources/log4j2.properties
@@ -15,7 +15,7 @@
 #
 
 name=AxonTestConfiguration
-appenders = console, in-memory
+appenders = console, recording
 packages = org.axonframework.eventsourcing.utils
 
 appender.console.type = Console
@@ -23,14 +23,14 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d [%t] %-5p %-30.30c{1} %x - %m%n
 
-appender.in-memory = org.axonframework.eventsourcing.utils.InMemoryAppender
-appender.in-memory.name = InMemoryAppender
-appender.in-memory.type = InMemoryAppender
+appender.recording = org.axonframework.eventsourcing.utils.RecordingAppender
+appender.recording.name = RecordingAppender
+appender.recording.type = RecordingAppender
 
 rootLogger.level = info
-rootLogger.appenderRefs = stdout, in-memory
+rootLogger.appenderRefs = stdout, recording
 rootLogger.appenderRef.stdout.ref = STDOUT
-rootLogger.appenderRef.in-memory.ref = InMemoryAppender
+rootLogger.appenderRef.recording.ref = RecordingAppender
 
 logger.axon.name = org.axonframework
 logger.axon.level = INFO

--- a/eventsourcing/src/test/resources/log4j2.properties
+++ b/eventsourcing/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,22 @@
 #
 
 name=AxonTestConfiguration
-appenders = console
+appenders = console, in-memory
+packages = org.axonframework.eventsourcing.utils
 
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d [%t] %-5p %-30.30c{1} %x - %m%n
 
+appender.in-memory = org.axonframework.eventsourcing.utils.InMemoryAppender
+appender.in-memory.name = InMemoryAppender
+appender.in-memory.type = InMemoryAppender
+
 rootLogger.level = info
-rootLogger.appenderRefs = stdout
+rootLogger.appenderRefs = stdout, in-memory
 rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.in-memory.ref = InMemoryAppender
 
 logger.axon.name = org.axonframework
 logger.axon.level = INFO

--- a/eventsourcing/src/test/resources/log4j2.properties
+++ b/eventsourcing/src/test/resources/log4j2.properties
@@ -15,28 +15,26 @@
 #
 
 name=AxonTestConfiguration
-appenders = console, recording
-packages = org.axonframework.eventsourcing.utils
 
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d [%t] %-5p %-30.30c{1} %x - %m%n
 
-appender.recording = org.axonframework.eventsourcing.utils.RecordingAppender
-appender.recording.name = RecordingAppender
-appender.recording.type = RecordingAppender
+appender.recording.type=RecordingAppender
+appender.recording.name=RECORD
 
 rootLogger.level = info
 rootLogger.appenderRefs = stdout, recording
-rootLogger.appenderRef.stdout.ref = STDOUT
-rootLogger.appenderRef.recording.ref = RecordingAppender
+rootLogger.appenderRef.stdout.ref=STDOUT
+rootLogger.appenderRef.recording.ref=RECORD
 
 logger.axon.name = org.axonframework
 logger.axon.level = INFO
-logger.axon.additivity = false
-logger.axon.appenderRefs = stdout
-logger.axon.appenderRef.stdout.ref = STDOUT
+logger.axon.additivity=false
+logger.axon.appenderRefs=stdout, recording
+logger.axon.appenderRef.stdout.ref=STDOUT
+logger.axon.appenderRef.recording.ref=RECORD
 
 logger.chaining-converter.name = org.axonframework.serialization.ChainingConverter
 logger.chaining-converter.level = OFF

--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -86,6 +86,7 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         xStream.alias("deadline", GenericDeadlineMessage.class);
         xStream.alias("meta-data", MetaData.class);
         xStream.registerConverter(new MetaDataConverter(xStream.getMapper()));
+        xStream.registerConverter(new GapAwareTrackingTokenConverter(xStream.getMapper()));
 
         xStream.addImmutableType(UUID.class, true);
         // For backward compatibility

--- a/messaging/src/main/java/org/axonframework/serialization/GapAwareTrackingTokenConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/GapAwareTrackingTokenConverter.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.mapper.Mapper;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Dedicated {@link CollectionConverter} implementation to de-/serializer the {@link GapAwareTrackingToken} and
+ * {@code org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken}.
+ * <p>
+ * Necessary due to the {@link java.util.concurrent.ConcurrentSkipListSet} used within the
+ * {@code GapAwareTrackingToken}, as {@link XStream} is incapable to marshall / unmarshall these
+ * {@link Collection Collections} from the {@code java.util.concurrent} package. In pre-JDK16 times, {@code XStream}
+ * would use the {@link com.thoughtworks.xstream.converters.reflection.ReflectionConverter} for this.
+ *
+ * @author Steven van Beelen
+ * @since 4.7.0
+ */
+public final class GapAwareTrackingTokenConverter extends CollectionConverter {
+
+    private static final String GAP_AWARE_TRACKING_TOKEN =
+            "org.axonframework.eventhandling.GapAwareTrackingToken";
+    private static final String LEGACY_GAP_AWARE_TRACKING_TOKEN =
+            "org.axonframework.eventsourcing.eventstore.GapAwareTrackingToken";
+
+    private static final String INDEX_NODE = "index";
+    private static final String GAPS_NODE = "gaps";
+
+    private final ReflectivelyConstructedGapSetConverter reflectivelyConstructedGapSetConverter;
+
+    /**
+     * Constructs a {@link GapAwareTrackingTokenConverter}.
+     *
+     * @param mapper The mapper to be used by the constructed {@link GapAwareTrackingTokenConverter}.
+     */
+    public GapAwareTrackingTokenConverter(Mapper mapper) {
+        super(mapper);
+        reflectivelyConstructedGapSetConverter = new ReflectivelyConstructedGapSetConverter(mapper);
+    }
+
+    @Override
+    public void marshal(Object source,
+                        HierarchicalStreamWriter writer,
+                        MarshallingContext context) {
+        GapAwareTrackingToken token = (GapAwareTrackingToken) source;
+
+        writer.startNode(INDEX_NODE);
+        writer.setValue(String.valueOf(token.getIndex()));
+        writer.endNode();
+
+        writer.startNode(GAPS_NODE);
+        SortedSet<Long> gaps = token.getGaps();
+        for (Long gap : gaps) {
+            writeCompleteItem(gap, context, writer);
+        }
+        writer.endNode();
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        // Read the index
+        reader.moveDown();
+        //noinspection WrapperTypeMayBePrimitive
+        Long index = Long.valueOf(reader.getValue());
+        reader.moveUp();
+
+        // Read the gaps
+        Set<Long> gaps;
+        reader.moveDown();
+        if (doesNotHaveClassAttribute(reader)) {
+            //noinspection unchecked
+            gaps = (TreeSet<Long>) createCollection(TreeSet.class);
+            populateCollection(reader, context, gaps);
+        } else {
+            //noinspection unchecked
+            gaps = ((TreeSet<Long>) reflectivelyConstructedGapSetConverter.unmarshal(reader, context));
+        }
+        reader.moveUp();
+        return new GapAwareTrackingToken(index, gaps);
+    }
+
+    /**
+     * Returns {@code true} if the given {@code reader} at its current position does not contain the {@code "class"}
+     * attribute, and {@code false} otherwise.
+     * <p>
+     * Since the {@link GapAwareTrackingTokenConverter} during marshalling <b>does not</b> set any class attributes, we
+     * can assume we are dealing with the marshalled format of this converter when {@code true} is returned. Otherwise,
+     * we need to assume we're dealing with a marshalled format from the
+     * {@link com.thoughtworks.xstream.converters.reflection.ReflectionConverter}.
+     *
+     * @param reader The reader used to request if the attribute {@code "class"} is present at the current position.
+     * @return {@code true} if the given {@code reader} at its current position does not contain the {@code "class"}
+     * attribute, and {@code false} otherwise.
+     */
+    private static boolean doesNotHaveClassAttribute(HierarchicalStreamReader reader) {
+        return reader.getAttribute("class") == null;
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return GAP_AWARE_TRACKING_TOKEN.equals(type.getName())
+                || LEGACY_GAP_AWARE_TRACKING_TOKEN.equals(type.getName());
+    }
+
+    private static final class ReflectivelyConstructedGapSetConverter extends CollectionConverter {
+
+        // The marshalled ConcurrentSkipListSet of a GapAwareTrackingToken starts the gap set with a node named "default".
+        private static final String DEFAULT_NODE = "default";
+        // The marshalled ConcurrentSkipListSet of a GapAwareTrackingToken ends the gap set with a node named "null".
+        private static final String NULL_NODE = "null";
+
+        ReflectivelyConstructedGapSetConverter(Mapper mapper) {
+            super(mapper);
+        }
+
+        @Override
+        public boolean canConvert(Class type) {
+            throw new UnsupportedOperationException(
+                    "This converter is only intended to directly unmarshal "
+                            + "a reflectively constructed GapAwareTrackingToken gaps collections"
+            );
+        }
+
+        @Override
+        public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
+            throw new UnsupportedOperationException(
+                    "This converter is only intended to directly unmarshal "
+                            + "a reflectively constructed GapAwareTrackingToken gaps collections"
+            );
+        }
+
+        /**
+         * Highly customized unmarshal method, expecting a very specific format following from the
+         * {@link java.util.concurrent.ConcurrentSkipListSet} XStream marshals through it's
+         * {@link com.thoughtworks.xstream.converters.reflection.ReflectionConverter}.
+         * <p>
+         * As we're certain we're dealing with the {@code gaps} {@link Collection} of a {@link GapAwareTrackingToken},
+         * we can skip the uninteresting private fields of the {@code ConcurrentSkipListSet}.
+         * <p>
+         * Furthermore, as the {@code ConcurrentSkipListSet} internally uses a
+         * {@link java.util.concurrent.ConcurrentSkipListMap}, we skip the values (which default to {@code booleans}.
+         */
+        @Override
+        public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+            //noinspection unchecked
+            Set<Long> gaps = (Set<Long>) createCollection(TreeSet.class);
+
+            reader.moveDown(); // skip <gaps class="java.util.concurrent.ConcurrentSkipListSet">
+            reader.moveDown(); // skip <m class="java.util.concurrent.ConcurrentSkipListMap" serialization="custom">
+            reader.moveUp(); // skip <unserializable-parents/>
+            reader.moveDown(); // skip <java.util.concurrent.ConcurrentSkipListMap>
+
+            while (reader.hasMoreChildren()) {
+                reader.moveDown();
+                if (readingDefaultOrNullNode(reader.getNodeName()) || readingBooleanNode(reader.getValue())) {
+                    reader.moveUp();
+                    continue;
+                }
+                gaps.add(Long.valueOf(reader.getValue()));
+                reader.moveUp();
+            }
+
+            reader.moveUp();
+            reader.moveUp();
+            return gaps;
+        }
+
+        private static boolean readingDefaultOrNullNode(String nodeName) {
+            return DEFAULT_NODE.equals(nodeName) || NULL_NODE.equals(nodeName);
+        }
+
+        private static boolean readingBooleanNode(String value) {
+            return Boolean.TRUE.toString().equals(value) || Boolean.FALSE.toString().equals(value);
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -33,6 +33,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
 import org.axonframework.tracing.TestSpanFactory;
+import org.axonframework.utils.DelegateScheduledExecutorService;
 import org.axonframework.utils.InMemoryStreamableEventSource;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
@@ -86,8 +87,8 @@ class PooledStreamingEventProcessorTest {
         stubMessageSource = new InMemoryStreamableEventSource();
         stubEventHandler = mock(EventHandlerInvoker.class);
         tokenStore = spy(new InMemoryTokenStore());
-        coordinatorExecutor = Executors.newScheduledThreadPool(2);
-        workerExecutor = Executors.newScheduledThreadPool(8);
+        coordinatorExecutor = new DelegateScheduledExecutorService(Executors.newScheduledThreadPool(2));
+        workerExecutor = new DelegateScheduledExecutorService(Executors.newScheduledThreadPool(8));
         spanFactory = new TestSpanFactory();
 
         setTestSubject(createTestSubject());

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
@@ -30,6 +30,7 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.utils.DelegateScheduledExecutorService;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
@@ -40,8 +41,8 @@ import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -59,7 +60,7 @@ class WorkPackageTest {
     private static final String PROCESSOR_NAME = "test";
 
     private TokenStore tokenStore;
-    private ExecutorService executorService;
+    private ScheduledExecutorService executorService;
     private TestEventFilter eventFilter;
     private TestBatchProcessor batchProcessor;
     private Segment segment;
@@ -76,7 +77,7 @@ class WorkPackageTest {
     @BeforeEach
     void setUp() {
         tokenStore = spy(new InMemoryTokenStore());
-        executorService = spy(Executors.newScheduledThreadPool(1));
+        executorService = spy(new DelegateScheduledExecutorService(Executors.newScheduledThreadPool(1)));
         eventFilter = new TestEventFilter();
         batchProcessor = new TestBatchProcessor();
         segment = Segment.ROOT_SEGMENT;

--- a/messaging/src/test/java/org/axonframework/serialization/xml/GapAwareTrackingTokenConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/xml/GapAwareTrackingTokenConverterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.serialization.xml;
+
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.serialization.GapAwareTrackingTokenConverter;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link GapAwareTrackingTokenConverter}. Does so against the new format the
+ * {@code GapAwareTrackingTokenConverter} constructs and the previous Reflective format constructed by XStream
+ * pre-JDK17.
+ *
+ * @author Steven van Beelen
+ */
+class GapAwareTrackingTokenConverterTest {
+
+    private static final GapAwareTrackingToken TEST_TOKEN =
+            GapAwareTrackingToken.newInstance(Long.MAX_VALUE, asList(0L, 1L));
+    public static final String TOKEN_CLASS_NAME = "org.axonframework.eventhandling.GapAwareTrackingToken";
+    private static final String REFLECTIVE_XML_FORMAT =
+            "<org.axonframework.eventhandling.GapAwareTrackingToken>"
+                    + "<index>9223372036854775807</index>"
+                    + "<gaps class=\"java.util.concurrent.ConcurrentSkipListSet\">"
+                    + "<m class=\"java.util.concurrent.ConcurrentSkipListMap\" serialization=\"custom\">"
+                    + "<unserializable-parents/>"
+                    + "<java.util.concurrent.ConcurrentSkipListMap>"
+                    + "<default/>"
+                    + "<long>0</long>"
+                    + "<boolean>true</boolean>"
+                    + "<long>1</long>"
+                    + "<boolean>true</boolean>"
+                    + "<null/>"
+                    + "</java.util.concurrent.ConcurrentSkipListMap>"
+                    + "</m>"
+                    + "</gaps>"
+                    + "</org.axonframework.eventhandling.GapAwareTrackingToken>";
+    private static final String CUSTOM_CONVERTER_XML_FORMAT =
+            "<org.axonframework.eventhandling.GapAwareTrackingToken>"
+                    + "<index>9223372036854775807</index>"
+                    + "<gaps>"
+                    + "<long>0</long>"
+                    + "<long>1</long>"
+                    + "</gaps>"
+                    + "</org.axonframework.eventhandling.GapAwareTrackingToken>";
+
+    private final XStreamSerializer serializer = (XStreamSerializer) TestSerializer.XSTREAM.getSerializer();
+
+    @Test
+    void canDeserializeReflectiveFormat() {
+        SerializedObject<String> reflectivelySerializedToken =
+                new SimpleSerializedObject<>(REFLECTIVE_XML_FORMAT, String.class, TOKEN_CLASS_NAME, null);
+
+        GapAwareTrackingToken result = serializer.deserialize(reflectivelySerializedToken);
+        assertEquals(TEST_TOKEN, result);
+    }
+
+    @Test
+    void canDeserializeCustomConverterFormat() {
+        SerializedObject<String> reflectivelySerializedToken =
+                new SimpleSerializedObject<>(CUSTOM_CONVERTER_XML_FORMAT, String.class, TOKEN_CLASS_NAME, null);
+
+        GapAwareTrackingToken result = serializer.deserialize(reflectivelySerializedToken);
+        assertEquals(TEST_TOKEN, result);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/utils/DelegateScheduledExecutorService.java
+++ b/messaging/src/test/java/org/axonframework/utils/DelegateScheduledExecutorService.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An {@link ExecutorService} implementation delegating all calls to another {@code ExecutorService}. This allows for
+ * spying the use of an executor, if necessary.
+ *
+ * @author Steven van Beelen
+ */
+public class DelegateScheduledExecutorService implements ScheduledExecutorService {
+
+    private final ScheduledExecutorService delegate;
+
+    /**
+     * Construct a {@link DelegateScheduledExecutorService} using the given {@code delegate}.
+     *
+     * @param delegate The {@link ScheduledExecutorService} to delegate all calls to.
+     */
+    public DelegateScheduledExecutorService(ScheduledExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                         long timeout,
+                                         TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks,
+                           long timeout,
+                           TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
 
         <!-- dependency versions -->
 
-        <slf4j.version>2.0.4</slf4j.version>
-        <log4j.version>2.18.0</log4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
+        <log4j.version>2.19.0</log4j.version>
         <spring.version>5.3.24</spring.version>
         <spring-security.version>5.7.3</spring-security.version>
         <spring.boot.version>2.7.7</spring.boot.version>
@@ -165,7 +165,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
@@ -157,12 +157,9 @@ public class SagaCustomizeIntegrationTest {
     @SuppressWarnings("unused")
     public static class SimpleSaga {
 
-        @Autowired
-        private AtomicInteger eventsReceived;
-
         @SagaEventHandler(associationProperty = "id")
         @StartSaga
-        public void on(EchoEvent echoEvent) {
+        public void on(EchoEvent echoEvent, AtomicInteger eventsReceived) {
             eventsReceived.getAndIncrement();
         }
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.PriorityQueue;
+import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -219,7 +219,7 @@ class InfraConfigurationTest {
 
         @Bean
         public Queue<String> handlingOutcome() {
-            return new PriorityQueue<>();
+            return new LinkedList<>();
         }
 
         @Bean

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -277,7 +277,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     @Override
     public ResultValidator<T> expectNoScheduledDeadline(Instant from, Instant to, Object deadline) {
-        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(equalTo(deadline, fieldFilter)));
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(deepEquals(deadline, fieldFilter)));
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureExecutionResultImpl.java
@@ -350,7 +350,7 @@ public class FixtureExecutionResultImpl<T> implements FixtureExecutionResult {
 
     @Override
     public FixtureExecutionResult expectNoScheduledDeadline(Instant from, Instant to, Object deadline) {
-        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(equalTo(deadline, fieldFilter)));
+        return expectNoScheduledDeadlineMatching(from, to, messageWithPayload(deepEquals(deadline, fieldFilter)));
     }
 
     @Override

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Deadlines.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Deadlines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class FixtureTest_Deadlines {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
-               .expectDeadlinesMetMatching(payloadsMatching(exactSequenceOf(equalTo(DEADLINE_PAYLOAD))));
+               .expectDeadlinesMetMatching(payloadsMatching(exactSequenceOf(deepEquals(DEADLINE_PAYLOAD))));
     }
 
     @Test
@@ -109,7 +109,7 @@ class FixtureTest_Deadlines {
         fixture.givenNoPriorActivity()
                .andGivenCommands(CREATE_COMMAND)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
-               .expectTriggeredDeadlinesMatching(payloadsMatching(exactSequenceOf(equalTo(DEADLINE_PAYLOAD))));
+               .expectTriggeredDeadlinesMatching(payloadsMatching(exactSequenceOf(deepEquals(DEADLINE_PAYLOAD))));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_Deadlines.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_Deadlines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ class FixtureTest_Deadlines {
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
                .expectActiveSagas(1)
-               .expectDeadlinesMetMatching(payloadsMatching(exactSequenceOf(equalTo(DEADLINE_PAYLOAD))))
+               .expectDeadlinesMetMatching(payloadsMatching(exactSequenceOf(deepEquals(DEADLINE_PAYLOAD))))
                .expectNoScheduledEvents();
     }
 
@@ -130,7 +130,7 @@ class FixtureTest_Deadlines {
                .published(START_SAGA_EVENT)
                .whenTimeElapses(Duration.ofMinutes(TRIGGER_DURATION_MINUTES + 1))
                .expectActiveSagas(1)
-               .expectTriggeredDeadlinesMatching(payloadsMatching(exactSequenceOf(equalTo(DEADLINE_PAYLOAD))))
+               .expectTriggeredDeadlinesMatching(payloadsMatching(exactSequenceOf(deepEquals(DEADLINE_PAYLOAD))))
                .expectNoScheduledEvents();
     }
 


### PR DESCRIPTION
This pull request aims to ensure the build of Axon Framework fully succeeds through all the test cases present.
Although Axon Framework is *already* usable within a JDK17 project, some of the framework's tests took approaches no longer valid in higher version of the JDK.
To sum up, the following adjustments have been made to make Axon Framework `mvn clean install` succeed:

- Removed `Logger` validation from the `AbstractSnapshotterTest`, as this was set through some (undesired) reflective operations. Furthermore, they did not provide any direct benefit for the test case.
- Introduce a `GapAwareTrackingTokenConverter` for the `XStreamSerializer`. This is necessary, as the `GapAwareTrackingToken` uses a `ConcurrentSkipListSet` internally. This is part of `java.util.concurrent`, a package `XStream` utilities should no longer access. As such, the `ReflectionConverter` (within `XStream`) could no longer marshal or unmarshal a `GapAwareTrackingToken`. The `GapAwareTrackingTokenConverter` resolves this by marshaling it to a custom format. When unmarshalling, it checks whether the custom format is provided or the "old" format. The latter ensures a safe transition to this version of Axon Framework whenever the `XStreamSerializer` is used in conjunction with `GapAwareTrackingTokens` (thus, when an `EmbeddedEventStore` is used).
- Some test cases use a `DelegateScheduledExecutorService`. This allows the spying, which is done in the `PooledStreamingEventProcessorTest` and `WorkPackageTest`, to proceed. JDK17 did not allow Mockito (or at least the version of Mockito we use) enough access to make the previous approach work.
- Made an `AtomicInteger` in a Saga test resolved as a parameter i.o. a field. As a field, the `XStreamSerializer` tried to deserialize it, which it cannot in JDK17.
- Adjusted a `Set` that was part of a Spring Application Context into a `Queue`. We spied the `Set` to be able to validate the invocation order. I assume Mockito wraps the bean in something that Spring can no longer correctly wire in JDK17 with the current versions of both Mockito and Spring.
- Replaced internal usage of the (deprecated) `EqualFieldsMatcher` in favor of the `DeepEqualsMatcher`. The latter takes into account it may not be able to access everything through reflection, while the former simply assumes it can.
