### PR TITLE
Fix not calling shutdown on `EmbeddedEventStore` in combination with `javax`

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -53,7 +53,7 @@ import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.axonframework.spring.stereotype.Saga;
 import org.axonframework.tracing.SpanFactory;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -69,14 +69,12 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singleton;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class AxonAutoConfigurationTest {
 
@@ -156,11 +154,32 @@ class AxonAutoConfigurationTest {
     }
 
     @Test
+    void shutDownCalledOnEmbeddedEventStoreEngine() {
+        ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withPropertyValues("axon.axonserver.enabled=false");
+
+        AtomicReference<EmbeddedEventStore> eventStore = new AtomicReference<>();
+
+        applicationContextRunner.run(context -> {
+            eventStore.set(context.getBean(EmbeddedEventStore.class));
+            assertNotNull(eventStore.get());
+        });
+        verify(eventStore.get(), atLeastOnce()).shutDown();
+    }
+
+    @Test
     void ambiguousPrimaryComponentsThrowExceptionWhenRequestedFromConfiguration() {
         ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
-                .withBean("gatewayOne", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(), beanDefinition -> beanDefinition.setPrimary(true))
-                .withBean("gatewayTwo", CommandGateway.class, () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(), beanDefinition -> beanDefinition.setPrimary(true))
+                .withBean("gatewayOne",
+                          CommandGateway.class,
+                          () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(),
+                          beanDefinition -> beanDefinition.setPrimary(true))
+                .withBean("gatewayTwo",
+                          CommandGateway.class,
+                          () -> DefaultCommandGateway.builder().commandBus(SimpleCommandBus.builder().build()).build(),
+                          beanDefinition -> beanDefinition.setPrimary(true))
                 .withPropertyValues("axon.axonserver.enabled=false");
 
         AxonConfigurationException actual = assertThrows(AxonConfigurationException.class, () -> {
@@ -210,7 +229,7 @@ class AxonAutoConfigurationTest {
 
         @Bean
         public EventStore eventStore() {
-            return EmbeddedEventStore.builder().storageEngine(storageEngine()).build();
+            return spy(EmbeddedEventStore.builder().storageEngine(storageEngine()).build());
         }
 
         @Bean

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/benchmark/JpaStorageEngineInsertionReadOrderTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/benchmark/JpaStorageEngineInsertionReadOrderTest.java
@@ -23,17 +23,14 @@ import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.BatchingEventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.legacyjpa.EmbeddedEventStore;
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.legacyjpa.JpaEventStorageEngine;
 import org.axonframework.eventsourcing.utils.EventStoreTestUtils;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.TestSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -49,10 +46,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.sql.DataSource;
 import java.beans.PropertyVetoException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -60,8 +53,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration test class validating the insertion order of events for the {@link JpaEventStorageEngine}.


### PR DESCRIPTION
By moving the trigger for the shutdown of the `EmbeddedEventStore` from using an annotation, to implementing `LifeCycle` it's no longer `javax` or `jakarta` specific. This makes sure it always works, and removes the need for a legacy `EmbeddedEventStore`.

Fixes https://github.com/AxonFramework/AxonFramework/issues/2584