### PR TITLE
[#2351] The `DeadLetter` Parameter Resolver

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
@@ -87,7 +87,7 @@ class DeadLetteredEventProcessingTask
 
         unitOfWork.attachTransaction(transactionManager);
         unitOfWork.resources()
-                  .put(DeadLetterParameterResolverFactory.CURRENT_DEAD_LETTER, letter);
+                  .put(DeadLetter.class.getName(), letter);
         unitOfWork.onPrepareCommit(uow -> decision.set(onCommit(letter)));
         unitOfWork.onRollback(uow -> decision.set(onRollback(letter, uow.getExecutionResult().getExceptionResult())));
         unitOfWork.executeWithResult(() -> handle(letter));

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
@@ -21,7 +21,6 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.messaging.deadletter.DeadLetter;
-import org.axonframework.messaging.deadletter.DeadLetterParameterResolverFactory;
 import org.axonframework.messaging.deadletter.Decisions;
 import org.axonframework.messaging.deadletter.EnqueueDecision;
 import org.axonframework.messaging.deadletter.EnqueuePolicy;
@@ -106,7 +105,8 @@ class DeadLetteredEventProcessingTask
 
     private EnqueueDecision<EventMessage<?>> onCommit(DeadLetter<? extends EventMessage<?>> letter) {
         if (logger.isInfoEnabled()) {
-            logger.info("Processing dead letter with message id [{}] was successful.", letter.message().getIdentifier());
+            logger.info("Processing dead letter with message id [{}] was successful.",
+                        letter.message().getIdentifier());
         }
         return Decisions.evict();
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.DeadLetterParameterResolverFactory;
 import org.axonframework.messaging.deadletter.Decisions;
 import org.axonframework.messaging.deadletter.EnqueueDecision;
 import org.axonframework.messaging.deadletter.EnqueuePolicy;
@@ -85,6 +86,8 @@ class DeadLetteredEventProcessingTask
         UnitOfWork<? extends EventMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(letter.message());
 
         unitOfWork.attachTransaction(transactionManager);
+        unitOfWork.resources()
+                  .put(DeadLetterParameterResolverFactory.CURRENT_DEAD_LETTER, letter);
         unitOfWork.onPrepareCommit(uow -> decision.set(onCommit(letter)));
         unitOfWork.onRollback(uow -> decision.set(onRollback(letter, uow.getExecutionResult().getExceptionResult())));
         unitOfWork.executeWithResult(() -> handle(letter));

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactory.java
@@ -41,6 +41,9 @@ import java.lang.reflect.Parameter;
  */
 public class DeadLetterParameterResolverFactory implements ParameterResolverFactory {
 
+    /**
+     * Constant referring to the current {@link DeadLetter} within the {@link UnitOfWork#resources()}.
+     */
     public static final String CURRENT_DEAD_LETTER = "___Axon_Current_Dead_Letter";
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.deadletter;
+
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Parameter;
+
+/**
+ * A {@link ParameterResolverFactory} constructing a {@link ParameterResolver} resolving the {@link DeadLetter} that is
+ * being processed.
+ * <p>
+ * Expects the {@code DeadLetter} to reside under the {@link UnitOfWork#resources()} under the key
+ * {@link DeadLetterParameterResolverFactory#CURRENT_DEAD_LETTER}. Hence, the {@code DeadLetter} processor is required
+ * to add it to the resources before invoking the message handlers. If no {@link UnitOfWork} is active or there is no
+ * {@code DeadLetter} is present, the resolver will return {@code null}.
+ * <p>
+ * The parameter resolver matches for any type of {@link Message}.
+ *
+ * @author Steven van Beelen
+ * @since 4.7.0
+ */
+public class DeadLetterParameterResolverFactory implements ParameterResolverFactory {
+
+    public static final String CURRENT_DEAD_LETTER = "___Axon_Current_Dead_Letter";
+
+    @Override
+    public ParameterResolver<DeadLetter<?>> createInstance(Executable executable,
+                                                           Parameter[] parameters,
+                                                           int parameterIndex) {
+        return DeadLetter.class.equals(parameters[parameterIndex].getType()) ? new DeadLetterParameterResolver() : null;
+    }
+
+    /**
+     * A {@link ParameterResolver} implementation resolving the current {@link DeadLetter}.
+     * <p>
+     * Expects the {@code DeadLetter} to reside under the {@link UnitOfWork#resources()} under the key
+     * {@link DeadLetterParameterResolverFactory#CURRENT_DEAD_LETTER}. Furthermore, this resolver matches for any type
+     * of {@link Message}.
+     */
+    static class DeadLetterParameterResolver implements ParameterResolver<DeadLetter<?>> {
+
+        @Override
+        public DeadLetter<?> resolveParameterValue(Message<?> message) {
+            return CurrentUnitOfWork.isStarted()
+                    ? CurrentUnitOfWork.get().getOrDefaultResource(CURRENT_DEAD_LETTER, null)
+                    : null;
+        }
+
+        @Override
+        public boolean matches(Message<?> message) {
+            return true;
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public abstract class CurrentUnitOfWork {
      * @throws NullPointerException when a Unit of Work is present and the function returns null
      */
     public static <T> Optional<T> map(Function<UnitOfWork<?>, T> function) {
-        return isStarted() ? Optional.of(function.apply(get())) : Optional.empty();
+        return isStarted() ? Optional.ofNullable(function.apply(get())) : Optional.empty();
     }
 
     /**

--- a/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
+++ b/messaging/src/main/resources/META-INF/services/org.axonframework.messaging.annotation.ParameterResolverFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,3 +28,4 @@ org.axonframework.messaging.annotation.SourceIdParameterResolverFactory
 org.axonframework.messaging.annotation.ResultParameterResolverFactory
 org.axonframework.messaging.annotation.ScopeDescriptorParameterResolverFactory
 org.axonframework.messaging.annotation.AggregateTypeParameterResolverFactory
+org.axonframework.messaging.deadletter.DeadLetterParameterResolverFactory

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
 import org.axonframework.utils.InMemoryStreamableEventSource;
 import org.junit.jupiter.api.*;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -52,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
+import static org.awaitility.Awaitility.await;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.utils.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
@@ -520,6 +522,42 @@ public abstract class DeadLetteringEventIntegrationTest {
         publishingThread.join();
     }
 
+    @Test
+    void processedDeadLetterIsResolvedAsParameterToEventHandlers() {
+        int expectedSuccessfulHandlingCount = 3;
+        String aggregateId = UUID.randomUUID().toString();
+        // Three events in sequence "aggregateId" succeed
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, SUCCEED)));
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, SUCCEED)));
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, SUCCEED)));
+        // On event in sequence "aggregateId" fails, causing the rest to fail, but succeed on a retry
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, FAIL, SUCCEED_RETRY)));
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, SUCCEED, SUCCEED_RETRY)));
+        eventSource.publishMessage(asEventMessage(new DeadLetterableEvent(aggregateId, SUCCEED, SUCCEED_RETRY)));
+
+        startProcessingEvent();
+
+        await().pollDelay(Duration.ofMillis(25))
+               .atMost(Duration.ofSeconds(1))
+               .until(() -> streamingProcessor.processingStatus().size() == 1);
+        //noinspection OptionalGetWithoutIsPresent
+        await().pollDelay(Duration.ofMillis(25))
+               .atMost(Duration.ofSeconds(1))
+               .until(() -> streamingProcessor.processingStatus().get(0).getCurrentPosition().getAsLong() >= 6);
+
+        assertTrue(eventHandlingComponent.initialHandlingWasSuccessful(aggregateId));
+        assertEquals(expectedSuccessfulHandlingCount,
+                     eventHandlingComponent.successfulInitialHandlingCount(aggregateId));
+        assertTrue(eventHandlingComponent.initialHandlingWasUnsuccessful(aggregateId));
+        assertEquals(1, eventHandlingComponent.unsuccessfulInitialHandlingCount(aggregateId));
+
+        assertTrue(deadLetterQueue.contains(aggregateId));
+
+        deadLetteringInvoker.process(deadLetter -> true);
+
+        assertEquals(3, eventHandlingComponent.resolvedDeadLetterParameterCount(aggregateId));
+    }
+
     private void publishEventsFor(String aggregateId,
                                   int immediateSuccessesPerAggregate,
                                   int failFirstAndThenSucceedPerAggregate,
@@ -547,9 +585,12 @@ public abstract class DeadLetteringEventIntegrationTest {
         private final Map<String, Integer> evaluationSuccesses = new ConcurrentSkipListMap<>();
         private final Map<String, Integer> firstTryFailures = new ConcurrentSkipListMap<>();
         private final Map<String, Integer> evaluationFailures = new ConcurrentSkipListMap<>();
+        private final Map<String, Integer> hasResolvedDeadLetterParameter = new ConcurrentSkipListMap<>();
 
         @EventHandler
-        public void on(DeadLetterableEvent event, @MessageIdentifier String eventIdentifier) {
+        public void on(DeadLetterableEvent event,
+                       @MessageIdentifier String eventIdentifier,
+                       DeadLetter<EventMessage<DeadLetterableEvent>> deadLetter) {
             // The aggregate identifier effectively references the sequence because of the configured SequencingPolicy.
             String sequenceId = event.getAggregateIdentifier();
 
@@ -566,6 +607,10 @@ public abstract class DeadLetteringEventIntegrationTest {
             } else {
                 // This is the second, third, ... time we get this event.
                 processEvaluationOf(event, sequenceId);
+            }
+
+            if (deadLetter != null) {
+                hasResolvedDeadLetterParameter.compute(sequenceId, (id, count) -> count == null ? 1 : ++count);
             }
         }
 
@@ -587,40 +632,44 @@ public abstract class DeadLetteringEventIntegrationTest {
             }
         }
 
-        public boolean initialHandlingWasSuccessful(String aggregateIdentifier) {
-            return firstTrySuccesses.containsKey(aggregateIdentifier);
+        public boolean initialHandlingWasSuccessful(String sequenceId) {
+            return firstTrySuccesses.containsKey(sequenceId);
         }
 
-        public int successfulInitialHandlingCount(String aggregateIdentifier) {
-            return initialHandlingWasSuccessful(aggregateIdentifier) ? firstTrySuccesses.get(aggregateIdentifier) : 0;
+        public int successfulInitialHandlingCount(String sequenceId) {
+            return initialHandlingWasSuccessful(sequenceId) ? firstTrySuccesses.get(sequenceId) : 0;
         }
 
-        public boolean evaluationWasSuccessful(String aggregateIdentifier) {
-            return evaluationSuccesses.containsKey(aggregateIdentifier);
+        public boolean evaluationWasSuccessful(String sequenceId) {
+            return evaluationSuccesses.containsKey(sequenceId);
         }
 
-        public int successfulEvaluationCount(String aggregateIdentifier) {
-            return evaluationWasSuccessful(aggregateIdentifier) ? evaluationSuccesses.get(aggregateIdentifier) : 0;
+        public int successfulEvaluationCount(String sequenceId) {
+            return evaluationWasSuccessful(sequenceId) ? evaluationSuccesses.get(sequenceId) : 0;
         }
 
-        public boolean initialHandlingWasUnsuccessful(String aggregateIdentifier) {
-            return firstTryFailures.containsKey(aggregateIdentifier);
+        public boolean initialHandlingWasUnsuccessful(String sequenceId) {
+            return firstTryFailures.containsKey(sequenceId);
         }
 
-        public int unsuccessfulInitialHandlingCount(String aggregateIdentifier) {
-            return initialHandlingWasUnsuccessful(aggregateIdentifier) ? firstTryFailures.get(aggregateIdentifier) : 0;
+        public int unsuccessfulInitialHandlingCount(String sequenceId) {
+            return initialHandlingWasUnsuccessful(sequenceId) ? firstTryFailures.get(sequenceId) : 0;
         }
 
-        public boolean evaluationWasUnsuccessful(String aggregateIdentifier) {
-            return evaluationFailures.containsKey(aggregateIdentifier);
+        public boolean evaluationWasUnsuccessful(String sequenceId) {
+            return evaluationFailures.containsKey(sequenceId);
         }
 
-        public int unsuccessfulEvaluationCount(String aggregateIdentifier) {
-            return evaluationWasUnsuccessful(aggregateIdentifier) ? evaluationFailures.get(aggregateIdentifier) : 0;
+        public int unsuccessfulEvaluationCount(String sequenceId) {
+            return evaluationWasUnsuccessful(sequenceId) ? evaluationFailures.get(sequenceId) : 0;
         }
 
-        public int overallSuccessfulHandlingCount(String aggregateIdentifier) {
-            return firstTrySuccesses.get(aggregateIdentifier) + evaluationSuccesses.get(aggregateIdentifier);
+        public int overallSuccessfulHandlingCount(String sequenceId) {
+            return firstTrySuccesses.get(sequenceId) + evaluationSuccesses.get(sequenceId);
+        }
+
+        public int resolvedDeadLetterParameterCount(String sequenceId) {
+            return hasResolvedDeadLetterParameter.get(sequenceId);
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.deadletter;
+
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.queryhandling.GenericQueryMessage;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link DeadLetterParameterResolverFactory} and
+ * {@link DeadLetterParameterResolverFactory.DeadLetterParameterResolver}.
+ *
+ * @author Steven van Beelen
+ */
+class DeadLetterParameterResolverFactoryTest {
+
+    private DeadLetterParameterResolverFactory testSubject;
+
+    private Method nonDeadLetterParameterMethod;
+    private Method deadLetterMethod;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        testSubject = new DeadLetterParameterResolverFactory();
+
+        nonDeadLetterParameterMethod = getClass().getMethod("nonDeadLetterParameterMethod", Object.class);
+        deadLetterMethod = getClass().getMethod("someDeadLetterMethod", DeadLetter.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (CurrentUnitOfWork.isStarted()) {
+            CurrentUnitOfWork.get().rollback();
+        }
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void nonDeadLetterParameterMethod(Object event) {
+        //Used in setUp()
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void someDeadLetterMethod(DeadLetter<?> deadLetter) {
+        //Used in setUp()
+    }
+
+    @Test
+    void ignoredForNonDeadLetterParameterMethod() {
+        assertNull(testSubject.createInstance(nonDeadLetterParameterMethod,
+                                              nonDeadLetterParameterMethod.getParameters(),
+                                              0));
+    }
+
+    @Test
+    void createsResolverForDeadLetterParameterContainingMethod() {
+        assertNotNull(testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0));
+    }
+
+    @Test
+    void resolverMatchesForAnyMessageType() {
+        ParameterResolver<DeadLetter<?>> resolver =
+                testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);
+
+        assertTrue(resolver.matches(GenericCommandMessage.asCommandMessage("some-command")));
+        assertTrue(resolver.matches(GenericEventMessage.asEventMessage("some-command")));
+        assertTrue(resolver.matches(new GenericQueryMessage<>("some-query", ResponseTypes.instanceOf(String.class))));
+    }
+
+    @Test
+    void resolvesDeadLetterFromUnitOfWorkResources() {
+        EventMessage<String> testMessage = GenericEventMessage.asEventMessage("some-event");
+        DeadLetter<EventMessage<String>> expected = new GenericDeadLetter<>(
+                "sequenceId", testMessage, new RuntimeException("some-cause")
+        );
+        UnitOfWork<EventMessage<String>> uow = DefaultUnitOfWork.startAndGet(testMessage);
+        uow.resources().put(DeadLetterParameterResolverFactory.CURRENT_DEAD_LETTER, expected);
+
+        ParameterResolver<DeadLetter<?>> resolver =
+                testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);
+
+        DeadLetter<?> result = resolver.resolveParameterValue(testMessage);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void resolvesNullWhenNoUnitOfWorkIsActive() {
+        Message<Object> testMessage = GenericEventMessage.asEventMessage("some-event");
+
+        ParameterResolver<DeadLetter<?>> resolver =
+                testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);
+
+        assertNull(resolver.resolveParameterValue(testMessage));
+    }
+
+    @Test
+    void resolvesNullWhenNoDeadLetterIsPresentInTheUnitOfWorkResources() {
+        EventMessage<String> testMessage = GenericEventMessage.asEventMessage("some-event");
+        DefaultUnitOfWork.startAndGet(testMessage);
+
+        ParameterResolver<DeadLetter<?>> resolver =
+                testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);
+
+        assertNull(resolver.resolveParameterValue(testMessage));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
@@ -99,7 +99,7 @@ class DeadLetterParameterResolverFactoryTest {
                 "sequenceId", testMessage, new RuntimeException("some-cause")
         );
         UnitOfWork<EventMessage<String>> uow = DefaultUnitOfWork.startAndGet(testMessage);
-        uow.resources().put(DeadLetterParameterResolverFactory.CURRENT_DEAD_LETTER, expected);
+        uow.resources().put(DeadLetter.class.getName(), expected);
 
         ParameterResolver<DeadLetter<?>> resolver =
                 testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2022. Axon Framework
+  ~ Copyright (c) 2010-2023. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -212,6 +212,11 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request introduces a mechanism to resolve the `DeadLetter` as a parameter for message handling methods.
It does so through the `DeadLetterParameterResolverFactory`, which constructs a `DeadLetterParameterResolver<DeadLetter<?>>` whenever the parameter at the given index is of type `DeadLetter<?>`.

The parameter resolver implementation will match for any type of `Message` (as in essence, dead letter support can be built for any type of `Message`).
It will resolve the `DeadLetter<?>` parameter by retrieving it from the `UnitOfWork#resources`.
If there is no active `UnitOfWork` or there is no `DeadLetter` in the resources, the resolver will return `null`.

Hence, the component processing the dead letters (the component initiating the `UnitOfWork`) is required to add the current `DeadLetter` to the resources of the `UnitOfWork`.
Since the only component processing dead letters is the `DeadLetteredEventProcessingTask`, it attaches the `DeadLetter` to the resources with the key being a public constant present on the `DeadLetterParameterResolverFactory`.

For testing, there's a unit test for the `DeadLetterParameterResolverFactory`, validating both the factory and the resolver.
Next to this, the `DeadLetteringEventIntegrationTest` has a new test case validating the presence of the `DeadLetter` parameter.
This new tests uses Awaitility, for which I had to add a dependency to the `axon-spring` module.
Lastly, I've resolved a discrepancy in the `DeadLetteringEventIntegrationTest`, by renaming the `aggregateIdentifier` parameter to `sequenceId`.

Doing the above, this PR resolves #2351.