### PR TITLE
Enable safe retry of aggregate commands in the event of (perceived) failures

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -86,6 +86,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     private final Component<AggregateModel<A>> metaModel;
     private final Component<Predicate<? super DomainEventMessage<?>>> eventStreamFilter;
     private final Component<Boolean> filterEventsByType;
+    private final Component<Boolean> idempotent;
     private final Set<Class<? extends A>> subtypes = new HashSet<>();
     private final List<Registration> registrations = new ArrayList<>();
 
@@ -215,6 +216,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
         cache = new Component<>(() -> parent, name("aggregateCache"), c -> null);
         eventStreamFilter = new Component<>(() -> parent, name("eventStreamFilter"), c -> null);
         filterEventsByType = new Component<>(() -> parent, name("filterByAggregateType"), c -> false);
+        idempotent = new Component<>(() -> parent, name("idempotent"), c -> false);
         repository = new Component<>(
                 () -> parent, name("Repository"),
                 c -> {
@@ -237,6 +239,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                     EventSourcingRepository.Builder<A> builder =
                             EventSourcingRepository.builder(aggregate)
                                                    .aggregateModel(metaModel.get())
+                                                   .idempotent(idempotent.get())
                                                    .lockFactory(lockFactory.get())
                                                    .eventStore(c.eventStore())
                                                    .snapshotTriggerDefinition(snapshotTriggerDefinition.get())
@@ -442,6 +445,12 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
     public AggregateConfigurer<A> configureFilterEventsByType(
             Function<Configuration, Boolean> filterConfigurationPredicate) {
         this.filterEventsByType.update(filterConfigurationPredicate);
+        return this;
+    }
+
+    public AggregateConfigurer<A> configureIdempotent(
+            Function<Configuration, Boolean> idempotentPredicate) {
+        this.idempotent.update(idempotentPredicate);
         return this;
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcedAggregate.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcedAggregate.java
@@ -75,6 +75,12 @@ public class EventSourcedAggregate<T> extends AnnotatedAggregate<T> {
         return new EventSourcedAggregate<>(aggregateRoot, inspector, eventBus, repositoryProvider, snapshotTrigger);
     }
 
+    public static <T> EventSourcedAggregate<T> initialize(T aggregateRoot, AggregateModel<T> inspector,
+                                                          EventBus eventBus, RepositoryProvider repositoryProvider,
+                                                          SnapshotTrigger snapshotTrigger, boolean idempotent) {
+        return new EventSourcedAggregate<>(aggregateRoot, inspector, eventBus, repositoryProvider, snapshotTrigger, idempotent);
+    }
+
     /**
      * Initializes an EventSourcedAggregate instance using the given {@code aggregateFactory}, based on the given {@code
      * inspector}, which publishes events to the given {@code eventBus} and stores events in the given {@code
@@ -203,6 +209,13 @@ public class EventSourcedAggregate<T> extends AnnotatedAggregate<T> {
     protected EventSourcedAggregate(T aggregateRoot, AggregateModel<T> model, EventBus eventBus,
                                     RepositoryProvider repositoryProvider, SnapshotTrigger snapshotTrigger) {
         super(aggregateRoot, model, eventBus, repositoryProvider);
+        this.initSequence();
+        this.snapshotTrigger = snapshotTrigger;
+    }
+
+    protected EventSourcedAggregate(T aggregateRoot, AggregateModel<T> model, EventBus eventBus,
+                                    RepositoryProvider repositoryProvider, SnapshotTrigger snapshotTrigger, boolean idempotent) {
+        super(aggregateRoot, model, eventBus, repositoryProvider, idempotent);
         this.initSequence();
         this.snapshotTrigger = snapshotTrigger;
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -59,6 +59,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
     private final AggregateFactory<T> aggregateFactory;
     private final RepositoryProvider repositoryProvider;
     private final Predicate<? super DomainEventMessage<?>> eventStreamFilter;
+    private final boolean idempotent;
 
     /**
      * Instantiate a {@link EventSourcingRepository} based on the fields contained in the {@link Builder}.
@@ -87,6 +88,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         this.snapshotTriggerDefinition = builder.snapshotTriggerDefinition;
         this.repositoryProvider = builder.repositoryProvider;
         this.eventStreamFilter = builder.eventStreamFilter;
+        this.idempotent = builder.idempotent;
     }
 
     /**
@@ -152,7 +154,8 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
                             model,
                             eventStore,
                             repositoryProvider,
-                            trigger);
+                            trigger,
+                            idempotent);
         loadingAggregate.initializeState(eventStream);
         return loadingAggregate;
     }
@@ -240,6 +243,7 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         protected RepositoryProvider repositoryProvider;
         protected Cache cache;
         protected Predicate<? super DomainEventMessage<?>> eventStreamFilter;
+        protected boolean idempotent;
 
         /**
          * Creates a builder for a Repository for given {@code aggregateType}.
@@ -383,6 +387,11 @@ public class EventSourcingRepository<T> extends LockingRepository<T, EventSource
         public Builder<T> filterByAggregateType() {
             final String aggregateType = buildAggregateModel().type();
             return eventStreamFilter(event -> aggregateType.equals(event.getType()));
+        }
+
+        public Builder<T> idempotent(boolean idempotent) {
+            this.idempotent = idempotent;
+            return this;
         }
 
         /**

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
@@ -72,6 +72,7 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
     private final RepositoryProvider repositoryProvider;
     private final Queue<Runnable> delayedTasks = new LinkedList<>();
     private final EventBus eventBus;
+    private final boolean idempotent;
     private T aggregateRoot;
     private boolean applying = false;
     private boolean executingDelayedTasks = false;
@@ -107,6 +108,14 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
         this.aggregateRoot = aggregateRoot;
     }
 
+    protected AnnotatedAggregate(T aggregateRoot,
+                                 AggregateModel<T> model,
+                                 EventBus eventBus,
+                                 RepositoryProvider repositoryProvider, boolean idempotent) {
+        this(model, eventBus, repositoryProvider, idempotent);
+        this.aggregateRoot = aggregateRoot;
+    }
+
     /**
      * Initialize an Aggregate instance for the given {@code aggregateRoot}, described by the given {@code
      * aggregateModel} that will publish events to the given {@code eventBus}.
@@ -129,9 +138,17 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
     protected AnnotatedAggregate(AggregateModel<T> inspector,
                                  EventBus eventBus,
                                  RepositoryProvider repositoryProvider) {
+        this(inspector, eventBus, repositoryProvider, false);
+    }
+
+    protected AnnotatedAggregate(AggregateModel<T> inspector,
+                                 EventBus eventBus,
+                                 RepositoryProvider repositoryProvider,
+                                 boolean idempotent) {
         this.inspector = inspector;
         this.eventBus = eventBus;
         this.repositoryProvider = repositoryProvider;
+        this.idempotent = idempotent;
     }
 
     /**
@@ -358,6 +375,10 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
     @Override
     public Class<? extends T> rootType() {
         return (Class<? extends T>) aggregateRoot.getClass();
+    }
+
+    public boolean isIdempotent() {
+        return idempotent;
     }
 
     @Override

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateConfigurer.java
@@ -58,6 +58,7 @@ public class SpringAggregateConfigurer<T> implements ConfigurerModule, Applicati
     private String lockFactory;
     private String commandTargetResolver;
     private boolean filterEventsByType;
+    private boolean idempotent;
     private ApplicationContext applicationContext;
     private String aggregateFactory;
 
@@ -119,6 +120,10 @@ public class SpringAggregateConfigurer<T> implements ConfigurerModule, Applicati
      */
     public void setFilterEventsByType(boolean filterEventsByType) {
         this.filterEventsByType = filterEventsByType;
+    }
+
+    public void setIdempotent(boolean idempotent) {
+        this.idempotent = idempotent;
     }
 
     /**
@@ -202,6 +207,7 @@ public class SpringAggregateConfigurer<T> implements ConfigurerModule, Applicati
             );
         }
         aggregateConfigurer.configureFilterEventsByType(c -> filterEventsByType);
+        aggregateConfigurer.configureIdempotent(c -> idempotent);
         configurer.configureAggregate(aggregateConfigurer);
     }
 

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -58,6 +58,7 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
     private static final String COMMAND_TARGET_RESOLVER = "commandTargetResolver";
     private static final String CACHE = "cache";
     private static final String LOCK_FACTORY = "lockFactory";
+    private static final String IDEMPOTENT = "idempotent";
 
     /**
      * Builds a hierarchy model from the given {@code aggregatePrototypes} found in the given {@code beanFactory}.
@@ -213,6 +214,7 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
             );
         }
         beanDefinitionBuilder.addPropertyValue("aggregateFactory", aggregateFactory);
+        beanDefinitionBuilder.addPropertyValue(IDEMPOTENT, props.get(IDEMPOTENT));
         return beanDefinitionBuilder.getBeanDefinition();
     }
 

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
@@ -25,6 +25,7 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.modelling.command.RepositoryProvider;
+import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.tracing.SpanFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -86,6 +87,13 @@ public class SpringAggregateSnapshotter extends AggregateSnapshotter implements 
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public boolean shouldAddCorrelationIds(Class<?> aggregateType) {
+        Aggregate aggregateAnnotation = aggregateType.getAnnotation(Aggregate.class);
+
+        return aggregateAnnotation != null && aggregateAnnotation.idempotent();
     }
 
     @Override

--- a/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
+++ b/spring/src/main/java/org/axonframework/spring/stereotype/Aggregate.java
@@ -85,6 +85,8 @@ public @interface Aggregate {
      */
     boolean filterEventsByType() default false;
 
+    boolean idempotent() default false;
+
     /**
      * Sets the name of the bean providing the {@link org.axonframework.common.caching.Cache caching}. If none is
      * provided, no cache is created, unless explicitly configured on the referenced repository.


### PR DESCRIPTION
# Proposal

This is a draft proposal. It aims to enable safe retry of aggregate commands in the event of (perceived) failures, without changing current default behavior (i.e. opt-in).

## Context

- Command failures are often transient (e.g. service down -> `NoHandlerForCommandException`). As such, it makes sense to introduce the concept of a `RetryScheduler`.
- Problem: retrying commands is not always a safe operation, as the initial "failed" command may already have produced side effects, in which case a redelivery might wrongfully produce those side effects a second time (this is particularly common in case of `COMMAND_TIMEOUT`)
- To enable safe retries, the command handler (CH) must be idempotent
- Message handlers can be made idempotent at the infrastructure layer by filtering out duplicate messages

The problem and the proposal are demonstrated in the following repository: https://github.com/jvanheesch/axon-command-idempotency

## Approach

1. When a command results in an aggregate event, store the command id (`Message.getIdentifier()`) in the event
2. When sourcing an aggregate from events (+ snapshot), keep track of command ids
3. Upon receiving a command: if the command has already resulted in an aggregate event (i.e. command id is stored in some event or snapshot in the event stream), bypass `@CommandHandler`

### Limitations

This approach cannot be used to make the following CHs idempotent:

- CH constructor
- external CH

I'm not entirely happy about this, but I do believe the benefits largely outweigh these limitations. For CH constructors, this problem can be mitigated by including a `@TargetAggregateIdentifier` in the command message and selecting an event store implementation that enforces `(aggregate_identifier, sequence_number)` uniqueness (e.g. when using axon server, duplicate creation commands result in `OUT_OF_RANGE: [AXONIQ-2000] Invalid sequence number 0 for aggregate a1, expected 1)`.

## Final thoughts

There is definitely room for improvement. Some current questions/concerns:

- `AggregateSnapshotter` stores ALL previous `correlationIds` (for idempotent aggregates), which presumably makes snapshot size unbounded. Is such naive implementation sufficient, or is a more complex strategy (retention policy) required?
- Is `return null;` the most appropriate way of handling duplicate commands? Would some kind of exception make more sense?
- The value of the `idempotent` attribute of the `@Aggregate` annotation is not always taken into account. This value should be available to every piece of code that instantiates an `AnnotatedAggregate`. `AggregateConfigurer` passes this value to `EventSourcingRepository` and as such, every `AnnotatedAggregate` returned by `EventSourcingRepository` will have the correct value for its `idempotent` property. There are however several other places where an `AnnotatedAggregate` is sourced (from `DomainEventStream` or state) that currently do not have access to this newly added property, e.g.:
  - `AggregateSnapshotter` does not have access to this value, and resorts to providing the method `shouldAddCorrelationIds()`, enabling `SpringAggregateSnapshotter` to mitigate this problem
  - `CommandHandlerInvoker.DisruptorRepository` does not have access to this value, and as such `DisruptorCommandBus` will not filter out redeliveries
  - `GenericJpaRepository` does not have access to this value. On top of that, additional changes would be required to take this value into account, as `GenericJpaRepository` currently does not store (and hence cannot restore) command ids.
- The default value of `idempotent` should be globally configurable, eliminating the need for `idempotent = true` in every `@Aggregate` annotation

I believe safe retries would greatly improve command failure handling, and I hope they will be available some day. I'd be happy to improve upon this draft, but would like to hear your thoughts first.