### PR TITLE
Introduce `AxonServerContainer` as test-container

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -83,6 +83,13 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-test</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -34,7 +34,6 @@ import org.axonframework.queryhandling.annotation.AnnotationQueryHandlerAdapter;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.test.server.AxonServerContainer;
-import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
@@ -47,7 +46,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -100,12 +98,10 @@ class StreamingQueryEndToEndTest {
                     .waitingFor(Wait.forHttp("/actuator/health").forPort(HTTP_PORT));
 
     @BeforeAll
-    static void initialize() throws IOException {
+    static void initialize() {
         axonServerAddress = axonServerContainer.getHost() + ":" + axonServerContainer.getMappedPort(GRPC_PORT);
         nonStreamingAxonServerAddress = nonStreamingAxonServerContainer.getHost()
                 + ":" + nonStreamingAxonServerContainer.getMappedPort(GRPC_PORT);
-
-        AxonServerContainerUtils.initCluster(HOSTNAME, axonServerContainer.getMappedPort(HTTP_PORT));
     }
 
     @BeforeEach

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -99,7 +99,7 @@ class StreamingQueryEndToEndTest {
 
     @BeforeAll
     static void initialize() {
-        axonServerAddress = axonServerContainer.getHost() + ":" + axonServerContainer.getMappedPort(GRPC_PORT);
+        axonServerAddress = axonServerContainer.getHost() + ":" + axonServerContainer.getGrpcPort();
         nonStreamingAxonServerAddress = nonStreamingAxonServerContainer.getHost()
                 + ":" + nonStreamingAxonServerContainer.getMappedPort(GRPC_PORT);
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -33,6 +33,8 @@ import org.axonframework.queryhandling.StreamingQueryMessage;
 import org.axonframework.queryhandling.annotation.AnnotationQueryHandlerAdapter;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.test.server.AxonServerContainer;
+import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
@@ -45,6 +47,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -60,6 +63,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @Testcontainers
 class StreamingQueryEndToEndTest {
 
+    private static final int HTTP_PORT = 8024;
+    private static final int GRPC_PORT = 8124;
+    private static final String HOSTNAME = "localhost";
+
     private static String axonServerAddress;
     private static String nonStreamingAxonServerAddress;
 
@@ -70,37 +77,35 @@ class StreamingQueryEndToEndTest {
     private Registration nonStreamingSubscription;
 
     @Container
-    private static final GenericContainer<?> axonServerContainer =
-            new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver"))
-                    .withExposedPorts(8024, 8124)
-                    .withEnv("AXONIQ_AXONSERVER_NAME", "axonserver")
-                    .withEnv("AXONIQ_AXONSERVER_HOSTNAME", "localhost")
-                    .withEnv("AXONIQ_AXONSERVER_DEVMODE_ENABLED", "true")
+    private static final AxonServerContainer axonServerContainer =
+            new AxonServerContainer("axoniq/axonserver:latest-dev")
+                    .withAxonServerName("axonserver")
+                    .withAxonServerHostname(HOSTNAME)
+                    .withDevMode(true)
                     .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(1)))
                     .withNetwork(Network.newNetwork())
-                    .withNetworkAliases("axonserver")
-                    .waitingFor(Wait.forHttp("/actuator/health").forPort(8024));
+                    .withNetworkAliases("axonserver");
 
+    @SuppressWarnings("resource")
     @Container
     private static final GenericContainer<?> nonStreamingAxonServerContainer =
             new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver:4.5.10"))
-                    .withExposedPorts(8024, 8124)
+                    .withExposedPorts(HTTP_PORT, GRPC_PORT)
                     .withEnv("AXONIQ_AXONSERVER_NAME", "axonserver")
-                    .withEnv("AXONIQ_AXONSERVER_HOSTNAME", "localhost")
+                    .withEnv("AXONIQ_AXONSERVER_HOSTNAME", HOSTNAME)
                     .withEnv("AXONIQ_AXONSERVER_DEVMODE_ENABLED", "true")
                     .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(1)))
                     .withNetwork(Network.newNetwork())
                     .withNetworkAliases("axonserver")
-                    .waitingFor(Wait.forHttp("/actuator/health").forPort(8024));
+                    .waitingFor(Wait.forHttp("/actuator/health").forPort(HTTP_PORT));
 
     @BeforeAll
-    static void initialize() {
-        axonServerAddress = axonServerContainer.getHost()
-                + ":" +
-                axonServerContainer.getMappedPort(8124);
+    static void initialize() throws IOException {
+        axonServerAddress = axonServerContainer.getHost() + ":" + axonServerContainer.getMappedPort(GRPC_PORT);
         nonStreamingAxonServerAddress = nonStreamingAxonServerContainer.getHost()
-                + ":" +
-                nonStreamingAxonServerContainer.getMappedPort(8124);
+                + ":" + nonStreamingAxonServerContainer.getMappedPort(GRPC_PORT);
+
+        AxonServerContainerUtils.initCluster(HOSTNAME, axonServerContainer.getMappedPort(HTTP_PORT));
     }
 
     @BeforeEach

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
@@ -36,14 +36,12 @@ import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.test.server.AxonServerContainer;
-import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Queue;
@@ -65,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @Testcontainers
 class MessagePriorityIntegrationTest {
 
-    private static final int HTTP_PORT = 8024;
     private static final int GRPC_PORT = 8124;
     private static final String HOSTNAME = "localhost";
 
@@ -86,10 +83,10 @@ class MessagePriorityIntegrationTest {
     private AxonServerCommandBus commandBus;
     private AxonServerQueryBus queryBus;
 
-    @BeforeAll
-    static void beforeAll() throws IOException {
-        AxonServerContainerUtils.initCluster(HOSTNAME, axonServer.getMappedPort(HTTP_PORT));
-    }
+//    @BeforeAll
+//    static void beforeAll() throws IOException {
+//        AxonServerContainerUtils.initCluster(HOSTNAME, axonServer.getMappedPort(HTTP_PORT));
+//    }
 
     @BeforeEach
     void setUp() {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
@@ -63,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @Testcontainers
 class MessagePriorityIntegrationTest {
 
-    private static final int GRPC_PORT = 8124;
     private static final String HOSTNAME = "localhost";
 
     private static final int PRIORITY = 42;
@@ -83,16 +82,11 @@ class MessagePriorityIntegrationTest {
     private AxonServerCommandBus commandBus;
     private AxonServerQueryBus queryBus;
 
-//    @BeforeAll
-//    static void beforeAll() throws IOException {
-//        AxonServerContainerUtils.initCluster(HOSTNAME, axonServer.getMappedPort(HTTP_PORT));
-//    }
-
     @BeforeEach
     void setUp() {
         Serializer serializer = JacksonSerializer.defaultSerializer();
 
-        String server = axonServer.getHost() + ":" + axonServer.getMappedPort(GRPC_PORT);
+        String server = axonServer.getHost() + ":" + axonServer.getGrpcPort();
         AxonServerConfiguration configuration = AxonServerConfiguration.builder()
                                                                        .componentName("messagePriority")
                                                                        .servers(server)

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -50,6 +50,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <optional>true</optional>

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");
+
     private static final int AXON_SERVER_HTTP_PORT = 8024;
     private static final int AXON_SERVER_GRPC_PORT = 8124;
 
@@ -106,7 +107,7 @@ public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
     protected void doStart() {
         super.doStart();
         try {
-            AxonServerContainerUtils.initCluster(axonServerHostname, getMappedPort(AXON_SERVER_HTTP_PORT));
+            AxonServerContainerUtils.initCluster(getHost(), getHttpPort());
         } catch (IOException e) {
             throw new ContainerLaunchException("Axon Server cluster initialization failed.", e);
         }
@@ -224,9 +225,18 @@ public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
     }
 
     /**
-     * Returns the mapped GRPC port used by this Axon Server container.
+     * Returns the mapped Http port used by this Axon Server container.
      *
-     * @return The mapped GRPC port used by this Axon Server container.
+     * @return The mapped Http port used by this Axon Server container.
+     */
+    public Integer getHttpPort() {
+        return this.getMappedPort(AXON_SERVER_HTTP_PORT);
+    }
+
+    /**
+     * Returns the mapped gRPC port used by this Axon Server container.
+     *
+     * @return The mapped gRPC port used by this Axon Server container.
      */
     public Integer getGrpcPort() {
         return this.getMappedPort(AXON_SERVER_GRPC_PORT);

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -27,8 +27,10 @@ import java.util.Optional;
 /**
  * Constructs an Axon Server container for testing.
  * <p>
- * By default, it starts in a single-node configuration. Note that to be able to utilize the container, the cluster
- * needs to be initialized.
+ * By default, it starts in a single-node configuration. Note that to be able to utilize the container the cluster needs
+ * to be initialized, for which you can use the {@link AxonServerContainerUtils#initCluster(String, int)} operation.
+ * Furthermore, there are other tasks present in the {@link AxonServerContainerUtils}, like
+ * {@link AxonServerContainerUtils#createContext(String, String, int)}, that can help with testing.
  *
  * @author Lucas Campos
  * @author Steven van Beelen

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.server;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Constructs an Axon Server container for testing.
+ * <p>
+ * By default, it starts in a single-node configuration. Note that to be able to utilize the container, the cluster
+ * needs to be initialized.
+ *
+ * @author Lucas Campos
+ * @author Steven van Beelen
+ * @author 4.8.0
+ */
+public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");
+    private static final int AXON_SERVER_HTTP_PORT = 8024;
+    private static final int AXON_SERVER_GRPC_PORT = 8124;
+
+    private static final String WAIT_FOR_LOG_MESSAGE = ".*Started AxonServer.*";
+    private static final String HEALTH_ENDPOINT = "/actuator/health";
+
+    private static final String LICENCE_DEFAULT_LOCATION = "/axonserver/config/axoniq.license";
+    private static final String CONFIGURATION_DEFAULT_LOCATION = "/axonserver/config/axonserver.properties";
+    private static final String CLUSTER_TEMPLATE_DEFAULT_LOCATION = "/axonserver/cluster-template.yml";
+
+    private static final String AXONIQ_LICENSE = "AXONIQ_LICENSE";
+    private static final String AXONIQ_AXONSERVER_NAME = "AXONIQ_AXONSERVER_NAME";
+    private static final String AXONIQ_AXONSERVER_INTERNAL_HOSTNAME = "AXONIQ_AXONSERVER_INTERNAL_HOSTNAME";
+    private static final String AXONIQ_AXONSERVER_HOSTNAME = "AXONIQ_AXONSERVER_HOSTNAME";
+    private static final String AXONIQ_AXONSERVER_DEVMODE_ENABLED = "AXONIQ_AXONSERVER_DEVMODE_ENABLED";
+
+    private static final String AXON_SERVER_ADDRESS_TEMPLATE = "%s:%s";
+
+    private String licensePath;
+    private String configurationPath;
+    private String clusterTemplatePath;
+    private String axonServerName;
+    private String axonServerInternalHostname;
+    private String axonServerHostname;
+    private boolean devMode;
+
+    /**
+     * Initialize Axon Server with the given {@code dockerImageName}.
+     *
+     * @param dockerImageName The name of the Docker image to initialize this test container with.
+     */
+    public AxonServerContainer(final String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    /**
+     * Initialize Axon Server with the given {@code dockerImageName}.
+     *
+     * @param dockerImageName The {@link DockerImageName} to initialize this test container with.
+     */
+    public AxonServerContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        //noinspection resource | ignore from AutoClosable on GenericContainer
+        withExposedPorts(AXON_SERVER_HTTP_PORT, AXON_SERVER_GRPC_PORT)
+                .withEnv(AXONIQ_LICENSE, LICENCE_DEFAULT_LOCATION)
+                .waitingFor(Wait.forLogMessage(WAIT_FOR_LOG_MESSAGE, 1))
+                .waitingFor(Wait.forHttp(HEALTH_ENDPOINT).forPort(8024));
+    }
+
+    @Override
+    protected void configure() {
+        optionallyCopyResourceToContainer(LICENCE_DEFAULT_LOCATION, licensePath);
+        optionallyCopyResourceToContainer(CONFIGURATION_DEFAULT_LOCATION, configurationPath);
+        optionallyCopyResourceToContainer(CLUSTER_TEMPLATE_DEFAULT_LOCATION, clusterTemplatePath);
+        withOptionalEnv(AXONIQ_AXONSERVER_NAME, axonServerName);
+        withOptionalEnv(AXONIQ_AXONSERVER_HOSTNAME, axonServerHostname);
+        withOptionalEnv(AXONIQ_AXONSERVER_INTERNAL_HOSTNAME, axonServerInternalHostname);
+        //noinspection resource | ignore from AutoClosable on GenericContainer
+        withEnv(AXONIQ_AXONSERVER_DEVMODE_ENABLED, String.valueOf(devMode));
+    }
+
+    /**
+     * Map (effectively replace) a directory in Docker with the content of {@code resourceLocation} if the resource
+     * location is not {@code null}.
+     * <p>
+     * Protected to allow for changing implementation by extending the class.
+     *
+     * @param pathNameInContainer The path in docker.
+     * @param resourceLocation    The relative classpath to the resource.
+     */
+    protected void optionallyCopyResourceToContainer(String pathNameInContainer, String resourceLocation) {
+        //noinspection resource | ignore from AutoClosable on GenericContainer
+        Optional.ofNullable(resourceLocation)
+                .map(MountableFile::forClasspathResource)
+                .ifPresent(mountableFile -> withCopyFileToContainer(mountableFile, pathNameInContainer));
+    }
+
+    /**
+     * Set an environment value if the value is present.
+     * <p>
+     * Protected to allow for changing implementation by extending the class
+     *
+     * @param key   Environment value key, usually a constant.
+     * @param value Environment value to be set.
+     */
+    protected void withOptionalEnv(String key, String value) {
+        //noinspection resource | ignore from AutoClosable on GenericContainer
+        Optional.ofNullable(value)
+                .ifPresent(v -> withEnv(key, value));
+    }
+
+    /**
+     * Initialize this Axon Server test container with a license file retrieved from the given {@code licensePath}.
+     *
+     * @param licensePath The path to the license file.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withLicense(String licensePath) {
+        this.licensePath = licensePath;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with a configuration file retrieved from the given
+     * {@code configurationPath}.
+     *
+     * @param configurationPath The path to the configuration file.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withConfiguration(String configurationPath) {
+        this.configurationPath = configurationPath;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with a cluster template configuration file retrieved from the given
+     * {@code clusterTemplatePath}.
+     *
+     * @param clusterTemplatePath The path to the cluster template file.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withClusterTemplate(String clusterTemplatePath) {
+        this.clusterTemplatePath = clusterTemplatePath;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with the given {@code axonServerName}.
+     *
+     * @param axonServerName The name of the Axon Server instance.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withAxonServerName(String axonServerName) {
+        this.axonServerName = axonServerName;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with the given {@code axonServerInternalHostname}.
+     *
+     * @param axonServerInternalHostname The internal hostname of the Axon Server instance.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withAxonServerInternalHostname(String axonServerInternalHostname) {
+        this.axonServerInternalHostname = axonServerInternalHostname;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with the given {@code axonServerHostname}.
+     *
+     * @param axonServerHostname The hostname of the Axon Server instance.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withAxonServerHostname(String axonServerHostname) {
+        this.axonServerHostname = axonServerHostname;
+        return self();
+    }
+
+    /**
+     * Initialize this Axon Server test container with the given {@code devMode}.
+     * <p>
+     * Development mode enables some features for development convenience. Default value is {@code false}.
+     *
+     * @param devMode A {@code boolean} dictating whether to enable development mode, yes or no.
+     * @return This container itself for fluent API.
+     */
+    public AxonServerContainer withDevMode(boolean devMode) {
+        this.devMode = devMode;
+        return self();
+    }
+
+    /**
+     * Returns the mapped GRPC port used by this Axon Server container.
+     *
+     * @return The mapped GRPC port used by this Axon Server container.
+     */
+    public Integer getGrpcPort() {
+        return this.getMappedPort(AXON_SERVER_GRPC_PORT);
+    }
+
+    /**
+     * Returns the container address in a {@code host:port} format.
+     *
+     * @return The container address in a {@code host:port} format.
+     */
+    public String getAxonServerAddress() {
+        return String.format(AXON_SERVER_ADDRESS_TEMPLATE,
+                             this.getHost(),
+                             this.getMappedPort(AXON_SERVER_GRPC_PORT));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        AxonServerContainer that = (AxonServerContainer) o;
+        return Objects.equals(licensePath, that.licensePath)
+                && Objects.equals(configurationPath, that.configurationPath)
+                && Objects.equals(clusterTemplatePath, that.clusterTemplatePath)
+                && Objects.equals(axonServerName, that.axonServerName)
+                && Objects.equals(axonServerInternalHostname, that.axonServerInternalHostname)
+                && Objects.equals(axonServerHostname, that.axonServerHostname)
+                && Objects.equals(devMode, that.devMode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(),
+                            licensePath,
+                            configurationPath,
+                            clusterTemplatePath,
+                            axonServerName,
+                            axonServerInternalHostname,
+                            axonServerHostname,
+                            devMode);
+    }
+
+    @Override
+    public String toString() {
+        return "AxonServerContainer{" +
+                "licensePath='" + licensePath + '\'' +
+                ", configurationPath='" + configurationPath + '\'' +
+                ", clusterTemplatePath='" + clusterTemplatePath + '\'' +
+                ", axonServerName='" + axonServerName + '\'' +
+                ", axonServerInternalHostname='" + axonServerInternalHostname + '\'' +
+                ", axonServerHostname='" + axonServerHostname + '\'' +
+                ", devMode='" + devMode + '\'' +
+                '}';
+    }
+}

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.server;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.axonframework.common.Assert;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * Utility class to work with the {@link AxonServerContainer}.
+ * <p>
+ * Allows for {@link #initCluster(String, int) cluster initialization}, context
+ * {@link #deleteContext(String, String, int) deletion} and context
+ * {@link #createContext(String, String, int) creation}, simplifying test cases using {@code AxonServerContainer(s)}.
+ *
+ * @author Milan Savic
+ * @author Sara Pelligrini
+ * @since 4.8.0
+ */
+public class AxonServerContainerUtils {
+
+    /**
+     * Purges events from the {@code default} context of the Axon Server instance contacted at the given
+     * {@code hostname} and {@code port} combination.
+     *
+     * @param hostname The hostname of the Axon Server instance to purge events for.
+     * @param port     The port of the Axon Server instance to purge events for.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static void purgeEventsFromAxonServer(String hostname, int port) throws IOException {
+        purgeEventsFromAxonServer("default", hostname, port);
+    }
+
+    /**
+     * Purges events from the given {@code context} of the Axon Server instance contacted at the given {@code hostname}
+     * and {@code port} combination.
+     *
+     * @param context  The context to purge the events of.
+     * @param hostname The hostname of the Axon Server instance to purge events for.
+     * @param port     The port of the Axon Server instance to purge events for.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static void purgeEventsFromAxonServer(String context, String hostname, int port) throws IOException {
+        deleteContext(context, hostname, port);
+        createContext(context, hostname, port);
+        // TODO: 6/20/23 Figure out why busy wait is necessary for newly created context to be operative
+        waitFor(1_000);
+    }
+
+    /**
+     * Delete the given {@code context} of the Axon Server instance contacted at the given {@code hostname} and
+     * {@code port} combination.
+     *
+     * @param context  The context to delete.
+     * @param hostname The hostname of the Axon Server instance to delete the given {@code context} of.
+     * @param port     The port of the Axon Server instance to delete the given {@code context} of.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static void deleteContext(String context, String hostname, int port) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/v1/context/%s", hostname, port, context));
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("DELETE");
+            connection.getInputStream().close();
+            int responseCode = connection.getResponseCode();
+            Assert.isTrue(202 == responseCode, () -> "The response code [" + responseCode + "] did not match 202.");
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        waitForContextsCondition(hostname, port, contexts -> !contexts.contains(context));
+    }
+
+    /**
+     * Create the given {@code context} of the Axon Server instance contacted at the given {@code hostname} and
+     * {@code port} combination.
+     *
+     * @param context  The context to create.
+     * @param hostname The hostname of the Axon Server instance to create the given {@code context} of.
+     * @param port     The port of the Axon Server instance to create the given {@code context} of.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static void createContext(String context, String hostname, int port) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/v1/context", hostname, port));
+        HttpURLConnection connection = null;
+        try {
+            String jsonRequest = String.format(
+                    "{\"context\": \"%s\", "
+                            + "\"replicationGroup\": \"%s\", "
+                            + "\"roles\": [{ \"node\": \"axonserver\", \"role\": \"PRIMARY\" }]}",
+                    context, context
+            );
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            try (OutputStream os = connection.getOutputStream()) {
+                byte[] input = jsonRequest.getBytes(StandardCharsets.UTF_8);
+                os.write(input, 0, input.length);
+            }
+            connection.getInputStream().close();
+            int responseCode = connection.getResponseCode();
+            Assert.isTrue(202 == responseCode, () -> "The response code [" + responseCode + "] did not match 202.");
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        waitForContextsCondition(hostname, port, contexts -> contexts.contains(context));
+    }
+
+    /**
+     * Retrieves all the contexts of the Axon Server instance located at the given {@code hostname} and {@code port}
+     * combination.
+     *
+     * @param hostname The hostname of the Axon Server instance to create the given {@code context} of.
+     * @param port     The port of the Axon Server instance to create the given {@code context} of.
+     * @return All the contexts of the Axon Server instances located at the given {@code hostname} and {@code port}
+     * combination.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static List<String> contexts(String hostname, int port) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/v1/public/context", hostname, port));
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setDoOutput(true);
+            connection.setRequestMethod("GET");
+
+            int responseCode = connection.getResponseCode();
+            Assert.isTrue(200 == responseCode, () -> "The response code [" + responseCode + "] did not match 200.");
+
+            return contexts(connection);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    /**
+     * Initialize the cluster of the Axon Server instance located at the given {@code hostname} and {@code port}
+     * combination.
+     * <p>
+     * Note that this constructs the contexts {@code _admin} and {@code default}.
+     *
+     * @param hostname The hostname of the Axon Server instance to initiate the cluster for.
+     * @param port     The port of the Axon Server instance to initiate the cluster for.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    public static void initCluster(String hostname, int port) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/v1/context/init", hostname, port));
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.getInputStream().close();
+
+            int responseCode = connection.getResponseCode();
+            Assert.isTrue(202 == responseCode, () -> "The response code [" + responseCode + "] did not match 202.");
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        waitForContextsCondition(
+                hostname, port,
+                contexts -> contexts.contains("_admin") && contexts.contains("default")
+        );
+    }
+
+    private static List<String> contexts(HttpURLConnection connection) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        StringBuilder output = new StringBuilder();
+        String outputLine;
+        while ((outputLine = br.readLine()) != null) {
+            output.append(outputLine);
+        }
+        JsonElement jsonElement = JsonParser.parseString(output.toString());
+        ArrayList<String> contexts = new ArrayList<>();
+        for (JsonElement element : jsonElement.getAsJsonArray()) {
+            String context = element.getAsJsonObject()
+                                    .get("context")
+                                    .getAsString();
+            contexts.add(context);
+        }
+        return contexts;
+    }
+
+    private static void waitForContextsCondition(String hostname,
+                                                 int port,
+                                                 Predicate<List<String>> condition) {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        CountDownLatch latch = new CountDownLatch(1);
+        try {
+            scheduler.submit(() -> checkContextsCondition(hostname, port, condition, latch, scheduler))
+                     .get();
+            if (!latch.await(60, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Condition on contexts has not been met!");
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+
+    private static void waitFor(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void checkContextsCondition(String hostname, int port,
+                                               Predicate<List<String>> condition,
+                                               CountDownLatch latch, ScheduledExecutorService scheduler) {
+        try {
+            if (condition.test(contexts(hostname, port))) {
+                latch.countDown();
+            } else {
+                scheduler.schedule(
+                        () -> checkContextsCondition(hostname, port, condition, latch, scheduler),
+                        10, TimeUnit.MILLISECONDS
+                );
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -44,37 +44,6 @@ import java.util.function.Predicate;
 class AxonServerContainerUtils {
 
     /**
-     * Retrieves all the contexts of the Axon Server instance located at the given {@code hostname} and {@code port}
-     * combination.
-     *
-     * @param hostname The hostname of the Axon Server instance to create the given {@code context} of.
-     * @param port     The port of the Axon Server instance to create the given {@code context} of.
-     * @return All the contexts of the Axon Server instances located at the given {@code hostname} and {@code port}
-     * combination.
-     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
-     *                     {@code hostname} and {@code port}.
-     */
-    static List<String> contexts(String hostname, int port) throws IOException {
-        final URL url = new URL(String.format("http://%s:%d/v1/public/context", hostname, port));
-        HttpURLConnection connection = null;
-        try {
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setDoOutput(true);
-            connection.setRequestMethod("GET");
-
-            int responseCode = connection.getResponseCode();
-            Assert.isTrue(200 == responseCode, () -> "The response code [" + responseCode + "] did not match 200.");
-
-            return contexts(connection);
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
-
-    /**
      * Initialize the cluster of the Axon Server instance located at the given {@code hostname} and {@code port}
      * combination.
      * <p>
@@ -105,6 +74,37 @@ class AxonServerContainerUtils {
                 hostname, port,
                 contexts -> contexts.contains("_admin") && contexts.contains("default")
         );
+    }
+
+    /**
+     * Retrieves all the contexts of the Axon Server instance located at the given {@code hostname} and {@code port}
+     * combination.
+     *
+     * @param hostname The hostname of the Axon Server instance to create the given {@code context} of.
+     * @param port     The port of the Axon Server instance to create the given {@code context} of.
+     * @return All the contexts of the Axon Server instances located at the given {@code hostname} and {@code port}
+     * combination.
+     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
+     *                     {@code hostname} and {@code port}.
+     */
+    static List<String> contexts(String hostname, int port) throws IOException {
+        final URL url = new URL(String.format("http://%s:%d/v1/public/context", hostname, port));
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setDoOutput(true);
+            connection.setRequestMethod("GET");
+
+            int responseCode = connection.getResponseCode();
+            Assert.isTrue(200 == responseCode, () -> "The response code [" + responseCode + "] did not match 200.");
+
+            return contexts(connection);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
     }
 
     private static List<String> contexts(HttpURLConnection connection) throws IOException {

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -23,10 +23,8 @@ import org.axonframework.common.Assert;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -37,115 +35,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 /**
- * Utility class to work with the {@link AxonServerContainer}.
- * <p>
- * Allows for {@link #initCluster(String, int) cluster initialization}, context
- * {@link #deleteContext(String, String, int) deletion} and context
- * {@link #createContext(String, String, int) creation}, simplifying test cases using {@code AxonServerContainer(s)}.
+ * Utility class for the {@link AxonServerContainer}, used to initialize the cluster.
  *
  * @author Milan Savic
  * @author Sara Pelligrini
  * @since 4.8.0
  */
-public class AxonServerContainerUtils {
-
-    /**
-     * Purges events from the {@code default} context of the Axon Server instance contacted at the given
-     * {@code hostname} and {@code port} combination.
-     *
-     * @param hostname The hostname of the Axon Server instance to purge events for.
-     * @param port     The port of the Axon Server instance to purge events for.
-     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
-     *                     {@code hostname} and {@code port}.
-     */
-    public static void purgeEventsFromAxonServer(String hostname, int port) throws IOException {
-        purgeEventsFromAxonServer("default", hostname, port);
-    }
-
-    /**
-     * Purges events from the given {@code context} of the Axon Server instance contacted at the given {@code hostname}
-     * and {@code port} combination.
-     *
-     * @param context  The context to purge the events of.
-     * @param hostname The hostname of the Axon Server instance to purge events for.
-     * @param port     The port of the Axon Server instance to purge events for.
-     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
-     *                     {@code hostname} and {@code port}.
-     */
-    public static void purgeEventsFromAxonServer(String context, String hostname, int port) throws IOException {
-        deleteContext(context, hostname, port);
-        createContext(context, hostname, port);
-        // TODO: 6/20/23 Figure out why busy wait is necessary for newly created context to be operative
-        waitFor(1_000);
-    }
-
-    /**
-     * Delete the given {@code context} of the Axon Server instance contacted at the given {@code hostname} and
-     * {@code port} combination.
-     *
-     * @param context  The context to delete.
-     * @param hostname The hostname of the Axon Server instance to delete the given {@code context} of.
-     * @param port     The port of the Axon Server instance to delete the given {@code context} of.
-     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
-     *                     {@code hostname} and {@code port}.
-     */
-    public static void deleteContext(String context, String hostname, int port) throws IOException {
-        final URL url = new URL(String.format("http://%s:%d/v1/context/%s", hostname, port, context));
-        HttpURLConnection connection = null;
-        try {
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setDoOutput(true);
-            connection.setRequestMethod("DELETE");
-            connection.getInputStream().close();
-            int responseCode = connection.getResponseCode();
-            Assert.isTrue(202 == responseCode, () -> "The response code [" + responseCode + "] did not match 202.");
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-        waitForContextsCondition(hostname, port, contexts -> !contexts.contains(context));
-    }
-
-    /**
-     * Create the given {@code context} of the Axon Server instance contacted at the given {@code hostname} and
-     * {@code port} combination.
-     *
-     * @param context  The context to create.
-     * @param hostname The hostname of the Axon Server instance to create the given {@code context} of.
-     * @param port     The port of the Axon Server instance to create the given {@code context} of.
-     * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
-     *                     {@code hostname} and {@code port}.
-     */
-    public static void createContext(String context, String hostname, int port) throws IOException {
-        final URL url = new URL(String.format("http://%s:%d/v1/context", hostname, port));
-        HttpURLConnection connection = null;
-        try {
-            String jsonRequest = String.format(
-                    "{\"context\": \"%s\", "
-                            + "\"replicationGroup\": \"%s\", "
-                            + "\"roles\": [{ \"node\": \"axonserver\", \"role\": \"PRIMARY\" }]}",
-                    context, context
-            );
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setDoOutput(true);
-            connection.setRequestMethod("POST");
-            try (OutputStream os = connection.getOutputStream()) {
-                byte[] input = jsonRequest.getBytes(StandardCharsets.UTF_8);
-                os.write(input, 0, input.length);
-            }
-            connection.getInputStream().close();
-            int responseCode = connection.getResponseCode();
-            Assert.isTrue(202 == responseCode, () -> "The response code [" + responseCode + "] did not match 202.");
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-        waitForContextsCondition(hostname, port, contexts -> contexts.contains(context));
-    }
+class AxonServerContainerUtils {
 
     /**
      * Retrieves all the contexts of the Axon Server instance located at the given {@code hostname} and {@code port}
@@ -158,7 +54,7 @@ public class AxonServerContainerUtils {
      * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
      *                     {@code hostname} and {@code port}.
      */
-    public static List<String> contexts(String hostname, int port) throws IOException {
+    static List<String> contexts(String hostname, int port) throws IOException {
         final URL url = new URL(String.format("http://%s:%d/v1/public/context", hostname, port));
         HttpURLConnection connection = null;
         try {
@@ -189,7 +85,7 @@ public class AxonServerContainerUtils {
      * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
      *                     {@code hostname} and {@code port}.
      */
-    public static void initCluster(String hostname, int port) throws IOException {
+    static void initCluster(String hostname, int port) throws IOException {
         final URL url = new URL(String.format("http://%s:%d/v1/context/init", hostname, port));
         HttpURLConnection connection = null;
         try {
@@ -244,14 +140,6 @@ public class AxonServerContainerUtils {
             throw new RuntimeException(e);
         } finally {
             scheduler.shutdown();
-        }
-    }
-
-    private static void waitFor(long millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerEEContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,10 @@ import java.util.Optional;
  *
  * @author Lucas Campos
  * @since 4.6.0
+ * @deprecated In favor of {@link AxonServerContainer} following the merger of Standard and Enterprise edition into a
+ * single version.
  */
+@Deprecated
 public class AxonServerEEContainer<SELF extends AxonServerEEContainer<SELF>> extends GenericContainer<SELF> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver-enterprise");

--- a/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerSEContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,10 @@ import java.util.Objects;
  *
  * @author Lucas Campos
  * @since 4.6.0
+ * @deprecated In favor of {@link AxonServerContainer} following the merger of Standard and Enterprise edition into a
+ * single version.
  */
+@Deprecated
 public class AxonServerSEContainer<SELF extends AxonServerSEContainer<SELF>> extends GenericContainer<SELF> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");

--- a/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.server;
+
+import org.junit.jupiter.api.*;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Simple test class for {@link AxonServerContainer}.
+ *
+ * @author Lucas Campos
+ * @author Steven van Beelen
+ */
+class AxonServerContainerTest {
+
+    @Test
+    void constructionThroughStringImageNameStartsAsExpected() {
+        String testName = "axoniq/axonserver:latest-dev";
+        try (
+                AxonServerContainer testSubject = new AxonServerContainer(testName)
+        ) {
+            testSubject.start();
+            assertTrue(testSubject.isRunning());
+        }
+    }
+
+    @Test
+    void constructionThroughDockerImageNameStartsAsExpected() {
+        DockerImageName testName = DockerImageName.parse("axoniq/axonserver:latest-dev");
+        try (
+                AxonServerContainer testSubject = new AxonServerContainer(testName)
+        ) {
+            testSubject.start();
+            assertTrue(testSubject.isRunning());
+            assertNotNull(testSubject.getAxonServerAddress());
+            assertNotNull(testSubject.getGrpcPort());
+            assertNotNull(testSubject.getHost());
+            List<Integer> resultExposedPorts = testSubject.getExposedPorts();
+            assertTrue(resultExposedPorts.contains(8024));
+            assertTrue(resultExposedPorts.contains(8124));
+        }
+    }
+
+    @Test
+    void fullyCustomizedAxonServerContainerStartsAsExpected() {
+        String testName = "axon-server-name";
+        String testHostName = "axon-server-hostname";
+        String testInternalHostName = "axon-server-internal-host-name";
+        boolean testDevMode = true;
+        try (
+                AxonServerContainer testSubject =
+                        new AxonServerContainer("axoniq/axonserver:latest-dev")
+                                .withAxonServerName(testName)
+                                .withAxonServerHostname(testHostName)
+                                .withAxonServerInternalHostname(testInternalHostName)
+                                .withDevMode(testDevMode)
+        ) {
+            testSubject.start();
+            assertTrue(testSubject.isRunning());
+
+            assertEquals(testName, testSubject.getEnvMap().get("AXONIQ_AXONSERVER_NAME"));
+            assertEquals(testInternalHostName, testSubject.getEnvMap().get("AXONIQ_AXONSERVER_INTERNAL_HOSTNAME"));
+            assertEquals(testHostName, testSubject.getEnvMap().get("AXONIQ_AXONSERVER_HOSTNAME"));
+            assertEquals(Boolean.toString(testDevMode),
+                         testSubject.getEnvMap().get("AXONIQ_AXONSERVER_DEVMODE_ENABLED"));
+        }
+    }
+}


### PR DESCRIPTION
As of Axon Server 2023.0.0, there are no longer combined releases of Axon Server Standard Edition and Axon Server Enterprise Edition.
Instead, there is now a single runnable that allows single-node mode and multi-node mode.

Due to this shift, the existence of `AxonServerSEContainer` and `AxonServerEEContainer` isn't very reasonable anymore.
As such, this pull request introduces the `AxonServerContainer`; essentially a merger and minor clean-up of the previous containers.

Next to the new container, we have included the `AxonServerContainerUtils`, which allows simplified operation towards cluster initialization, context creation, and context deletion.
Lastly, test cases constructed their own `GenericContainer` of the Axon Server image are reverted to use the new `AxonServerContainer`.