### PR TITLE
Add a warning to the creation of the in memory token store.

### DIFF
--- a/integrationtests/src/test/resources/log4j2.properties
+++ b/integrationtests/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,3 +77,6 @@ logger.docker-java.name = com.github.dockerjava
 logger.docker-java.level = WARN
 logger.docker-java-http5.name = com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire
 logger.docker-java-http5.level = OFF
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.UnableToClaimTokenException;
 import org.axonframework.eventhandling.tokenstore.UnableToInitializeTokenException;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -40,10 +43,23 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  */
 public class InMemoryTokenStore implements TokenStore {
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final GlobalSequenceTrackingToken NULL_TOKEN = new GlobalSequenceTrackingToken(-1);
 
     private final Map<ProcessAndSegment, TrackingToken> tokens = new ConcurrentHashMap<>();
     private final String identifier = UUID.randomUUID().toString();
+
+    /**
+     * No-arg constructor for the {@link InMemoryTokenStore} which will log a warning on initialization.
+     */
+    public InMemoryTokenStore() {
+        logger.warn(
+                "An in memory token store is being created.\n" +
+                        "This means the event processor using this token store might process the " +
+                        "same events again when the application is restarted.\n" +
+                        "If the use of an in memory token store is intentional, this warning can be ignored.\n" +
+                        "If the tokens should be persisted, use the JPA, JDBC or MongoDB token store instead.");
+    }
 
     @Override
     public void initializeTokenSegments(@Nonnull String processorName, int segmentCount)

--- a/messaging/src/test/resources/log4j2.properties
+++ b/messaging/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,3 +84,6 @@ logger.quartz.name = org.quartz
 logger.quartz.level = WARN
 logger.quartz-job.name = org.axonframework.eventhandling.scheduling.quartz.FireEventJob
 logger.quartz-job.level = OFF
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR

--- a/modelling/src/test/resources/log4j2.properties
+++ b/modelling/src/test/resources/log4j2.properties
@@ -50,3 +50,6 @@ logger.spring-orm.name = org.springframework.orm
 logger.spring-orm.level = WARN
 logger.spring-test.name = org.springframework.test
 logger.spring-test.level = WARN
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR

--- a/spring-boot-3-integrationtests/src/test/resources/log4j2.properties
+++ b/spring-boot-3-integrationtests/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2022. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,3 +105,6 @@ logger.docker-java-http5.level = OFF
 # Test
 logger.tracking-event-processor-integration-test.name = org.axonframework.springboot.TrackingEventProcessorIntegrationTest
 logger.tracking-event-processor-integration-test.level = WARN
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR

--- a/spring-boot-autoconfigure/src/test/resources/log4j2.properties
+++ b/spring-boot-autoconfigure/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,3 +85,6 @@ logger.spring-orm.name = org.springframework.orm
 logger.spring-orm.level = WARN
 logger.spring-test.name = org.springframework.test
 logger.spring-test.level = WARN
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR

--- a/spring/src/test/resources/log4j2.properties
+++ b/spring/src/test/resources/log4j2.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2020. Axon Framework
+# Copyright (c) 2010-2023. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,3 +74,6 @@ logger.docker-java.name = com.github.dockerjava
 logger.docker-java.level = WARN
 logger.docker-java-http5.name = com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire
 logger.docker-java-http5.level = OFF
+# Token store
+logger.in-memory-token-store.name=org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+logger.in-memory-token-store.level = ERROR


### PR DESCRIPTION
End users are often surprised when an event processor rereads events when no persistent token store is configured. The warning will help them to notice why this is the case earlier.