### PR TITLE
Fix OpenTelemetry support

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -88,6 +88,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <scope>test</scope>

--- a/axon-server-connector/src/test/resources/log4j2.properties
+++ b/axon-server-connector/src/test/resources/log4j2.properties
@@ -40,3 +40,6 @@ logger.asc-event-processor-service.level = OFF
 
 logger.chaining-converter.name = org.axonframework.serialization.ChainingConverter
 logger.chaining-converter.level = OFF
+
+logger.tracing.name = org.axonframework.tracing
+logger.tracing.level = INFO

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.6.4-SNAPSHOT</version>
+        <version>4.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-coverage-report</artifactId>

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
@@ -29,6 +29,7 @@ import org.axonframework.modelling.command.ConcurrencyException;
 import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.Span;
 import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.SpanScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,7 @@ public abstract class AbstractSnapshotter implements Snapshotter {
         }
         if (snapshotsInProgress.add(typeAndId)) {
             Span span = spanFactory.createRootTrace(() -> traceName(aggregateType)).start();
-            try {
+            try(SpanScope unused = span.makeCurrent()) {
                 Span internalSpan = spanFactory.createInternalSpan(() -> getInnerTraceName(aggregateType,
                                                                                            aggregateIdentifier));
                 executor.execute(silently(internalSpan.wrapRunnable(

--- a/integrationtests-jakarta/pom.xml
+++ b/integrationtests-jakarta/pom.xml
@@ -183,6 +183,11 @@
             <artifactId>quartz</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -180,6 +180,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
+import static org.awaitility.Awaitility.await;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.integrationtests.utils.AssertUtils.assertWithin;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
@@ -144,9 +145,8 @@ public abstract class AbstractDeadlineManagerTestSuite {
         assertPublishedEvents(new MyAggregateCreatedEvent(IDENTIFIER),
                               new DeadlineOccurredEvent(new DeadlinePayload(IDENTIFIER)));
         spanFactory.verifySpanCompleted(managerName + ".schedule(deadlineName)");
-
-        Thread.sleep(100); // Takes time to complete
-        spanFactory.verifySpanCompleted("DeadlineJob.execute");
+        await().pollDelay(Duration.ofMillis(50)).atMost(Duration.ofMillis(100))
+               .untilAsserted(() -> spanFactory.verifySpanCompleted("DeadlineJob.execute"));
     }
 
 

--- a/messaging/src/main/java/org/axonframework/tracing/MultiSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/MultiSpanFactory.java
@@ -125,6 +125,12 @@ public class MultiSpanFactory implements SpanFactory {
         }
 
         @Override
+        public SpanScope makeCurrent() {
+            List<SpanScope> scopes = spans.stream().map(Span::makeCurrent).collect(Collectors.toList());
+            return () -> scopes.forEach(SpanScope::close);
+        }
+
+        @Override
         public void end() {
             spans.forEach(Span::end);
         }

--- a/messaging/src/main/java/org/axonframework/tracing/NoOpSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/tracing/NoOpSpanFactory.java
@@ -73,11 +73,16 @@ public class NoOpSpanFactory implements SpanFactory {
         return message;
     }
 
-    static class NoOpSpan implements Span {
+    public static class NoOpSpan implements Span {
 
         @Override
         public Span start() {
             return this;
+        }
+
+        @Override
+        public SpanScope makeCurrent() {
+            return () -> {};
         }
 
         @Override

--- a/messaging/src/main/java/org/axonframework/tracing/SpanScope.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.tracing;
+
+/**
+ * Represents the scope of a {@link Span}. This is attached to the thread, and should be closed
+ * on the same thread as it was created before the span is ended.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.6.5
+ */
+@FunctionalInterface
+public interface SpanScope extends AutoCloseable {
+    /**
+     * Closes the scope of the Span on which it was opened.
+     * <p/>
+     * {@inheritDoc}
+     */
+    @Override
+    void close();
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -79,11 +79,11 @@ class SimpleCommandBusTest {
         testSubject.subscribe(String.class.getName(), new MyStringCommandHandler());
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
+                                 spanFactory.verifySpanActive("SimpleCommandBus.dispatch");
                                  spanFactory.verifySpanPropagated("SimpleCommandBus.dispatch", command);
-                                 spanFactory.verifySpanActive("SimpleCommandBus.handle");
+                                 spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
                              });
-        spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+        spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
     }
 
     @Test
@@ -94,11 +94,10 @@ class SimpleCommandBusTest {
         });
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
                                  spanFactory.verifySpanPropagated("SimpleCommandBus.dispatch", command);
-                                 spanFactory.verifySpanActive("SimpleCommandBus.handle");
+                                 spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
                              });
-        spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+        spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
         spanFactory.verifySpanHasException("SimpleCommandBus.dispatch", RuntimeException.class);
     }
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -278,18 +278,21 @@ class SimpleQueryBusTest {
                                                                                         multipleStringResponse);
 
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
-            spanFactory.verifySpanActive("SimpleQueryBus.scatterGather(0)", testQueryMessage);
+            spanFactory.verifySpanActive("SimpleQueryBus.scatterGather", testQueryMessage);
+            spanFactory.verifySpanActive("SimpleQueryBus.scatterGatherHandler-0");
             return q.getPayload() + "1234";
         });
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
-            spanFactory.verifySpanActive("SimpleQueryBus.scatterGather(1)", testQueryMessage);
+            spanFactory.verifySpanActive("SimpleQueryBus.scatterGather", testQueryMessage);
+            spanFactory.verifySpanActive("SimpleQueryBus.scatterGatherHandler-1");
             return q.getPayload() + "12345678";
         });
 
         testSubject.scatterGather(testQueryMessage, 500, TimeUnit.MILLISECONDS).collect(Collectors.toList());
 
-        spanFactory.verifySpanCompleted("SimpleQueryBus.scatterGather(0)", testQueryMessage);
-        spanFactory.verifySpanCompleted("SimpleQueryBus.scatterGather(1)", testQueryMessage);
+        spanFactory.verifySpanCompleted("SimpleQueryBus.scatterGather", testQueryMessage);
+        spanFactory.verifySpanCompleted("SimpleQueryBus.scatterGatherHandler-0");
+        spanFactory.verifySpanCompleted("SimpleQueryBus.scatterGatherHandler-1");
     }
 
 
@@ -764,18 +767,21 @@ class SimpleQueryBusTest {
                                     .subscribe();
 
 
-        SubscriptionQueryResult<QueryResponseMessage<Long>, SubscriptionQueryUpdateMessage<Long>> result = testSubject
-                .subscriptionQuery(new GenericSubscriptionQueryMessage<>("test",
-                                                                         "queryName",
-                                                                         ResponseTypes.instanceOf(Long.class),
-                                                                         ResponseTypes.instanceOf(Long.class)));
-        Mono<QueryResponseMessage<Long>> initialResult = result.initialResult();
-        Objects.requireNonNull(initialResult.block()).getPayload();
-        spanFactory.verifySpanCompleted("SimpleQueryBus.query");
-        updatedLatch.await();
-        Objects.requireNonNull(result.updates().next().block()).getPayload();
-        spanFactory.verifySpanCompleted("QueryUpdateEmitter.emit queryName");
-        disposable.dispose();
+        try {
+            SubscriptionQueryResult<QueryResponseMessage<Long>, SubscriptionQueryUpdateMessage<Long>> result = testSubject
+                    .subscriptionQuery(new GenericSubscriptionQueryMessage<>("test",
+                                                                             "queryName",
+                                                                             ResponseTypes.instanceOf(Long.class),
+                                                                             ResponseTypes.instanceOf(Long.class)));
+            Mono<QueryResponseMessage<Long>> initialResult = result.initialResult();
+            Objects.requireNonNull(initialResult.block()).getPayload();
+            spanFactory.verifySpanCompleted("SimpleQueryBus.query");
+            updatedLatch.await();
+            Objects.requireNonNull(result.updates().next().block()).getPayload();
+            spanFactory.verifySpanCompleted("SimpleQueryUpdateEmitter.emit");
+        } finally {
+            disposable.dispose();
+        }
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -183,8 +183,8 @@ class SimpleQueryUpdateEmitterTest {
 
         spanFactory.verifySpanCompleted("SimpleQueryUpdateEmitter.emit");
         spanFactory.verifySpanHasType("SimpleQueryUpdateEmitter.emit", TestSpanFactory.TestSpanType.INTERNAL);
-        spanFactory.verifySpanCompleted("QueryUpdateEmitter.emit chatMessages");
-        spanFactory.verifySpanHasType("QueryUpdateEmitter.emit chatMessages", TestSpanFactory.TestSpanType.DISPATCH);
+        spanFactory.verifySpanCompleted("SimpleQueryUpdateEmitter.doEmit");
+        spanFactory.verifySpanHasType("SimpleQueryUpdateEmitter.doEmit", TestSpanFactory.TestSpanType.DISPATCH);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/tracing/SpanTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/SpanTest.java
@@ -203,6 +203,11 @@ class SpanTest {
         }
 
         @Override
+        public SpanScope makeCurrent() {
+            return () -> {};
+        }
+
+        @Override
         public void end() {
             this.ended = true;
         }

--- a/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -46,7 +48,6 @@ public class TestSpanFactory implements SpanFactory {
     private final Deque<TestSpan> activeSpan = new ArrayDeque<>();
     private final List<TestSpan> createdSpans = new CopyOnWriteArrayList<>();
     private final Map<Message<?>, TestSpan> propagatedContexts = new HashMap<>();
-    private final Map<Message<?>, TestSpan> spanParents = new HashMap<>();
 
 
     /**
@@ -56,7 +57,6 @@ public class TestSpanFactory implements SpanFactory {
         this.activeSpan.clear();
         this.createdSpans.clear();
         this.propagatedContexts.clear();
-        this.spanParents.clear();
         logger.debug("SpanFactory cleared");
     }
 
@@ -66,8 +66,7 @@ public class TestSpanFactory implements SpanFactory {
      * @param name Name of the span to verify.
      */
     public void verifyNotStarted(String name) {
-        assertFalse(findSpan(name).started);
-        assertFalse(findSpan(name).ended);
+        assertFalse(findSpan(name, span -> span.started).isPresent(), () -> createErrorMessageForSpan(name));
     }
 
     /**
@@ -76,8 +75,8 @@ public class TestSpanFactory implements SpanFactory {
      * @param name Name of the span to verify.
      */
     public void verifySpanActive(String name) {
-        assertTrue(findSpan(name).started);
-        assertFalse(findSpan(name).ended);
+        assertTrue(findSpan(name, span -> span.started && !span.ended).isPresent(),
+                   () -> createErrorMessageForSpan(name));
     }
 
     /**
@@ -87,29 +86,29 @@ public class TestSpanFactory implements SpanFactory {
      * @param message The exact message the span should have been created for.
      */
     public void verifySpanActive(String name, Message<?> message) {
-        assertTrue(findSpan(name, message).started);
-        assertFalse(findSpan(name, message).ended);
+        assertTrue(findSpan(name, message, span -> span.started && !span.ended).isPresent(),
+                   () -> createErrorMessageForSpan(name));
     }
 
     /**
-     * Verifies that a span was created, started and ended.
+     * Verifies that a span was created, started, and ended.
      *
      * @param name Name of the span to verify.
      */
     public void verifySpanCompleted(String name) {
-        assertTrue(findSpan(name).started);
-        assertTrue(findSpan(name).ended);
+        assertTrue(findSpan(name, span -> span.started && span.ended).isPresent(),
+                   () -> createErrorMessageForSpan(name));
     }
 
     /**
-     * Verifies that a span was created, started and ended.
+     * Verifies that a span was created, started, and ended.
      *
      * @param name    Name of the span to verify.
      * @param message The exact message the span should have been created for.
      */
     public void verifySpanCompleted(String name, Message<?> message) {
-        assertTrue(findSpan(name, message).started);
-        assertTrue(findSpan(name, message).ended);
+        assertTrue(findSpan(name, message, span -> span.started && span.ended).isPresent(),
+                   () -> createErrorMessageForSpan(name));
     }
 
 
@@ -120,7 +119,7 @@ public class TestSpanFactory implements SpanFactory {
      * @param exceptionClass The type of exception
      */
     public void verifySpanHasException(String name, Class<?> exceptionClass) {
-        assertInstanceOf(exceptionClass, findSpan(name).exception);
+        assertInstanceOf(exceptionClass, findSpan(name).map(s -> s.exception).orElse(null));
     }
 
     /**
@@ -129,11 +128,7 @@ public class TestSpanFactory implements SpanFactory {
      * @param name Name of the span to verify.
      */
     public void verifyNoSpan(String name) {
-        Optional<TestSpan> span = createdSpans.stream()
-                                              .filter(s -> s.name.equals(name))
-                                              .findFirst();
-
-        assertFalse(span.isPresent());
+        assertFalse(findSpan(name).isPresent());
     }
 
     /**
@@ -157,15 +152,26 @@ public class TestSpanFactory implements SpanFactory {
      * @see TestSpanType
      */
     public void verifySpanHasType(String name, TestSpanType type) {
-        assertEquals(type, findSpan(name).type);
+        assertEquals(type, findSpan(name).map(s -> s.type).orElse(null));
     }
 
-    private TestSpan findSpan(String name) {
-        Optional<TestSpan> span = createdSpans.stream().filter(s -> s.name.equals(name))
-                                              .findFirst();
+    private void verifySpanExists(String name) {
+        assertTrue(findSpan(name).isPresent(), () -> createErrorMessageForSpan(name));
+    }
 
-        assertTrue(span.isPresent(), () -> createErrorMessageForSpan(name));
-        return span.get();
+    private Optional<TestSpan> findSpan(String name) {
+        return findSpan(name, testSpan -> true);
+    }
+
+    private void verifySpanExists(String name, Predicate<TestSpan> filter) {
+        assertTrue(findSpan(name, filter).isPresent(), () -> createErrorMessageForSpan(name));
+    }
+
+    private Optional<TestSpan> findSpan(String name, Predicate<TestSpan> filter) {
+        return createdSpans.stream()
+                           .filter(s -> s.name.equals(name))
+                           .filter(filter)
+                           .findFirst();
     }
 
     private String createErrorMessageForSpan(String name) {
@@ -175,18 +181,10 @@ public class TestSpanFactory implements SpanFactory {
                 createdSpans.stream().map(TestSpan::toString).collect(Collectors.joining("\n")));
     }
 
-    private TestSpan findSpan(String name, Message<?> message) {
-        Optional<TestSpan> span = createdSpans.stream().filter(s -> s.name.equals(name)
-                                                      && s.message != null
-                                                      && s.message.equals(message))
-                                              .findFirst();
-
-        assertTrue(span.isPresent(), () -> String.format(
-                "No span matching name %s and message %s, but got the following recorded spans: \n%s",
-                name,
-                message,
-                createdSpans.stream().map(TestSpan::toString).collect(Collectors.joining("\n"))));
-        return span.get();
+    private Optional<TestSpan> findSpan(String name, Message<?> message, Predicate<TestSpan> filter) {
+        return findSpan(name, filter.and(
+                s -> s.message != null
+                        && s.message.equals(message)));
     }
 
     @Override
@@ -197,18 +195,19 @@ public class TestSpanFactory implements SpanFactory {
     }
 
     @Override
-    public Span createHandlerSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage, boolean isChildTrace,
+    public Span createHandlerSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                  boolean isChildTrace,
                                   Message<?>... linkedParents) {
         TestSpan span = new TestSpan(isChildTrace ? TestSpanType.HANDLER_CHILD : TestSpanType.HANDLER_LINK,
                                      operationNameSupplier.get(),
                                      parentMessage);
         createdSpans.add(span);
-        spanParents.put(parentMessage, span);
         return span;
     }
 
     @Override
-    public Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage, Message<?>... linkedSiblings) {
+    public Span createDispatchSpan(Supplier<String> operationNameSupplier, Message<?> parentMessage,
+                                   Message<?>... linkedSiblings) {
         TestSpan span = new TestSpan(TestSpanType.DISPATCH, operationNameSupplier.get(), parentMessage);
         createdSpans.add(span);
         return span;
@@ -269,12 +268,14 @@ public class TestSpanFactory implements SpanFactory {
      */
     public class TestSpan implements Span {
 
+        private final List<SpanScope> scopes = new CopyOnWriteArrayList<>();
         private final TestSpanType type;
         private final String name;
         private final Message<?> message;
         private boolean started;
         private boolean ended;
         private Throwable exception;
+        private AtomicInteger scopeCount = new AtomicInteger(-1);
 
         public TestSpan(TestSpanType type, String name, Message<?> message) {
             this.type = type;
@@ -293,8 +294,32 @@ public class TestSpanFactory implements SpanFactory {
         }
 
         @Override
+        public SpanScope makeCurrent() {
+            return new TestSpanScope(scopeCount.incrementAndGet());
+        }
+
+        private class TestSpanScope implements SpanScope {
+
+            private final int scopeNum;
+
+            private TestSpanScope(int scopeNum) {
+                this.scopeNum = scopeNum;
+                logger.debug("++ {}:{}", name, scopeNum);
+            }
+
+            @Override
+            public void close() {
+                logger.debug("-- {}:{}", name, scopeNum);
+                scopes.remove(this);
+            }
+        }
+
+        @Override
         public void end() {
             ended = true;
+            if (scopes.size() > 0) {
+                throw new IllegalStateException("All scopes should be closed! Still have " + scopes.size() + " open!");
+            }
             synchronized (activeSpan) {
                 activeSpan.remove(this);
             }

--- a/messaging/src/test/resources/log4j2.properties
+++ b/messaging/src/test/resources/log4j2.properties
@@ -32,6 +32,10 @@ logger.axon.additivity = false
 logger.axon.appenderRefs = stdout
 logger.axon.appenderRef.stdout.ref = STDOUT
 
+
+logger.tracing.name = org.axonframework.tracing
+logger.tracing.level = INFO
+
 logger.retry-scheduler.name = org.axonframework.commandhandling.gateway
 logger.retry-scheduler.level = WARN
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
@@ -30,6 +30,7 @@ import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.Span;
 import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.SpanScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +178,7 @@ public abstract class AbstractSagaManager<T> implements EventHandlerInvoker, Sco
     private boolean doInvokeSaga(EventMessage<?> event, Saga<T> saga) throws Exception {
         if (saga.canHandle(event)) {
             Span span = spanFactory.createInternalSpan(() -> createInvokeSpanName(saga)).start();
-            try {
+            try(SpanScope unused = span.makeCurrent()) {
                 saga.handle(event);
             } catch (Exception e) {
                 span.recordException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <slf4j.version>2.0.3</slf4j.version>
         <log4j.version>2.18.0</log4j.version>
         <spring.version>5.3.24</spring.version>
+        <awaitility.version>4.2.0</awaitility.version>
         <spring-security.version>5.7.3</spring-security.version>
         <spring.boot.version>2.7.7</spring.boot.version>
         <mockito.version>4.8.1</mockito.version>
@@ -289,6 +290,11 @@
                 <artifactId>reactor-test</artifactId>
                 <version>${projectreactor.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpan.java
@@ -20,10 +20,13 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
 import org.axonframework.tracing.Span;
+import org.axonframework.tracing.SpanScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * {@link Span} implementation that uses OpenTelemetry's {@link io.opentelemetry.api.trace.Span} to provide tracing
@@ -32,19 +35,19 @@ import java.util.Objects;
  * These traces should always be created using the {@link OpenTelemetrySpanFactory} since this will make sure the proper
  * parent context is extracted before creating the {@link Span}.
  * <p>
- * Each {@link #start()} should result in an {@link #end()} being called. Only when the last {@code end()} is called
- * will the OpenTelemetry span actually be ended. This is because {@link Scope}s that are kept active should be closed
- * before ending the span, or memory leaks can occur. This is also the reason the {@code scopes} are kept in a
- * {@link Deque}.
+ * {@inheritDoc}
  *
  * @author Mitchell Herrijgers
  * @since 4.6.0
  */
 public class OpenTelemetrySpan implements Span {
 
+    private static final Logger logger = LoggerFactory.getLogger(OpenTelemetrySpan.class);
+
     private final SpanBuilder spanBuilder;
-    private final Deque<Scope> scopeQueue = new ArrayDeque<>();
+    private final List<Scope> scopes = new CopyOnWriteArrayList<>();
     private io.opentelemetry.api.trace.Span span = null;
+    private boolean ended = false;
 
     /**
      * Creates the span, based on the {@link SpanBuilder} provided. This {@link SpanBuilder} will supply the
@@ -61,19 +64,54 @@ public class OpenTelemetrySpan implements Span {
     public Span start() {
         if (span == null) {
             span = spanBuilder.startSpan();
+        } else {
+            logger.error("An attempt was made to start span with id [{}] of trace [{}] a second time",
+                         span.getSpanContext().getSpanId(),
+                         span.getSpanContext().getTraceId());
         }
-        scopeQueue.addFirst(span.makeCurrent());
         return this;
     }
 
     @Override
+    public SpanScope makeCurrent() {
+        if (span == null) {
+            logger.error(
+                    "Span was attempted to be made current while not started yet! Please report this to the Axon Framework team.",
+                    new IllegalStateException("Span attempted to be made current while not started"));
+            // Return empty scope as to not influence user's code
+            return () -> {
+            };
+        }
+        Scope scope = span.makeCurrent();
+        scopes.add(scope);
+        return () -> {
+            scopes.remove(scope);
+            scope.close();
+        };
+    }
+
+
+    @Override
     public void end() {
-        if (!scopeQueue.isEmpty()) {
-            scopeQueue.remove().close();
+        if (span == null) {
+            logger.error(
+                    "Span was attempted to be ended while not started yet! Please report this to the Axon Framework team.",
+                    new IllegalStateException("Span attempted to be ended while not started"));
+            return;
         }
-        if (scopeQueue.isEmpty()) {
-            span.end();
+        if (ended) {
+            logger.error(
+                    "Span ended a second time! Will ignore this ended invocation. Please report this to the Axon Framework team.",
+                    new IllegalStateException("Span ended a second time"));
+            return;
         }
+        if (!scopes.isEmpty()) {
+            logger.error(
+                    "Span ended without all scopes! Please report this to the Axon Framework team. This might influence reliability of your OpenTelemetry traces.",
+                    new IllegalStateException("Span ended with still " + scopes.size() + " open!"));
+        }
+        span.end();
+        ended = true;
     }
 
     @Override


### PR DESCRIPTION
The current implementation of OpenTelemetry support is wrong. It confused starting a span (starting its timer) with making it the current span for the thread (so that any span created by this thread gets the current as a parent).
In addition, spans get their parent at the moment they are started, not when they are created.

This has various effects, such as spans being nested despite being siblings, some span collectors not working at all, or spans not being correlated as parent/child. 

To remedy the situation, the `SpanScope` is introduced in this commit. Before ending a span, all open scopes should have been closed to prevent context leaking into the current thread, messing up the traces. Context propagation has been fixed and testen with Google Cloud Tracing, Jaeger, and the OpenTelemetry auto-instrumentation. 

After this PR has been merged and forward-ported to 4.7, a demo project will be released with various tracing configurations. 

Traces have remained almost semantically the same as much as possible. However, in some cases an additional span has been added for a better child-parent relationship (for example in the ScattterGather query on the `SimpleQueryBus`. 