### PR TITLE
Add Segment and Token to UnitOfWork of PooledStreamingEventProcessor

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,13 +84,13 @@ class WorkPackage {
     private final long claimExtensionThreshold;
     private final Consumer<UnaryOperator<TrackerStatus>> segmentStatusUpdater;
     private final Clock clock;
+    private final String segmentIdResourceKey;
+    private final String lastTokenResourceKey;
 
     private TrackingToken lastDeliveredToken; // For use only by event delivery threads, like Coordinator
     private TrackingToken lastConsumedToken;
     private TrackingToken lastStoredToken;
     private long lastClaimExtension;
-    private final String segmentIdResourceKey;
-    private final String lastTokenResourceKey;
 
     private final Queue<ProcessingEntry> processingQueue = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean scheduled = new AtomicBoolean();


### PR DESCRIPTION
The `TrackingEventProcessor` adds the token and segment into the resources of the `UnitOfwork` while processing. The `PooledStreamingEventProcessor` is still lacking this, while it can be very useful in some cases.

This PR introduces these resources to the `PooledStreamingEventProcessor` in the same way as the `TrackingEventProcessor` 