### PR TITLE
Fix autoconfiguration not picking up SpanFactory for AxonServerQueryBus 4.6

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
@@ -99,15 +99,14 @@ public class AxonServerBusAutoConfiguration {
                                        Serializer genericSerializer,
                                        QueryPriorityCalculator priorityCalculator,
                                        QueryInvocationErrorHandler queryInvocationErrorHandler,
-                                       TargetContextResolver<? super QueryMessage<?, ?>> targetContextResolver,
-                                       SpanFactory spanFactory) {
+                                       TargetContextResolver<? super QueryMessage<?, ?>> targetContextResolver) {
         SimpleQueryBus simpleQueryBus =
                 SimpleQueryBus.builder()
                               .messageMonitor(axonConfiguration.messageMonitor(QueryBus.class, "queryBus"))
                               .transactionManager(txManager)
                               .queryUpdateEmitter(axonConfiguration.getComponent(QueryUpdateEmitter.class))
                               .errorHandler(queryInvocationErrorHandler)
-                              .spanFactory(spanFactory)
+                              .spanFactory(axonConfiguration.spanFactory())
                               .build();
         simpleQueryBus.registerHandlerInterceptor(
                 new CorrelationDataInterceptor<>(axonConfiguration.correlationDataProviders())
@@ -122,7 +121,7 @@ public class AxonServerBusAutoConfiguration {
                                  .genericSerializer(genericSerializer)
                                  .priorityCalculator(priorityCalculator)
                                  .targetContextResolver(targetContextResolver)
-                                 .spanFactory(spanFactory)
+                                 .spanFactory(axonConfiguration.spanFactory())
                                  .build();
     }
 


### PR DESCRIPTION
When using other libraries, like Inspector Axon, the right `SpanFactory` is not picked up.
In the old situation, it received a `NoOpSpanFactory` through the `SpanFactory` parameter, while the `Configuration` contains an `InspectorSpanFactory` and got the right one. 

This is probably due to bean initialization ordering. This has been corrected by always using `Configuration.spanFactory`