### PR TITLE
Default to ReplayToken upon creation of new event processor

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
@@ -47,7 +47,7 @@ public class TrackingEventProcessorConfiguration {
     private final int maxThreadCount;
     private int batchSize;
     private int initialSegmentCount;
-    private Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialTrackingTokenBuilder = StreamableMessageSource::createTailToken;
+    private Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialTrackingTokenBuilder;
     private Function<String, ThreadFactory> threadFactory;
     private long tokenClaimInterval;
     private int eventAvailabilityTimeout = 1000;
@@ -84,6 +84,7 @@ public class TrackingEventProcessorConfiguration {
         this.tokenClaimInterval = DEFAULT_TOKEN_CLAIM_INTERVAL;
         this.autoStart = true;
         this.workerTerminationTimeout = DEFAULT_WORKER_TERMINATION_TIMEOUT_MS;
+        this.initialTrackingTokenBuilder = messageSource -> ReplayToken.createReplayToken(messageSource.createTailToken());
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -433,8 +433,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         private Function<String, ScheduledExecutorService> coordinatorExecutorBuilder;
         private Function<String, ScheduledExecutorService> workerExecutorBuilder;
         private int initialSegmentCount = 16;
-        private Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken =
-                StreamableMessageSource::createTailToken;
+        private Function<StreamableMessageSource<TrackedEventMessage<?>>, TrackingToken> initialToken;
         private long tokenClaimInterval = 5000;
         private int maxClaimedSegments = Short.MAX_VALUE;
         private long claimExtensionThreshold = 5000;
@@ -442,6 +441,7 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         private Clock clock = GenericEventMessage.clock;
 
         protected Builder() {
+            initialToken(messageSource -> ReplayToken.createReplayToken(messageSource.createTailToken()));
             rollbackConfiguration(RollbackConfigurationType.ANY_THROWABLE);
         }
 


### PR DESCRIPTION
Users expect processors to initially behave as a replay. So, if the head of the event store is at 10.000, most users expect the `ReplayStatus` flag to be of type `REPLAY`, instead of `REGULAR`.

This PR changes the default configuration to do just that. The initial token has been adjusted to by default be a `ReplayToken`, coming with all the functionality of doing a replay.

Use-cases include event processors that act upon an external non-idempotent system, where you during a replay don't want that action to happen but still want to insert data into the database for later use.