### PR TITLE
Adjust the JavaDoc of the `EventProcessorLatencyMonitor`

### DIFF
--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitorCallback;
@@ -36,7 +37,15 @@ import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Measures the difference in message timestamps between the last ingested and the last processed message.
+ * A {@link MessageMonitor} implementation dedicated to {@link EventMessage EventMessages}.
+ * <p>
+ * This monitor defines the latency between the {@link EventMessage#getTimestamp()} and the {@link Clock#wallTime()}.
+ * Doing so, it depicts the latency from when an event was published compared to when an
+ * {@link org.axonframework.eventhandling.EventProcessor} processes the event to clarify how far behind an
+ * {@code EventProcessor} is.
+ * <p>
+ * Do note that a replay (as triggered through {@link StreamingEventProcessor#resetTokens()}, for example) will cause
+ * this metric to bump up due to the processor handling old events.
  *
  * @author Marijn van Zelst
  * @author Ivan Dugalic
@@ -147,8 +156,8 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
         private Clock clock = Clock.SYSTEM;
 
         /**
-         * Sets the name used to prefix the names of the {@link Gauge} instances created by this {@link
-         * MessageMonitor}.
+         * Sets the name used to prefix the names of the {@link Gauge} instances created by this
+         * {@link MessageMonitor}.
          *
          * @param meterNamePrefix a {@link String} used to prefix the names of the {@link Gauge} instances created by
          *                        this {@link MessageMonitor}

--- a/metrics/src/main/java/org/axonframework/metrics/EventProcessorLatencyMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/EventProcessorLatencyMonitor.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitorCallback;
 
@@ -31,7 +32,15 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
 
 /**
- * Measures the difference in message timestamps between the last ingested and the last processed message.
+ * A {@link MessageMonitor} implementation dedicated to {@link EventMessage EventMessages}.
+ * <p>
+ * This monitor defines the latency between the {@link EventMessage#getTimestamp()} and the {@link Clock#instant()}.
+ * Doing so, it depicts the latency from when an event was published compared to when an
+ * {@link org.axonframework.eventhandling.EventProcessor} processes the event to clarify how far behind an
+ * {@code EventProcessor} is.
+ * <p>
+ * Do note that a replay (as triggered through {@link StreamingEventProcessor#resetTokens()}, for example) will cause
+ * this metric to bump up due to the processor handling old events.
  *
  * @author Marijn van Zelst
  * @author Allard Buijze


### PR DESCRIPTION
The `EventProcessorLatencyMonitor` JavaDoc incorrectly depicts the intent of the monitor, which changed in December 2020.
With the provided changes, the documentation correctly describes that the monitored time is the time difference between the `EventMessage#getTimestamp` and the current time.