### PR TITLE
[#2129] Fine tune `Repository` registration in the `AggregateTestFixture`

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -24,7 +24,6 @@ import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.common.Assert;
-import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.eventhandling.DomainEventMessage;
@@ -378,7 +377,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     @Override
     public TestExecutor<T> andGiven(List<?> domainEvents) {
         if (this.useStateStorage) {
-            throw new AxonConfigurationException(
+            throw new FixtureExecutionException(
                     "Given events not supported, because the fixture is configured to use state storage");
         }
 
@@ -575,8 +574,9 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
             AggregateModel<T> aggregateModel = aggregateModel();
             this.registerRepository(EventSourcingRepository.builder(aggregateType)
                                                            .aggregateModel(aggregateModel)
-                                                           .aggregateFactory(new GenericAggregateFactory<>(
-                                                                   aggregateModel))
+                                                           .aggregateFactory(
+                                                                   new GenericAggregateFactory<>(aggregateModel)
+                                                           )
                                                            .eventStore(eventStore)
                                                            .parameterResolverFactory(getParameterResolverFactory())
                                                            .handlerDefinition(getHandlerDefinition())

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,11 +176,19 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     @Override
     public FixtureConfiguration<T> registerRepository(Repository<T> repository) {
         this.repository = new IdentifierValidatingRepository<>(repository);
+        resources.add(repository);
         return this;
     }
 
     @Override
     public FixtureConfiguration<T> registerRepositoryProvider(RepositoryProvider repositoryProvider) {
+        if (repository != null) {
+            throw new FixtureExecutionException(
+                    "Cannot register a RepositoryProvider since the Repository is already defined in this fixture."
+                            + " It is recommended to first a RepositoryProvider"
+                            + " and then register or retrieve the Repository."
+            );
+        }
         this.repositoryProvider = repositoryProvider;
         return this;
     }
@@ -237,6 +245,13 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public FixtureConfiguration<T> registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory) {
+        if (repository != null) {
+            throw new FixtureExecutionException(
+                    "Cannot register more ParameterResolverFactories since the Repository is already defined"
+                            + " in this fixture. It is recommended to first register ParameterResolverFactories"
+                            + " and then register or retrieve the Repository."
+            );
+        }
         this.registeredParameterResolverFactories.addFirst(parameterResolverFactory);
         return this;
     }
@@ -284,13 +299,28 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
     @Override
     public FixtureConfiguration<T> registerHandlerDefinition(HandlerDefinition handlerDefinition) {
+        if (repository != null) {
+            throw new FixtureExecutionException(
+                    "Cannot register more HandlerDefinitions since the Repository is already defined in this fixture."
+                            + " It is recommended to first register HandlerDefinitions"
+                            + " and then register or retrieve the Repository."
+            );
+        }
         this.registeredHandlerDefinitions.addFirst(handlerDefinition);
         return this;
     }
 
     @Override
     public FixtureConfiguration<T> registerHandlerEnhancerDefinition(
-            HandlerEnhancerDefinition handlerEnhancerDefinition) {
+            HandlerEnhancerDefinition handlerEnhancerDefinition
+    ) {
+        if (repository != null) {
+            throw new FixtureExecutionException(
+                    "Cannot register more HandlerEnhancerDefinitions since the Repository is already defined"
+                            + " in this fixture. It is recommended to first register HandlerEnhancerDefinitions"
+                            + " and then register or retrieve the Repository."
+            );
+        }
         this.registeredHandlerEnhancerDefinitions.addFirst(handlerEnhancerDefinition);
         return this;
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureRepositoryRegistrationTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureRepositoryRegistrationTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.aggregate;
+
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
+import org.axonframework.eventhandling.SimpleEventBus;
+import org.axonframework.eventhandling.TimestampParameterResolverFactory;
+import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.eventsourcing.EventSourcingRepository;
+import org.axonframework.messaging.annotation.AnnotatedMessageHandlingMemberDefinition;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.GenericJpaRepository;
+import org.axonframework.modelling.command.Repository;
+import org.axonframework.modelling.command.RepositoryProvider;
+import org.axonframework.modelling.saga.SagaMethodMessageHandlerDefinition;
+import org.axonframework.test.FixtureExecutionException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.*;
+
+import javax.persistence.EntityManager;
+
+import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the following behavior around the fixture's {@link Repository}:
+ * <ul>
+ *     <li>The default {@code Repository} of the fixture can be wired in message handling methods.</li>
+ *     <li>A registered {@code Repository} in the fixture can be wired in message handling methods.</li>
+ *     <li>A {@link FixtureExecutionException} is thrown whenever a {@link RepositoryProvider} is registered after the {@code Repository} is defined.</li>
+ *     <li>A {@link FixtureExecutionException} is thrown whenever a {@link org.axonframework.messaging.annotation.ParameterResolverFactory} is registered after the {@code Repository} is defined.</li>
+ *     <li>A {@link FixtureExecutionException} is thrown whenever a {@link org.axonframework.messaging.annotation.HandlerDefinition} is registered after the {@code Repository} is defined.</li>
+ *     <li>A {@link FixtureExecutionException} is thrown whenever a {@link org.axonframework.messaging.annotation.HandlerEnhancerDefinition} is registered after the {@code Repository} is defined.</li>
+ * </ul>
+ *
+ * @author Steven van Beelen
+ */
+class FixtureRepositoryRegistrationTest {
+
+    private AggregateTestFixture<MyAggregate> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        testSubject = new AggregateTestFixture<>(MyAggregate.class);
+    }
+
+    @Test
+    void fixturesDefaultRepositoryCanBeWiredAsMessageHandlingParameter() {
+        testSubject.givenNoPriorActivity()
+                   .when("some-command")
+                   .expectEvents("some-command_" + EventSourcingRepository.class.getSimpleName());
+    }
+
+    @Test
+    void customRepositoryCanBeWiredAsMessageHandlingParameter() {
+        Repository<MyAggregate> testRepository =
+                CustomRepository.builder()
+                                .eventStore(testSubject.getEventStore())
+                                .build();
+
+        testSubject.registerRepository(testRepository)
+                   .givenNoPriorActivity()
+                   .when("some-command")
+                   .expectEvents("some-command_" + testRepository.getClass().getSimpleName());
+    }
+
+    @Test
+    void registeringTheRepositoryProviderThrowsFixtureExecutionExceptionAfterRegisteringTheRepository() {
+        Repository<MyAggregate> testRepository =
+                GenericJpaRepository.builder(MyAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mock(EntityManager.class)))
+                                    .eventBus(SimpleEventBus.builder().build())
+                                    .build();
+        testSubject.registerRepository(testRepository);
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerRepositoryProvider(new RepositoryProvider() {
+                         @Override
+                         public <T> Repository<T> repositoryFor(@NotNull Class<T> aggregateType) {
+                             return null;
+                         }
+                     }));
+    }
+
+    @Test
+    void registeringTheRepositoryProviderThrowsFixtureExecutionExceptionAfterRetrievingTheRepository() {
+        testSubject.getRepository();
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerRepositoryProvider(new RepositoryProvider() {
+                         @Override
+                         public <T> Repository<T> repositoryFor(@NotNull Class<T> aggregateType) {
+                             return null;
+                         }
+                     }));
+    }
+
+    @Test
+    void registeringParameterResolversThrowsFixtureExecutionExceptionAfterRegisteringTheRepository() {
+        Repository<MyAggregate> testRepository =
+                GenericJpaRepository.builder(MyAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mock(EntityManager.class)))
+                                    .eventBus(SimpleEventBus.builder().build())
+                                    .build();
+        testSubject.registerRepository(testRepository);
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerParameterResolverFactory(new TimestampParameterResolverFactory()));
+    }
+
+    @Test
+    void registeringParameterResolversThrowsFixtureExecutionExceptionAfterRetrievingTheRepository() {
+        testSubject.getRepository();
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerParameterResolverFactory(new TimestampParameterResolverFactory()));
+    }
+
+    @Test
+    void registeringHandlerDefinitionThrowsFixtureExecutionExceptionAfterRegisteringTheRepository() {
+        Repository<MyAggregate> testRepository =
+                GenericJpaRepository.builder(MyAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mock(EntityManager.class)))
+                                    .eventBus(SimpleEventBus.builder().build())
+                                    .build();
+        testSubject.registerRepository(testRepository);
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerHandlerDefinition(new AnnotatedMessageHandlingMemberDefinition()));
+    }
+
+    @Test
+    void registeringHandlerDefinitionThrowsFixtureExecutionExceptionAfterRetrievingTheRepository() {
+        testSubject.getRepository();
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerHandlerDefinition(new AnnotatedMessageHandlingMemberDefinition()));
+    }
+
+    @Test
+    void registeringHandlerEnhancersThrowsFixtureExecutionExceptionAfterRegisteringTheRepository() {
+        Repository<MyAggregate> testRepository =
+                GenericJpaRepository.builder(MyAggregate.class)
+                                    .entityManagerProvider(new SimpleEntityManagerProvider(mock(EntityManager.class)))
+                                    .eventBus(SimpleEventBus.builder().build())
+                                    .build();
+        testSubject.registerRepository(testRepository);
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerHandlerEnhancerDefinition(new SagaMethodMessageHandlerDefinition()));
+    }
+
+    @Test
+    void registeringHandlerEnhancersThrowsFixtureExecutionExceptionAfterRetrievingTheRepository() {
+        testSubject.getRepository();
+
+        assertThrows(FixtureExecutionException.class,
+                     () -> testSubject.registerHandlerEnhancerDefinition(new SagaMethodMessageHandlerDefinition()));
+    }
+
+    private static class MyAggregate {
+
+        @AggregateIdentifier
+        private String aggregateId;
+
+        @CommandHandler
+        public MyAggregate(String command, Repository<MyAggregate> repository) {
+            apply(command + "_" + repository.getClass().getSimpleName());
+        }
+
+        @EventSourcingHandler
+        public void on(String event) {
+            aggregateId = event;
+        }
+
+        @SuppressWarnings("unused")
+        public MyAggregate() {
+            // Required by Axon Framework
+        }
+    }
+
+    private static class CustomRepository extends EventSourcingRepository<MyAggregate> {
+
+        protected CustomRepository(Builder builder) {
+            super(builder);
+        }
+
+        public static Builder builder() {
+            return new Builder(MyAggregate.class);
+        }
+
+        private static class Builder extends EventSourcingRepository.Builder<MyAggregate> {
+
+            protected Builder(Class<MyAggregate> aggregateType) {
+                super(aggregateType);
+            }
+
+            @SuppressWarnings("unchecked")
+            public CustomRepository build() {
+                return new CustomRepository(this);
+            }
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_StateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.modelling.command.AggregateIdentifier;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
+import org.axonframework.test.FixtureExecutionException;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
@@ -131,7 +132,7 @@ class FixtureTest_StateStorage {
         fixture.useStateStorage();
 
         assertThrows(
-                AxonConfigurationException.class,
+                FixtureExecutionException.class,
                 () -> fixture.given(new StubDomainEvent())
         );
     }
@@ -141,7 +142,7 @@ class FixtureTest_StateStorage {
         fixture.useStateStorage();
 
         assertThrows(
-                AxonConfigurationException.class,
+                FixtureExecutionException.class,
                 () -> fixture.given(Collections.singletonList(new StubDomainEvent()))
         );
     }


### PR DESCRIPTION
This pull request adjusts two pointers around the `AggregateTestFixture's` `Repository` usage:

1. It ensures the registered `Repository` is added to the `resources` collection of the fixture. By adding it to the resources, users are able to wire the `Repository` inside the aggregate or registered annotated command handling components. Since the framework already does this in a production environment, this adjustment allows the fixture to more closely align with the a production setup,
2. A `FixtureExecutionException` is thrown when a `RepositoryProvider`, `ParameterResolverFactory`, `HandlerDefinition` or `HandlerEnhancerDefinition` is registered while the `Repository` is already defined for the fixture. Since all four of these components impact the `Repository` within the fixture, none of these operation should be allowed once the `Repository` is already retrieved (through `AggregateTestFixture#getRepository`, as this builds the default `Repository`) or when a custom version is registered (through `AggregateTestFixture#registerRepository`).

By doing the above, the pull request resolves #2129.