### PR TITLE
Ensure Aggregate Member Command Handlers are retrievable in complex Aggregate Hierarchy

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,19 +276,19 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
         }
 
         /**
-         * For every discovered type of the aggregate hierarchy, check whether there are {@link ChildEntity}s present.
-         * If they are not present on the type's level, move to that class' superclass (if possible) and check whether
-         * it has any {@code ChildEntity} instances registered. If this is the case, add them to the {@link Class} type
-         * being validated. Doing so ensures that each level in the hierarchy knows of all it's entities' command
-         * handlers and its parent their entity command handlers.
+         * For every discovered type of the aggregate hierarchy, check whether there are
+         * {@link ChildEntity ChildEntitys} present. If they are not present on the type's level, move to that class'
+         * superclass (if possible) and check whether it has any {@code ChildEntity} instances registered. If this is
+         * the case, add them to the {@link Class} type being validated. Doing so ensures that each level in the
+         * hierarchy knows of all it's entities' command handlers and its parent their entity command handlers.
          */
         private void prepareChildEntityCommandHandlers() {
             for (Class<?> aggregateType : types.values()) {
                 Class<?> type = aggregateType;
-                List<ChildEntity<T>> childrenPerType = children.getOrDefault(type, Collections.emptyList());
-                while (childrenPerType.isEmpty() && !type.equals(Object.class) && type.getSuperclass() != null) {
+                List<ChildEntity<T>> childrenPerType = new ArrayList<>(children.getOrDefault(type, Collections.emptyList()));
+                while (!type.equals(Object.class) && type.getSuperclass() != null) {
                     type = type.getSuperclass();
-                    childrenPerType = children.getOrDefault(type, Collections.emptyList());
+                    childrenPerType.addAll(new ArrayList<>(children.getOrDefault(type, Collections.emptyList())));
                 }
 
                 for (ChildEntity<T> child : childrenPerType) {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Hierarchy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,59 +17,342 @@
 package org.axonframework.test.aggregate;
 
 import org.axonframework.commandhandling.CommandHandler;
-import org.axonframework.modelling.command.AggregateIdentifier;
-import org.axonframework.eventhandling.DomainEventMessage;
-import org.axonframework.eventsourcing.AggregateFactory;
 import org.axonframework.eventsourcing.EventSourcingHandler;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateMember;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import org.junit.jupiter.api.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 /**
+ * Test class validating aggregate hierarchy. Note that this is slightly different from aggregate polymorphism, as here
+ * we are only dealing with a single concrete type.
+ *
  * @author Allard Buijze
  */
 class FixtureTest_Hierarchy {
 
-    @Test
-    void fixtureSetupWithAggregateHierarchy() {
-        new AggregateTestFixture<>(AbstractAggregate.class)
-                .registerAggregateFactory(new AggregateFactory<AbstractAggregate>() {
-                    @Override
-                    public AbstractAggregate createAggregateRoot(String aggregateIdentifier, DomainEventMessage<?> firstEvent) {
-                        return new ConcreteAggregate();
-                    }
+    private static final String AGGREGATE_IDENTIFIER = "123";
 
-                    @Override
-                    public Class<AbstractAggregate> getAggregateType() {
-                        return AbstractAggregate.class;
-                    }
-                })
-                .given(new MyEvent("123", 0)).when(new TestCommand("123"))
-                .expectEvents(new MyEvent("123", 1));
+    private FixtureConfiguration<TopAggregate> fixture;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new AggregateTestFixture<>(TopAggregate.class);
     }
 
-    public static abstract class AbstractAggregate {
+    @Test
+    void creatingAggregateWithHierarchy() {
+        fixture.givenNoPriorActivity()
+               .when(new CreateAggregateCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER));
+    }
+
+    @Test
+    void updateAggregateWithHierarchy() {
+        fixture.given(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER))
+               .when(new UpdateAggregateCommand(AGGREGATE_IDENTIFIER, "some state"))
+               .expectEvents(new AggregateUpdatedEvent(AGGREGATE_IDENTIFIER, "some state"));
+    }
+
+    @Test
+    void createFirstLevelAggregateMemberWithinHierarchy() {
+        fixture.given(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER))
+               .when(new CreateFirstLevelAggregateMemberCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new FirstLevelAggregateMemberCreatedEvent(AGGREGATE_IDENTIFIER));
+    }
+
+    @Test
+    void createSecondLevelAggregateMemberWithinHierarchy() {
+        fixture.given(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER))
+               .when(new CreateSecondLevelAggregateMemberCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new SecondLevelAggregateMemberCreatedEvent(AGGREGATE_IDENTIFIER));
+    }
+
+    @Test
+    void handlingCommandsOnFirstLevelAggregateMemberWithinHierarchy() {
+        fixture.given(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER),
+                      new FirstLevelAggregateMemberCreatedEvent(AGGREGATE_IDENTIFIER))
+               .when(new UpdateFirstLevelAggregateMemberCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new FirstLevelAggregateMemberUpdatedEvent(AGGREGATE_IDENTIFIER));
+    }
+
+    @Test
+    void handlingCommandsOnSecondLevelAggregateMemberWithinHierarchy() {
+        fixture.given(new AggregateCreatedEvent(AGGREGATE_IDENTIFIER),
+                      new SecondLevelAggregateMemberCreatedEvent(AGGREGATE_IDENTIFIER))
+               .when(new UpdateSecondLevelAggregateMemberCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new SecondLevelAggregateMemberUpdatedEvent(AGGREGATE_IDENTIFIER));
+    }
+
+    @SuppressWarnings({"FieldCanBeLocal", "unused"})
+    private static abstract class RootAggregate {
 
         @AggregateIdentifier
         private String id;
-
-        public AbstractAggregate() {
-        }
+        private String someState;
 
         @CommandHandler
-        public abstract void handle(TestCommand testCommand);
+        public abstract void handle(UpdateAggregateCommand command);
 
         @EventSourcingHandler
-        protected void on(MyEvent event) {
-            this.id = event.getAggregateIdentifier().toString();
+        protected void on(AggregateCreatedEvent event) {
+            id = event.getAggregateIdentifier();
+        }
+
+        @EventSourcingHandler
+        public void on(AggregateUpdatedEvent event) {
+            someState = event.getSomeState();
         }
     }
 
-    public static class ConcreteAggregate extends AbstractAggregate {
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private static abstract class FirstLevelAggregate extends RootAggregate {
+
+        @AggregateMember
+        private FirstLevelAggregateMember aggregateMember;
+
+        @CommandHandler
+        public void handle(CreateFirstLevelAggregateMemberCommand command) {
+            apply(new FirstLevelAggregateMemberCreatedEvent(command.getAggregateIdentifier()));
+        }
+
+        @EventSourcingHandler
+        public void on(FirstLevelAggregateMemberCreatedEvent event) {
+            aggregateMember = new FirstLevelAggregateMember();
+        }
+    }
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private static abstract class SecondLevelAggregate extends FirstLevelAggregate {
+
+        @AggregateMember
+        private SecondLevelAggregateMember aggregateMember;
+
+        @CommandHandler
+        public void handle(CreateSecondLevelAggregateMemberCommand command) {
+            apply(new SecondLevelAggregateMemberCreatedEvent(command.getAggregateIdentifier()));
+        }
+
+        @EventSourcingHandler
+        public void on(SecondLevelAggregateMemberCreatedEvent event) {
+            aggregateMember = new SecondLevelAggregateMember();
+        }
+    }
+
+    private static class TopAggregate extends SecondLevelAggregate {
+
+        @CommandHandler
+        public TopAggregate(CreateAggregateCommand command) {
+            apply(new AggregateCreatedEvent(command.getAggregateIdentifier()));
+        }
 
         @Override
-        public void handle(TestCommand testCommand) {
-            apply(new MyEvent(testCommand.getAggregateIdentifier(), 1));
+        public void handle(UpdateAggregateCommand command) {
+            apply(new AggregateUpdatedEvent(command.getAggregateIdentifier(), command.getSomeState()));
+        }
+
+        @SuppressWarnings("unused")
+        public TopAggregate() {
+            // Required by Axon
+        }
+    }
+
+    private static class FirstLevelAggregateMember {
+
+        @CommandHandler
+        public void handle(UpdateFirstLevelAggregateMemberCommand command) {
+            apply(new FirstLevelAggregateMemberUpdatedEvent(command.aggregateIdentifier));
+        }
+    }
+
+    private static class SecondLevelAggregateMember {
+
+        @CommandHandler
+        public void handle(UpdateSecondLevelAggregateMemberCommand command) {
+            apply(new SecondLevelAggregateMemberUpdatedEvent(command.aggregateIdentifier));
+        }
+    }
+
+    private static class CreateAggregateCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+
+        CreateAggregateCommand(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class AggregateCreatedEvent {
+
+        private final String aggregateIdentifier;
+
+        AggregateCreatedEvent(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class UpdateAggregateCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+        private final String someState;
+
+        UpdateAggregateCommand(String aggregateIdentifier, String someState) {
+            this.aggregateIdentifier = aggregateIdentifier;
+            this.someState = someState;
+        }
+
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+
+        public String getSomeState() {
+            return someState;
+        }
+    }
+
+    private static class AggregateUpdatedEvent {
+
+        private final String aggregateIdentifier;
+        private final String someState;
+
+        AggregateUpdatedEvent(String aggregateIdentifier, String someState) {
+            this.aggregateIdentifier = aggregateIdentifier;
+            this.someState = someState;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+
+        public String getSomeState() {
+            return someState;
+        }
+    }
+
+    private static class CreateFirstLevelAggregateMemberCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+
+        CreateFirstLevelAggregateMemberCommand(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class FirstLevelAggregateMemberCreatedEvent {
+
+        private final String aggregateIdentifier;
+
+        FirstLevelAggregateMemberCreatedEvent(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class UpdateFirstLevelAggregateMemberCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+
+        UpdateFirstLevelAggregateMemberCommand(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class FirstLevelAggregateMemberUpdatedEvent {
+
+        private final String aggregateIdentifier;
+
+        FirstLevelAggregateMemberUpdatedEvent(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class CreateSecondLevelAggregateMemberCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+
+        CreateSecondLevelAggregateMemberCommand(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class SecondLevelAggregateMemberCreatedEvent {
+
+        private final String aggregateIdentifier;
+
+        SecondLevelAggregateMemberCreatedEvent(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class UpdateSecondLevelAggregateMemberCommand {
+
+        @TargetAggregateIdentifier
+        private final String aggregateIdentifier;
+
+        UpdateSecondLevelAggregateMemberCommand(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
+        }
+    }
+
+    private static class SecondLevelAggregateMemberUpdatedEvent {
+
+        private final String aggregateIdentifier;
+
+        SecondLevelAggregateMemberUpdatedEvent(String aggregateIdentifier) {
+            this.aggregateIdentifier = aggregateIdentifier;
+        }
+
+        @SuppressWarnings("unused")
+        public String getAggregateIdentifier() {
+            return aggregateIdentifier;
         }
     }
 }


### PR DESCRIPTION
This pull request resolves a predicament within the registration of Command Handling functions on entities within an Aggregate class hierarchy.
The `AnnotatedAggregateMetaModelFactory#prepareChildEntityCommandHandlers`  did investigate one layer down the hierarchy for existing Aggregate Members to register its Command Handling functions with the top Aggregate.

But, it would stop as soon as it had found **any**.
Hence, if there was another layer deeper down the Aggregate hierarchy that contained `@AggregateMember` annotated fields with command handlers in them, those would be disregarded.

I have solved the predicament by having the `AnnotatedAggregateMetaModelFactory#prepareChildEntityCommandHandlers` operation move further down the class hierarchy until it reaches the `Object`.
The majority of the changes in this PR lie with the test case, as I was required to construct a complex Aggregate Hierarchy for the predicament to show.