### PR TITLE
When registering the same Saga multiple times, only the last one is kept.

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -106,7 +106,7 @@ public class EventProcessingModule
             TypeProcessingGroupSelector.defaultSelector(DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION);
     private InstanceProcessingGroupSelector instanceFallbackSelector = InstanceProcessingGroupSelector.defaultSelector(EventProcessingModule::packageOfObject);
 
-    private final List<SagaConfigurer<?>> sagaConfigurations = new ArrayList<>();
+    private final Map<String, SagaConfigurer<?>> sagaConfigurations = new HashMap<>();
     private final List<Component<Object>> eventHandlerBuilders = new ArrayList<>();
     private final Map<String, EventProcessorBuilder> eventProcessorBuilders = new HashMap<>();
 
@@ -330,7 +330,7 @@ public class EventProcessingModule
     }
 
     private void registerSagaManagers(Map<String, List<Function<Configuration, EventHandlerInvoker>>> handlerInvokers) {
-        sagaConfigurations.forEach(sc -> {
+        sagaConfigurations.values().forEach(sc -> {
             SagaConfiguration<?> sagaConfig = sc.initialize(configuration);
             String processingGroup = selectProcessingGroupByType(sagaConfig.type());
             String processorName = processorNameForProcessingGroup(processingGroup);
@@ -449,7 +449,8 @@ public class EventProcessingModule
     @Override
     public List<SagaConfiguration<?>> sagaConfigurations() {
         validateConfigInitialization();
-        return sagaConfigurations.stream().map(sc -> sc.initialize(configuration)).collect(Collectors.toList());
+        return sagaConfigurations.values().stream().map(sc -> sc.initialize(configuration))
+                                 .collect(Collectors.toList());
     }
 
     private String processorNameForProcessingGroup(String processingGroup) {
@@ -523,7 +524,7 @@ public class EventProcessingModule
     public <T> EventProcessingConfigurer registerSaga(Class<T> sagaType, Consumer<SagaConfigurer<T>> sagaConfigurer) {
         SagaConfigurer<T> configurer = SagaConfigurer.forType(sagaType);
         sagaConfigurer.accept(configurer);
-        this.sagaConfigurations.add(configurer);
+        this.sagaConfigurations.put(sagaType.getName(), configurer);
         return this;
     }
 

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>4.7.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-coverage-report</artifactId>

--- a/hibernate-6-integrationtests/pom.xml
+++ b/hibernate-6-integrationtests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.7.4-SNAPSHOT</version>
+        <version>4.7.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -32,7 +32,7 @@
     <description>
         Module containing integration tests using Spring Boot 3. Does not contain any production code.
     </description>
-    <version>4.7.4-SNAPSHOT</version>
+    <version>4.7.6-SNAPSHOT</version>
 
     <dependencies>
 


### PR DESCRIPTION
This fixes the problem of having multiple saga handlers for the same saga. By switching to a map, only the last one is kept. Making it possible to do custom overrides in Spring without creating duplications.