### PR TITLE
Wait till processing is done until setting the caughtUp flag for the PooledStreamingEventProcessor.

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -717,8 +717,10 @@ class Coordinator {
                     // It will likely jump all the if-statement directly, thus initiating the reading of events ASAP.
                     scheduleImmediateCoordinationTask();
                 } else if (isSpaceAvailable()) {
-                    // There is space, but no events to process. We caught up.
-                    workPackages.keySet().forEach(i -> processingStatusUpdater.accept(i, TrackerStatus::caughtUp));
+                    // There is space, but no events to process. We seem to have caught up, some might be processed still.
+                    if (isDone()){
+                        workPackages.keySet().forEach(i -> processingStatusUpdater.accept(i, TrackerStatus::caughtUp));
+                    }
 
                     if (!availabilityCallbackSupported) {
                         scheduleCoordinationTask(500);
@@ -818,6 +820,11 @@ class Coordinator {
         private boolean isSpaceAvailable() {
             return workPackages.values().stream()
                                .allMatch(WorkPackage::hasRemainingCapacity);
+        }
+
+        private boolean isDone() {
+            return workPackages.values().stream()
+                               .allMatch(WorkPackage::isDone);
         }
 
         /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/WorkPackage.java
@@ -340,6 +340,16 @@ class WorkPackage {
     }
 
     /**
+     * Indicates whether this {@link WorkPackage} has any work in the queue or scheduled.
+     *
+     * @return {@code true} if the {@code processingQueue} is empty and there is nothing scheduled, or {@code false}
+     * otherwise.
+     */
+    public boolean isDone() {
+        return this.processingQueue.isEmpty() && !this.scheduled.get();
+    }
+
+    /**
      * Returns the {@link Segment} that this {@link WorkPackage} is processing events for.
      *
      * @return the {@link Segment} that this {@link WorkPackage} is processing events for


### PR DESCRIPTION
Fixes https://github.com/AxonFramework/AxonFramework/issues/2694