### PR TITLE
Add property to easily disable using Axon Server as event store.

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -238,7 +238,7 @@ public class AxonServerConfiguration {
     private EventProcessorConfiguration eventProcessorConfiguration = new EventProcessorConfiguration();
 
     /**
-     * Properties describing the settings for
+     * Properties describing the settings for the
      * {@link org.axonframework.axonserver.connector.event.axon.AxonServerEventStore EventStore}.
      */
     private EventStoreConfiguration eventStoreConfiguration = new EventStoreConfiguration();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -238,6 +238,12 @@ public class AxonServerConfiguration {
     private EventProcessorConfiguration eventProcessorConfiguration = new EventProcessorConfiguration();
 
     /**
+     * Properties describing the settings for
+     * {@link org.axonframework.axonserver.connector.event.axon.AxonServerEventStore EventStore}.
+     */
+    private EventStoreConfiguration eventStoreConfiguration = new EventStoreConfiguration();
+
+    /**
      * Instantiate a {@link Builder} to create an {@link AxonServerConfiguration}.
      *
      * @return a {@link Builder} to be able to create an {@link AxonServerConfiguration}.
@@ -564,6 +570,25 @@ public class AxonServerConfiguration {
     }
 
     /**
+     * Return the configured {@link EventStoreConfiguration} of this application for Axon Server.
+     *
+     * @return The configured {@link EventStoreConfiguration} of this application for Axon Server.
+     */
+    @ConfigurationProperties(prefix = "axon.axonserver.event-store")
+    public EventStoreConfiguration getEventStoreConfiguration() {
+        return eventStoreConfiguration;
+    }
+
+    /**
+     * Set the {@link EventStoreConfiguration} of this application for Axon Server
+     *
+     * @param eventStoreConfiguration The {@link EventStoreConfiguration} to set for this application.
+     */
+    public void setEventStoreConfiguration(EventStoreConfiguration eventStoreConfiguration) {
+        this.eventStoreConfiguration = eventStoreConfiguration;
+    }
+
+    /**
      * Configuration class for Flow Control of specific message types.
      *
      * @author Gerlo Hesselink
@@ -769,6 +794,25 @@ public class AxonServerConfiguration {
             public void setAutomaticBalancing(boolean automaticBalancing) {
                 this.automaticBalancing = automaticBalancing;
             }
+        }
+    }
+
+    public static class EventStoreConfiguration {
+
+        /**
+         * Whether (automatic) configuration of the AxonServer Event Store is enabled. When {@code false}, the event
+         * store will not be implicitly be configured. Defaults to {@code true}.
+         * <p>
+         * Note that this setting will only affect automatic configuration by Application Containers (such as Spring).
+         */
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,6 +153,7 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
     public EventScheduler eventScheduler(@Qualifier("eventSerializer") Serializer eventSerializer,
                                          AxonServerConnectionManager connectionManager) {
         return AxonServerEventScheduler.builder()

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,7 @@ public class AxonServerBusAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
     public EventStore eventStore(AxonServerConfiguration axonServerConfiguration,
                                  org.axonframework.config.Configuration configuration,
                                  AxonServerConnectionManager axonServerConnectionManager,

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -134,6 +134,20 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
+    void axonServerDefaultConfiguration_AxonServerEventStoreDisabled() {
+        testContext.withPropertyValues("axon.axonserver.event-store.enabled=false")
+                   .run(context -> {
+                       QueryBus queryBus = context.getBean(QueryBus.class);
+                       assertThat(queryBus).isNotNull();
+                       assertThat(queryBus).isInstanceOf(AxonServerQueryBus.class);
+                       assertThat(context).getBean("axonServerCommandBus")
+                                          .isExactlyInstanceOf(AxonServerCommandBus.class);
+                       assertThat(context).doesNotHaveBean("eventScheduler");
+                       assertThat(context).doesNotHaveBean("eventStore");
+                   });
+    }
+
+    @Test
     void axonServerUserDefinedCommandBusConfiguration() {
         testContext.withUserConfiguration(ExplicitUserCommandBusConfiguration.class)
                    .run(context -> {


### PR DESCRIPTION
With this `axon.axonserver.event-store.enabled=false` can be used to easily leverage Axon Server as command and query router, while not creating an `EventStore` or `EventScheduler` bean using Axon Server.