### PR TITLE
[#2555 Switch to `ConcurrentHashMap` in Saga related classes

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 
 import java.lang.reflect.Executable;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 import static java.lang.String.format;
@@ -36,7 +36,7 @@ import static java.lang.String.format;
  */
 public class PayloadAssociationResolver implements AssociationResolver {
 
-    private Map<String, Property<?>> propertyMap = new HashMap<>();
+    private Map<String, Property<?>> propertyMap = new ConcurrentHashMap<>();
 
     /**
      * Validates that the association property name exists as checked with the payload type. This is done by attempting

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
@@ -48,24 +48,24 @@ public class SagaMethodMessageHandlerDefinition implements HandlerEnhancerDefini
     }
 
     @Override
-    public @Nonnull
-    <T> MessageHandlingMember<T> wrapHandler(@Nonnull MessageHandlingMember<T> original) {
-        Optional<Map<String, Object>> annotationAttributes = original.annotationAttributes(SagaEventHandler.class);
-        SagaCreationPolicy creationPolicy =
-                original.annotationAttributes(StartSaga.class)
-                        .map(
-                                attr -> ((boolean) attr.getOrDefault("forceNew", false))
-                                        ? SagaCreationPolicy.ALWAYS
-                                        : SagaCreationPolicy.IF_NONE_FOUND
-                        )
-                        .orElse(SagaCreationPolicy.NONE);
-
-        //noinspection unchecked
-        return annotationAttributes
-                .map(attr -> doWrapHandler(original, creationPolicy, (String) attr.get("keyName"),
-                                           (String) attr.get("associationProperty"),
-                                           (Class<? extends AssociationResolver>) attr.get("associationResolver")))
-                .orElse(original);
+    public @Nonnull <T> MessageHandlingMember<T> wrapHandler(@Nonnull MessageHandlingMember<T> original) {
+        Optional<String> keyName = original.attribute("SagaEventHandler.keyName");
+        if (keyName.isPresent()) {
+            Optional<String> associationProperty = original.attribute("SagaEventHandler.associationProperty");
+            Optional<Class<? extends AssociationResolver>> associationResolver = original.attribute(
+                    "SagaEventHandler.associationResolver");
+            Optional<Boolean> optionalCreationPolicy = original.attribute("StartSaga.forceNew");
+            SagaCreationPolicy creationPolicy = optionalCreationPolicy
+                    .map(forceNew -> forceNew ? SagaCreationPolicy.ALWAYS : SagaCreationPolicy.IF_NONE_FOUND)
+                    .orElse(SagaCreationPolicy.NONE);
+            return doWrapHandler(original,
+                                 creationPolicy,
+                                 keyName.get(),
+                                 associationProperty.get(),
+                                 associationResolver.get());
+        } else {
+            return original;
+        }
     }
 
     private <T> MessageHandlingMember<T> doWrapHandler(MessageHandlingMember<T> original,
@@ -95,7 +95,8 @@ public class SagaMethodMessageHandlerDefinition implements HandlerEnhancerDefini
     ) {
         try {
             return associationResolverClass.getConstructor().newInstance();
-        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException |
+                 InvocationTargetException e) {
             throw new AxonConfigurationException(format(
                     "`AssociationResolver` %s must define an accessible no-args constructor.",
                     associationResolverClass.getName()

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
@@ -50,12 +50,12 @@ public class SagaMethodMessageHandlerDefinition implements HandlerEnhancerDefini
     @Override
     public @Nonnull <T> MessageHandlingMember<T> wrapHandler(@Nonnull MessageHandlingMember<T> original) {
         Optional<String> keyName = original.attribute("SagaEventHandler.keyName");
-        if (keyName.isPresent()) {
-            Optional<String> associationProperty = original.attribute("SagaEventHandler.associationProperty");
-            Optional<Class<? extends AssociationResolver>> associationResolver = original.attribute(
-                    "SagaEventHandler.associationResolver");
-            Optional<Boolean> optionalCreationPolicy = original.attribute("StartSaga.forceNew");
-            SagaCreationPolicy creationPolicy = optionalCreationPolicy
+        Optional<String> associationProperty = original.attribute("SagaEventHandler.associationProperty");
+        Optional<Class<? extends AssociationResolver>> associationResolver = original.attribute(
+                "SagaEventHandler.associationResolver");
+        if (keyName.isPresent() && associationProperty.isPresent() && associationResolver.isPresent()) {
+            Optional<Boolean> optionalForceNew = original.attribute("StartSaga.forceNew");
+            SagaCreationPolicy creationPolicy = optionalForceNew
                     .map(forceNew -> forceNew ? SagaCreationPolicy.ALWAYS : SagaCreationPolicy.IF_NONE_FOUND)
                     .orElse(SagaCreationPolicy.NONE);
             return doWrapHandler(original,

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 import static java.lang.String.format;
@@ -44,7 +44,7 @@ public class SagaMethodMessageHandlerDefinition implements HandlerEnhancerDefini
      * Constructs a default {@link SagaMethodMessageHandlerDefinition}.
      */
     public SagaMethodMessageHandlerDefinition() {
-        this.associationResolverMap = new HashMap<>();
+        this.associationResolverMap = new ConcurrentHashMap<>();
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/StartSaga.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/StartSaga.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.axonframework.modelling.saga;
+
+import org.axonframework.messaging.annotation.HasHandlerAttributes;
 
 import java.lang.annotation.*;
 
@@ -39,6 +41,7 @@ import java.lang.annotation.*;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@HasHandlerAttributes
 public @interface StartSaga {
 
     /**

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -30,7 +30,7 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 
-class PayLoadAssociationResolverTest {
+class PayloadAssociationResolverTest {
 
     private PayloadAssociationResolver testSubject;
     private MessageHandlingMember<Object> handlingMember;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.axonframework.modelling.utils.ConcurencyUtils.testConcurrent;
+import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PayLoadAssociationResolverTest {

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.saga;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PayLoadAssociationResolverTest {
+
+    private PayloadAssociationResolver testSubject;
+    private MessageHandlingMember<Object> handlingMember;
+    private static final String TEST_PROPERTY_NAME = "testProperty";
+    private static final int TEST_PROPERTY_VALUE = 42;
+
+    @BeforeEach
+    void setup() {
+        testSubject = new PayloadAssociationResolver();
+        handlingMember = new TestHandlingMember();
+    }
+
+    @Test
+    void setTestPropertyValueIsReturnedFromResolve() {
+        testResolveOnce();
+    }
+
+    @Test
+    void resolveWorksThreadSafe() {
+        testConcurrent(4, this::testResolveOnce);
+    }
+
+    private void testConcurrent(int threadCount, Runnable runnable) {
+        ExecutorService service = Executors.newFixedThreadPool(threadCount);
+        List<Exception> exceptions = new ArrayList<>();
+        try {
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                service.submit(() -> {
+                    try {
+                        runnable.run();
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                    latch.countDown();
+                });
+            }
+            latch.await();
+        } catch (Exception e) {
+            exceptions.add(e);
+        } finally {
+            service.shutdown();
+        }
+        assertEquals(Collections.emptyList(), exceptions);
+    }
+
+    private void testResolveOnce() {
+        EventMessage<?> eventMessage = asEventMessage(new TestEvent(TEST_PROPERTY_VALUE));
+        Object result = testSubject.resolve(TEST_PROPERTY_NAME, eventMessage, handlingMember);
+        assertEquals(TEST_PROPERTY_VALUE, result);
+    }
+
+    private class TestEvent {
+
+        private final int testProperty;
+
+        public TestEvent(int testProperty) {
+            this.testProperty = testProperty;
+        }
+
+        public int getTestProperty() {
+            return testProperty;
+        }
+    }
+
+    /**
+     * Sleep added to {@link #payloadType()} such that the
+     * {@link PayLoadAssociationResolverTest#resolveWorksThreadSafe()} test would always fail with a non thread safe
+     * map.
+     */
+    private class TestHandlingMember implements MessageHandlingMember {
+
+        @Override
+        public Class<?> payloadType() {
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return TestEvent.class;
+        }
+
+        @Override
+        public Optional<Map<String, Object>> annotationAttributes(Class annotationType) {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean hasAnnotation(Class annotationType) {
+            return false;
+        }
+
+        @Override
+        public Optional unwrap(Class handlerType) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Object handle(@Nonnull Message message, @Nullable Object target) throws Exception {
+            return null;
+        }
+
+        @Override
+        public boolean canHandleMessageType(@Nonnull Class messageType) {
+            return true;
+        }
+
+        @Override
+        public boolean canHandle(@Nonnull Message message) {
+            return true;
+        }
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -21,18 +21,13 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.junit.jupiter.api.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.modelling.utils.ConcurencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PayLoadAssociationResolverTest {
@@ -56,30 +51,6 @@ class PayLoadAssociationResolverTest {
     @Test
     void resolveWorksThreadSafe() {
         testConcurrent(4, this::testResolveOnce);
-    }
-
-    private void testConcurrent(int threadCount, Runnable runnable) {
-        ExecutorService service = Executors.newFixedThreadPool(threadCount);
-        List<Exception> exceptions = new ArrayList<>();
-        try {
-            CountDownLatch latch = new CountDownLatch(threadCount);
-            for (int i = 0; i < threadCount; i++) {
-                service.submit(() -> {
-                    try {
-                        runnable.run();
-                    } catch (Exception e) {
-                        exceptions.add(e);
-                    }
-                    latch.countDown();
-                });
-            }
-            latch.await();
-        } catch (Exception e) {
-            exceptions.add(e);
-        } finally {
-            service.shutdown();
-        }
-        assertEquals(Collections.emptyList(), exceptions);
     }
 
     private void testResolveOnce() {

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.saga;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.modelling.saga.metamodel.AnnotationSagaMetaModelFactory;
+import org.axonframework.modelling.saga.metamodel.SagaModel;
+import org.junit.jupiter.api.*;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.modelling.utils.ConcurencyUtils.testConcurrent;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SagaMethodMessageHandlerDefinitionTest {
+
+    private SagaMethodMessageHandlerDefinition testSubject;
+    private SagaModel<StubAnnotatedSaga> sagaModel;
+    private static final String TEST_PROPERTY_NAME = "testProperty";
+    private static final int TEST_PROPERTY_VALUE = 42;
+
+    @BeforeEach
+    void setup() {
+        testSubject = new SagaMethodMessageHandlerDefinition();
+        sagaModel = new AnnotationSagaMetaModelFactory().modelOf(StubAnnotatedSaga.class);
+    }
+
+    @Test
+    void shouldWrapHandler() {
+        EventMessage<?> eventMessage = asEventMessage(new TestEvent(TEST_PROPERTY_VALUE));
+        testWrapHandler(eventMessage);
+    }
+
+    @Test
+    void shouldWrapHandlerConcurrently() {
+        EventMessage<?> eventMessage = asEventMessage(new TestEvent(TEST_PROPERTY_VALUE));
+        testConcurrent(4, () -> testWrapHandler(eventMessage));
+    }
+
+    public void testWrapHandler(EventMessage<?> eventMessage) {
+        MessageHandlingMember<?> result = testSubject.wrapHandler(sagaModel.findHandlerMethods(eventMessage).get(0));
+        assertNotNull(result);
+        assertTrue(result instanceof SagaMethodMessageHandlingMember);
+        assertEquals(SagaCreationPolicy.NONE, ((SagaMethodMessageHandlingMember<?>) result).getCreationPolicy());
+    }
+
+    @SagaEventHandler(associationProperty = TEST_PROPERTY_NAME)
+    public void on(TestEvent event) {
+    }
+
+    private class TestEvent {
+
+        private final int testProperty;
+
+        public TestEvent(int testProperty) {
+            this.testProperty = testProperty;
+        }
+
+        public int getTestProperty() {
+            return testProperty;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class StubAnnotatedSaga {
+
+        @SagaEventHandler(associationProperty = TEST_PROPERTY_NAME, associationResolver = TestAssociationResolver.class)
+        public void handleTestEvent(TestEvent event) {
+        }
+    }
+
+    /**
+     * Sleep added to constructor such that the
+     * {@link SagaMethodMessageHandlerDefinitionTest#shouldWrapHandlerConcurrently()} test would always fail with a non
+     * thread safe map.
+     */
+    private static class TestAssociationResolver extends PayloadAssociationResolver {
+
+        public TestAssociationResolver() {
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
@@ -26,7 +26,7 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.axonframework.modelling.utils.ConcurencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SagaMethodMessageHandlerDefinitionTest {
+class SagaMethodMessageHandlerDefinitionTest {
 
     private SagaMethodMessageHandlerDefinition testSubject;
     private SagaModel<StubAnnotatedSaga> sagaModel;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
@@ -23,7 +23,7 @@ import org.axonframework.modelling.saga.metamodel.SagaModel;
 import org.junit.jupiter.api.*;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.axonframework.modelling.utils.ConcurencyUtils.testConcurrent;
+import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SagaMethodMessageHandlerDefinitionTest {

--- a/modelling/src/test/java/org/axonframework/modelling/utils/ConcurencyUtils.java
+++ b/modelling/src/test/java/org/axonframework/modelling/utils/ConcurencyUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Utility methods related to testing concurency
+ */
+public class ConcurencyUtils {
+
+    /**
+     * Will exucute the runnable as much times as the given {@code threadCount} and assest none caused exceptions.
+     * @param threadCount the number of times of envocations at the 'same' time
+     * @param runnable something that is expected to be run concurrently
+     */
+    public static void testConcurrent(int threadCount, Runnable runnable) {
+        ExecutorService service = Executors.newFixedThreadPool(threadCount);
+        List<Exception> exceptions = new ArrayList<>();
+        try {
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            for (int i = 0; i < threadCount; i++) {
+                service.submit(() -> {
+                    try {
+                        runnable.run();
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                    latch.countDown();
+                });
+            }
+            latch.await();
+        } catch (Exception e) {
+            exceptions.add(e);
+        } finally {
+            service.shutdown();
+        }
+        assertEquals(Collections.emptyList(), exceptions);
+    }
+
+    private ConcurencyUtils(){
+
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/utils/ConcurrencyUtils.java
+++ b/modelling/src/test/java/org/axonframework/modelling/utils/ConcurrencyUtils.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Utility methods related to testing concurency
  */
-public class ConcurrencyUtils {
+public abstract class ConcurrencyUtils {
 
     /**
      * Will execute the runnable as many times as the given {@code threadCount} and assert none caused exceptions. The


### PR DESCRIPTION
This pull request switches to use a `ConcurrentHashMap` for the `PayloadAssociationResolver` and the `SagaMethodMessageHandlerDefinition`.
Furthermore, tests are added to validate both classes to be thread-safe.

In doing so, this pull request resolves #2555.