### PR TITLE
[#2561] Move Sonar to JDK17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
             sonar-enabled: false
             deploy-enabled: true
           - java-version: 11
-            sonar-enabled: true
+            sonar-enabled: false
             deploy-enabled: false
           - java-version: 17
-            sonar-enabled: false
+            sonar-enabled: true
             deploy-enabled: false
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,9 +13,9 @@ jobs:
           - java-version: 8
             sonar-enabled: false
           - java-version: 11
-            sonar-enabled: true
-          - java-version: 17
             sonar-enabled: false
+          - java-version: 17
+            sonar-enabled: true
       fail-fast: false # run both to the end
 
     steps:

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -119,6 +119,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-3-integrationtests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -25,6 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.axonframework</groupId>
     <artifactId>axon-spring-boot-3-integrationtests</artifactId>
 
     <name>Axon Framework - Spring Boot 3 Integration Tests</name>
@@ -175,6 +176,33 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <!--suppress MavenModelInspection -->
+                    <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent-for-unit-tests</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                            <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Adding the Spring Boot 3 integration tests to the coverage report, and change the github actions to enable sonar for JDK 17 instead of 11.
This will resolve #2561.