### PR TITLE
[#2752] Truncate `Cause` message to fit default column width

### DIFF
--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -49,6 +49,7 @@ import org.axonframework.messaging.deadletter.Decisions;
 import org.axonframework.messaging.deadletter.EnqueuePolicy;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterProcessor;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.ThrowableCause;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.unitofwork.RollbackConfiguration;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
@@ -170,9 +171,10 @@ public class EventProcessingModule
     );
     @SuppressWarnings({"unchecked", "rawtypes"})
     private final Component<EnqueuePolicy<EventMessage<?>>> defaultDeadLetterPolicy = new Component<>(
-            () -> configuration,
-            "deadLetterPolicy",
-            c -> c.getComponent(EnqueuePolicy.class, () -> (letter, cause) -> Decisions.enqueue(cause))
+            () -> configuration, "deadLetterPolicy",
+            c -> c.getComponent(EnqueuePolicy.class,
+                                () -> (letter, cause) -> Decisions.enqueue(ThrowableCause.truncated(cause))
+            )
     );
     @SuppressWarnings("unchecked")
     private final Component<StreamableMessageSource<TrackedEventMessage<?>>> defaultStreamableSource =

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
@@ -107,8 +107,7 @@ public class DeadLetteringEventHandlerInvoker
     public void handle(@Nonnull EventMessage<?> message, @Nonnull Segment segment) throws Exception {
         if (!super.sequencingPolicyMatchesSegment(message, segment)) {
             logger.trace("Ignoring event with id [{}] as it is not assigned to segment [{}].",
-                         message.getIdentifier(),
-                         segment);
+                         message.getIdentifier(), segment);
             return;
         }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
@@ -43,6 +43,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.messaging.deadletter.ThrowableCause.truncated;
 
 /**
  * Implementation of an {@link EventHandlerInvoker} utilizing a {@link SequencedDeadLetterQueue} to enqueue
@@ -89,7 +90,8 @@ public class DeadLetteringEventHandlerInvoker
     /**
      * Instantiate a builder to construct a {@link DeadLetteringEventHandlerInvoker}.
      * <p>
-     * The {@link EnqueuePolicy} defaults to returning {@link Decisions#enqueue(Throwable)} when invoked, the
+     * The {@link EnqueuePolicy} defaults to returning {@link Decisions#enqueue(Throwable)} that truncates the
+     * {@link Throwable#getMessage()} size to {@code 1024} characters when invoked for any dead letter, the
      * {@link ListenerInvocationErrorHandler} is defaulted to a {@link PropagatingErrorHandler}, the
      * {@link SequencingPolicy} to a {@link SequentialPerAggregatePolicy}, and {@code allowReset} defaults to
      * {@code false}. Providing at least one Event Handler, a {@link SequencedDeadLetterQueue}, and a
@@ -104,14 +106,17 @@ public class DeadLetteringEventHandlerInvoker
     @Override
     public void handle(@Nonnull EventMessage<?> message, @Nonnull Segment segment) throws Exception {
         if (!super.sequencingPolicyMatchesSegment(message, segment)) {
-            logger.trace("Ignoring event with id [{}] as it is not assigned to segment [{}].", message.getIdentifier(), segment);
+            logger.trace("Ignoring event with id [{}] as it is not assigned to segment [{}].",
+                         message.getIdentifier(),
+                         segment);
             return;
         }
 
         Object sequenceIdentifier = super.sequenceIdentifier(message);
         if (queue.enqueueIfPresent(sequenceIdentifier, () -> new GenericDeadLetter<>(sequenceIdentifier, message))) {
             if (logger.isInfoEnabled()) {
-                logger.info("Event with id [{}] is added to the dead-letter queue since its queue id [{}] is already present.",
+                logger.info("Event with id [{}] is added to the dead-letter queue "
+                                    + "since its queue id [{}] is already present.",
                             message.getIdentifier(), sequenceIdentifier);
             }
         } else {
@@ -164,7 +169,8 @@ public class DeadLetteringEventHandlerInvoker
     /**
      * Builder class to instantiate a {@link DeadLetteringEventHandlerInvoker}.
      * <p>
-     * The {@link EnqueuePolicy} defaults to returning {@link Decisions#enqueue(Throwable)} when invoked, the
+     * The {@link EnqueuePolicy} defaults to returning {@link Decisions#enqueue(Throwable)} that truncates the
+     * {@link Throwable#getMessage()} size to {@code 1024} characters when invoked for any dead letter, the
      * {@link ListenerInvocationErrorHandler} is defaulted to a {@link PropagatingErrorHandler}, the
      * {@link SequencingPolicy} to a {@link SequentialPerAggregatePolicy}, and {@code allowReset} defaults to
      * {@code false}. Providing at least one Event Handler, a {@link SequencedDeadLetterQueue}, and a
@@ -173,7 +179,7 @@ public class DeadLetteringEventHandlerInvoker
     public static class Builder extends SimpleEventHandlerInvoker.Builder<Builder> {
 
         private SequencedDeadLetterQueue<EventMessage<?>> queue;
-        private EnqueuePolicy<EventMessage<?>> enqueuePolicy = (letter, cause) -> Decisions.enqueue(cause);
+        private EnqueuePolicy<EventMessage<?>> enqueuePolicy = (letter, cause) -> Decisions.enqueue(truncated(cause));
         private TransactionManager transactionManager;
         private boolean allowReset = false;
 
@@ -199,7 +205,8 @@ public class DeadLetteringEventHandlerInvoker
         /**
          * Sets the {@link EnqueuePolicy} this {@link EventHandlerInvoker} uses to decide whether a
          * {@link DeadLetter dead letter} should be added to the {@link SequencedDeadLetterQueue}. Defaults to returning
-         * {@link Decisions#enqueue(Throwable)} when invoked for any dead letter.
+         * {@link Decisions#enqueue(Throwable)} that truncates the {@link Throwable#getMessage()} size to {@code 1024}
+         * characters when invoked for any dead letter.
          *
          * @param enqueuePolicy The {@link EnqueuePolicy} this {@link EventHandlerInvoker} uses to decide whether a
          *                      {@link DeadLetter dead letter} should be added to the {@link SequencedDeadLetterQueue}.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterEntry.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterEntry.java
@@ -81,6 +81,7 @@ public class DeadLetterEntry {
     private Instant processingStarted;
 
     private String causeType;
+    @Column(length = 1023)
     private String causeMessage;
 
     @Basic

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterEntry.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/DeadLetterEntry.java
@@ -82,6 +82,7 @@ public class DeadLetterEntry {
 
     private String causeType;
     @Column(length = 1023)
+    @javax.persistence.Column(length = 1023)
     private String causeMessage;
 
     @Basic
@@ -91,7 +92,6 @@ public class DeadLetterEntry {
     @javax.persistence.Lob
     @javax.persistence.Column(length = 10000)
     private byte[] diagnostics;
-
 
     /**
      * Constructor required by JPA. Do not use.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaDeadLetter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaDeadLetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ public class JpaDeadLetter<M extends EventMessage<?>> implements DeadLetter<M> {
                                    sequenceIdentifier,
                                    enqueuedAt,
                                    GenericDeadLetter.clock.instant(),
-                                   requeueCause != null ? new ThrowableCause(requeueCause) : cause,
+                                   requeueCause != null ? ThrowableCause.asCause(requeueCause) : cause,
                                    diagnostics,
                                    message);
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaDeadLetter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaDeadLetter.java
@@ -178,7 +178,7 @@ public class JpaDeadLetter<M extends EventMessage<?>> implements DeadLetter<M> {
                                    sequenceIdentifier,
                                    enqueuedAt,
                                    GenericDeadLetter.clock.instant(),
-                                   requeueCause != null ? new ThrowableCause(requeueCause) : cause,
+                                   requeueCause != null ? ThrowableCause.asCause(requeueCause) : cause,
                                    diagnostics,
                                    message);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/GenericDeadLetter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/GenericDeadLetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public class GenericDeadLetter<M extends Message<?>> implements DeadLetter<M> {
     private GenericDeadLetter(GenericDeadLetter<M> delegate, Throwable requeueCause) {
         this(delegate.sequenceIdentifier,
              delegate.message(),
-             requeueCause != null ? new ThrowableCause(requeueCause) : delegate.cause,
+             requeueCause != null ? ThrowableCause.asCause(requeueCause) : delegate.cause,
              delegate.enqueuedAt(),
              clock.instant(),
              delegate.diagnostics());

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/ThrowableCause.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/ThrowableCause.java
@@ -102,7 +102,10 @@ public class ThrowableCause extends AxonException implements Cause {
      * {@code messageSize}.
      */
     public static ThrowableCause truncated(Throwable throwable, int messageSize) {
-        return new ThrowableCause(throwable.getClass().getName(), throwable.getMessage().substring(0, messageSize));
+        return new ThrowableCause(
+                throwable.getClass().getName(),
+                throwable.getMessage().substring(0, Math.min(throwable.getMessage().length(), messageSize))
+        );
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
@@ -28,10 +28,12 @@ import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.annotation.MessageIdentifier;
+import org.axonframework.messaging.deadletter.Cause;
 import org.axonframework.messaging.deadletter.DeadLetter;
 import org.axonframework.messaging.deadletter.Decisions;
 import org.axonframework.messaging.deadletter.EnqueuePolicy;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.ThrowableCause;
 import org.axonframework.messaging.unitofwork.RollbackConfigurationType;
 import org.axonframework.utils.InMemoryStreamableEventSource;
 import org.junit.jupiter.api.*;
@@ -41,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
@@ -88,16 +91,40 @@ public abstract class DeadLetteringEventIntegrationTest {
     private static final boolean SUCCEED_RETRY = true;
     private static final boolean FAIL = false;
     private static final boolean FAIL_RETRY = false;
+    private static final String BLOB_OF_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+            + "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            + "Gravida quis blandit turpis cursus in. "
+            + "Nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum. "
+            + "Egestas maecenas pharetra convallis posuere morbi leo urna. "
+            + "Dictumst quisque sagittis purus sit amet volutpat consequat. "
+            + "At volutpat diam ut venenatis tellus in metus vulputate eu. "
+            + "Imperdiet dui accumsan sit amet nulla facilisi. Eget est lorem ipsum dolor sit amet. "
+            + "Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. "
+            + "Sed tempus urna et pharetra pharetra massa massa. Dolor magna eget est lorem. "
+            + "Purus semper eget duis at tellus. "
+            + "Tincidunt augue interdum velit euismod in pellentesque massa placerat duis."
+            + "\n\n"
+            + "Quis ipsum suspendisse ultrices gravida dictum fusce ut. "
+            + "Nascetur ridiculus mus mauris vitae ultricies leo integer malesuada. "
+            + "Sit amet purus gravida quis blandit turpis cursus in. "
+            + "Gravida rutrum quisque non tellus. "
+            + "Eros donec ac odio tempor orci dapibus. "
+            + "Dictum varius duis at consectetur lorem donec massa sapien."
+            + "Tincidunt arcu non sodales neque sodales ut etiam sit amet. "
+            + "Sagittis aliquam malesuada bibendum arcu vitae. "
+            + "Vel turpis nunc eget lorem dolor sed viverra. "
+            + "In egestas erat imperdiet sed euismod nisi. "
+            + "Lorem ipsum dolor sit amet consectetur.";
 
     private ProblematicEventHandlingComponent eventHandlingComponent;
     private SequencedDeadLetterQueue<EventMessage<?>> deadLetterQueue;
     private DeadLetteringEventHandlerInvoker deadLetteringInvoker;
     private InMemoryStreamableEventSource eventSource;
     private StreamingEventProcessor streamingProcessor;
-    private AtomicBoolean returnReferenceErrorFromPolicy = new AtomicBoolean(false);
     protected TransactionManager transactionManager;
 
     private ScheduledExecutorService executor;
+    private final AtomicBoolean returnReferenceErrorFromPolicy = new AtomicBoolean(false);
 
     /**
      * Constructs the {@link SequencedDeadLetterQueue} implementation used during the integration test.
@@ -125,7 +152,7 @@ public abstract class DeadLetteringEventIntegrationTest {
                     decisionThrowable = new ReferenceException(UUID.randomUUID());
                 }
                 return Decisions.enqueue(
-                        decisionThrowable,
+                        ThrowableCause.truncated(decisionThrowable),
                         l -> MetaData.with("retries", (int) l.diagnostics().getOrDefault("retries", 0) + 1)
                 );
             } else {
@@ -582,6 +609,30 @@ public abstract class DeadLetteringEventIntegrationTest {
         assertEquals(ReferenceException.class.getName(), causeType);
     }
 
+    @Test
+    void largeThrowableMessageIsTruncatedUponCauseCreation() {
+        String aggregateId = UUID.randomUUID().toString();
+        String truncatedText = "truncated-text";
+        String testCauseMessage = BLOB_OF_TEXT + truncatedText;
+
+        eventSource.publishMessage(
+                asEventMessage(new DeadLetterableEvent(aggregateId, FAIL, FAIL, testCauseMessage))
+        );
+
+        startProcessingEvent();
+        await().pollDelay(Duration.ofMillis(25))
+               .atMost(Duration.ofSeconds(1))
+               .until(() -> deadLetterQueue.amountOfSequences() == 1);
+
+        DeadLetter<?> deadLetter = deadLetterQueue.deadLetters().iterator().next().iterator().next();
+        Optional<Cause> optionalCause = deadLetter.cause();
+        assertTrue(optionalCause.isPresent());
+        String resultMessage = optionalCause.get().message();
+        assertNotEquals(testCauseMessage, resultMessage);
+        assertFalse(resultMessage.contains(truncatedText));
+        assertTrue(resultMessage.contains(BLOB_OF_TEXT.substring(0, 10)));
+    }
+
     private void publishEventsFor(String aggregateId,
                                   int immediateSuccessesPerAggregate,
                                   int failFirstAndThenSucceedPerAggregate,
@@ -643,7 +694,10 @@ public abstract class DeadLetteringEventIntegrationTest {
                 firstTrySuccesses.compute(sequenceId, (id, count) -> count == null ? 1 : ++count);
             } else {
                 firstTryFailures.compute(sequenceId, (id, count) -> count == null ? 1 : ++count);
-                throw new RuntimeException("Initial handling failed. Let's dead letter event [" + sequenceId + "].");
+                throw new RuntimeException(
+                        "Initial handling failed. Let's dead letter event [" + sequenceId + "].\n"
+                                + event.getCauseMessage()
+                );
             }
         }
 
@@ -652,7 +706,9 @@ public abstract class DeadLetteringEventIntegrationTest {
                 evaluationSuccesses.compute(sequenceId, (id, count) -> count == null ? 1 : ++count);
             } else {
                 evaluationFailures.compute(sequenceId, (id, count) -> count == null ? 1 : ++count);
-                throw new RuntimeException("Evaluation failed. Let's dead letter event [" + sequenceId + "].");
+                throw new RuntimeException(
+                        "Evaluation failed. Let's dead letter event [" + sequenceId + "].\n" + event.getCauseMessage()
+                );
             }
         }
 
@@ -702,19 +758,28 @@ public abstract class DeadLetteringEventIntegrationTest {
         private final String aggregateIdentifier;
         private final boolean shouldSucceed;
         private final boolean shouldSucceedOnEvaluation;
+        private final String causeMessage;
 
         private DeadLetterableEvent(String aggregateIdentifier,
                                     boolean shouldSucceed) {
             this(aggregateIdentifier, shouldSucceed, true);
         }
 
+        private DeadLetterableEvent(String aggregateIdentifier,
+                                    boolean shouldSucceed,
+                                    boolean shouldSucceedOnEvaluation) {
+            this(aggregateIdentifier, shouldSucceed, shouldSucceedOnEvaluation, "");
+        }
+
         @JsonCreator
         public DeadLetterableEvent(@JsonProperty("aggregateIdentifier") String aggregateIdentifier,
                                    @JsonProperty("shouldSucceed") boolean shouldSucceed,
-                                   @JsonProperty("shouldSucceedOnEvaluation") boolean shouldSucceedOnEvaluation) {
+                                   @JsonProperty("shouldSucceedOnEvaluation") boolean shouldSucceedOnEvaluation,
+                                   @JsonProperty("causeMessage") String causeMessage) {
             this.aggregateIdentifier = aggregateIdentifier;
             this.shouldSucceed = shouldSucceed;
             this.shouldSucceedOnEvaluation = shouldSucceedOnEvaluation;
+            this.causeMessage = causeMessage;
         }
 
         public String getAggregateIdentifier() {
@@ -729,6 +794,10 @@ public abstract class DeadLetteringEventIntegrationTest {
             return shouldSucceedOnEvaluation;
         }
 
+        public String getCauseMessage() {
+            return causeMessage;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -738,14 +807,15 @@ public abstract class DeadLetteringEventIntegrationTest {
                 return false;
             }
             DeadLetterableEvent that = (DeadLetterableEvent) o;
-            return shouldSucceed == that.shouldSucceed
-                    && shouldSucceedOnEvaluation == that.shouldSucceedOnEvaluation
-                    && Objects.equals(aggregateIdentifier, that.aggregateIdentifier);
+            return shouldSucceed == that.shouldSucceed && shouldSucceedOnEvaluation == that.shouldSucceedOnEvaluation
+                    && Objects.equals(aggregateIdentifier, that.aggregateIdentifier) && Objects.equals(
+                    causeMessage,
+                    that.causeMessage);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(aggregateIdentifier, shouldSucceed, shouldSucceedOnEvaluation);
+            return Objects.hash(aggregateIdentifier, shouldSucceed, shouldSucceedOnEvaluation, causeMessage);
         }
 
         @Override
@@ -754,6 +824,7 @@ public abstract class DeadLetteringEventIntegrationTest {
                     "aggregateIdentifier='" + aggregateIdentifier + '\'' +
                     ", shouldSucceed=" + shouldSucceed +
                     ", shouldSucceedOnEvaluation=" + shouldSucceedOnEvaluation +
+                    ", causeMessage='" + causeMessage + '\'' +
                     '}';
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/ThrowableCauseTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/ThrowableCauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,31 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class ThrowableCauseTest {
 
+    private static final String BLOB_OF_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+            + "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            + "Gravida quis blandit turpis cursus in. "
+            + "Nulla facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum. "
+            + "Egestas maecenas pharetra convallis posuere morbi leo urna. "
+            + "Dictumst quisque sagittis purus sit amet volutpat consequat. "
+            + "At volutpat diam ut venenatis tellus in metus vulputate eu. "
+            + "Imperdiet dui accumsan sit amet nulla facilisi. Eget est lorem ipsum dolor sit amet. "
+            + "Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. "
+            + "Sed tempus urna et pharetra pharetra massa massa. Dolor magna eget est lorem. "
+            + "Purus semper eget duis at tellus. "
+            + "Tincidunt augue interdum velit euismod in pellentesque massa placerat duis."
+            + "\n\n"
+            + "Quis ipsum suspendisse ultrices gravida dictum fusce ut. "
+            + "Nascetur ridiculus mus mauris vitae ultricies leo integer malesuada. "
+            + "Sit amet purus gravida quis blandit turpis cursus in. "
+            + "Gravida rutrum quisque non tellus. "
+            + "Eros donec ac odio tempor orci dapibus. "
+            + "Dictum varius duis at consectetur lorem donec massa sapien."
+            + "Tincidunt arcu non sodales neque sodales ut etiam sit amet. "
+            + "Sagittis aliquam malesuada bibendum arcu vitae. "
+            + "Vel turpis nunc eget lorem dolor sed viverra. "
+            + "In egestas erat imperdiet sed euismod nisi. "
+            + "Lorem ipsum dolor sit amet consectetur.";
+
     @Test
     void constructThrowableCauseWithThrowable() {
         Throwable testThrowable = new RuntimeException("some-message");
@@ -46,5 +71,71 @@ class ThrowableCauseTest {
 
         assertEquals(testType, testSubject.type());
         assertEquals(testMessage, testSubject.message());
+    }
+
+    @Test
+    void asCauseWrapsThrowable() {
+        Throwable testThrowable = new RuntimeException("some-message");
+
+        ThrowableCause result = ThrowableCause.asCause(testThrowable);
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertEquals(testThrowable.getMessage(), result.message());
+    }
+
+    @Test
+    void asCauseReturnsCauseAsIs() {
+        ThrowableCause testCause = new ThrowableCause("type", "message");
+
+        ThrowableCause result = ThrowableCause.asCause(testCause);
+
+        assertEquals(testCause, result);
+    }
+
+    @Test
+    void truncateLeavesMessageAsIsIfItDoesNotExceedMessageSize() {
+        Throwable testThrowable = new RuntimeException("some-message");
+
+        ThrowableCause result = ThrowableCause.truncated(testThrowable);
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertEquals(testThrowable.getMessage(), result.message());
+    }
+
+    @Test
+    void truncateShortensMessageIfItExceedsMessageSize() {
+        String textThatShouldBeTruncated = "truncated-text-at-the-end";
+        Throwable testThrowable = new RuntimeException(BLOB_OF_TEXT + textThatShouldBeTruncated);
+
+        ThrowableCause result = ThrowableCause.truncated(testThrowable);
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertNotEquals(testThrowable.getMessage(), result.getMessage());
+        assertFalse(result.getMessage().contains(textThatShouldBeTruncated));
+    }
+
+    @Test
+    void truncateWithSpecifiedMessageSizeLeavesMessageAsIsIfItDoesNotExceedGivenSize() {
+        String testMessage = "some-message";
+        Throwable testThrowable = new RuntimeException(testMessage);
+
+        ThrowableCause result = ThrowableCause.truncated(testThrowable, testMessage.length());
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertEquals(testThrowable.getMessage(), result.message());
+    }
+
+    @Test
+    void truncateWithSpecifiedMessageSizeShortensMessageIfItExceedsGivenSize() {
+        String textThatShouldBeTruncated = "truncated-text-at-the-end";
+        Throwable testThrowable = new RuntimeException(textThatShouldBeTruncated);
+        int testMessageSize = textThatShouldBeTruncated.length() - 3;
+
+        ThrowableCause result = ThrowableCause.truncated(testThrowable, testMessageSize);
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertNotEquals(testThrowable.getMessage(), result.getMessage());
+        assertFalse(result.getMessage().contains(textThatShouldBeTruncated));
+        assertTrue(result.getMessage().contains(textThatShouldBeTruncated.substring(0, testMessageSize)));
     }
 }


### PR DESCRIPTION
The `Cause` generated by the `SequencedDeadLetterQueue` implementations may exceed the desired column width for the `causeMessage` field.
To resolve this predicament, I've added three operations to the `ThrowableCause` (the default `Cause` implementation used):

1. `asCause(Throwable)` - Check whether the given `Throwable` is an instance of `ThrowableCause`. If `true`, return as is. If `false`, wrap the `Throwable` in a `ThrowableCause`.
2. `truncate(Throwable)` - Truncates the `Throwable#getMessage` to a maximum size of `1023`. 
3. `truncate(Throwable, int)` - Truncates the `Throwable#getMessage` to the given `int` messageSize`.

On top of this, the default `EnqueuePolicy` as configured in the `EventProcessingModule` and `DeadLetteringEventHandlerInvoker` now truncates the given `Throwable`.
To allow for this truncate operation to occur during the `EnqueuePolicy`, I have adjusted the `ThrowableCause` to be an `AxonException` implementation, and in effect thus a `Throwable` implementation.
By doing so, we ensure users will, by default, not exceed the default column width.
To comply with this default size, the `DeadLetterEntry#causeMessage` field is now annotated with a (Javax and Jakarta) `@Column(length = 1023)` annotation.

Lastly, to ensure we do not re-wrap `Throwable` instances on a `requeue` invocation, the `withCause(Throwable)` operations on the `GenericDeadLetter` and `JpaDeadLetter`.

In doing the above, we enhance the resilience of the `causeMessage` and resolve #2752. 
 