### PR TITLE
Add an auto-merge step for Dependabot Pull Request

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -2,10 +2,11 @@ name: Dependabot Automation
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
-  dependabot:
+  dependabot-approve:
     name: Dependabot PR Automation
 
     runs-on: ubuntu-latest
@@ -19,6 +20,23 @@ jobs:
 
       - name: Approve Pull Request
         run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Retrieve Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge Pull Request
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request aims to further automize Dependabot pull requests.
Earlier, we introduced automation to approve pull requests.
The adjustments below aim to automatically merge pull requests originating from the "actor" `dependabot[bot]`.

Note that part of this pull request is branch protection settings within this repository, which since they are GitHub settings cannot be part of the PR.
These settings require a successful run of the JDK8, JDK11, and JDK17 builds for a given pull request. 
So when any of the three fails, the branch protection rule ensures the pull request cannot be automatically merged.

Furthermore, to minimize the impact of this automation, for now, I've set it to only act on patch version increments.
This is done through the `if` block validating whether the `update-type` is of type `semver-patch`.

Lastly, it's worthwhile to note that I've based all this on the [Dependabot automation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request) documentation of GitHub