### PR TITLE
Add `Configurer#registerHandlerEnhancerDefinition`

### DIFF
--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.monitoring.MessageMonitor;
@@ -475,6 +476,24 @@ public interface Configurer extends LifecycleOperations {
      */
     Configurer registerHandlerDefinition(
             @Nonnull BiFunction<Configuration, Class, HandlerDefinition> handlerDefinitionClass);
+
+    /**
+     * Registers a builder function for a {@link HandlerEnhancerDefinition} used during constructing of the default
+     * {@link HandlerDefinition}.
+     * <p>
+     * Any number of handler enhancer builder functions can be registered through this method. Note that any
+     * {@code HandlerEnhancerDefinitions} registered through this method are <b>ignored</b> for handlers matching the
+     * type used in the {@link #registerHandlerDefinition(BiFunction)} method's lambda.
+     *
+     * @param handlerEnhancerBuilder A lambda constructing a {@link HandlerEnhancerDefinition} based on the
+     *                               {@link Configuration}.
+     * @return The current instance of the {@link Configurer}, for chaining purposes.
+     */
+    default Configurer registerHandlerEnhancerDefinition(
+            Function<Configuration, HandlerEnhancerDefinition> handlerEnhancerBuilder
+    ) {
+        return this;
+    }
 
     /**
      * Registers a {@link Snapshotter} instance with this {@link Configurer}. Defaults to a {@link

--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -489,11 +489,9 @@ public interface Configurer extends LifecycleOperations {
      *                               {@link Configuration}.
      * @return The current instance of the {@link Configurer}, for chaining purposes.
      */
-    default Configurer registerHandlerEnhancerDefinition(
+    Configurer registerHandlerEnhancerDefinition(
             Function<Configuration, HandlerEnhancerDefinition> handlerEnhancerBuilder
-    ) {
-        return this;
-    }
+    );
 
     /**
      * Registers a {@link Snapshotter} instance with this {@link Configurer}. Defaults to a {@link

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,9 @@ import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.MultiHandlerDefinition;
+import org.axonframework.messaging.annotation.MultiHandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
@@ -157,6 +160,7 @@ public class DefaultConfigurer implements Configurer {
             config, "handlerDefinition",
             c -> this::defaultHandlerDefinition
     );
+    private final List<Component<HandlerEnhancerDefinition>> handlerEnhancerDefinitions = new ArrayList<>();
 
     private final List<Consumer<Configuration>> initHandlers = new ArrayList<>();
     private final TreeMap<Integer, List<LifecycleHandler>> startHandlers = new TreeMap<>();
@@ -390,8 +394,21 @@ public class DefaultConfigurer implements Configurer {
      * @return The default HandlerDefinition to use
      */
     protected HandlerDefinition defaultHandlerDefinition(Class<?> inspectedClass) {
-        return defaultComponent(HandlerDefinition.class, config)
+        HandlerDefinition definition = defaultComponent(HandlerDefinition.class, config)
                 .orElseGet(() -> ClasspathHandlerDefinition.forClass(inspectedClass));
+
+        List<HandlerEnhancerDefinition> registeredEnhancerDefinitions =
+                handlerEnhancerDefinitions.stream()
+                                          .map(Component::get)
+                                          .collect(toList());
+        if (definition instanceof MultiHandlerDefinition) {
+            registeredEnhancerDefinitions.add(((MultiHandlerDefinition) definition).getHandlerEnhancerDefinition());
+        }
+
+        return MultiHandlerDefinition.ordered(
+                Collections.singletonList(definition),
+                MultiHandlerEnhancerDefinition.ordered(registeredEnhancerDefinitions)
+        );
     }
 
     /**
@@ -732,6 +749,16 @@ public class DefaultConfigurer implements Configurer {
     public Configurer registerHandlerDefinition(
             @Nonnull BiFunction<Configuration, Class, HandlerDefinition> handlerDefinitionClass) {
         this.handlerDefinition.update(c -> clazz -> handlerDefinitionClass.apply(c, clazz));
+        return this;
+    }
+
+    @Override
+    public Configurer registerHandlerEnhancerDefinition(
+            Function<Configuration, HandlerEnhancerDefinition> handlerEnhancerBuilder
+    ) {
+        this.handlerEnhancerDefinitions.add(
+                new Component<>(config, "HandlerEnhancerDefinition", handlerEnhancerBuilder)
+        );
         return this;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class MultiHandlerDefinition implements HandlerDefinition {
      */
     public static MultiHandlerDefinition ordered(List<HandlerDefinition> delegates,
                                                  HandlerEnhancerDefinition handlerEnhancerDefinition) {
-        return new MultiHandlerDefinition(delegates, handlerEnhancerDefinition);
+        return new MultiHandlerDefinition(delegates, MultiHandlerEnhancerDefinition.ordered(handlerEnhancerDefinition));
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,9 +84,9 @@ public class MultiHandlerEnhancerDefinition implements HandlerEnhancerDefinition
         this.enhancers = delegates.toArray(new HandlerEnhancerDefinition[delegates.size()]);
     }
 
-    private static HandlerEnhancerDefinition[] flatten(Collection<HandlerEnhancerDefinition> factories) {
-        List<HandlerEnhancerDefinition> flattened = new ArrayList<>(factories.size());
-        for (HandlerEnhancerDefinition handlerEnhancer : factories) {
+    private static HandlerEnhancerDefinition[] flatten(Collection<HandlerEnhancerDefinition> enhancers) {
+        List<HandlerEnhancerDefinition> flattened = new ArrayList<>(enhancers.size());
+        for (HandlerEnhancerDefinition handlerEnhancer : enhancers) {
             if (handlerEnhancer instanceof MultiHandlerEnhancerDefinition) {
                 flattened.addAll(((MultiHandlerEnhancerDefinition) handlerEnhancer).getDelegates());
             } else {


### PR DESCRIPTION
This pull request introduces a method to the `Configurer` to register `HandlerEnhancerDefinitions`. 
The `DefaultConfigurer#defaultHandlerDefinition` operation is adjusted to combine all `HandlerEnhancerDefinitions` registered through the `Configurer` with enhancer definitions originating from the ServiceLoader mechanism.

It does so through construction of the default `HandlerDefinition` through the `ClasspathHandlerDefinition`.
This implementation in turn uses the `ClasspathHandlerEnhancerDefinition` to retrieve enhancers through the ServiceLoader mechanism.

The service-loaded instances and registered instances are flattened into a single collection and given to a new `MultiHandlerDefinition.

Lastly, this PR validates this behavior to work for non-Spring *and* Spring environments.