### PR TITLE
[#1630] Allow disabling of sequence number generation in the `GenericJpaRepository`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/GenericJpaRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/GenericJpaRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,16 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * <p/>
  * When this repository is requested to persist changes to an aggregate, it will also flush the EntityManager, to
  * enforce checking of database constraints and optimistic locks.
+ * <p>
+ * By default, this repository implementation will generate sequences for the events published by the aggregate. In
+ * doing so, the user is capable of querying the events based on the aggregate identifier and order them based on the
+ * aforementioned sequence number. The downside of this, is that even if the stored aggregate is removed, the aggregate
+ * identifier cannot be reused. This follows from the uniqueness constraint on the Event Store defining that the
+ * combination of aggregate identifier to sequence number should be unique. However, sequence number generation can be
+ * disabled, through {@link Builder#disableSequenceNumberGeneration()}. When disabled, published events will <b>no
+ * longer</b> hold the sequence number nor the aggregate identifier. As such, the aggregate identifier can be reused
+ * (after removal of the previous aggregate referring to that identifier). The obvious downside of this is that the
+ * events in the store can no longer be queried based on the aggregate identifier.
  *
  * @param <T> The type of aggregate the repository provides access to
  * @author Allard Buijze
@@ -59,15 +69,17 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
     private final EventBus eventBus;
     private final RepositoryProvider repositoryProvider;
     private final Function<String, ?> identifierConverter;
+    private final boolean generateSequenceNumbers;
 
     private boolean forceFlushOnSave = true;
 
     /**
      * Instantiate a Builder to be able to create a {@link GenericJpaRepository} for aggregate type {@code T}.
      * <p>
-     * The {@link LockFactory} is defaulted to an {@link NullLockFactory}, thus providing no additional locking, and
-     * the {@code identifierConverter} to {@link Function#identity()}. The {@link SpanFactory} is defaulted to a
-     * {@link org.axonframework.tracing.NoOpSpanFactory}.
+     * The {@link LockFactory} is defaulted to an {@link NullLockFactory}, thus providing no additional locking, the
+     * {@code identifierConverter} to {@link Function#identity()}, the {@link SpanFactory} defaults to a
+     * {@link org.axonframework.tracing.NoOpSpanFactory}, and sequence number generation is <b>enabled</b>.
+     * <p>
      * A goal of this Builder goal is to create an {@link AggregateModel} specifying generic {@code T} as the aggregate
      * type to be stored. All aggregates in this repository must be {@code instanceOf} this aggregate type. To
      * instantiate this AggregateModel, either an {@link AggregateModel} can be provided directly or an
@@ -107,6 +119,7 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
         this.eventBus = builder.eventBus;
         this.identifierConverter = builder.identifierConverter;
         this.repositoryProvider = builder.repositoryProvider;
+        this.generateSequenceNumbers = builder.generateSequenceNumbers;
     }
 
     @Override
@@ -123,7 +136,7 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
                                                                         aggregateModel(),
                                                                         eventBus,
                                                                         repositoryProvider);
-        if (eventBus instanceof DomainEventSequenceAware) {
+        if (shouldGenerateSequences()) {
             Optional<Long> sequenceNumber =
                     ((DomainEventSequenceAware) eventBus).lastSequenceNumberFor(aggregateIdentifier);
             sequenceNumber.ifPresent(aggregate::initSequence);
@@ -138,7 +151,11 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
                                              aggregateModel(),
                                              eventBus,
                                              repositoryProvider,
-                                             eventBus instanceof DomainEventSequenceAware);
+                                             shouldGenerateSequences());
+    }
+
+    private boolean shouldGenerateSequences() {
+        return eventBus instanceof DomainEventSequenceAware && generateSequenceNumbers;
     }
 
     @Override
@@ -176,9 +193,9 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
     /**
      * Builder class to instantiate a {@link GenericJpaRepository} for aggregate type {@code T}.
      * <p>
-     * The {@link LockFactory} is defaulted to an {@link NullLockFactory}, thus providing no additional locking, and
-     * the {@code identifierConverter} to {@link Function#identity()}. The {@link SpanFactory} is defaulted to a
-     * {@link org.axonframework.tracing.NoOpSpanFactory}.
+     * The {@link LockFactory} is defaulted to an {@link NullLockFactory}, thus providing no additional locking, the
+     * {@code identifierConverter} to {@link Function#identity()}, the {@link SpanFactory} defaults to a
+     * {@link org.axonframework.tracing.NoOpSpanFactory}, and sequence number generation is <b>enabled</b>.
      * <p>
      * A goal of this Builder goal is to create an {@link AggregateModel} specifying generic {@code T} as the aggregate
      * type to be stored. All aggregates in this repository must be {@code instanceOf} this aggregate type. To
@@ -197,6 +214,7 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
         private EventBus eventBus;
         private RepositoryProvider repositoryProvider;
         private Function<String, ?> identifierConverter = Function.identity();
+        private boolean generateSequenceNumbers = true;
 
         /**
          * Creates a builder for a Repository for given {@code aggregateType}.
@@ -299,6 +317,29 @@ public class GenericJpaRepository<T> extends LockingRepository<T, AnnotatedAggre
         public Builder<T> identifierConverter(Function<String, ?> identifierConverter) {
             assertNonNull(identifierConverter, "The identifierConverter may not be null");
             this.identifierConverter = identifierConverter;
+            return this;
+        }
+
+        /**
+         * Disables sequence number generation within this {@link Repository} implementation.
+         * <p>
+         * Disabling this feature allows reuse of Aggregate identifiers <b>after</b> removal of the Aggregate instance
+         * referred to with said identifier. This opportunity arises from the fact that events published within an
+         * Aggregate require a sequence number to change into so-called domain events. These domain events are
+         * constrained in the Event Store to have a unique combination of Aggregate identifier to sequence number. Thus,
+         * when reusing an Aggregate identifier for which sequences were enabled, will have the Event Store complain
+         * with this uniqueness constraint.
+         * <p>
+         * So disabling sequence number generation will resolve the uniqueness complaints from the Event Store. And, in
+         * doing so, allows reuse of an Aggregate identifier.
+         * <p>
+         * Disabling sequence number generation comes with another cost, though. The events published within a
+         * state-stored Aggregate will no longer refer to the Aggregate they originate from.
+         *
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder<T> disableSequenceNumberGeneration() {
+            generateSequenceNumbers = false;
             return this;
         }
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,26 +148,26 @@ class GenericJpaRepositoryTest {
         });
         CurrentUnitOfWork.commit();
 
-        List<EventMessage> publishedEvents = testEventBus.getPublishedEvents();
+        List<EventMessage<?>> publishedEvents = testEventBus.getPublishedEvents();
         assertEquals(3, publishedEvents.size());
 
-        EventMessage eventOne = publishedEvents.get(0);
+        EventMessage<?> eventOne = publishedEvents.get(0);
         assertTrue(eventOne instanceof DomainEventMessage);
-        DomainEventMessage domainEventOne = (DomainEventMessage) eventOne;
+        DomainEventMessage<?> domainEventOne = (DomainEventMessage<?>) eventOne;
         assertEquals("test1", domainEventOne.getPayload());
         assertEquals(0, domainEventOne.getSequenceNumber());
         assertEquals("id", domainEventOne.getAggregateIdentifier());
 
-        EventMessage eventTwo = publishedEvents.get(1);
+        EventMessage<?> eventTwo = publishedEvents.get(1);
         assertTrue(eventTwo instanceof DomainEventMessage);
-        DomainEventMessage domainEventTwo = (DomainEventMessage) eventTwo;
+        DomainEventMessage<?> domainEventTwo = (DomainEventMessage<?>) eventTwo;
         assertEquals("test2", domainEventTwo.getPayload());
         assertEquals(1, domainEventTwo.getSequenceNumber());
         assertEquals("id", domainEventTwo.getAggregateIdentifier());
 
-        EventMessage eventThree = publishedEvents.get(2);
+        EventMessage<?> eventThree = publishedEvents.get(2);
         assertTrue(eventThree instanceof DomainEventMessage);
-        DomainEventMessage domainEventThree = (DomainEventMessage) eventThree;
+        DomainEventMessage<?> domainEventThree = (DomainEventMessage<?>) eventThree;
         assertEquals("test3", domainEventThree.getPayload());
         assertEquals(2, domainEventThree.getSequenceNumber());
         assertEquals("id", domainEventThree.getAggregateIdentifier());
@@ -193,7 +193,7 @@ class GenericJpaRepositoryTest {
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<? extends EventMessage<?>>> eventCaptor =
-                ArgumentCaptor.forClass((Class<List<? extends EventMessage<?>>>) (Class) List.class);
+                ArgumentCaptor.forClass((Class<List<? extends EventMessage<?>>>) (Class<?>) List.class);
 
         verify(testEventBus).publish(eventCaptor.capture());
         List<? extends EventMessage<?>> capturedEvents = eventCaptor.getValue();
@@ -202,6 +202,46 @@ class GenericJpaRepositoryTest {
         EventMessage<?> eventOne = capturedEvents.get(0);
         assertFalse(eventOne instanceof DomainEventMessage);
         assertEquals("test2", eventOne.getPayload());
+    }
+
+    @Test
+    void aggregateDoesNotCreateSequenceNumbersWhenSequenceNumberGenerationIsDisabled() {
+        String expectedFirstPayload = "test1";
+        String expectedSecondPayload = "test2";
+        String expectedThirdPayload = "test3";
+
+        DomainSequenceAwareEventBus testEventBus = new DomainSequenceAwareEventBus();
+        testSubject = GenericJpaRepository.builder(StubJpaAggregate.class)
+                                          .entityManagerProvider(new SimpleEntityManagerProvider(mockEntityManager))
+                                          .eventBus(testEventBus)
+                                          .identifierConverter(identifierConverter)
+                                          .disableSequenceNumberGeneration()
+                                          .build();
+
+        DefaultUnitOfWork.startAndGet(null)
+                         .executeWithResult(() -> {
+                             Aggregate<StubJpaAggregate> aggregate = testSubject.newInstance(
+                                     () -> new StubJpaAggregate("id", expectedFirstPayload, expectedSecondPayload)
+                             );
+                             aggregate.execute(e -> e.doSomething(expectedThirdPayload));
+                             return null;
+                         });
+        CurrentUnitOfWork.commit();
+
+        List<EventMessage<?>> publishedEvents = testEventBus.getPublishedEvents();
+        assertEquals(3, publishedEvents.size());
+
+        EventMessage<?> eventOne = publishedEvents.get(0);
+        assertFalse(eventOne instanceof DomainEventMessage);
+        assertEquals(expectedFirstPayload, eventOne.getPayload());
+
+        EventMessage<?> eventTwo = publishedEvents.get(1);
+        assertFalse(eventTwo instanceof DomainEventMessage);
+        assertEquals(expectedSecondPayload, eventTwo.getPayload());
+
+        EventMessage<?> eventThree = publishedEvents.get(2);
+        assertFalse(eventThree instanceof DomainEventMessage);
+        assertEquals(expectedThirdPayload, eventThree.getPayload());
     }
 
     @Test
@@ -299,10 +339,10 @@ class GenericJpaRepositoryTest {
         }
     }
 
-    private class DomainSequenceAwareEventBus extends SimpleEventBus implements DomainEventSequenceAware {
+    private static class DomainSequenceAwareEventBus extends SimpleEventBus implements DomainEventSequenceAware {
 
-        private List<EventMessage> publishedEvents = new ArrayList<>();
-        private Map<String, Long> sequencePerAggregate = new HashMap<>();
+        private final List<EventMessage<?>> publishedEvents = new ArrayList<>();
+        private final Map<String, Long> sequencePerAggregate = new HashMap<>();
 
         DomainSequenceAwareEventBus() {
             super(SimpleEventBus.builder());
@@ -314,7 +354,7 @@ class GenericJpaRepositoryTest {
             super.publish(events);
         }
 
-        List<EventMessage> getPublishedEvents() {
+        List<EventMessage<?>> getPublishedEvents() {
             return publishedEvents;
         }
 


### PR DESCRIPTION
This pull request introduces the `GenericJpaRepository.Builder#disableSequenceNumberGeneration` method.
Invoking this method during the construction of the `GenericJpaRepository` will disable the generation of sequence numbers for events published by the Aggregate store repository manages.

The result of this invocation is that published events will become regular `EventMessages` instead of `DomainEventMessages`. 

The benefit of this is that a user is capable of *reusing* aggregate identifiers whenever they remove a state-stored aggregate instance. 
This follows from the uniqueness constraint present on the `EventStore`, enforcing the combination of aggregate identifier *and* sequence number to be unique.

However, the downside is that the published events can *no longer* be queried based on the aggregate identifier.
This loss follows from the fact that only the `DomainEventMessage` carries the aggregate identifier (and sequence number).
As such, stored events will no longer contain the aggregate identifier whenever sequence number generation is removed.

The pros and cons of disabling sequence generation have been made clear in the JavaDoc of the `GenericJpaRepository`.
Furthermore, as this is not something every user needs, the configuration of this feature has not been made easier through, for example, the `AggregateConfigurer` or `@Aggregate` annotaiton.

By doing the above, this pull request resolves #1630.