### PR TITLE
Fix OpenTelemetry warning

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -126,9 +126,13 @@ class AxonServerEventStoreTest {
         Arrays.stream(eventMessages).forEach(e -> {
             testSpanFactory.verifySpanCompleted("AxonServerEventStore.publish", e);
         });
+        testSpanFactory.verifyNotStarted("AxonServerEventStore.prepareCommit");
         testSpanFactory.verifyNotStarted("AxonServerEventStore.commit");
+        testSpanFactory.verifyNotStarted("AxonServerEventStore.afterCommit");
         uow.commit();
+        testSpanFactory.verifySpanCompleted("AxonServerEventStore.prepareCommit");
         testSpanFactory.verifySpanCompleted("AxonServerEventStore.commit");
+        testSpanFactory.verifySpanCompleted("AxonServerEventStore.afterCommit");
 
         TrackingEventStream stream = testSubject.openStream(null);
 

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpan.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpan.java
@@ -65,7 +65,7 @@ public class OpenTelemetrySpan implements Span {
         if (span == null) {
             span = spanBuilder.startSpan();
         } else {
-            logger.error("An attempt was made to start span with id [{}] of trace [{}] a second time",
+            logger.warn("An attempt was made to start span with id [{}] of trace [{}] a second time",
                          span.getSpanContext().getSpanId(),
                          span.getSpanContext().getTraceId());
         }
@@ -75,7 +75,7 @@ public class OpenTelemetrySpan implements Span {
     @Override
     public SpanScope makeCurrent() {
         if (span == null) {
-            logger.error(
+            logger.warn(
                     "Span was attempted to be made current while not started yet! Please report this to the Axon Framework team.",
                     new IllegalStateException("Span attempted to be made current while not started"));
             // Return empty scope as to not influence user's code
@@ -94,19 +94,19 @@ public class OpenTelemetrySpan implements Span {
     @Override
     public void end() {
         if (span == null) {
-            logger.error(
+            logger.warn(
                     "Span was attempted to be ended while not started yet! Please report this to the Axon Framework team.",
                     new IllegalStateException("Span attempted to be ended while not started"));
             return;
         }
         if (ended) {
-            logger.error(
+            logger.warn(
                     "Span ended a second time! Will ignore this ended invocation. Please report this to the Axon Framework team.",
                     new IllegalStateException("Span ended a second time"));
             return;
         }
         if (!scopes.isEmpty()) {
-            logger.error(
+            logger.warn(
                     "Span ended without all scopes! Please report this to the Axon Framework team. This might influence reliability of your OpenTelemetry traces.",
                     new IllegalStateException("Span ended with still " + scopes.size() + " open!"));
         }


### PR DESCRIPTION
When a command handler applies an event and stages events for publication in the UoW, but then fails, an error is logged by Axon Framework: Span was attempted to be ended while not started yet

This is because the cleanup phase (that ends the span) is called even when the span is not started. Since it's nearly impossible to tell what has been executed and what hasn't, the commit span has been split up for each phase in the UnitOfWork - preCommit, commit and postCommit.

Last but not least, the error logs have been reduced to warn - we can handle the issues gracefully.