### PR TITLE
Make SnapshotFilter a hard requirement

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -28,6 +28,7 @@ import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.util.GrpcMetaDataConverter;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.BuilderUtils;
 import org.axonframework.common.StringUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.stream.BlockingStream;
@@ -382,6 +383,7 @@ public class AxonServerEventStore extends AbstractEventStore {
          */
         @Override
         protected void validate() throws AxonConfigurationException {
+            BuilderUtils.assertNonNull(snapshotFilter, "The SnapshotFilter is a hard requirement and should be provided");
             super.validate();
         }
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -344,16 +344,13 @@ class AxonServerEventStoreTest {
     @Test
     void eventStoreConfigurationThrowsAxonConfigurationExceptionIfNoSnapshotFilterIsProvided() {
         JacksonSerializer eventSerializer = JacksonSerializer.defaultSerializer();
-        AxonServerEventStore.Builder testSubjectWithoutSnapshotFilterBuilder = AxonServerEventStore.builder()
-                                                                                                   .configuration(config)
-                                                                                                   .platformConnectionManager(
-                                                                                                           axonServerConnectionManager)
-                                                                                                   .upcasterChain(
-                                                                                                           upcasterChain)
-                                                                                                   .eventSerializer(
-                                                                                                           eventSerializer)
-                                                                                                   .snapshotSerializer(
-                                                                                                           eventSerializer);
+        AxonServerEventStore.Builder testSubjectWithoutSnapshotFilterBuilder =
+                AxonServerEventStore.builder()
+                                    .configuration(config)
+                                    .platformConnectionManager(axonServerConnectionManager)
+                                    .upcasterChain(upcasterChain)
+                                    .eventSerializer(eventSerializer)
+                                    .snapshotSerializer(eventSerializer);
         assertThrows(AxonConfigurationException.class, testSubjectWithoutSnapshotFilterBuilder::build);
     }
 


### PR DESCRIPTION
Make `SnapshotFilter` a hard requirement inside the event store configuration. In case there is no `SnapshotFilter`, `AxonConfigurationException` should be thrown. 