### PR TITLE
Enable provisioning a `Message` with custom `MetaData` for `QueryGateway#streamingQuery`

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class DefaultQueryGateway implements QueryGateway {
 
     @Override
     public <R, Q> Publisher<R> streamingQuery(String queryName, Q query, Class<R> responseType) {
-        return Mono.fromSupplier(() -> new GenericStreamingQueryMessage<>(query, queryName, responseType))
+        return Mono.fromSupplier(() -> new GenericStreamingQueryMessage<>(asMessage(query), queryName, responseType))
                    .flatMapMany(queryMessage -> queryBus.streamingQuery(processInterceptors(queryMessage)))
                    .map(Message::getPayload);
     }

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -466,6 +466,21 @@ class DefaultQueryGatewayTest {
         StepVerifier.create(testSubject.streamingQuery("query", String.class))
                 .expectErrorMatches(t->t instanceof IllegalStateException && t.getMessage().equals("test"))
                 .verify();
+    }
+
+    @Test
+    void dispatchStreamingQueryWithMetaData() {
+        when(mockBus.streamingQuery(any())).thenReturn(Flux.empty());
+
+        StreamingQueryMessage<String, String> testQuery =
+                new GenericStreamingQueryMessage<>("Query", String.class).andMetaData(MetaData.with("key", "value"));
+
+        StepVerifier.create(testSubject.streamingQuery(testQuery, String.class))
+                    .verifyComplete();
+
+        verify(mockBus).streamingQuery(argThat(
+                streamingQuery -> "value".equals(streamingQuery.getMetaData().get("key"))
+        ));
     }
 
     @SuppressWarnings({"unused", "SameParameterValue"})


### PR DESCRIPTION
The streaming query operation on the `QueryGateway` did not take into account that you may want to provide a `Message` instead of an `Object`.
The specific use case is to be able to provide custom `MetaData` for specific gateway operations.
As we support this throughout the other gateways, it's only feasible that `QueryGateway#streamingQuery` supports it too.