### PR TITLE
Remove payloadType tag from EventProcessorLatencyMetric

### DIFF
--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
@@ -90,14 +90,14 @@ class GlobalMetricRegistryTest {
 
     @Test
     void createEventProcessorMonitorWithTags() {
-        MessageMonitor<? super EventMessage<?>> monitor1 = subject.registerEventProcessor("test1", message -> Tags
-                .of(TagsUtil.PAYLOAD_TYPE_TAG,
-                    message.getPayloadType()
-                           .getSimpleName()));
-        MessageMonitor<? super EventMessage<?>> monitor2 = subject.registerEventProcessor("test2", message -> Tags
-                .of(TagsUtil.PAYLOAD_TYPE_TAG,
-                    message.getPayloadType()
-                           .getSimpleName()));
+        MessageMonitor<? super EventMessage<?>> monitor1 = subject.registerEventProcessor(
+                "test1",
+                message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()),
+                message -> Tags.empty());
+        MessageMonitor<? super EventMessage<?>> monitor2 = subject.registerEventProcessor(
+                "test2",
+                message -> Tags.of(TagsUtil.PAYLOAD_TYPE_TAG, message.getPayloadType().getSimpleName()),
+                message -> Tags.empty());
 
         monitor1.onMessageIngested(asEventMessage("test")).reportSuccess();
         monitor2.onMessageIngested(asEventMessage("test")).reportSuccess();


### PR DESCRIPTION
The latency per payload type makes no sense to track for an event processor. When monitoring this metric, this will make the value dependent on the rate of certain types of events.

For example, when an event only takes place once a week, and is delayed because of an error, this metric will stay at a high value for the remainder of the week