### PR TITLE
Log when `HandlerExecutionException#details` are missing and on `AbstractRepository` failures

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,11 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.SerializedMessage;
 import org.axonframework.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.axonframework.common.ObjectUtils.getOrDefault;
@@ -52,6 +56,8 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @since 4.0
  */
 public class CommandSerializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final AxonServerConfiguration configuration;
     private final Serializer messageSerializer;
@@ -127,8 +133,14 @@ public class CommandSerializer {
             Throwable throwable = commandResultMessage.exceptionResult();
             responseBuilder.setErrorCode(ErrorCode.getCommandExecutionErrorCode(throwable).errorCode());
             responseBuilder.setErrorMessage(ExceptionSerializer.serialize(configuration.getClientId(), throwable));
-            commandResultMessage.exceptionDetails()
-                                .ifPresent(details -> responseBuilder.setPayload(objectSerializer.apply(details)));
+            Optional<Object> optionalDetails = commandResultMessage.exceptionDetails();
+            if (optionalDetails.isPresent()) {
+                optionalDetails.map(details -> responseBuilder.setPayload(objectSerializer.apply(details)));
+            } else {
+                logger.warn("Serializing exception [{}] without details.", throwable.getClass(), throwable);
+                logger.info("To share exceptional information with the recipient it is recommended to wrap the "
+                                    + "exception in a CommandExecutionException with provided details.");
+            }
         } else if (commandResultMessage.getPayload() != null) {
             responseBuilder.setPayload(objectSerializer.apply(commandResultMessage.getPayload()));
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandSerializer.java
@@ -135,7 +135,7 @@ public class CommandSerializer {
             responseBuilder.setErrorMessage(ExceptionSerializer.serialize(configuration.getClientId(), throwable));
             Optional<Object> optionalDetails = commandResultMessage.exceptionDetails();
             if (optionalDetails.isPresent()) {
-                optionalDetails.map(details -> responseBuilder.setPayload(objectSerializer.apply(details)));
+                responseBuilder.setPayload(objectSerializer.apply(optionalDetails.get()));
             } else {
                 logger.warn("Serializing exception [{}] without details.", throwable.getClass(), throwable);
                 logger.info("To share exceptional information with the recipient it is recommended to wrap the "

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QuerySerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QuerySerializer.java
@@ -188,7 +188,7 @@ public class QuerySerializer {
             );
             Optional<Object> optionalDetails = queryResponse.exceptionDetails();
             if (optionalDetails.isPresent()) {
-                optionalDetails.map(details -> responseBuilder.setPayload(exceptionDetailsSerializer.apply(details)));
+                responseBuilder.setPayload(exceptionDetailsSerializer.apply(optionalDetails.get()));
             } else {
                 logger.warn("Serializing exception [{}] without details.", exceptionResult.getClass(), exceptionResult);
                 logger.info("To share exceptional information with the recipient it is recommended to wrap the "

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,12 @@ import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.axoniq.axonserver.grpc.query.QueryProviderOutbound.newBuilder;
 
@@ -54,6 +58,8 @@ import static io.axoniq.axonserver.grpc.query.QueryProviderOutbound.newBuilder;
  * @since 4.0
  */
 public class SubscriptionMessageSerializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final AxonServerConfiguration configuration;
     private final Serializer messageSerializer;
@@ -136,10 +142,16 @@ public class SubscriptionMessageSerializer {
             updateMessageBuilder.setErrorMessage(
                     ExceptionSerializer.serialize(configuration.getClientId(), exceptionResult)
             );
-            subscriptionQueryUpdateMessage.exceptionDetails()
-                                          .ifPresent(details -> updateMessageBuilder.setPayload(
-                                                  exceptionDetailsSerializer.apply(details)
-                                          ));
+            Optional<Object> optionalDetails = subscriptionQueryUpdateMessage.exceptionDetails();
+            if (optionalDetails.isPresent()) {
+                optionalDetails.map(
+                        details -> updateMessageBuilder.setPayload(exceptionDetailsSerializer.apply(details))
+                );
+            } else {
+                logger.warn("Serializing exception [{}] without details.", exceptionResult.getClass(), exceptionResult);
+                logger.info("To share exceptional information with the recipient it is recommended to wrap the "
+                                    + "exception in a QueryExecutionException with provided details.");
+            }
         } else {
             updateMessageBuilder.setPayload(payloadSerializer.apply(subscriptionQueryUpdateMessage));
         }
@@ -236,8 +248,14 @@ public class SubscriptionMessageSerializer {
             responseBuilder.setErrorMessage(
                     ExceptionSerializer.serialize(configuration.getClientId(), exceptionResult)
             );
-            initialResult.exceptionDetails()
-                         .ifPresent(details -> responseBuilder.setPayload(exceptionDetailsSerializer.apply(details)));
+            Optional<Object> optionalDetails = initialResult.exceptionDetails();
+            if (optionalDetails.isPresent()) {
+                optionalDetails.map(details -> responseBuilder.setPayload(exceptionDetailsSerializer.apply(details)));
+            } else {
+                logger.warn("Serializing exception [{}] without details.", exceptionResult.getClass(), exceptionResult);
+                logger.info("To share exceptional information with the recipient it is recommended to wrap the "
+                                    + "exception in a QueryExecutionException with provided details.");
+            }
         } else {
             responseBuilder.setPayload(payloadSerializer.apply(initialResult));
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
@@ -144,9 +144,7 @@ public class SubscriptionMessageSerializer {
             );
             Optional<Object> optionalDetails = subscriptionQueryUpdateMessage.exceptionDetails();
             if (optionalDetails.isPresent()) {
-                optionalDetails.map(
-                        details -> updateMessageBuilder.setPayload(exceptionDetailsSerializer.apply(details))
-                );
+                updateMessageBuilder.setPayload(exceptionDetailsSerializer.apply(optionalDetails.get()));
             } else {
                 logger.warn("Serializing exception [{}] without details.", exceptionResult.getClass(), exceptionResult);
                 logger.info("To share exceptional information with the recipient it is recommended to wrap the "
@@ -250,7 +248,7 @@ public class SubscriptionMessageSerializer {
             );
             Optional<Object> optionalDetails = initialResult.exceptionDetails();
             if (optionalDetails.isPresent()) {
-                optionalDetails.map(details -> responseBuilder.setPayload(exceptionDetailsSerializer.apply(details)));
+                responseBuilder.setPayload(exceptionDetailsSerializer.apply(optionalDetails.get()));
             } else {
                 logger.warn("Serializing exception [{}] without details.", exceptionResult.getClass(), exceptionResult);
                 logger.info("To share exceptional information with the recipient it is recommended to wrap the "

--- a/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AbstractRepository.java
@@ -34,7 +34,6 @@ import org.axonframework.tracing.SpanFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -106,7 +105,14 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
             }
         });
 
-        A aggregate = doCreateNew(factoryMethod);
+        A aggregate;
+        try {
+            aggregate = doCreateNew(factoryMethod);
+        } catch (Exception e) {
+            logger.warn("Exception occurred while trying to create an aggregate.", e);
+            throw e;
+        }
+
         initMethod.accept(aggregate);
         aggregateReference.set(aggregate);
         Assert.isTrue(aggregateModel.entityClass().isAssignableFrom(aggregate.rootType()),
@@ -135,20 +141,27 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
      */
     @Override
     public A load(@Nonnull String aggregateIdentifier, Long expectedVersion) {
-        return spanFactory
-                .createInternalSpan(() -> this.getClass().getSimpleName() + ".load " + aggregateIdentifier)
-                .runSupplier(() -> {
-                    UnitOfWork<?> uow = currentUnitOfWork();
-                    Map<String, A> aggregates = managedAggregates(uow);
-                    A aggregate = aggregates.computeIfAbsent(aggregateIdentifier,
-                                                             s -> doLoad(aggregateIdentifier,
-                                                                         expectedVersion));
-                    uow.onRollback(u -> aggregates.remove(aggregateIdentifier));
-                    validateOnLoad(aggregate, expectedVersion);
-                    prepareForCommit(aggregate);
+        return spanFactory.createInternalSpan(() -> this.getClass().getSimpleName() + ".load " + aggregateIdentifier)
+                          .runSupplier(() -> {
+                              UnitOfWork<?> uow = currentUnitOfWork();
+                              Map<String, A> aggregates = managedAggregates(uow);
+                              A aggregate = aggregates.computeIfAbsent(
+                                      aggregateIdentifier, s -> {
+                                          try {
+                                              return doLoad(aggregateIdentifier, expectedVersion);
+                                          } catch (Exception e) {
+                                              logger.warn("Exception occurred while trying to load a aggregate "
+                                                                  + "with identifier [{}].", aggregateIdentifier, e);
+                                              throw e;
+                                          }
+                                      }
+                              );
+                              uow.onRollback(u -> aggregates.remove(aggregateIdentifier));
+                              validateOnLoad(aggregate, expectedVersion);
+                              prepareForCommit(aggregate);
 
-                    return aggregate;
-                });
+                              return aggregate;
+                          });
     }
 
 
@@ -156,17 +169,23 @@ public abstract class AbstractRepository<T, A extends Aggregate<T>> implements R
     public Aggregate<T> loadOrCreate(@Nonnull String aggregateIdentifier, @Nonnull Callable<T> factoryMethod) {
         UnitOfWork<?> uow = currentUnitOfWork();
         Map<String, A> aggregates = managedAggregates(uow);
-        A aggregate = aggregates.computeIfAbsent(aggregateIdentifier,
-                                                 s -> {
-                                                     try {
-                                                         return doLoadOrCreate(aggregateIdentifier,
-                                                                               factoryMethod);
-                                                     } catch (RuntimeException e) {
-                                                         throw e;
-                                                     } catch (Exception e) {
-                                                         throw new RuntimeException(e);
-                                                     }
-                                                 });
+        A aggregate = aggregates.computeIfAbsent(
+                aggregateIdentifier,
+                s -> {
+                    try {
+                        return doLoadOrCreate(aggregateIdentifier,
+                                              factoryMethod);
+                    } catch (RuntimeException e) {
+                        logger.warn("Exception occurred while trying to load/create aggregate with identifier [{}].",
+                                    aggregateIdentifier, e);
+                        throw e;
+                    } catch (Exception e) {
+                        logger.warn("Exception occurred while trying to load/create aggregate with identifier [{}].",
+                                    aggregateIdentifier, e);
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
         uow.onRollback(u -> aggregates.remove(aggregateIdentifier));
         prepareForCommit(aggregate);
 


### PR DESCRIPTION
This pull request adds additional logging in conceptually two spots of the framework:

1. Whenever loading or creation fails on the Repository
2. Whenever an exception is serialized to be sent back to the dispatcher

For spot one, the `AbstractRepository` wraps the `doLoad`, `doCreateNew`, and `doLoadOrCreate` operations in a try-catch block.
This ensures that it is clearer to the user the `Repository` failed in loading/constructing an aggregate.

Scenario two is covered by adjusting the `CommandSerializer`, `QuerySerializer`, and `SubscriptionQuerySerializer` (these serializers are Axon Server specific).
These serializers will serialize `HandlerExecutionException` details if they are present.
It is these details that the user is suggested to fill to provide exception info (details) to the dispatcher of the message.
This is done as de-/serializing the full stack trace can lead to exceptions of its own, swallowing the failure on that level.

By logging whenever there are *no* details, we ensure the stack trace is kept visible on the handling side of the application.
If there are details present, we may assume the user has consciously delt with the exception already and provided their own details.
The later scenario thus does not require additional logging.