### PR TITLE
[#1509] Add `whenConstructing` and `whenInvoking` to the `AggregateTestFixture`

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -203,6 +203,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         AnnotationCommandHandlerAdapter<?> adapter = new AnnotationCommandHandlerAdapter<>(
                 annotatedCommandHandler, getParameterResolverFactory(), getHandlerDefinition()
         );
+        //noinspection resource
         adapter.subscribe(commandBus);
         return this;
     }
@@ -218,6 +219,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                                                           MessageHandler<CommandMessage<?>> commandHandler) {
         registerAggregateCommandHandlers();
         explicitCommandHandlersSet = true;
+        //noinspection resource
         commandBus.subscribe(commandName, commandHandler);
         return this;
     }
@@ -245,6 +247,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     public FixtureConfiguration<T> registerCommandDispatchInterceptor(
             MessageDispatchInterceptor<? super CommandMessage<?>> commandDispatchInterceptor
     ) {
+        //noinspection resource
         this.commandBus.registerDispatchInterceptor(commandDispatchInterceptor);
         return this;
     }
@@ -253,6 +256,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     public FixtureConfiguration<T> registerCommandHandlerInterceptor(
             MessageHandlerInterceptor<? super CommandMessage<?>> commandHandlerInterceptor
     ) {
+        //noinspection resource
         this.commandBus.registerHandlerInterceptor(commandHandlerInterceptor);
         return this;
     }
@@ -260,6 +264,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     @Override
     public FixtureConfiguration<T> registerDeadlineDispatchInterceptor(
             MessageDispatchInterceptor<? super DeadlineMessage<?>> deadlineDispatchInterceptor) {
+        //noinspection resource
         this.deadlineManager.registerDispatchInterceptor(deadlineDispatchInterceptor);
         return this;
     }
@@ -267,6 +272,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     @Override
     public FixtureConfiguration<T> registerDeadlineHandlerInterceptor(
             MessageHandlerInterceptor<? super DeadlineMessage<?>> deadlineHandlerInterceptor) {
+        //noinspection resource
         this.deadlineManager.registerHandlerInterceptor(deadlineHandlerInterceptor);
         return this;
     }
@@ -556,6 +562,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
             }
 
             AggregateAnnotationCommandHandler<T> handler = builder.build();
+            //noinspection resource
             handler.subscribe(commandBus);
         }
     }
@@ -815,7 +822,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                 throw new AssertionError(String.format(
                         "The aggregate used in this fixture was initialized with an identifier different than " +
                                 "the one used to load it. Loaded [%s], but actual identifier is [%s].\n" +
-                                "Make sure the identifier passed in the Command matches that of the given Events.",
+                                "Make sure the identifier passed during construction matches that of the when-phase.",
                         aggregateIdentifier, aggregate.identifierAsString()));
             }
         }

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -493,10 +493,19 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
     public void onResult(@Nonnull CommandMessage<?> commandMessage,
                          @Nonnull CommandResultMessage<?> commandResultMessage) {
         if (commandResultMessage.isExceptional()) {
-            actualException = commandResultMessage.exceptionResult();
+            recordException(commandResultMessage.exceptionResult());
         } else {
             actualReturnValue = commandResultMessage;
         }
+    }
+
+    /**
+     * Record the given {@code exception} as a result of this validator.
+     *
+     * @param exception The exception to record as a result of this validator.
+     */
+    public void recordException(Throwable exception) {
+        this.actualException = exception;
     }
 
     /**

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -510,7 +510,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T>, CommandCallba
 
     /**
      * Makes sure the execution phase has finishes without any Errors ir FixtureExecutionExceptions. If an error was
-     * recorded, it will be thrown immediately. This allow one to distinguish between failed tests, and tests in error.
+     * recorded, it will be thrown immediately. This allows one to distinguish between failed tests, and tests in error.
      */
     public void assertValidRecording() {
         if (actualException instanceof Error) {

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -47,14 +47,14 @@ public interface TestExecutor<T> {
     ResultValidator<T> when(Object command);
 
     /**
-     * Dispatches the given command and meta data to the appropriate command handler and records all
+     * Dispatches the given command and meta-data to the appropriate command handler and records all
      * activity in the fixture for result validation. If the given {@code command} is a {@link
      * org.axonframework.commandhandling.CommandMessage} instance, it will be dispatched as-is, with given
      * additional {@code metaData}. Any other object will cause the given {@code command} to be wrapped in a
      * {@code CommandMessage} as its payload.
      *
      * @param command  The command to execute
-     * @param metaData The meta data to attach to the
+     * @param metaData The meta-data to attach to the
      * @return a ResultValidator that can be used to validate the resulting actions of the command execution
      */
     ResultValidator<T> when(Object command, Map<String, ?> metaData);
@@ -64,8 +64,8 @@ public interface TestExecutor<T> {
      * store when an aggregate is loaded.
      * <p/>
      * If an item in the given {@code domainEvents} implements {@link Message}, the
-     * payload and meta data from that message are copied into a newly created Domain Event Message. Otherwise, a
-     * Domain Event Message with the item as payload and empty meta data is created.
+     * payload and meta-data from that message are copied into a newly created Domain Event Message. Otherwise, a
+     * Domain Event Message with the item as payload and empty meta-data is created.
      *
      * @param domainEvents the domain events the event store should return
      * @return a TestExecutor instance that can execute the test with this configuration
@@ -76,9 +76,9 @@ public interface TestExecutor<T> {
      * Configures the given {@code domainEvents} as the "given" events. These are the events returned by the event
      * store when an aggregate is loaded.
      * <p/>
-     * If an item in the list implements {@link Message}, the payload and meta data from that
+     * If an item in the list implements {@link Message}, the payload and meta-data from that
      * message are copied into a newly created Domain Event Message. Otherwise, a Domain Event Message with the item
-     * as payload and empty meta data is created.
+     * as payload and empty meta-data is created.
      *
      * @param domainEvents the domain events the event store should return
      * @return a TestExecutor instance that can execute the test with this configuration
@@ -153,7 +153,7 @@ public interface TestExecutor<T> {
      * Simulates the time elapsing in the current given state using a {@link Duration} as the unit of time. This can be
      * useful when the time between given events is of importance, for example when leveraging the
      * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
-     *
+     * <p>
      * Note: As this method is added to the interface as a replacement for the deprecated
      * {@link #whenThenTimeAdvancesTo(Instant)} method, and in case there are other implementations by 3rd party
      * libraries, this method is changed to a default method that rely on the deprecated method so that there is no
@@ -200,7 +200,7 @@ public interface TestExecutor<T> {
      * Simulates the time advancing in the current given state using an {@link Instant} as the unit of time. This can be
      * useful when the time between given events is of importance, for example when leveraging the
      * {@link org.axonframework.deadline.DeadlineManager} to schedule deadlines in the context of a given Aggregate.
-     *
+     * <p>
      * Note: As this method is added to the interface as a replacement for the deprecated
      * {@link #whenThenTimeAdvancesTo(Instant)} method, and in case there are other implementations by 3rd party
      * libraries, this method is changed to a default method that rely on the deprecated method so that there is no

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 /**
  * Interface describing the operations available on a test fixture in the execution stage. In this stage, there is only
@@ -212,4 +214,41 @@ public interface TestExecutor<T> {
         return whenThenTimeAdvancesTo(newPointInTime);
     }
 
+    /**
+     * Invokes the given {@code aggregateFactory} expecting an aggregate instance of type {@code T} to be returned.
+     * <p>
+     * All activity is recorded in the fixture for result validation. The {@code aggregateFactory} typically refers to
+     * one of the aggregate's constructors.
+     * <p>
+     * You should use this when-phase operation whenever you do not use the
+     * {@link org.axonframework.commandhandling.CommandHandler} annotation on the aggregate's methods, nor have
+     * {@link org.axonframework.test.aggregate.FixtureConfiguration#registerAnnotatedCommandHandler(Object) registered
+     * an external command handler} invoking the {@link org.axonframework.modelling.command.Repository}.
+     *
+     * @param aggregateFactory A callable operation expecting an aggregate instance of type {@code T} to be returned.
+     *                         This typically is an aggregate constructor invocation.
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of executing the given
+     * {@code aggregateFactory}.
+     */
+    ResultValidator<T> whenConstructing(Callable<T> aggregateFactory);
+
+    /**
+     * Invokes the given {@code aggregateConsumer} after loading an aggregate of type {@code T} based on the given
+     * {@code aggregateIdentifier}.
+     * <p>
+     * All activity is recorded in the fixture for result validation.
+     * <p>
+     * You should use this when-phase operation whenever you do not use the
+     * {@link org.axonframework.commandhandling.CommandHandler} annotation on the aggregate's methods, nor have
+     * {@link org.axonframework.test.aggregate.FixtureConfiguration#registerAnnotatedCommandHandler(Object) registered
+     * an external command handler} invoking the {@link org.axonframework.modelling.command.Repository}.
+     *
+     * @param aggregateIdentifier The identifier of the aggregate to
+     *                            {@link org.axonframework.modelling.command.Repository#load(String)}.
+     * @param aggregateConsumer   A lambda providing an aggregate instance of type {@code T} based on the given
+     *                            {@code aggregateIdentifier}.
+     * @return a {@link ResultValidator} that can be used to validate the resulting actions of executing the given
+     * {@code aggregateConsumer}.
+     */
+    ResultValidator<T> whenInvoking(String aggregateIdentifier, Consumer<T> aggregateConsumer);
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureWhenPhaseAggregateInvocationTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureWhenPhaseAggregateInvocationTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateLifecycle;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Test class validating the use of {@link AggregateTestFixture#whenConstructing(Callable)} and
+ * {@link AggregateTestFixture#whenInvoking(String, Consumer)}.
+ *
+ * @author Steven van Beelen
+ */
+class FixtureWhenPhaseAggregateInvocationTest {
+
+    private static final String AGGREGATE_ID = "some-id";
+    private static final String STATE = "some-state";
+    private static final boolean SHOULD_NOT_FAIL = false;
+    private static final boolean SHOULD_FAIL = true;
+
+    private AggregateTestFixture<MyAggregate> testFixture;
+
+    @BeforeEach
+    void setUp() {
+        testFixture = new AggregateTestFixture<>(MyAggregate.class);
+    }
+
+    @Test
+    void creatingAggregateThroughWhenConstructingPublishesEventsWhenSuccessful() {
+        testFixture.givenNoPriorActivity()
+                   .whenConstructing(() -> new MyAggregate(AGGREGATE_ID, SHOULD_NOT_FAIL))
+                   .expectEvents(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL));
+    }
+
+    @Test
+    void creatingAggregateThroughWhenConstructingThrowsExceptionsWhenUnsuccessful() {
+        testFixture.givenNoPriorActivity()
+                   .whenConstructing(() -> new MyAggregate(AGGREGATE_ID, SHOULD_FAIL))
+                   .expectNoEvents()
+                   .expectException(RuntimeException.class);
+    }
+
+    @Test
+    void changingAggregateThroughWhenInvokingPublishesEventsWhenSuccessful() {
+        testFixture.given(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL))
+                   .whenInvoking(AGGREGATE_ID, aggregate -> aggregate.createEntity(STATE, SHOULD_NOT_FAIL))
+                   .expectEvents(new AggregateMemberCreatedEvent(AGGREGATE_ID, STATE, SHOULD_NOT_FAIL));
+    }
+
+    @Test
+    void changingAggregateThroughWhenInvokingThrowsExceptionWhenUnsuccessful() {
+        testFixture.given(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL))
+                   .whenInvoking(AGGREGATE_ID, aggregate -> aggregate.createEntity(STATE, SHOULD_FAIL))
+                   .expectNoEvents()
+                   .expectException(RuntimeException.class);
+    }
+
+    @Test
+    void changingAggregateMemberThroughWhenInvokedWorks() {
+        String expectedState = "new-state";
+
+        testFixture.given(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL),
+                          new AggregateMemberCreatedEvent(AGGREGATE_ID, STATE, SHOULD_NOT_FAIL))
+                   .whenInvoking(AGGREGATE_ID, aggregate -> aggregate.getMember().changeMember(expectedState))
+                   .expectEvents(new AggregateMemberChangedEvent(AGGREGATE_ID, expectedState));
+    }
+
+    @Test
+    void usingWhenInvokedWithNullAggregateIdentifierThrowsIllegalArgumentException() {
+        testFixture.given(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL))
+                   .whenInvoking(null, aggregate -> aggregate.createEntity(STATE, SHOULD_NOT_FAIL))
+                   .expectException(IllegalArgumentException.class);
+    }
+
+    @Test
+    void usingWhenInvokedWithNonExistingAggregateIdentifierThrowsIllegalArgumentException() {
+        assertThrows(
+                AssertionError.class,
+                () -> testFixture.given(new AggregateCreatedEvent(AGGREGATE_ID, SHOULD_NOT_FAIL))
+                                 .whenInvoking(
+                                         "non-existing-aggregate-id",
+                                         aggregate -> aggregate.createEntity(STATE, SHOULD_NOT_FAIL)
+                                 )
+        );
+    }
+
+    private static class AggregateCreatedEvent {
+
+        private final String aggregateId;
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final boolean shouldFail;
+
+        private AggregateCreatedEvent(String aggregateId, boolean shouldFail) {
+            this.aggregateId = aggregateId;
+            this.shouldFail = shouldFail;
+        }
+    }
+
+    private static class AggregateMemberCreatedEvent {
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final String aggregateId;
+        private final String state;
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final boolean shouldFail;
+
+        private AggregateMemberCreatedEvent(String aggregateId, String state, boolean shouldFail) {
+            this.aggregateId = aggregateId;
+            this.state = state;
+            this.shouldFail = shouldFail;
+        }
+    }
+
+    private static class AggregateMemberChangedEvent {
+
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final String aggregateId;
+        private final String state;
+
+        private AggregateMemberChangedEvent(String aggregateId, String state) {
+            this.aggregateId = aggregateId;
+            this.state = state;
+        }
+    }
+
+    private static class MyAggregate {
+
+        @AggregateIdentifier
+        private String aggregateId;
+        private MyAggregateMember member;
+
+        public MyAggregate(String aggregateId, boolean shouldFail) {
+            if (shouldFail) {
+                throw new RuntimeException();
+            }
+            //noinspection ConstantValue
+            AggregateLifecycle.apply(new AggregateCreatedEvent(aggregateId, shouldFail));
+        }
+
+        public void createEntity(String memberState, boolean shouldFail) {
+            if (shouldFail) {
+                throw new RuntimeException();
+            }
+            //noinspection ConstantValue
+            AggregateLifecycle.apply(new AggregateMemberCreatedEvent(aggregateId, memberState, shouldFail));
+        }
+
+        @EventSourcingHandler
+        public void on(AggregateCreatedEvent event) {
+            aggregateId = event.aggregateId;
+        }
+
+        @EventSourcingHandler
+        public void on(AggregateMemberCreatedEvent event) {
+            member = new MyAggregateMember(aggregateId, event.state);
+        }
+
+        public MyAggregateMember getMember() {
+            return member;
+        }
+
+        @SuppressWarnings("unused")
+        public MyAggregate() {
+            // Required by Axon Framework
+        }
+    }
+
+    private static class MyAggregateMember {
+
+        private final String aggregateId;
+        @SuppressWarnings("unused")
+        private String state;
+
+        private MyAggregateMember(String aggregateId, String state) {
+            this.aggregateId = aggregateId;
+            this.state = state;
+        }
+
+        public void changeMember(String change) {
+            AggregateLifecycle.apply(new AggregateMemberChangedEvent(aggregateId, change));
+        }
+
+        @EventSourcingHandler
+        public void on(AggregateMemberChangedEvent event) {
+            this.state = event.state;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces two new when-phase operations:

- `whenConstructing(Callable<T>)`
- `whenInvoking(String, Consumer<T>)`

These when-phase operations allow the users to simulate a test environment where they do not have an annotated command model.
In other words, the `@CommandHandler` annotation is not used on the Aggregate.
Instead, users would wire the `Repository` of their aggregate in a separate class, invoking `Repository#newInstance(Callable<T>)` and `Repository#load(String)` manually before interacting with the Aggregate (of type T).

Although users can register an (annotated-)command handler with the `AggregateTestFixture` that typically performs the `Repository` invocations, having direct Aggregate method operations in the when-phase can be considered as additional user freedom.

Next to this new feature, some warnings and typos within the `AggregateTestFixture`, `TestExecutor` and `ResultValidatorImpl` have been resolved too.

In doing the above, this pull request resolves #1509.