### PR TITLE
Allow property based configuration of load balancing strategies

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -717,62 +717,29 @@ public class AxonServerConfiguration {
              * {@link org.axonframework.eventhandling.StreamingEventProcessor StreamingEventProcessors}, as only
              * {@code StreamingEventProcessors} are capable of splitting the event handling load in segments.
              * <p>
-             * Defaults to {@link LoadBalancingStrategy#DISABLED}.
+             * As the strategies names may change per Axon Server version it is recommended to check the documentation
+             * for the possible strategies.
+             * <p>
+             * Defaults to {@code "disabled"}.
              */
-            private LoadBalancingStrategy loadBalancingStrategy = LoadBalancingStrategy.DISABLED;
+            private String loadBalancingStrategy = "disabled";
 
             /**
-             * Returns the {@link LoadBalancingStrategy load balancing strategy} for this event processor. Defaults to
-             * {@link LoadBalancingStrategy#DISABLED}.
+             * Returns the load balancing strategy for this event processor. Defaults to {@code "disabled"}.
              *
-             * @return The {@link LoadBalancingStrategy load balancing strategy} for this event processor.
+             * @return The load balancing strategy for this event processor.
              */
-            public LoadBalancingStrategy getLoadBalancingStrategy() {
+            public String getLoadBalancingStrategy() {
                 return loadBalancingStrategy;
             }
 
             /**
-             * Sets the {@link LoadBalancingStrategy load balancing strategy} for this event processor.
+             * Sets the load balancing strategy for this event processor.
              *
-             * @param loadBalancingStrategy The {@link LoadBalancingStrategy load balancing strategy} for this event
-             *                              processor.
+             * @param loadBalancingStrategy The load balancing strategy for this event processor.
              */
-            public void setLoadBalancingStrategy(LoadBalancingStrategy loadBalancingStrategy) {
+            public void setLoadBalancingStrategy(String loadBalancingStrategy) {
                 this.loadBalancingStrategy = loadBalancingStrategy;
-            }
-        }
-
-        /**
-         * The possible load balancing strategies for
-         * {@link org.axonframework.eventhandling.StreamingEventProcessor StreamingEventProcessors}.
-         */
-        public enum LoadBalancingStrategy {
-            /**
-             * Indication that load balancing is <em>disabled</em> for a given
-             * {@link org.axonframework.eventhandling.StreamingEventProcessor}.
-             */
-            DISABLED("disabled"),
-            /**
-             * Indication that load balancing for a given
-             * {@link org.axonframework.eventhandling.StreamingEventProcessor} is done based on the number of threads.
-             * Setting this strategy results in an equal dispersion of segments over the available threads per
-             * {@code StreamingEventProcessor} instance.
-             */
-            THREAD_NUMBER("threadNumber");
-
-            private final String description;
-
-            LoadBalancingStrategy(String description) {
-                this.description = description;
-            }
-
-            /**
-             * Describes this load balancing strategy.
-             *
-             * @return The description of this load balancing strategy.
-             */
-            public String describe() {
-                return description;
             }
         }
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -23,7 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -144,8 +146,8 @@ public class AxonServerConfiguration {
     private int processorsNotificationInitialDelay = 5000;
 
     /**
-     * An {@link EventCipher} which is used to encrypt and decrypt events and snapshots. Defaults to {@link
-     * EventCipher#EventCipher()}.
+     * An {@link EventCipher} which is used to encrypt and decrypt events and snapshots. Defaults to
+     * {@link EventCipher#EventCipher()}.
      *
      * @deprecated in through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">AxonServer java
      * connector</a>
@@ -164,8 +166,8 @@ public class AxonServerConfiguration {
     private long keepAliveTime = 1_000;
 
     /**
-     * An {@code int} indicating the maximum number of Aggregate snapshots which will be retrieved. Defaults to {@code
-     * 1}.
+     * An {@code int} indicating the maximum number of Aggregate snapshots which will be retrieved. Defaults to
+     * {@code 1}.
      */
     private int snapshotPrefetch = 1;
 
@@ -229,6 +231,11 @@ public class AxonServerConfiguration {
      * Axon Server.
      */
     private HeartbeatConfiguration heartbeat = new HeartbeatConfiguration();
+
+    /**
+     * Properties describing the settings for {@link org.axonframework.eventhandling.EventProcessor EventProcessors}.
+     */
+    private EventProcessorConfiguration eventProcessorConfiguration = new EventProcessorConfiguration();
 
     /**
      * Instantiate a {@link Builder} to create an {@link AxonServerConfiguration}.
@@ -538,6 +545,24 @@ public class AxonServerConfiguration {
     }
 
     /**
+     * Return the configured {@link EventProcessorConfiguration} of this application for Axon Server.
+     *
+     * @return The configured {@link EventProcessorConfiguration} of this application for Axon Server.
+     */
+    public EventProcessorConfiguration getEventProcessorConfiguration() {
+        return eventProcessorConfiguration;
+    }
+
+    /**
+     * Set the {@link EventProcessorConfiguration} of this application for Axon Server
+     *
+     * @param eventProcessorConfiguration The {@link EventProcessorConfiguration} to set for this application.
+     */
+    public void setEventProcessorConfiguration(EventProcessorConfiguration eventProcessorConfiguration) {
+        this.eventProcessorConfiguration = eventProcessorConfiguration;
+    }
+
+    /**
      * Configuration class for Flow Control of specific message types.
      *
      * @author Gerlo Hesselink
@@ -660,6 +685,94 @@ public class AxonServerConfiguration {
 
         public void setTimeout(long timeout) {
             this.timeout = timeout;
+        }
+    }
+
+    public static class EventProcessorConfiguration {
+
+        /**
+         * The configuration of each of the processors. The key is the name of the processor, the value represents the
+         * settings to use for the processor with that name.
+         */
+        private final Map<String, ProcessorSettings> processors = new HashMap<>();
+
+        /**
+         * Returns the settings for each of the configured processors, by name.
+         *
+         * @return the settings for each of the configured processors, by name.
+         */
+        public Map<String, ProcessorSettings> getProcessors() {
+            return processors;
+        }
+
+        public static class ProcessorSettings {
+
+            /**
+             * Configures the desired load balancing strategy for this event processor.
+             * <p>
+             * The load balancing strategy tells Axon Server how to share the event handling load among all available
+             * application instances running this event processor, by moving segments from one instance to another. Note
+             * that load balancing is <b>only</b> supported for
+             * {@link org.axonframework.eventhandling.StreamingEventProcessor StreamingEventProcessors}, as only
+             * {@code StreamingEventProcessors} are capable of splitting the event handling load in segments.
+             * <p>
+             * Defaults to {@link LoadBalancingStrategy#DISABLED}.
+             */
+            private LoadBalancingStrategy loadBalancingStrategy = LoadBalancingStrategy.DISABLED;
+
+            /**
+             * Returns the {@link LoadBalancingStrategy load balancing strategy} for this event processor. Defaults to
+             * {@link LoadBalancingStrategy#DISABLED}.
+             *
+             * @return The {@link LoadBalancingStrategy load balancing strategy} for this event processor.
+             */
+            public LoadBalancingStrategy getLoadBalancingStrategy() {
+                return loadBalancingStrategy;
+            }
+
+            /**
+             * Sets the {@link LoadBalancingStrategy load balancing strategy} for this event processor.
+             *
+             * @param loadBalancingStrategy The {@link LoadBalancingStrategy load balancing strategy} for this event
+             *                              processor.
+             */
+            public void setLoadBalancingStrategy(LoadBalancingStrategy loadBalancingStrategy) {
+                this.loadBalancingStrategy = loadBalancingStrategy;
+            }
+        }
+
+        /**
+         * The possible load balancing strategies for
+         * {@link org.axonframework.eventhandling.StreamingEventProcessor StreamingEventProcessors}.
+         */
+        public enum LoadBalancingStrategy {
+            /**
+             * Indication that load balancing is <em>disabled</em> for a given
+             * {@link org.axonframework.eventhandling.StreamingEventProcessor}.
+             */
+            DISABLED("disabled"),
+            /**
+             * Indication that load balancing for a given
+             * {@link org.axonframework.eventhandling.StreamingEventProcessor} is done based on the number of threads.
+             * Setting this strategy results in an equal dispersion of segments over the available threads per
+             * {@code StreamingEventProcessor} instance.
+             */
+            THREAD_NUMBER("threadNumber");
+
+            private final String description;
+
+            LoadBalancingStrategy(String description) {
+                this.description = description;
+            }
+
+            /**
+             * Describes this load balancing strategy.
+             *
+             * @return The description of this load balancing strategy.
+             */
+            public String describe() {
+                return description;
+            }
         }
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -549,6 +549,7 @@ public class AxonServerConfiguration {
      *
      * @return The configured {@link EventProcessorConfiguration} of this application for Axon Server.
      */
+    @ConfigurationProperties(prefix = "axon.axonserver.eventhandling")
     public EventProcessorConfiguration getEventProcessorConfiguration() {
         return eventProcessorConfiguration;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -725,6 +725,15 @@ public class AxonServerConfiguration {
             private String loadBalancingStrategy = "disabled";
 
             /**
+             * A {@code boolean} dictating whether the configured
+             * {@link #getLoadBalancingStrategy() load balancing strategy} is set to be automatically triggered through
+             * Axon Server.
+             * <p>
+             * Note that this is an Axon Server Enterprise feature only! Defaults to {@code false}.
+             */
+            private boolean automaticBalancing = false;
+
+            /**
              * Returns the load balancing strategy for this event processor. Defaults to {@code "disabled"}.
              *
              * @return The load balancing strategy for this event processor.
@@ -740,6 +749,25 @@ public class AxonServerConfiguration {
              */
             public void setLoadBalancingStrategy(String loadBalancingStrategy) {
                 this.loadBalancingStrategy = loadBalancingStrategy;
+            }
+
+            /**
+             * Returns whether automatic load balancing is configured, yes or no.
+             *
+             * @return Whether automatic load balancing is configured, yes or no.
+             */
+            public boolean shouldAutomaticallyBalance() {
+                return automaticBalancing;
+            }
+
+            /**
+             * Sets the automatic load balancing strategy to the given {@code automaticBalancing}.
+             *
+             * @param automaticBalancing The {@code boolean} to set as to whether automatic load balancing is enabled or
+             *                           disabled.
+             */
+            public void setAutomaticBalancing(boolean automaticBalancing) {
+                this.automaticBalancing = automaticBalancing;
             }
         }
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -67,9 +67,8 @@ public class EventProcessorControlService implements Lifecycle {
      * This service adds processor instruction handlers to the {@link ControlChannel} of the
      * {@link AxonServerConnectionManager#getDefaultContext() default context}. Doing so ensures operation like the
      * {@link EventProcessor#start() start} and {@link EventProcessor#shutDown() shutdown} can be triggered through Axon
-     * Server. Furthermore, it sets the configured
-     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
-     * through the {@link AdminChannel}  of the default context.
+     * Server. Furthermore, it sets the configured load balancing strategies} through the {@link AdminChannel}  of the
+     * default context.
      *
      * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
      *                                     {@link ControlChannel} and {@link AdminChannel}.
@@ -94,9 +93,7 @@ public class EventProcessorControlService implements Lifecycle {
      * This service adds processor instruction handlers to the {@link ControlChannel} of the given {@code context}.
      * Doing so ensures operation like the {@link EventProcessor#start() start} and
      * {@link EventProcessor#shutDown() shutdown} can be triggered through Axon Server. Furthermore, it sets the
-     * configured
-     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
-     * through the {@link AdminChannel}  of the {@code context}.
+     * configured load balancing strategies} through the {@link AdminChannel}  of the {@code context}.
      *
      * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
      *                                     {@link ControlChannel} and {@link AdminChannel}.
@@ -121,9 +118,7 @@ public class EventProcessorControlService implements Lifecycle {
      * This service adds processor instruction handlers to the {@link ControlChannel} of the given {@code context}.
      * Doing so ensures operation like the {@link EventProcessor#start() start} and
      * {@link EventProcessor#shutDown() shutdown} can be triggered through Axon Server. Furthermore, it sets the
-     * configured
-     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
-     * through the {@link AdminChannel}  of the {@code context}.
+     * configured load balancing strategies through the {@link AdminChannel}  of the {@code context}.
      *
      * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
      *                                     {@link ControlChannel} and {@link AdminChannel}.
@@ -173,7 +168,7 @@ public class EventProcessorControlService implements Lifecycle {
     private void setLoadBalancingStrategies(AxonServerConnection connection, Set<String> processorNames) {
         AdminChannel adminChannel = connection.adminChannel();
 
-        Map<String, AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy> strategiesPerProcessor =
+        Map<String, String> strategiesPerProcessor =
                 processorConfig.entrySet()
                                .stream()
                                .filter(entry -> {
@@ -195,15 +190,15 @@ public class EventProcessorControlService implements Lifecycle {
                 return;
             }
 
-            adminChannel.setAutoLoadBalanceStrategy(processorName, tokenStoreIdentifier.get(), strategy.describe())
+            adminChannel.setAutoLoadBalanceStrategy(processorName, tokenStoreIdentifier.get(), strategy)
                         .whenComplete((r, e) -> {
                             if (e == null) {
                                 logger.debug("Successfully requested to automatically balance processor [{}]"
-                                                     + " with strategy [{}].", processorName, strategy.describe());
+                                                     + " with strategy [{}].", processorName, strategy);
                                 return;
                             }
                             logger.warn("Requesting to automatically balance processor [{}] with strategy [{}] failed.",
-                                        processorName, strategy.describe(), e);
+                                        processorName, strategy, e);
                         });
         });
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.axonserver.connector.processor;
 
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.admin.AdminChannel;
 import io.axoniq.axonserver.connector.control.ControlChannel;
 import io.axoniq.axonserver.connector.control.ProcessorInstructionHandler;
 import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
@@ -31,9 +33,15 @@ import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Service that listens to {@link PlatformOutboundInstruction}s to control {@link EventProcessor}s when for example
@@ -51,42 +59,89 @@ public class EventProcessorControlService implements Lifecycle {
     protected final AxonServerConnectionManager axonServerConnectionManager;
     protected final EventProcessingConfiguration eventProcessingConfiguration;
     protected final String context;
+    protected final Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorConfig;
 
     /**
-     * Initialize a {@link EventProcessorControlService} which adds {@link java.util.function.Consumer}s to the given
-     * {@link AxonServerConnectionManager} on {@link PlatformOutboundInstruction}s. Uses the {@link
-     * AxonServerConnectionManager#getDefaultContext()} specified in the given {@code axonServerConnectionManager} as
-     * the context to dispatch operations in
+     * Initialize a {@link EventProcessorControlService}.
+     * <p>
+     * This service adds processor instruction handlers to the {@link ControlChannel} of the
+     * {@link AxonServerConnectionManager#getDefaultContext() default context}. Doing so ensures operation like the
+     * {@link EventProcessor#start() start} and {@link EventProcessor#shutDown() shutdown} can be triggered through Axon
+     * Server. Furthermore, it sets the configured
+     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
+     * through the {@link AdminChannel}  of the default context.
      *
-     * @param axonServerConnectionManager a {@link AxonServerConnectionManager} used to add operations when {@link
-     *                                    PlatformOutboundInstruction} have been received
-     * @param axonServerConfiguration     the {@link AxonServerConfiguration} used to retrieve the client identifier
+     * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
+     *                                     {@link ControlChannel} and {@link AdminChannel}.
+     * @param eventProcessingConfiguration The {@link EventProcessor} configuration of this application, used to
+     *                                     retrieve the registered event processors from.
+     * @param axonServerConfiguration      The {@link AxonServerConfiguration} used to retrieve the
+     *                                     {@link AxonServerConnectionManager#getDefaultContext() default context}
+     *                                     from.
      */
     public EventProcessorControlService(AxonServerConnectionManager axonServerConnectionManager,
                                         EventProcessingConfiguration eventProcessingConfiguration,
                                         AxonServerConfiguration axonServerConfiguration) {
         this(axonServerConnectionManager,
              eventProcessingConfiguration,
-             axonServerConfiguration.getContext());
+             axonServerConfiguration.getContext(),
+             axonServerConfiguration.getEventProcessorConfiguration().getProcessors());
     }
 
     /**
-     * Initialize a {@link EventProcessorControlService} which adds {@link java.util.function.Consumer}s to the given
-     * {@link AxonServerConnectionManager} on {@link PlatformOutboundInstruction}s. Uses the {@link
-     * AxonServerConnectionManager#getDefaultContext()} specified in the given {@code axonServerConnectionManager} as
-     * the context to dispatch operations in
+     * Initialize a {@link EventProcessorControlService}.
+     * <p>
+     * This service adds processor instruction handlers to the {@link ControlChannel} of the given {@code context}.
+     * Doing so ensures operation like the {@link EventProcessor#start() start} and
+     * {@link EventProcessor#shutDown() shutdown} can be triggered through Axon Server. Furthermore, it sets the
+     * configured
+     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
+     * through the {@link AdminChannel}  of the {@code context}.
      *
-     * @param axonServerConnectionManager a {@link AxonServerConnectionManager} used to add operations when {@link
-     *                                    PlatformOutboundInstruction} have been received
-     * @param context                     the context of this application instance within which outbound instruction
-     *                                    handlers should be specified on the given {@code axonServerConnectionManager}
+     * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
+     *                                     {@link ControlChannel} and {@link AdminChannel}.
+     * @param eventProcessingConfiguration The {@link EventProcessor} configuration of this application, used to
+     *                                     retrieve the registered event processors from.
+     * @param context                      The context of this application instance to retrieve the
+     *                                     {@link ControlChannel} and {@link AdminChannel} for.
+     * @deprecated Please use
+     * {@link #EventProcessorControlService(AxonServerConnectionManager, EventProcessingConfiguration, String, Map)} to
+     * ensure processor settings are provided.
      */
+    @Deprecated
     public EventProcessorControlService(AxonServerConnectionManager axonServerConnectionManager,
                                         EventProcessingConfiguration eventProcessingConfiguration,
                                         String context) {
+        this(axonServerConnectionManager, eventProcessingConfiguration, context, Collections.emptyMap());
+    }
+
+    /**
+     * Initialize a {@link EventProcessorControlService}.
+     * <p>
+     * This service adds processor instruction handlers to the {@link ControlChannel} of the given {@code context}.
+     * Doing so ensures operation like the {@link EventProcessor#start() start} and
+     * {@link EventProcessor#shutDown() shutdown} can be triggered through Axon Server. Furthermore, it sets the
+     * configured
+     * {@link AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy load balancing strategies}
+     * through the {@link AdminChannel}  of the {@code context}.
+     *
+     * @param axonServerConnectionManager  A {@link AxonServerConnectionManager} from which to retrieve the
+     *                                     {@link ControlChannel} and {@link AdminChannel}.
+     * @param eventProcessingConfiguration The {@link EventProcessor} configuration of this application, used to
+     *                                     retrieve the registered event processors from.
+     * @param context                      The context of this application instance to retrieve the
+     *                                     {@link ControlChannel} and {@link AdminChannel} for.
+     * @param processorConfig              The processor configuration from the {@link AxonServerConfiguration}, used to
+     *                                     (for example) retrieve the load balancing strategies from.
+     */
+    public EventProcessorControlService(AxonServerConnectionManager axonServerConnectionManager,
+                                        EventProcessingConfiguration eventProcessingConfiguration,
+                                        String context,
+                                        Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorConfig) {
         this.axonServerConnectionManager = axonServerConnectionManager;
         this.eventProcessingConfiguration = eventProcessingConfiguration;
         this.context = context;
+        this.processorConfig = processorConfig;
     }
 
     @Override
@@ -95,27 +150,78 @@ public class EventProcessorControlService implements Lifecycle {
     }
 
     /**
-     * Add {@link java.util.function.Consumer}s to the {@link AxonServerConnectionManager} for several {@link
-     * PlatformOutboundInstruction}s. Will be started in phase {@link Phase#INBOUND_EVENT_CONNECTORS}, to ensure the
-     * event processors this service provides control over have been started.
+     * Registers {@link EventProcessor} instruction handlers to the {@link ControlChannel} for the configured
+     * {@code context} and set the load balancing strategies through the {@link AdminChannel} for the configured
+     * {@code context}.
+     * <p>
+     * The registration is performed in {@link Phase#INBOUND_EVENT_CONNECTORS} phase, to ensure the event processors
+     * this service provides control over have been started.
      */
     @SuppressWarnings("Duplicates")
     public void start() {
-        if (axonServerConnectionManager != null && eventProcessingConfiguration != null) {
-            ControlChannel controlChannel = axonServerConnectionManager.getConnection(context)
-                                                                       .controlChannel();
-            eventProcessingConfiguration.eventProcessors()
-                                        .forEach(
-                                                (name, processor) ->
-                                                        controlChannel.registerEventProcessor(name,
-                                                                                              infoSupplier(processor),
-                                                                                              new AxonProcessorInstructionHandler(
-                                                                                                      processor,
-                                                                                                      name)));
+        if (axonServerConnectionManager == null || eventProcessingConfiguration == null) {
+            return;
         }
+
+        Map<String, EventProcessor> eventProcessors = eventProcessingConfiguration.eventProcessors();
+        AxonServerConnection connection = axonServerConnectionManager.getConnection(context);
+
+        registerInstructionHandlers(connection, eventProcessors);
+        setLoadBalancingStrategies(connection, eventProcessors.keySet());
     }
 
-    public Supplier<EventProcessorInfo> infoSupplier(EventProcessor processor) {
+    private void setLoadBalancingStrategies(AxonServerConnection connection, Set<String> processorNames) {
+        AdminChannel adminChannel = connection.adminChannel();
+
+        Map<String, AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy> strategiesPerProcessor =
+                processorConfig.entrySet()
+                               .stream()
+                               .filter(entry -> {
+                                   if (!processorNames.contains(entry.getKey())) {
+                                       logger.info("Event Processor [{}] is not a registered. "
+                                                           + "Please check the name or register the Event Processor",
+                                                   entry.getKey());
+                                       return false;
+                                   }
+                                   return true;
+                               })
+                               .collect(toMap(Map.Entry::getKey, entry -> entry.getValue().getLoadBalancingStrategy()));
+
+        strategiesPerProcessor.forEach((processorName, strategy) -> {
+            Optional<String> tokenStoreIdentifier = tokenStoreIdentifierFor(processorName);
+            if (!tokenStoreIdentifier.isPresent()) {
+                logger.warn("Cannot find token store identifier for processor [{}]. "
+                                    + "Load balancing cannot be configured without this identifier.", processorName);
+                return;
+            }
+
+            adminChannel.loadBalanceEventProcessor(processorName, tokenStoreIdentifier.get(), strategy.describe())
+                        .whenComplete((r, e) -> {
+                            if (e == null) {
+                                logger.debug("Successfully requested to balance processor [{}] with strategy [{}].",
+                                             processorName, strategy.describe());
+                                return;
+                            }
+                            logger.warn("Requesting to balance processor [{}] with strategy [{}] failed.",
+                                        processorName, strategy.describe(), e);
+                        });
+        });
+    }
+
+    private Optional<String> tokenStoreIdentifierFor(String processorName) {
+        return eventProcessingConfiguration.tokenStore(processorName)
+                                           .retrieveStorageIdentifier();
+    }
+
+    private void registerInstructionHandlers(AxonServerConnection connection,
+                                             Map<String, EventProcessor> eventProcessors) {
+        ControlChannel controlChannel = connection.controlChannel();
+        eventProcessors.forEach((name, processor) -> controlChannel.registerEventProcessor(
+                name, infoSupplier(processor), new AxonProcessorInstructionHandler(processor, name)
+        ));
+    }
+
+    private Supplier<EventProcessorInfo> infoSupplier(EventProcessor processor) {
         if (processor instanceof StreamingEventProcessor) {
             return () -> StreamingEventProcessorInfoMessage.describe((StreamingEventProcessor) processor);
         } else if (processor instanceof SubscribingEventProcessor) {
@@ -140,7 +246,6 @@ public class EventProcessorControlService implements Lifecycle {
                                  .setIsStreamingProcessor(false)
                                  .build();
     }
-
 
     protected static class AxonProcessorInstructionHandler implements ProcessorInstructionHandler {
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -195,14 +195,14 @@ public class EventProcessorControlService implements Lifecycle {
                 return;
             }
 
-            adminChannel.loadBalanceEventProcessor(processorName, tokenStoreIdentifier.get(), strategy.describe())
+            adminChannel.setAutoLoadBalanceStrategy(processorName, tokenStoreIdentifier.get(), strategy.describe())
                         .whenComplete((r, e) -> {
                             if (e == null) {
-                                logger.debug("Successfully requested to balance processor [{}] with strategy [{}].",
-                                             processorName, strategy.describe());
+                                logger.debug("Successfully requested to automatically balance processor [{}]"
+                                                     + " with strategy [{}].", processorName, strategy.describe());
                                 return;
                             }
-                            logger.warn("Requesting to balance processor [{}] with strategy [{}] failed.",
+                            logger.warn("Requesting to automatically balance processor [{}] with strategy [{}] failed.",
                                         processorName, strategy.describe(), e);
                         });
         });

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -45,6 +45,7 @@ class EventProcessorControlServiceTest {
     private static final String THAT_PROCESSOR = "that-processor";
     private static final String NON_EXISTING = "non-existing";
     private static final String TOKEN_STORE_IDENTIFIER = "some-identifier";
+    private static final String LOAD_BALANCING_STRATEGY = "some-strategy";
 
     private AxonServerConnectionManager connectionManager;
     private EventProcessingConfiguration processingConfiguration;
@@ -76,7 +77,7 @@ class EventProcessorControlServiceTest {
         adminChannel = mock(AdminChannel.class);
         CompletableFuture<Void> loadBalancingResult = new CompletableFuture<>();
         loadBalancingResult.complete(null);
-        when(adminChannel.loadBalanceEventProcessor(anyString(), anyString(), anyString()))
+        when(adminChannel.setAutoLoadBalanceStrategy(anyString(), anyString(), anyString()))
                 .thenReturn(loadBalancingResult);
         when(connection.adminChannel()).thenReturn(adminChannel);
     }
@@ -113,6 +114,7 @@ class EventProcessorControlServiceTest {
 
         AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
                 new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        testSetting.setLoadBalancingStrategy(LOAD_BALANCING_STRATEGY);
         processorSettings.put(THIS_PROCESSOR, testSetting);
         processorSettings.put(NON_EXISTING, testSetting);
 
@@ -120,15 +122,15 @@ class EventProcessorControlServiceTest {
 
         verify(connectionManager).getConnection(CONTEXT);
         verify(connection).adminChannel();
-        verify(adminChannel).loadBalanceEventProcessor(
+        verify(adminChannel).setAutoLoadBalanceStrategy(
                 THIS_PROCESSOR,
                 TOKEN_STORE_IDENTIFIER,
-                AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy.DISABLED.name()
+                LOAD_BALANCING_STRATEGY
         );
         // There is no registered strategy for THAT_PROCESSOR.
-        verify(adminChannel, never()).loadBalanceEventProcessor(eq(THAT_PROCESSOR), anyString(), anyString());
+        verify(adminChannel, never()).setAutoLoadBalanceStrategy(eq(THAT_PROCESSOR), anyString(), anyString());
         // There is no Event Processor called NON_EXISTING.
-        verify(adminChannel, never()).loadBalanceEventProcessor(eq(NON_EXISTING), anyString(), anyString());
+        verify(adminChannel, never()).setAutoLoadBalanceStrategy(eq(NON_EXISTING), anyString(), anyString());
     }
 
     @Test
@@ -143,6 +145,7 @@ class EventProcessorControlServiceTest {
 
         AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
                 new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        testSetting.setLoadBalancingStrategy(LOAD_BALANCING_STRATEGY);
         processorSettings.put(THIS_PROCESSOR, testSetting);
         processorSettings.put(THAT_PROCESSOR, testSetting);
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.processor;
+
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.admin.AdminChannel;
+import io.axoniq.axonserver.connector.control.ControlChannel;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.config.EventProcessingConfiguration;
+import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.junit.jupiter.api.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link EventProcessorControlService}.
+ *
+ * @author Steven van Beelen
+ */
+class EventProcessorControlServiceTest {
+
+    private static final String CONTEXT = "some-context";
+    private static final String THIS_PROCESSOR = "this-processor";
+    private static final String THAT_PROCESSOR = "that-processor";
+    private static final String NON_EXISTING = "non-existing";
+    private static final String TOKEN_STORE_IDENTIFIER = "some-identifier";
+
+    private AxonServerConnectionManager connectionManager;
+    private EventProcessingConfiguration processingConfiguration;
+    private Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorSettings;
+
+    private EventProcessorControlService testSubject;
+    private AxonServerConnection connection;
+    private AdminChannel adminChannel;
+
+    @BeforeEach
+    void setUp() {
+        mockConnectionManager();
+        processingConfiguration = mock(EventProcessingConfiguration.class);
+        processorSettings = new HashMap<>();
+
+        testSubject = new EventProcessorControlService(
+                connectionManager, processingConfiguration, CONTEXT, processorSettings
+        );
+    }
+
+    private void mockConnectionManager() {
+        connectionManager = mock(AxonServerConnectionManager.class);
+        connection = mock(AxonServerConnection.class);
+        when(connectionManager.getConnection(CONTEXT)).thenReturn(connection);
+
+        ControlChannel controlChannel = mock(ControlChannel.class);
+        when(connection.controlChannel()).thenReturn(controlChannel);
+
+        adminChannel = mock(AdminChannel.class);
+        CompletableFuture<Void> loadBalancingResult = new CompletableFuture<>();
+        loadBalancingResult.complete(null);
+        when(adminChannel.loadBalanceEventProcessor(anyString(), anyString(), anyString()))
+                .thenReturn(loadBalancingResult);
+        when(connection.adminChannel()).thenReturn(adminChannel);
+    }
+
+    @Test
+    void startDoesNothingForNullAxonServerConnectionManager() {
+        EventProcessorControlService unusableControlService =
+                new EventProcessorControlService(null, processingConfiguration, CONTEXT, processorSettings);
+
+        unusableControlService.start();
+
+        verifyNoInteractions(processingConfiguration);
+    }
+
+    @Test
+    void startDoesNothingForNullEventProcessingConfiguration() {
+        EventProcessorControlService unusableControlService =
+                new EventProcessorControlService(null, processingConfiguration, CONTEXT, processorSettings);
+
+        unusableControlService.start();
+
+        verifyNoInteractions(connectionManager);
+    }
+
+    @Test
+    void startSetsLoadBalancingStrategiesForMatchingProcessorsThroughAdminChannel() {
+        Map<String, EventProcessor> eventProcessors = new HashMap<>();
+        eventProcessors.put(THIS_PROCESSOR, mock(EventProcessor.class));
+        eventProcessors.put(THAT_PROCESSOR, mock(EventProcessor.class));
+        when(processingConfiguration.eventProcessors()).thenReturn(eventProcessors);
+        TokenStore tokenStore = mock(TokenStore.class);
+        when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.of(TOKEN_STORE_IDENTIFIER));
+        when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
+
+        AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
+                new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        processorSettings.put(THIS_PROCESSOR, testSetting);
+        processorSettings.put(NON_EXISTING, testSetting);
+
+        testSubject.start();
+
+        verify(connectionManager).getConnection(CONTEXT);
+        verify(connection).adminChannel();
+        verify(adminChannel).loadBalanceEventProcessor(
+                THIS_PROCESSOR,
+                TOKEN_STORE_IDENTIFIER,
+                AxonServerConfiguration.EventProcessorConfiguration.LoadBalancingStrategy.DISABLED.name()
+        );
+        // There is no registered strategy for THAT_PROCESSOR.
+        verify(adminChannel, never()).loadBalanceEventProcessor(eq(THAT_PROCESSOR), anyString(), anyString());
+        // There is no Event Processor called NON_EXISTING.
+        verify(adminChannel, never()).loadBalanceEventProcessor(eq(NON_EXISTING), anyString(), anyString());
+    }
+
+    @Test
+    void startDoesNotSetLoadBalancingStrategiesWhenTheTokenStoreCannotBeFound() {
+        Map<String, EventProcessor> eventProcessors = new HashMap<>();
+        eventProcessors.put(THIS_PROCESSOR, mock(EventProcessor.class));
+        eventProcessors.put(THAT_PROCESSOR, mock(EventProcessor.class));
+        when(processingConfiguration.eventProcessors()).thenReturn(eventProcessors);
+        TokenStore tokenStore = mock(TokenStore.class);
+        when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.empty());
+        when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
+
+        AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
+                new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        processorSettings.put(THIS_PROCESSOR, testSetting);
+        processorSettings.put(THAT_PROCESSOR, testSetting);
+
+        testSubject.start();
+
+        verify(connectionManager).getConnection(CONTEXT);
+        verify(connection).adminChannel();
+        verifyNoInteractions(adminChannel);
+    }
+}


### PR DESCRIPTION
This pull request introduces a property-based configuration of load-balancing strategies. 
This is done by expanding the `AxonServerConfiguration` with `EventProcessingConfiguration` (added under `axon.axonserver.eventhandling` to align with regular event processing configuration).
The `EventProcessingConfiguration`, in turn, contains `ProcessorSettings` and a `LoadBalancingStrategy`, reflecting the options "disabled" and "thread number."

The properties are, in turn, used by the `EventProcessorControlService` to set the configured load balancing strategy through the `AdminChannel`.
When an event processor or token store identifier cannot be found, information is logged to the user.
Similarly, when requesting to set load-balancing strategies through the `AdminChannel`, both successes and failures are logged.
Not stopping the application if either of the above fails seemed fair, as the property is a convenient solution instead of a necessity for an Axon Framework application to run.

In doing the above, this PR resolves #2453.