### PR TITLE
Fix OpenTelemetry support on queries

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -164,12 +164,11 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
 
     private <C, R> void doDispatch(CommandMessage<C> commandMessage,
                                    CommandCallback<? super C, ? super R> commandCallback) {
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerCommandBus.dispatch", commandMessage).start();
-        SpanScope spanScope = span.makeCurrent();
         shutdownLatch.ifShuttingDown("Cannot dispatch new commands as this bus is being shutdown");
         //noinspection resource
         ShutdownLatch.ActivityHandle commandInTransit = shutdownLatch.registerActivity();
-        try {
+        Span span = spanFactory.createDispatchSpan(() -> "AxonServerCommandBus.dispatch", commandMessage).start();
+        try (SpanScope unused = span.makeCurrent()) {
             Command command = serializer.serialize(spanFactory.propagateContext(commandMessage),
                                                    routingStrategy.getRoutingKey(commandMessage),
                                                    priorityCalculator.determinePriority(commandMessage));
@@ -202,7 +201,6 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
                     commandMessage, GenericCommandResultMessage.asCommandResultMessage(dispatchException)
             );
         }
-        spanScope.close();
     }
 
     @Override

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -318,8 +318,10 @@ class AxonServerQueryBusTest {
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
                         && -1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
-        spanFactory.verifySpanCompleted("AxonServerQueryBus.scatterGather", testQuery);
-        spanFactory.verifySpanPropagated("AxonServerQueryBus.scatterGather", testQuery);
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            spanFactory.verifySpanCompleted("AxonServerQueryBus.scatterGather", testQuery);
+            spanFactory.verifySpanPropagated("AxonServerQueryBus.scatterGather", testQuery);
+        });
     }
 
     @Test
@@ -344,8 +346,10 @@ class AxonServerQueryBusTest {
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
-        spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery", testQuery);
-        spanFactory.verifySpanPropagated("AxonServerQueryBus.streamingQuery", testQuery);
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery", testQuery);
+            spanFactory.verifySpanPropagated("AxonServerQueryBus.streamingQuery", testQuery);
+        });
     }
 
     @Test
@@ -364,12 +368,10 @@ class AxonServerQueryBusTest {
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
-        await().atMost(Duration.ofSeconds(3l))
-                .untilAsserted(() ->
-                        spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery"));
-        await().atMost(Duration.ofSeconds(3l))
-                .untilAsserted(() ->
-                        spanFactory.verifySpanHasException("AxonServerQueryBus.streamingQuery", RuntimeException.class));
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery");
+            spanFactory.verifySpanHasException("AxonServerQueryBus.streamingQuery", RuntimeException.class);
+        });
     }
 
     @Test

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.6.5-SNAPSHOT</version>
+        <version>4.6.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-coverage-report</artifactId>


### PR DESCRIPTION
During the last change for OpenTelemetry on 4.6.x branch, an error was made by wrapping the response processing task in a span that is then executed multiple times. This wrap has been removed, and the span is now started by the task itself when appropriate.

For all makeCurrent calls, we now use try-with-resources statements. That ensures scopes are closed even when exceptions occur while the bus is shutting down or a dispatch interceptor throws an exception.