### PR TITLE
[#2611] Clarify active `UnitOfWork` expectation in the `Repository`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.command;
 
+import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.Message;
@@ -89,7 +90,7 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
     @Override
     public A newInstance(@Nonnull Callable<T> factoryMethod,
                          @Nonnull Consumer<Aggregate<T>> initMethod) throws Exception {
-        UnitOfWork<?> uow = CurrentUnitOfWork.get();
+        UnitOfWork<?> uow = currentUnitOfWork();
         AtomicReference<A> aggregateReference = new AtomicReference<>();
         // a constructor may apply events, and the persistence of an aggregate must take precedence over publishing its events.
         uow.onPrepareCommit(x -> {
@@ -135,7 +136,7 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
         return spanFactory
                 .createInternalSpan(() -> this.getClass().getSimpleName() + ".load " + aggregateIdentifier)
                 .runSupplier(() -> {
-                    UnitOfWork<?> uow = CurrentUnitOfWork.get();
+                    UnitOfWork<?> uow = currentUnitOfWork();
                     Map<String, A> aggregates = managedAggregates(uow);
                     A aggregate = aggregates.computeIfAbsent(aggregateIdentifier,
                                                              s -> doLoad(aggregateIdentifier,
@@ -151,7 +152,7 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
 
     @Override
     public Aggregate<T> loadOrCreate(@Nonnull String aggregateIdentifier, @Nonnull Callable<T> factoryMethod) {
-        UnitOfWork<?> uow = CurrentUnitOfWork.get();
+        UnitOfWork<?> uow = currentUnitOfWork();
         Map<String, A> aggregates = managedAggregates(uow);
         A aggregate = aggregates.computeIfAbsent(aggregateIdentifier,
                                                  s -> {
@@ -168,6 +169,16 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
         prepareForCommit(aggregate);
 
         return aggregate;
+    }
+
+    private UnitOfWork<?> currentUnitOfWork() {
+        UnitOfWork<?> uow = CurrentUnitOfWork.get();
+        Class<?> messageType = uow.getMessage() != null ? uow.getMessage().getClass() : null;
+        if (messageType != null && !CommandMessage.class.isAssignableFrom(messageType)) {
+            logger.warn("The active Unit of Work is expected to contain a CommandMessage, but instead contains a [{}]",
+                        messageType);
+        }
+        return uow;
     }
 
     /**

--- a/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
@@ -24,9 +24,16 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * The repository provides an abstraction of the storage of aggregates.
+ * The {@link Repository} provides an abstraction of the storage of aggregates.
+ * <p>
+ * When interacting with the {@code Repository} the framework expects an active
+ * {@link org.axonframework.messaging.unitofwork.UnitOfWork} containing a
+ * {@link org.axonframework.commandhandling.CommandMessage} implementation on the invoking thread to be present. If
+ * there is no active {@code UnitOfWork} an {@link IllegalStateException} is thrown.
  *
  * @param <T> The type of aggregate this repository stores.
+ * @author Allard Buijze
+ * @since 0.1
  */
 public interface Repository<T> extends ScopeAware {
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request does two things:

1. Expand the `Repository` JavaDoc to clarify the expectation of an active `UnitOfWork` containing a `CommandMessage` implementation. If there's no active `UnitOfWork` and `IllegalStateException` is thrown (by the `CurrentUnitOfWork`).
2. Add WARN-level logging to the `AbstractRepository`, validating whether the active `UnitOfWork` does not contain a `CommandMessage`. If it does not, that signals `Repository` invocation from an Event Handler or Query Handler, making it so that the context is unexpected down the line.

Point two specifically helps to resolve #2611, wherein an end-user invoked the `Repository` from within an `@EventHandler` annotated method.
This succeeded on the fact a `UnitOfWork` is active, but further down the line in Aggregate command handling logic, a `CommandMessage` implementation is expected instead.