### PR TITLE
Ensure retrieved Saga Identifiers collection is thread-safe

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/CachingSagaStore.java
@@ -23,8 +23,8 @@ import org.axonframework.modelling.saga.AssociationValues;
 import org.axonframework.modelling.saga.SagaRepository;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -80,9 +80,9 @@ public class CachingSagaStore<T> implements SagaStore<T> {
         return associationsCache.computeIfAbsent(
                 key,
                 () -> {
-                    // Wrap the original collection in a synchronized implementation, since it might be changed while
-                    // the SagaManager is reading it using the insertSaga/deleteSaga methods.
-                    return Collections.synchronizedSet(delegate.findSagas(sagaType, associationValue));
+                    // We copy the original collection in a thread-safe implementation, since the original might be
+                    // changed while the SagaManager is reading it using the insertSaga/deleteSaga methods.
+                    return new ConcurrentSkipListSet<>(delegate.findSagas(sagaType, associationValue));
                 }
         );
     }

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
@@ -191,7 +191,7 @@ public abstract class CachingSagaStoreTest {
 
     @Test
     void canHandleConcurrentReadsAndWrites() {
-        int concurrentOperations = 64;
+        int concurrentOperations = 32;
 
         AssociationValue associationValue = new AssociationValue("StubSaga-id", "value");
         Set<AssociationValue> associationValues = singleton(associationValue);
@@ -219,7 +219,7 @@ public abstract class CachingSagaStoreTest {
                      ))
                      .reduce(CompletableFuture::allOf)
                      .orElse(CompletableFuture.completedFuture(null))
-                     .get(30, TimeUnit.SECONDS);
+                     .get(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("An unexpected exception occurred during concurrent invocations on the CachingSagaStore.", e);
         }
@@ -231,7 +231,7 @@ public abstract class CachingSagaStoreTest {
                                                                          .sagaType(StubSaga.class)
                                                                          .sagaStore(testSubject)
                                                                          .build();
-        int concurrentOperations = 64;
+        int concurrentOperations = 32;
         ExecutorService executor = Executors.newFixedThreadPool(16);
         AssociationValue associationValue = new AssociationValue("StubSaga-id", "value");
 
@@ -258,7 +258,7 @@ public abstract class CachingSagaStoreTest {
                      ))
                      .reduce(CompletableFuture::allOf)
                      .orElse(CompletableFuture.completedFuture(null))
-                     .get(30, TimeUnit.SECONDS);
+                     .get(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("An unexpected exception occurred during concurrent invocations on the CachingSagaStore.", e);
         }

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
@@ -222,6 +222,8 @@ public abstract class CachingSagaStoreTest {
                      .get(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("An unexpected exception occurred during concurrent invocations on the CachingSagaStore.", e);
+        } finally {
+            executor.shutdown();
         }
     }
 
@@ -261,6 +263,8 @@ public abstract class CachingSagaStoreTest {
                      .get(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             fail("An unexpected exception occurred during concurrent invocations on the CachingSagaStore.", e);
+        } finally {
+            executor.shutdown();
         }
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/CachingSagaStoreTest.java
@@ -18,8 +18,13 @@ package org.axonframework.modelling.saga.repository;
 
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.caching.Cache;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.saga.AssociationValue;
 import org.axonframework.modelling.saga.AssociationValuesImpl;
+import org.axonframework.modelling.saga.Saga;
+import org.axonframework.modelling.saga.SagaRepository;
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -206,6 +211,45 @@ public abstract class CachingSagaStoreTest {
                                      testSubject.deleteSaga(
                                              StubSaga.class, sagaId, associationValues
                                      );
+                                 } catch (Exception e) {
+                                     throw new RuntimeException(e);
+                                 }
+                             },
+                             executor
+                     ))
+                     .reduce(CompletableFuture::allOf)
+                     .orElse(CompletableFuture.completedFuture(null))
+                     .get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("An unexpected exception occurred during concurrent invocations on the CachingSagaStore.", e);
+        }
+    }
+
+    @Test
+    void canHandleConcurrentReadsAndWritesThroughAnnotatedSagaRepository() {
+        SagaRepository<StubSaga> sagaRepository = AnnotatedSagaRepository.<StubSaga>builder()
+                                                                         .sagaType(StubSaga.class)
+                                                                         .sagaStore(testSubject)
+                                                                         .build();
+        int concurrentOperations = 64;
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+        AssociationValue associationValue = new AssociationValue("StubSaga-id", "value");
+
+        try {
+            IntStream.range(0, concurrentOperations)
+                     .mapToObj(i -> CompletableFuture.runAsync(
+                             () -> {
+                                 try {
+                                     UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
+                                     String sagaId = IdentifierFactory.getInstance().generateIdentifier();
+                                     // Create instances
+                                     Saga<StubSaga> saga = sagaRepository.createInstance(sagaId, StubSaga::new);
+                                     uow.execute(() -> saga.getAssociationValues().add(associationValue));
+                                     // Find Saga identifiers
+                                     Set<String> sagaIds = sagaRepository.find(associationValue);
+                                     // Load Sagas
+                                     DefaultUnitOfWork.startAndGet(null)
+                                                      .execute(() -> sagaIds.forEach(sagaRepository::load));
                                  } catch (Exception e) {
                                      throw new RuntimeException(e);
                                  }


### PR DESCRIPTION
This pull request introduces a test case to reproduce a `ConcurrentModificationException` through the `AnnotatedSagaRepository#find` method.
This exception only occurs in particularly heavy use cases of the Saga utilizing a `CachingSagaStore`.

This follows from the returned saga identifiers collection from the `CachingSagaStore`.
Although a synchronized collection (through Collections#synchronized`) was returned, this approach expects *all* usages of the wrapped set to go through it.
As we cannot guarantee this, it is safer to construct a new thread-safe set based on the retrieved saga identifiers.