### PR TITLE
Spring AoT fix

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
+++ b/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
@@ -1,0 +1,17 @@
+package org.axonframework.spring.config;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.modelling.command.Repository;
+
+/**
+ * Helper class to simplify creation of bean definitions for components configured in Axon Configuration
+ */
+public abstract class BeanHelper {
+
+    private BeanHelper() {
+    }
+
+    public static <T> Repository<T> repository(Class<T> aggregateType, Configuration configuration) {
+        return configuration.repository(aggregateType);
+    }
+}

--- a/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
+++ b/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
@@ -11,6 +11,16 @@ public abstract class BeanHelper {
     private BeanHelper() {
     }
 
+    /**
+     * Retrieves the repository for given {@code aggregateType} from given {@code configuration}
+     *
+     * @param aggregateType The type to find the repository for
+     * @param configuration The configuration from which to retrieve the Repository
+     * @param <T>           The type of aggregate
+     *
+     * @return the Repository instance for the aggregate
+     * @throws IllegalArgumentException if the given aggregateType has not been configured
+     */
     public static <T> Repository<T> repository(Class<T> aggregateType, Configuration configuration) {
         return configuration.repository(aggregateType);
     }

--- a/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
+++ b/spring/src/main/java/org/axonframework/spring/config/BeanHelper.java
@@ -1,27 +1,46 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.spring.config;
 
 import org.axonframework.config.Configuration;
 import org.axonframework.modelling.command.Repository;
 
 /**
- * Helper class to simplify creation of bean definitions for components configured in Axon Configuration
+ * Helper class to simplify the creation of bean definitions for components configured in Axon Configuration.
+ *
+ * @author Allard Buijze
+ * @since 4.7.4
  */
 public abstract class BeanHelper {
 
-    private BeanHelper() {
-    }
-
     /**
-     * Retrieves the repository for given {@code aggregateType} from given {@code configuration}
+     * Retrieves the {@link Repository} for given {@code aggregateType} from given {@code configuration}.
      *
-     * @param aggregateType The type to find the repository for
-     * @param configuration The configuration from which to retrieve the Repository
-     * @param <T>           The type of aggregate
-     *
-     * @return the Repository instance for the aggregate
-     * @throws IllegalArgumentException if the given aggregateType has not been configured
+     * @param aggregateType The type to find the repository for.
+     * @param configuration The configuration from which to retrieve the {@link Repository}.
+     * @param <T>           The type of aggregate.
+     * @return The {@link Repository} instance for the aggregate.
+     * @throws IllegalArgumentException if the given {@code aggregateType} has not been configured.
      */
     public static <T> Repository<T> repository(Class<T> aggregateType, Configuration configuration) {
         return configuration.repository(aggregateType);
+    }
+
+    private BeanHelper() {
+        // Utility class
     }
 }

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -21,7 +21,6 @@ import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.config.Configuration;
 import org.axonframework.modelling.command.Repository;
 import org.axonframework.spring.eventsourcing.SpringPrototypeAggregateFactory;
-import org.axonframework.spring.modelling.SpringRepositoryFactoryBean;
 import org.axonframework.spring.stereotype.Aggregate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +70,7 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
      * @param beanFactory         The beanFactory containing the definitions of the Aggregates.
      * @param aggregatePrototypes The prototype beans found for each individual type of Aggregate.
      * @param <A>                 The type of Aggregate.
+     *
      * @return A hierarchy model with subtypes for each declared main Aggregate.
      */
     @SuppressWarnings("unchecked")
@@ -202,11 +202,10 @@ public class SpringAggregateLookup implements BeanDefinitionRegistryPostProcesso
             } else {
                 ((BeanDefinitionRegistry) registry).registerBeanDefinition(
                         repositoryName,
-                        BeanDefinitionBuilder.rootBeanDefinition(SpringRepositoryFactoryBean.class)
+                        BeanDefinitionBuilder.rootBeanDefinition(BeanHelper.class)
                                              .addConstructorArgValue(aggregateType)
-                                             .addPropertyValue(
-                                                     "configuration", new RuntimeBeanReference(Configuration.class)
-                                             )
+                                             .addConstructorArgValue(new RuntimeBeanReference(Configuration.class))
+                                             .setFactoryMethod("repository")
                                              .applyCustomizers(bd -> {
                                                  ResolvableType resolvableRepositoryType =
                                                          forClassWithGenerics(Repository.class, aggregateType);

--- a/spring/src/main/java/org/axonframework/spring/modelling/SpringRepositoryFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/modelling/SpringRepositoryFactoryBean.java
@@ -18,6 +18,7 @@ package org.axonframework.spring.modelling;
 
 import org.axonframework.config.Configuration;
 import org.axonframework.modelling.command.Repository;
+import org.axonframework.spring.config.BeanHelper;
 import org.axonframework.spring.config.SpringAggregateConfigurer;
 import org.springframework.beans.factory.FactoryBean;
 
@@ -25,10 +26,14 @@ import org.springframework.beans.factory.FactoryBean;
  * Supplies the {@link Repository} created by the {@link SpringAggregateConfigurer} to the Spring Application Context.
  * This will allow it to be injected as a bean.
  *
+ * @param <T> The aggregate type
+ *
  * @author Mitchell Herrijgers
  * @since 4.6.1
- * @param <T> The aggregate type
+ * @deprecated Instead of using a factory bean, consider retrieving the Repository directly from the Axon Configuration.
+ * Alternatively, when building a BeanDefinition, use the {@link BeanHelper} factory methods to retrieve it.
  */
+@Deprecated
 public class SpringRepositoryFactoryBean<T> implements FactoryBean<Repository<T>> {
 
     private final Class<T> aggregateClass;

--- a/spring/src/test/java/org/axonframework/spring/config/BeanHelperTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/BeanHelperTest.java
@@ -1,0 +1,29 @@
+package org.axonframework.spring.config;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.modelling.command.Repository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BeanHelperTest {
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    void verifyRetrievesRepositoryFromConfiguration() {
+        Configuration configuration = mock(Configuration.class);
+        Repository mockRepository = mock(Repository.class);
+        when(configuration.repository(any())).thenReturn(mockRepository);
+
+        Repository<?> actual = BeanHelper.repository(Random.class, configuration);
+
+        verify(configuration).repository(Random.class);
+        assertSame(mockRepository, actual);
+    }
+}

--- a/spring/src/test/java/org/axonframework/spring/config/BeanHelperTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/BeanHelperTest.java
@@ -1,16 +1,30 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.spring.config;
 
 import org.axonframework.config.Configuration;
 import org.axonframework.modelling.command.Repository;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class BeanHelperTest {
 


### PR DESCRIPTION
The combination of a FactoryBean, defining a targetType on the bean definition and Spring AOT caused problems. As the FactoryBean wasn't strictly required to retrieve a Repository, it has been replaced by a static method.