### PR TITLE
[#2755] Align assertion messages

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1025,7 +1025,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                                               "indicate that a wrong aggregate is being triggered.");
                           } else if (lastEvent.getSequenceNumber() != event.getSequenceNumber() - 1) {
                               throw new EventStoreException(format("Unexpected sequence number on stored event. " +
-                                                                           "Expected %s, but got %s.",
+                                                                           "Expected %s, \n but got %s.",
                                                                    lastEvent.getSequenceNumber() + 1,
                                                                    event.getSequenceNumber()));
                           }

--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * The reporter generates extensive human readable reports of what the expected outcome of a test was, and what the
+ * The reporter generates extensive human-readable reports of what the expected outcome of a test was, and what the
  * actual results were.
  *
  * @author Allard Buijze
@@ -77,11 +77,11 @@ public class Reporter {
     public void reportWrongEvent(Collection<?> actualEvents, StringDescription expectation, Throwable probableCause) {
         StringBuilder sb = new StringBuilder(
                 "The published events do not match the expected events.");
-        sb.append("Expected :")
+        sb.append("Expected:")
           .append(NEWLINE)
           .append(expectation)
           .append(NEWLINE)
-          .append("But got");
+          .append(" But got");
         if (actualEvents.isEmpty()) {
             sb.append(" none");
         } else {
@@ -113,14 +113,14 @@ public class Reporter {
      */
     public void reportWrongEvent(Collection<?> actualEvents, Description expectation, Description mismatch, Throwable probableCause) {
         StringBuilder sb = new StringBuilder("The published events do not match the expected events.");
-        sb.append("Expected :");
-        sb.append(NEWLINE);
-        sb.append(expectation);
-        sb.append(NEWLINE);
-        sb.append("Did not match:");
-        sb.append(NEWLINE);
-        sb.append(mismatch);
-        sb.append(NEWLINE);
+        sb.append("Expected <")
+          .append(expectation)
+          .append(">,")
+          .append(NEWLINE)
+          .append(" but got <")
+          .append(mismatch)
+          .append(">.")
+          .append(NEWLINE);
         sb.append("Actual Sequence of events:");
         if (actualEvents.isEmpty()) { 
             sb.append(" no events emitted");
@@ -148,11 +148,15 @@ public class Reporter {
         StringBuilder sb = new StringBuilder("The command handler threw an unexpected exception");
         sb.append(NEWLINE)
           .append(NEWLINE)
-          .append("Expected <") //NOSONAR
+          .append("Expected <")
           .append(expectation.toString())
-          .append("> but got <exception of type [")
+          .append(">,")
+          .append(NEWLINE)
+          .append(" but got <exception of type [")
           .append(actualException.getClass().getSimpleName())
-          .append("]>. Stack trace follows:")
+          .append("]>.")
+          .append(NEWLINE)
+          .append("Stack trace follows:")
           .append(NEWLINE);
         writeStackTrace(actualException, sb);
         sb.append(NEWLINE);
@@ -169,11 +173,13 @@ public class Reporter {
         StringBuilder sb = new StringBuilder("The command handler returned an unexpected value");
         sb.append(NEWLINE)
           .append(NEWLINE)
-          .append("Expected <"); //NOSONAR
-        sb.append(expectation.toString());
-        sb.append("> but got <");
+          .append("Expected <")
+          .append(expectation.toString())
+          .append(">,")
+          .append(NEWLINE)
+          .append(" but got <");
         describe(actual, sb);
-        sb.append(">")
+        sb.append(">.")
           .append(NEWLINE);
         throw new AxonAssertionError(sb.toString());
     }
@@ -188,11 +194,13 @@ public class Reporter {
         StringBuilder sb = new StringBuilder("The command handler returned normally, but an exception was expected");
         sb.append(NEWLINE)
           .append(NEWLINE)
-          .append("Expected <"); //NOSONAR
-        sb.append(description.toString());
-        sb.append("> but returned with <");
+          .append("Expected <")
+          .append(description.toString())
+          .append(">,")
+          .append(NEWLINE)
+          .append(" but got <");
         describe(actualReturnValue, sb);
-        sb.append(">")
+        sb.append(">.")
           .append(NEWLINE);
         throw new AxonAssertionError(sb.toString());
     }
@@ -207,11 +215,15 @@ public class Reporter {
         StringBuilder sb = new StringBuilder("The command handler threw an exception, but not of the expected type")
                 .append(NEWLINE)
                 .append(NEWLINE)
-                .append("Expected <") //NOSONAR
+                .append("Expected <")
                 .append(description.toString())
-                .append("> but got <exception of type [")
+                .append(">,")
+                .append(NEWLINE)
+                .append(" but got <exception of type [")
                 .append(actualException.getClass().getSimpleName())
-                .append("]>. Stacktrace follows: ")
+                .append("]>.")
+                .append(NEWLINE)
+                .append("Stack trace follows:")
                 .append(NEWLINE);
         writeStackTrace(actualException, sb);
         sb.append(NEWLINE);
@@ -226,15 +238,17 @@ public class Reporter {
      */
     public void reportWrongExceptionMessage(Throwable actualException, Description description) {
         throw new AxonAssertionError("The command handler threw an exception, but not with expected message"
-                                             + NEWLINE +
-                                             NEWLINE +
-                                             "Expected <" + //NOSONAR
-                                             description.toString() +
-                                             "> but got <message [" +
-                                             actualException.getMessage() +
-                                             "]>." +
-                                             NEWLINE +
-                                             NEWLINE);
+                                             + NEWLINE
+                                             + NEWLINE
+                                             + "Expected <"
+                                             + description.toString()
+                                             + ">, "
+                                             + NEWLINE
+                                             + " but got <message ["
+                                             + actualException.getMessage()
+                                             + "]>."
+                                             + NEWLINE
+                                             + NEWLINE);
     }
 
     /**
@@ -245,15 +259,17 @@ public class Reporter {
      */
     public void reportWrongExceptionDetails(Object details, Description description) {
         throw new AxonAssertionError("The command handler threw an exception, but not with expected details"
-                                             + NEWLINE +
-                                             NEWLINE +
-                                             "Expected <" + //NOSONAR
-                                             description.toString() +
-                                             "> but got <details [" +
-                                             details +
-                                             "]>." +
-                                             NEWLINE +
-                                             NEWLINE);
+                                             + NEWLINE
+                                             + NEWLINE
+                                             + "Expected <"
+                                             + description.toString()
+                                             + ">,"
+                                             + NEWLINE
+                                             + " but got <details ["
+                                             + details
+                                             + "]>."
+                                             + NEWLINE
+                                             + NEWLINE);
     }
 
     /**
@@ -265,15 +281,19 @@ public class Reporter {
      */
     public void reportDifferentPayloads(Class<?> messageType, Object actual, Object expected) {
         throw new AxonAssertionError("One of the messages contained a different payload than expected"
-                                             + NEWLINE + NEWLINE
+                                             + NEWLINE
+                                             + NEWLINE
                                              + "The message of type [" + messageType.getSimpleName() + "] "
                                              + "was not as expected."
                                              + NEWLINE
-                                             + "Expected <" //NOSONAR
+                                             + "Expected <"
                                              + nullSafeToString(expected)
-                                             + "> but got <"
+                                             + ">,"
+                                             + NEWLINE
+                                             + " but got <"
                                              + nullSafeToString(actual)
-                                             + ">"
+                                             + ">."
+                                             + NEWLINE
                                              + NEWLINE);
     }
 
@@ -302,11 +322,13 @@ public class Reporter {
 
         sb.append("was not as expected.")
           .append(NEWLINE)
-          .append("Expected <") //NOSONAR
+          .append("Expected <")
           .append(nullSafeToString(expected))
-          .append("> but got <")
+          .append(">,")
+          .append(NEWLINE)
+          .append(" but got <")
           .append(nullSafeToString(actual))
-          .append(">")
+          .append(">.")
           .append(NEWLINE);
         throw new AxonAssertionError(sb.toString());
     }

--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
+++ b/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
@@ -98,7 +98,8 @@ public class DeadlineManagerValidator {
         matcher.describeTo(expected);
         describe(scheduledDeadlines, actual);
         throw new AxonAssertionError(format(
-                "Did not find a deadline at the given deadline manager. \nExpected:\n<%s> at <%s>\nGot:%s\n",
+                "Did not find a deadline at the given deadline manager.\n"
+                        + "Expected <%s> at <%s>,\n but got <%s>.\n",
                 expected, scheduledTime, actual
         ));
     }
@@ -114,7 +115,7 @@ public class DeadlineManagerValidator {
                 Description unexpected = new StringDescription();
                 matcher.describeTo(unexpected);
                 throw new AxonAssertionError(format(
-                        "Unexpected matching deadline found at the given deadline manager. \nGot:%s\n",
+                        "Unexpected matching deadline found at the given deadline manager.\nGot <%s>.\n",
                         unexpected
                 ));
             }
@@ -148,7 +149,8 @@ public class DeadlineManagerValidator {
             matcher.describeTo(expected);
             describe(triggeredDeadlines, actual);
             throw new AxonAssertionError(format(
-                    "Expected deadlines were not triggered at the given deadline manager. \nExpected:\n<%s>\nGot:%s\n",
+                    "Expected deadlines were not triggered at the given deadline manager.\n"
+                            + "Expected <%s>,\n but got <%s>.\n",
                     expected, actual
             ));
         }
@@ -233,9 +235,10 @@ public class DeadlineManagerValidator {
                                                           Matcher<? extends Iterable<?>> deadlinesMatcher) {
         List<ScheduledDeadlineInfo> triggeredDeadlines = deadlineManager.getTriggeredDeadlines();
         if (triggeredDeadlines.size() != numberOfExpectedDeadlines) {
-            throw new AxonAssertionError(format("Got wrong number of triggered deadlines. Expected <%s>, got <%s>",
-                                                numberOfExpectedDeadlines,
-                                                triggeredDeadlines.size()));
+            throw new AxonAssertionError(format(
+                    "Got wrong number of triggered deadlines.\nExpected <%s>,\n but got <%s>.",
+                    numberOfExpectedDeadlines, triggeredDeadlines.size()
+            ));
         }
         assertTriggeredDeadlinesMatching(deadlinesMatcher);
     }
@@ -246,7 +249,9 @@ public class DeadlineManagerValidator {
     public void assertNoScheduledDeadlines() {
         List<ScheduledDeadlineInfo> scheduledDeadlines = deadlineManager.getScheduledDeadlines();
         if (scheduledDeadlines != null && !scheduledDeadlines.isEmpty()) {
-            throw new AxonAssertionError("Expected no scheduled deadlines, got " + scheduledDeadlines.size());
+            throw new AxonAssertionError(
+                    "Expected no scheduled deadlines, but got " + scheduledDeadlines.size() + " deadlines."
+            );
         }
     }
 

--- a/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
+++ b/test/src/main/java/org/axonframework/test/deadline/DeadlineManagerValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import static java.lang.String.format;
 import static org.axonframework.test.saga.DescriptionUtils.describe;
 
 /**
@@ -69,10 +68,10 @@ public class CommandValidator {
     public void assertDispatchedEqualTo(Object... expected) {
         List<CommandMessage<?>> actual = commandBus.getDispatchedCommands();
         if (actual.size() != expected.length) {
-            throw new AxonAssertionError(format(
-                    "Got wrong number of commands dispatched.\nExpected <%s>,\n but got <%s>.",
-                    expected.length, actual.size()
-            ));
+            throw new AxonAssertionError(
+                    "Got wrong number of commands dispatched.\n"
+                            + "Expected <" + expected.length + ">,\n but got <" + actual.size() + ">."
+            );
         }
         Iterator<CommandMessage<?>> actualIterator = actual.iterator();
         Iterator<Object> expectedIterator = Arrays.asList(expected).iterator();
@@ -84,18 +83,19 @@ public class CommandValidator {
             if (expectedItem instanceof CommandMessage) {
                 CommandMessage<?> expectedMessage = (CommandMessage<?>) expectedItem;
                 if (!expectedMessage.getPayloadType().equals(actualItem.getPayloadType())) {
-                    throw new AxonAssertionError(format(
-                            "Unexpected payload type of command at position %s (0-based).\n"
-                                    + "Expected <%s>,\n but got <%s>.",
-                            counter, expectedMessage.getPayloadType(), actualItem.getPayloadType()
-                    ));
+                    throw new AxonAssertionError(
+                            "Unexpected payload type of command at position " + counter + " (0-based).\n"
+                                    + "Expected <" + expectedMessage.getPayloadType() + ">,\n"
+                                    + " but got <" + actualItem.getPayloadType() + ">."
+                    );
                 }
                 assertCommandEquality(counter, expectedMessage.getPayload(), actualItem.getPayload());
                 if (!expectedMessage.getMetaData().equals(actualItem.getMetaData())) {
-                    throw new AxonAssertionError(format(
-                            "Unexpected Meta Data of command at position %s (0-based).\nExpected <%s>,\n but got <%s>.",
-                            counter, expectedMessage.getMetaData(), actualItem.getMetaData()
-                    ));
+                    throw new AxonAssertionError(
+                            "Unexpected Meta Data of command at position " + counter + " (0-based).\n"
+                                    + "Expected <" + expectedMessage.getMetaData() + ">,\n"
+                                    + " but got <" + actualItem.getMetaData() + ">."
+                    );
                 }
             } else {
                 assertCommandEquality(counter, expectedItem, actualItem.getPayload());
@@ -115,25 +115,28 @@ public class CommandValidator {
             Description actualDescription = new StringDescription();
             matcher.describeTo(expectedDescription);
             describe(commandBus.getDispatchedCommands(), actualDescription);
-            throw new AxonAssertionError(format("Incorrect dispatched command.\nExpected <%s>,\n but got <%s>.",
-                                                expectedDescription, actualDescription));
+            throw new AxonAssertionError(
+                    "Incorrect dispatched command.\n"
+                            + "Expected <" + expectedDescription + ">,\n but got <" + actualDescription + ">."
+            );
         }
     }
 
     private void assertCommandEquality(int commandIndex, Object expected, Object actual) {
         if (!expected.equals(actual)) {
             if (!expected.getClass().equals(actual.getClass())) {
-                throw new AxonAssertionError(format(
-                        "Wrong command type at index %s (0-based).\nExpected <%s>,\n but got <%s>.",
-                        commandIndex, expected.getClass().getSimpleName(), actual.getClass().getSimpleName()
-                ));
+                throw new AxonAssertionError(
+                        "Wrong command type at index " + commandIndex + " (0-based).\n"
+                                + "Expected <" + expected.getClass().getSimpleName() + ">,\n"
+                                + " but got <" + actual.getClass().getSimpleName() + ">."
+                );
             }
             Matcher<Object> matcher = Matchers.deepEquals(expected, fieldFilter);
             if (!matcher.matches(actual)) {
-                throw new AxonAssertionError(format(
-                        "Unexpected command at index %s (0-based).\nExpected <%s>,\n but got <%s>.",
-                        commandIndex, expected, actual
-                ));
+                throw new AxonAssertionError(
+                        "Unexpected command at index " + commandIndex + " (0-based).\n"
+                                + "Expected <" + expected + ">,\n but got <" + actual + ">."
+                );
             }
         }
     }

--- a/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
@@ -70,9 +70,9 @@ public class CommandValidator {
         List<CommandMessage<?>> actual = commandBus.getDispatchedCommands();
         if (actual.size() != expected.length) {
             throw new AxonAssertionError(format(
-                    "Got wrong number of commands dispatched. Expected <%s>, got <%s>",
-                    expected.length,
-                    actual.size()));
+                    "Got wrong number of commands dispatched.\nExpected <%s>,\n but got <%s>.",
+                    expected.length, actual.size()
+            ));
         }
         Iterator<CommandMessage<?>> actualIterator = actual.iterator();
         Iterator<Object> expectedIterator = Arrays.asList(expected).iterator();
@@ -85,18 +85,17 @@ public class CommandValidator {
                 CommandMessage<?> expectedMessage = (CommandMessage<?>) expectedItem;
                 if (!expectedMessage.getPayloadType().equals(actualItem.getPayloadType())) {
                     throw new AxonAssertionError(format(
-                            "Unexpected payload type of command at position %s (0-based). Expected <%s>, got <%s>",
-                            counter,
-                            expectedMessage.getPayloadType(),
-                            actualItem.getPayloadType()));
+                            "Unexpected payload type of command at position %s (0-based).\n"
+                                    + "Expected <%s>,\n but got <%s>.",
+                            counter, expectedMessage.getPayloadType(), actualItem.getPayloadType()
+                    ));
                 }
                 assertCommandEquality(counter, expectedMessage.getPayload(), actualItem.getPayload());
                 if (!expectedMessage.getMetaData().equals(actualItem.getMetaData())) {
                     throw new AxonAssertionError(format(
-                            "Unexpected Meta Data of command at position %s (0-based). Expected <%s>, got <%s>",
-                            counter,
-                            expectedMessage.getMetaData(),
-                            actualItem.getMetaData()));
+                            "Unexpected Meta Data of command at position %s (0-based).\nExpected <%s>,\n but got <%s>.",
+                            counter, expectedMessage.getMetaData(), actualItem.getMetaData()
+                    ));
                 }
             } else {
                 assertCommandEquality(counter, expectedItem, actualItem.getPayload());
@@ -116,7 +115,7 @@ public class CommandValidator {
             Description actualDescription = new StringDescription();
             matcher.describeTo(expectedDescription);
             describe(commandBus.getDispatchedCommands(), actualDescription);
-            throw new AxonAssertionError(format("Incorrect dispatched command. Expected <%s>, but got <%s>",
+            throw new AxonAssertionError(format("Incorrect dispatched command.\nExpected <%s>,\n but got <%s>.",
                                                 expectedDescription, actualDescription));
         }
     }
@@ -124,16 +123,15 @@ public class CommandValidator {
     private void assertCommandEquality(int commandIndex, Object expected, Object actual) {
         if (!expected.equals(actual)) {
             if (!expected.getClass().equals(actual.getClass())) {
-                throw new AxonAssertionError(format("Wrong command type at index %s (0-based). "
-                                                            + "Expected <%s>, but got <%s>",
-                                                    commandIndex,
-                                                    expected.getClass().getSimpleName(),
-                                                    actual.getClass().getSimpleName()));
+                throw new AxonAssertionError(format(
+                        "Wrong command type at index %s (0-based).\nExpected <%s>,\n but got <%s>.",
+                        commandIndex, expected.getClass().getSimpleName(), actual.getClass().getSimpleName()
+                ));
             }
             Matcher<Object> matcher = Matchers.deepEquals(expected, fieldFilter);
             if (!matcher.matches(actual)) {
                 throw new AxonAssertionError(format(
-                        "Unexpected command at index %s (0-based). Expected <%s>, but got <%s>",
+                        "Unexpected command at index %s (0-based).\nExpected <%s>,\n but got <%s>.",
                         commandIndex, expected, actual
                 ));
             }

--- a/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -39,7 +39,7 @@ import static org.axonframework.test.saga.DescriptionUtils.describe;
  */
 public class EventValidator implements EventMessageHandler {
 
-    private final List<EventMessage> publishedEvents = new ArrayList<>();
+    private final List<EventMessage<?>> publishedEvents = new ArrayList<>();
     private final EventBus eventBus;
     private final FieldFilter fieldFilter;
     private boolean recording = false;
@@ -66,7 +66,7 @@ public class EventValidator implements EventMessageHandler {
             StringDescription actualDescription = new StringDescription();
             matcher.describeTo(expectedDescription);
             describe(publishedEvents, actualDescription);
-            throw new AxonAssertionError(format("Published events did not match.\nExpected:\n<%s>\n\nGot:\n<%s>\n",
+            throw new AxonAssertionError(format("Published events did not match.\nExpected <%s>,\n but got <%s>\n",
                                                 expectedDescription, actualDescription));
         }
     }
@@ -79,16 +79,16 @@ public class EventValidator implements EventMessageHandler {
     public void assertPublishedEvents(Object... expected) {
         if (publishedEvents.size() != expected.length) {
             throw new AxonAssertionError(format(
-                    "Got wrong number of events published. Expected <%s>, got <%s>",
-                    expected.length,
-                    publishedEvents.size()));
+                    "Got wrong number of events published.\nExpected <%s>,\n but got <%s>.",
+                    expected.length, publishedEvents.size()
+            ));
         }
 
         assertPublishedEventsMatching(payloadsMatching(exactSequenceOf(createEqualToMatchers(expected))));
     }
 
     @Override
-    public Object handle(EventMessage event) {
+    public Object handle(EventMessage<?> event) {
         publishedEvents.add(event);
         return null;
     }

--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/org/axonframework/test/saga/RepositoryContentValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/RepositoryContentValidator.java
@@ -90,9 +90,9 @@ public class RepositoryContentValidator<T> {
      */
     public void assertActiveSagas(int expected) {
         if (expected != sagaStore.size()) {
-            throw new AxonAssertionError(format("Wrong number of active sagas. Expected <%s>, got <%s>.",
-                                                expected,
-                                                sagaStore.size()));
+            throw new AxonAssertionError(format(
+                    "Wrong number of active sagas.\nExpected <%s>,\n but got <%s>.", expected, sagaStore.size()
+            ));
         }
     }
 }

--- a/test/src/main/java/org/axonframework/test/saga/RepositoryContentValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/RepositoryContentValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
@@ -99,7 +99,10 @@ class FixtureTest_MatcherParams {
                         .when(new StrangeCommand("aggregateId"))
                         .expectResultMessageMatching(new DoesMatch<>())
         );
-        assertTrue(e.getMessage().contains("but got <exception of type [StrangeCommandReceivedException]>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("but got <exception of type [StrangeCommandReceivedException]>"), resultMessage
+        );
     }
 
     @Test
@@ -115,9 +118,12 @@ class FixtureTest_MatcherParams {
                         .when(new TestCommand("aggregateId"))
                         .expectException(new DoesMatch<>())
         );
-        assertTrue(e.getMessage().contains("The command handler returned normally, but an exception was expected"));
-        assertTrue(e.getMessage().contains(
-                "<anything> but returned with <null>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("The command handler returned normally, but an exception was expected"),
+                resultMessage
+        );
+        assertTrue(resultMessage.contains("<anything>,\n but got <null>"), resultMessage);
     }
 
     @Test
@@ -133,7 +139,12 @@ class FixtureTest_MatcherParams {
                         .when(new TestCommand("aggregateId"))
                         .expectResultMessageMatching(new DoesNotMatch<>())
         );
-        assertTrue(e.getMessage().contains("<something you can never give me> but got <GenericCommandResultMessage{payload={null}"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("<something you can never give me>,\n"
+                                               + " but got <GenericCommandResultMessage{payload={null}"),
+                resultMessage
+        );
     }
 
     @Test
@@ -149,8 +160,12 @@ class FixtureTest_MatcherParams {
                         .when(new StrangeCommand("aggregateId"))
                         .expectException(new DoesNotMatch<>())
         );
-        assertTrue(e.getMessage().contains(
-                "<something you can never give me> but got <exception of type [StrangeCommandReceivedException]>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("<something you can never give me>,\n"
+                                               + " but got <exception of type [StrangeCommandReceivedException]>"),
+                resultMessage
+        );
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_MatcherParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
@@ -272,7 +272,11 @@ class FixtureTest_RegularParams {
                         .when(new StrangeCommand("aggregateId"))
                         .expectSuccessfulHandlerExecution()
         );
-        assertTrue(e.getMessage().contains("but got <exception of type [StrangeCommandReceivedException]>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("but got <exception of type [StrangeCommandReceivedException]>"),
+                resultMessage
+        );
     }
 
     @Test
@@ -289,9 +293,15 @@ class FixtureTest_RegularParams {
                         .when(new TestCommand("aggregateId"))
                         .expectException(RuntimeException.class)
         );
-        assertTrue(e.getMessage().contains("The command handler returned normally, but an exception was expected"));
-        assertTrue(e.getMessage().contains(
-                "<an instance of java.lang.RuntimeException> but returned with <null>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("The command handler returned normally, but an exception was expected"),
+                resultMessage
+        );
+        assertTrue(
+                resultMessage.contains("<an instance of java.lang.RuntimeException>,\n but got <null>"),
+                resultMessage
+        );
     }
 
     @Test
@@ -306,7 +316,11 @@ class FixtureTest_RegularParams {
                         .when(new TestCommand("aggregateId"))
                         .expectResultMessagePayload("some")
         );
-        assertTrue(e.getMessage().contains("<Message with payload <\"some\">> but got <Message with payload <null>>"), e.getMessage());
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("<Message with payload <\"some\">>,\n but got <Message with payload <null>>."),
+                resultMessage
+        );
     }
 
     @Test
@@ -322,8 +336,12 @@ class FixtureTest_RegularParams {
                         .when(new StrangeCommand("aggregateId"))
                         .expectException(IOException.class)
         );
-        assertTrue(e.getMessage().contains(
-                "<an instance of java.io.IOException> but got <exception of type [StrangeCommandReceivedException]>"));
+        String resultMessage = e.getMessage();
+        assertTrue(
+                resultMessage.contains("<an instance of java.io.IOException>,\n "
+                                               + "but got <exception of type [StrangeCommandReceivedException]>"),
+                resultMessage
+        );
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegularParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ensure all assertion messages thrown by Axon Framework's test fixtures are aligned. 
As part of this, align the `actual` and `expected` values on separate lines for clarity to the user.

In doing so, this PR resolves #2755.