### PR TITLE
Replace `SpringPrototypeAggregateFactory` `BeanDefinition` introspection for direct method invocation

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -36,10 +36,10 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProce
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.core.ResolvableType;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
@@ -220,12 +220,13 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
         if (!registry.containsBeanDefinition(aggregateFactory)) {
             ((BeanDefinitionRegistry) registry).registerBeanDefinition(
                     aggregateFactory,
-                    BeanDefinitionBuilder.genericBeanDefinition(SpringPrototypeAggregateFactory.class)
-                                         // using static method to avoid ambiguous constructor resolution in Spring AOT
-                                         .setFactoryMethod("withSubtypeSupport")
-                                         .addConstructorArgValue(aggregateBeanName)
-                                         .addConstructorArgValue(subTypes)
-                                         .getBeanDefinition()
+                    BeanDefinitionBuilder.rootBeanDefinition(
+                            SpringPrototypeAggregateFactory.class,
+                            // using static method to avoid ambiguous constructor resolution in Spring AOT
+                            () -> SpringPrototypeAggregateFactory.withSubtypeSupport(
+                                    aggregateBeanName, subTypes
+                            )
+                    ).getBeanDefinition()
             );
         }
         beanDefinitionBuilder.addPropertyValue("aggregateFactory", aggregateFactory);


### PR DESCRIPTION
For some reason, Spring Framework logs the following message open usages of the static factory method of the `SpringPrototypeAggregateFactory` inside the `SpringAggregateLookup` component:

`LocalVariableTableParameterNameDiscoverer : Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: org.axonframework.spring.eventsourcing.SpringPrototypeAggregateFactory`

Although none of the methods are marked deprecated on the `BeanDefinition` API, we are, apparently, dealing with undesired behavior for Spring. 
Regardless, we can easily use a `Supplier<SpringPrototypeAggregateFactory>` in this case since the required properties (the aggregate name and its subtypes) for constructing the `SpringPrototypeAggregateFactory` are known upfront.

By switching from introspection to using a `Supplier`, we resolve #2630.