### PR TITLE
Fix Inititalization of PSEP when using Saga

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -337,10 +337,10 @@ public class EventProcessingModule
             String processingGroup = selectProcessingGroupByType(sagaConfig.type());
             String processorName = processorNameForProcessingGroup(processingGroup);
             // The Event Processor type is unknown as it is not build yet, so we check for both TEP or PSEP configs.
-            if (noTepCustomization(sagaConfig.type(), processingGroup, processorName)) {
+            if (noTepCustomization(processorName)) {
                 registerTrackingEventProcessorConfiguration(processorName, config -> DEFAULT_SAGA_TEP_CONFIG);
             }
-            if (noPsepCustomization(sagaConfig.type(), processingGroup, processorName)) {
+            if (noPsepCustomization(processorName)) {
                 registerPooledStreamingEventProcessorConfiguration(processorName, DEFAULT_SAGA_PSEP_CONFIG);
             }
 
@@ -349,18 +349,14 @@ public class EventProcessingModule
         });
     }
 
-    private boolean noTepCustomization(Class<?> type, String processingGroup, String processorName) {
-        return DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION.apply(type).equals(processingGroup)
-                && processingGroup.equals(processorName)
-                && !eventProcessorBuilders.containsKey(processorName)
+    private boolean noTepCustomization(String processorName) {
+        return !eventProcessorBuilders.containsKey(processorName)
                 && !tepConfigs.containsKey(processorName)
                 && !tepConfigs.containsKey(CONFIGURED_DEFAULT_TEP_CONFIG);
     }
 
-    private boolean noPsepCustomization(Class<?> type, String processingGroup, String processorName) {
-        return DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION.apply(type).equals(processingGroup)
-                && processingGroup.equals(processorName)
-                && !eventProcessorBuilders.containsKey(processorName)
+    private boolean noPsepCustomization(String processorName) {
+        return !eventProcessorBuilders.containsKey(processorName)
                 && !psepConfigs.containsKey(processorName)
                 && !psepConfigs.containsKey(CONFIGURED_DEFAULT_PSEP_CONFIG);
     }

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -93,6 +93,9 @@ public class EventProcessingModule
             TrackingEventProcessorConfiguration.forSingleThreadedProcessing();
     private static final TrackingEventProcessorConfiguration DEFAULT_SAGA_TEP_CONFIG =
             DEFAULT_TEP_CONFIG.andInitialTrackingToken(StreamableMessageSource::createHeadToken);
+    private static final String CONFIGURED_DEFAULT_PSEP_CONFIG = "___DEFAULT_PSEP_CONFIG";
+    private static final PooledStreamingProcessorConfiguration DEFAULT_SAGA_PSEP_CONFIG =
+            (config, builder) -> builder.initialToken(StreamableMessageSource::createHeadToken);
     private static final Function<Class<?>, String> DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION =
             c -> c.getSimpleName() + "Processor";
 
@@ -193,7 +196,6 @@ public class EventProcessingModule
                             TrackingEventProcessorConfiguration::forSingleThreadedProcessing
                     )
             );
-    protected PooledStreamingProcessorConfiguration defaultPooledStreamingProcessorConfiguration = noOp();
     private EventProcessorBuilder defaultEventProcessorBuilder = this::defaultEventProcessor;
     private Function<String, String> defaultProcessingGroupAssignment = Function.identity();
 
@@ -334,21 +336,33 @@ public class EventProcessingModule
             SagaConfiguration<?> sagaConfig = sc.initialize(configuration);
             String processingGroup = selectProcessingGroupByType(sagaConfig.type());
             String processorName = processorNameForProcessingGroup(processingGroup);
-            if (noSagaProcessorCustomization(sagaConfig.type(), processingGroup, processorName)) {
+            // The Event Processor type is unknown as it is not build yet, so we check for both TEP or PSEP configs.
+            if (noTepCustomization(sagaConfig.type(), processingGroup, processorName)) {
                 registerTrackingEventProcessorConfiguration(processorName, config -> DEFAULT_SAGA_TEP_CONFIG);
             }
+            if (noPsepCustomization(sagaConfig.type(), processingGroup, processorName)) {
+                registerPooledStreamingEventProcessorConfiguration(processorName, DEFAULT_SAGA_PSEP_CONFIG);
+            }
+
             handlerInvokers.computeIfAbsent(processorName, k -> new ArrayList<>())
                            .add(c -> sagaConfig.manager());
         });
     }
 
-    private boolean noSagaProcessorCustomization(Class<?> type, String processingGroup, String processorName) {
+    private boolean noTepCustomization(Class<?> type, String processingGroup, String processorName) {
         return DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION.apply(type).equals(processingGroup)
                 && processingGroup.equals(processorName)
                 && !eventProcessorBuilders.containsKey(processorName)
                 && !tepConfigs.containsKey(processorName)
-                && !psepConfigs.containsKey(processorName)
                 && !tepConfigs.containsKey(CONFIGURED_DEFAULT_TEP_CONFIG);
+    }
+
+    private boolean noPsepCustomization(Class<?> type, String processingGroup, String processorName) {
+        return DEFAULT_SAGA_PROCESSING_GROUP_FUNCTION.apply(type).equals(processingGroup)
+                && processingGroup.equals(processorName)
+                && !eventProcessorBuilders.containsKey(processorName)
+                && !psepConfigs.containsKey(processorName)
+                && !psepConfigs.containsKey(CONFIGURED_DEFAULT_PSEP_CONFIG);
     }
 
     private EventProcessor buildEventProcessor(List<Function<Configuration, EventHandlerInvoker>> builderFunctions,
@@ -864,7 +878,7 @@ public class EventProcessingModule
     public EventProcessingConfigurer registerPooledStreamingEventProcessorConfiguration(
             PooledStreamingProcessorConfiguration pooledStreamingProcessorConfiguration
     ) {
-        this.defaultPooledStreamingProcessorConfiguration = pooledStreamingProcessorConfiguration;
+        this.psepConfigs.put(CONFIGURED_DEFAULT_PSEP_CONFIG, pooledStreamingProcessorConfiguration);
         return this;
     }
 
@@ -981,10 +995,12 @@ public class EventProcessingModule
                                                  return workerExecutor;
                                              })
                                              .spanFactory(config.spanFactory());
-        return defaultPooledStreamingProcessorConfiguration.andThen(psepConfigs.getOrDefault(name, noOp()))
-                                                           .andThen(processorConfiguration)
-                                                           .apply(config, builder)
-                                                           .build();
+
+        return psepConfigs.getOrDefault(CONFIGURED_DEFAULT_PSEP_CONFIG, noOp())
+                          .andThen(psepConfigs.getOrDefault(name, noOp()))
+                          .andThen(processorConfiguration)
+                          .apply(config, builder)
+                          .build();
     }
 
     private ScheduledExecutorService defaultExecutor(int poolSize, String factoryName) {

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -812,6 +812,187 @@ class EventProcessingModuleTest {
     }
 
     @Test
+    void sagaPooledStreamingProcessorConstructionUsesDefaultSagaProcessorConfigIfNoCustomizationIsPresent(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        configurer.eventProcessing()
+                  .usingPooledStreamingEventProcessors()
+                  .configureDefaultStreamableMessageSource(config -> mockedSource)
+                  .registerSaga(Object.class);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("ObjectProcessor", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        long tokenClaimInterval =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("tokenClaimInterval"), psep);
+        assertEquals(5000L, tokenClaimInterval);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        verify(mockedSourceForVerification, times(0)).createTailToken();
+        // The default Saga Config starts the stream at the head
+        verify(mockedSourceForVerification).createHeadToken();
+    }
+
+    @Test
+    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomProcessingGroup(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        configurer.eventProcessing()
+                  .usingPooledStreamingEventProcessors()
+                  .configureDefaultStreamableMessageSource(config -> mockedSource)
+                  .registerSaga(CustomSaga.class);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("my-saga-processing-group", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        long tokenClaimInterval =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("tokenClaimInterval"), psep);
+        assertEquals(5000L, tokenClaimInterval);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        // In absence of the default Saga Config, the stream starts at the tail
+        verify(mockedSourceForVerification).createTailToken();
+        verify(mockedSourceForVerification, times(0)).createHeadToken();
+    }
+
+    @Test
+    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomProcessor(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        configurer.eventProcessing()
+                  .assignProcessingGroup(someGroup -> "custom-processor")
+                  .registerPooledStreamingEventProcessor("custom-processor", config -> mockedSource)
+                  .registerSaga(CustomSaga.class);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("custom-processor", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        long tokenClaimInterval =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("tokenClaimInterval"), psep);
+        assertEquals(5000L, tokenClaimInterval);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        // In absence of the default Saga Config, the stream starts at the tail
+        verify(mockedSourceForVerification).createTailToken();
+        verify(mockedSourceForVerification, times(0)).createHeadToken();
+    }
+
+    @Test
+    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomPooledStreamingProcessorBuilder(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        EventProcessingConfigurer.PooledStreamingProcessorConfiguration testPsepConfig =
+                (config, builder) -> builder.maxClaimedSegments(4);
+        configurer.eventProcessing()
+                  .registerPooledStreamingEventProcessor("ObjectProcessor", config -> mockedSource, testPsepConfig)
+                  .registerSaga(Object.class);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("ObjectProcessor", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        int maxClaimedSegments =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("maxClaimedSegments"), psep);
+        assertEquals(4, maxClaimedSegments);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        // In absence of the default Saga Config, the stream starts at the tail
+        verify(mockedSourceForVerification).createTailToken();
+        verify(mockedSourceForVerification, times(0)).createHeadToken();
+    }
+
+    @Test
+    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomConfigInstance(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        EventProcessingConfigurer.PooledStreamingProcessorConfiguration testPsepConfig =
+                (config, builder) -> builder.maxClaimedSegments(4);
+        configurer.eventProcessing()
+                  .usingPooledStreamingEventProcessors()
+                  .configureDefaultStreamableMessageSource(config -> mockedSource)
+                  .registerSaga(Object.class)
+                  .registerPooledStreamingEventProcessorConfiguration("ObjectProcessor", testPsepConfig);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("ObjectProcessor", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        int maxClaimedSegments =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("maxClaimedSegments"), psep);
+        assertEquals(4, maxClaimedSegments);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        // In absence of the default Saga Config, the stream starts at the tail
+        verify(mockedSourceForVerification).createTailToken();
+        verify(mockedSourceForVerification, times(0)).createHeadToken();
+    }
+
+    @Test
+    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomDefaultConfig(
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
+            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
+    ) throws NoSuchFieldException {
+        EventProcessingConfigurer.PooledStreamingProcessorConfiguration psepConfig =
+                (config, builder) -> builder.maxClaimedSegments(4);
+        configurer.eventProcessing()
+                  .usingPooledStreamingEventProcessors(psepConfig)
+                  .configureDefaultStreamableMessageSource(config -> mockedSource)
+                  .registerSaga(Object.class);
+        Configuration config = configurer.start();
+
+        Optional<PooledStreamingEventProcessor> resultPsep =
+                config.eventProcessingConfiguration()
+                      .eventProcessor("ObjectProcessor", PooledStreamingEventProcessor.class);
+        assertTrue(resultPsep.isPresent());
+
+        PooledStreamingEventProcessor psep = resultPsep.get();
+        int maxClaimedSegments = getFieldValue(
+                PooledStreamingEventProcessor.class.getDeclaredField("maxClaimedSegments"), psep
+        );
+        assertEquals(4, maxClaimedSegments);
+
+        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
+                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
+        initialToken.apply(mockedSourceForVerification);
+        // In absence of the default Saga Config, the stream starts at the tail
+        verify(mockedSourceForVerification).createTailToken();
+        verify(mockedSourceForVerification, times(0)).createHeadToken();
+    }
+
+    @Test
     void defaultPooledStreamingEventProcessingConfiguration(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource
     ) {

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -673,33 +673,6 @@ class EventProcessingModuleTest {
     }
 
     @Test
-    void sagaTrackingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomProcessingGroup(
-            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
-            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
-    ) throws NoSuchFieldException {
-        configurer.eventProcessing()
-                  .usingTrackingEventProcessors()
-                  .configureDefaultStreamableMessageSource(config -> mockedSource)
-                  .registerSaga(CustomSaga.class);
-        Configuration config = configurer.start();
-
-        Optional<TrackingEventProcessor> resultTep = config.eventProcessingConfiguration().eventProcessor(
-                "my-saga-processing-group", TrackingEventProcessor.class
-        );
-        assertTrue(resultTep.isPresent());
-        TrackingEventProcessor tep = resultTep.get();
-        int tepSegmentsSize = getFieldValue(TrackingEventProcessor.class.getDeclaredField("segmentsSize"), tep);
-        assertEquals(1, tepSegmentsSize);
-
-        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> tepInitialTokenBuilder =
-                getFieldValue(TrackingEventProcessor.class.getDeclaredField("initialTrackingTokenBuilder"), tep);
-        tepInitialTokenBuilder.apply(mockedSourceForVerification);
-        // In absence of the default Saga Config, the stream starts at the tail
-        verify(mockedSourceForVerification).createTailToken();
-        verify(mockedSourceForVerification, times(0)).createHeadToken();
-    }
-
-    @Test
     void sagaTrackingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomProcessor(
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
             @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
@@ -838,35 +811,6 @@ class EventProcessingModuleTest {
         verify(mockedSourceForVerification, times(0)).createTailToken();
         // The default Saga Config starts the stream at the head
         verify(mockedSourceForVerification).createHeadToken();
-    }
-
-    @Test
-    void sagaPooledStreamingProcessorConstructionDoesNotPickDefaultSagaProcessorConfigForCustomProcessingGroup(
-            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSource,
-            @Mock StreamableMessageSource<TrackedEventMessage<?>> mockedSourceForVerification
-    ) throws NoSuchFieldException {
-        configurer.eventProcessing()
-                  .usingPooledStreamingEventProcessors()
-                  .configureDefaultStreamableMessageSource(config -> mockedSource)
-                  .registerSaga(CustomSaga.class);
-        Configuration config = configurer.start();
-
-        Optional<PooledStreamingEventProcessor> resultPsep =
-                config.eventProcessingConfiguration()
-                      .eventProcessor("my-saga-processing-group", PooledStreamingEventProcessor.class);
-        assertTrue(resultPsep.isPresent());
-
-        PooledStreamingEventProcessor psep = resultPsep.get();
-        long tokenClaimInterval =
-                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("tokenClaimInterval"), psep);
-        assertEquals(5000L, tokenClaimInterval);
-
-        Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
-                getFieldValue(PooledStreamingEventProcessor.class.getDeclaredField("initialToken"), psep);
-        initialToken.apply(mockedSourceForVerification);
-        // In absence of the default Saga Config, the stream starts at the tail
-        verify(mockedSourceForVerification).createTailToken();
-        verify(mockedSourceForVerification, times(0)).createHeadToken();
     }
 
     @Test

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When using the `registerPooledStreamingEventProcessor` function, it will not take effect for saga's, since the EventProcessingModule overwrites the config because it sets it to the default TEP one.