### PR TITLE
Move the check for whether the event processor is caught up before do…

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -707,6 +707,9 @@ class Coordinator {
             }
 
             try {
+                if (!eventStream.hasNextAvailable() && isDone()) {
+                    workPackages.keySet().forEach(i -> processingStatusUpdater.accept(i, TrackerStatus::caughtUp));
+                }
                 coordinateWorkPackages();
                 errorWaitBackOff = 500;
                 processingGate.set(false);
@@ -717,11 +720,6 @@ class Coordinator {
                     // It will likely jump all the if-statement directly, thus initiating the reading of events ASAP.
                     scheduleImmediateCoordinationTask();
                 } else if (isSpaceAvailable()) {
-                    // There is space, but no events to process. We seem to have caught up, some might be processed still.
-                    if (isDone()){
-                        workPackages.keySet().forEach(i -> processingStatusUpdater.accept(i, TrackerStatus::caughtUp));
-                    }
-
                     if (!availabilityCallbackSupported) {
                         scheduleCoordinationTask(500);
                     } else {

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.mockito.*;
 import org.mockito.stubbing.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -151,6 +150,7 @@ class CoordinatorTest {
         BlockingStream<TrackedEventMessage<?>> testStream = mock(BlockingStream.class);
         when(testStream.setOnAvailableCallback(any())).thenReturn(false);
         when(testStream.hasNextAvailable()).thenReturn(true)
+                                           .thenReturn(true)
                                            .thenReturn(false);
         //noinspection unchecked
         when(testStream.nextAvailable()).thenReturn(testEventOne)


### PR DESCRIPTION
Move the check for whether the event processor is caught up before doing the call to coordinateWorkPackages().
This should make sure the tests run more stable.