### PR TITLE
[#2476] Support `EventMessage` handler interceptor registration on the `SagaTestFixture`

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
@@ -187,6 +188,23 @@ public interface FixtureConfiguration {
     FixtureConfiguration registerDeadlineHandlerInterceptor(
             MessageHandlerInterceptor<? super DeadlineMessage<?>> deadlineHandlerInterceptor
     );
+
+    /**
+     * Registers a {@link MessageHandlerInterceptor} for {@link EventMessage EventMessages}.
+     * <p>
+     * Will always be invoked before an event is handled to perform a task specified in the interceptor. Interceptors
+     * are invoked in the order they have been registered in.
+     *
+     * @param eventHandlerInterceptor the interceptor for handling {@link EventMessage EventMessages}
+     * @return The current {@link FixtureConfiguration}, for fluent interfacing.
+     */
+    default FixtureConfiguration registerEventHandlerInterceptor(
+            MessageHandlerInterceptor<? super EventMessage<?>> eventHandlerInterceptor
+    ) {
+        throw new UnsupportedOperationException(
+                "The FixtureConfiguration implementation does not support this operation"
+        );
+    }
 
     /**
      * Registers a callback to be invoked when the fixture execution starts recording. This happens right before

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.eventhandling.LoggingErrorHandler;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.SimpleEventBus;
+import org.axonframework.messaging.DefaultInterceptorChain;
 import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.ScopeDescriptor;
@@ -92,6 +94,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     private final LinkedList<ParameterResolverFactory> registeredParameterResolverFactories = new LinkedList<>();
     private final LinkedList<HandlerDefinition> registeredHandlerDefinitions = new LinkedList<>();
     private final LinkedList<HandlerEnhancerDefinition> registeredHandlerEnhancerDefinitions = new LinkedList<>();
+    private final LinkedList<MessageHandlerInterceptor<? super EventMessage<?>>> eventHandlerInterceptors = new LinkedList<>();
     private final RecordingListenerInvocationErrorHandler recordingListenerInvocationErrorHandler;
 
     private final Class<T> sagaType;
@@ -144,10 +147,16 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
      */
     protected void handleInSaga(EventMessage<?> event) {
         ensureSagaResourcesInitialized();
-        ResultMessage<?> resultMessage = DefaultUnitOfWork.startAndGet(event).executeWithResult(() -> {
-            sagaManager.handle(event, Segment.ROOT_SEGMENT);
-            return null;
-        });
+        DefaultUnitOfWork<? extends EventMessage<?>> unitOfWork = DefaultUnitOfWork.startAndGet(event);
+        ResultMessage<?> resultMessage = unitOfWork.executeWithResult(() -> new DefaultInterceptorChain<>(
+                unitOfWork,
+                eventHandlerInterceptors,
+                (MessageHandler<EventMessage<?>>) message -> {
+                    sagaManager.handle(message, Segment.ROOT_SEGMENT);
+                    return null;
+                }).proceed()
+        );
+
         if (resultMessage.isExceptional()) {
             Throwable e = resultMessage.exceptionResult();
             if (Error.class.isAssignableFrom(e.getClass())) {
@@ -400,6 +409,14 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
             MessageHandlerInterceptor<? super DeadlineMessage<?>> deadlineHandlerInterceptor
     ) {
         this.deadlineManager.registerHandlerInterceptor(deadlineHandlerInterceptor);
+        return this;
+    }
+
+    @Override
+    public FixtureConfiguration registerEventHandlerInterceptor(
+            MessageHandlerInterceptor<? super EventMessage<?>> eventHandlerInterceptor
+    ) {
+        this.eventHandlerInterceptors.add(eventHandlerInterceptor);
         return this;
     }
 

--- a/test/src/test/java/org/axonframework/test/saga/FixtureMessageHandlerInterceptorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureMessageHandlerInterceptorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.saga;
+
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.InterceptorChain;
+import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.annotation.MetaDataValue;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.modelling.saga.SagaEventHandler;
+import org.axonframework.modelling.saga.StartSaga;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.*;
+
+import java.util.Objects;
+
+/**
+ * Test class validating the registration of {@link MessageHandlerInterceptor} instances through the
+ * {@link FixtureConfiguration}.
+ *
+ * @author Steven van Beelen
+ */
+class FixtureMessageHandlerInterceptorTest {
+
+    private static final String META_DATA_KEY = "key";
+
+    private FixtureConfiguration fixture;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new SagaTestFixture<>(TestSaga.class);
+    }
+
+    @Test
+    void registeredEventHandlerInterceptorIsInvokedBeforeHandlingEvents() {
+        String testId = "some-identifier";
+        String testValue = "some-value";
+
+        fixture.registerEventHandlerInterceptor(new CustomEventHandlerInterceptor(testValue))
+               .givenNoPriorActivity()
+               .whenPublishingA(new SagaStartEvent(testId))
+               .expectDispatchedCommands(new StartProcessCommand(testId, testValue));
+    }
+
+    private static class CustomEventHandlerInterceptor implements MessageHandlerInterceptor<EventMessage<?>> {
+
+        private final String value;
+
+        private CustomEventHandlerInterceptor(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public Object handle(@NotNull UnitOfWork<? extends EventMessage<?>> unitOfWork,
+                             @NotNull InterceptorChain interceptorChain) throws Exception {
+            unitOfWork.transformMessage(event -> event.withMetaData(MetaData.with(META_DATA_KEY, value)));
+            return interceptorChain.proceed();
+        }
+    }
+
+    private static class SagaStartEvent {
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final String identifier;
+
+        private SagaStartEvent(String identifier) {
+            this.identifier = identifier;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+    }
+
+    private static class StartProcessCommand {
+
+        private final String identifier;
+        private final String metaDataValue;
+
+        private StartProcessCommand(String identifier, String metaDataValue) {
+            this.identifier = identifier;
+            this.metaDataValue = metaDataValue;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public String getMetaDataValue() {
+            return metaDataValue;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            StartProcessCommand that = (StartProcessCommand) o;
+            return Objects.equals(identifier, that.identifier)
+                    && Objects.equals(metaDataValue, that.metaDataValue);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identifier, metaDataValue);
+        }
+
+        @Override
+        public String toString() {
+            return "StartProcessCommand{" +
+                    "identifier='" + identifier + '\'' +
+                    ", metaDataValue='" + metaDataValue + '\'' +
+                    '}';
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class TestSaga {
+
+        @StartSaga
+        @SagaEventHandler(associationProperty = "identifier")
+        public void on(SagaStartEvent event,
+                       @MetaDataValue(META_DATA_KEY) String value,
+                       CommandGateway commandGateway) {
+            commandGateway.send(new StartProcessCommand(event.getIdentifier(), value));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new operation to the `FixtureConfiguration`: `registerEventHandlerInterceptor(MessageHandlerInterceptor<? super EventMessage<?>>)`.

This new method allows users to register `MessageHandlerInterceptors` for the events passed to their saga event handler.
Registered handler interceptors are combined in an `InterceptorChain`, invoking the Saga event handler as the last entry.
Doing so, we mirror the behavior of the `AbstractEventProcessor` that, in a live system, would invoke the `MessageHandlerInterceptors` for events.

Note that the interceptors are invoked in the order they've been registered in.
With this introduction, users can more closely mirror their entire Saga process within the `SagaTestFixture`.

Doing the above, this pull request resolves #2476.