### PR TITLE
Include dependency upgrades with migration

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -22,3 +22,15 @@ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
 
 #### Gradle
 Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).
+
+
+## Migrate to Axon Framework 4.7 Jakarta and Spring Boot 3.0
+### Maven
+```bash
+mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST,org.axonframework:axon-migration:LATEST \
+  -DactiveRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0,org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta
+```
+
+#### Gradle
+Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,11 +1,8 @@
 # Migration
-
 Module containing [OpenRewrite](https://docs.openrewrite.org/) recipes for migrating Axon Framework applications.
 
 ## Migrate to Axon Framework 4.7 Javax
-
 ### Maven
-
 ```bash
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.axonframework:axon-migration:LATEST \
@@ -13,11 +10,9 @@ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
 ```
 
 #### Gradle
-
 Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).
 
 ## Migrate to Axon Framework 4.7 Jakarta
-
 ### Maven
 ```bash
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
@@ -26,5 +21,4 @@ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
 ```
 
 #### Gradle
-
 Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).

--- a/migration/src/main/resources/META-INF/rewrite/axon-jakarta-47.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon-jakarta-47.yml
@@ -3,6 +3,10 @@ name: org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta
 displayName: Upgrade to Axonframework 4.7 Jakarta
 description: Migration file to upgrade from an Axon Framework Javax-specific project to Jakarta.
 recipeList:
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.axonframework
+      artifactId: "*"
+      newVersion: 4.x
   # Include the Jakarta migration recipe
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
   # Swap 4.6 dependencies for 4.7 dependencies

--- a/migration/src/main/resources/META-INF/rewrite/axon-javax-47.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon-javax-47.yml
@@ -3,6 +3,10 @@ name: org.axonframework.migration.UpgradeAxonFramework_4_7_Javax
 displayName: Upgrade to Axonframework 4.7 Javax
 description: Migration file to upgrade an Axon Framework Javax-specific project and remain on Javax.
 recipeList:
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.axonframework
+      artifactId: "*"
+      newVersion: 4.x
   # Move all classes from org.axonframework.common.jpa to org.axonframework.common.legacyjpa
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.axonframework.common.jpa


### PR DESCRIPTION
Noticed this step was missing when upgrading https://github.com/Axoniq/hotel-demo .
Figured add the Spring Boot upgrade command to the README as well, as it was only on the blog.
Hotel-demo migrates successfully using only the command in the README now for me.