### PR TITLE
Fix property-based Load Balancing Strategy configuration bug

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -755,7 +755,8 @@ public class AxonServerConfiguration {
              *
              * @return Whether automatic load balancing is configured, yes or no.
              */
-            public boolean shouldAutomaticallyBalance() {
+            // The method name is 'awkward' as otherwise property files cannot resolve the field.
+            public boolean isAutomaticBalancing() {
                 return automaticBalancing;
             }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -235,7 +235,7 @@ public class AxonServerConfiguration {
     /**
      * Properties describing the settings for {@link org.axonframework.eventhandling.EventProcessor EventProcessors}.
      */
-    private EventProcessorConfiguration eventProcessorConfiguration = new EventProcessorConfiguration();
+    private Eventhandling eventHandling = new Eventhandling();
 
     /**
      * Instantiate a {@link Builder} to create an {@link AxonServerConfiguration}.
@@ -545,22 +545,21 @@ public class AxonServerConfiguration {
     }
 
     /**
-     * Return the configured {@link EventProcessorConfiguration} of this application for Axon Server.
+     * Return the configured {@link Eventhandling} of this application for Axon Server.
      *
-     * @return The configured {@link EventProcessorConfiguration} of this application for Axon Server.
+     * @return The configured {@link Eventhandling} of this application for Axon Server.
      */
-    @ConfigurationProperties(prefix = "axon.axonserver.eventhandling")
-    public EventProcessorConfiguration getEventProcessorConfiguration() {
-        return eventProcessorConfiguration;
+    public Eventhandling getEventhandling() {
+        return eventHandling;
     }
 
     /**
-     * Set the {@link EventProcessorConfiguration} of this application for Axon Server
+     * Set the {@link Eventhandling} of this application for Axon Server
      *
-     * @param eventProcessorConfiguration The {@link EventProcessorConfiguration} to set for this application.
+     * @param eventHandling The {@link Eventhandling} to set for this application.
      */
-    public void setEventProcessorConfiguration(EventProcessorConfiguration eventProcessorConfiguration) {
-        this.eventProcessorConfiguration = eventProcessorConfiguration;
+    public void setEventHandling(Eventhandling eventHandling) {
+        this.eventHandling = eventHandling;
     }
 
     /**
@@ -689,7 +688,7 @@ public class AxonServerConfiguration {
         }
     }
 
-    public static class EventProcessorConfiguration {
+    public static class Eventhandling {
 
         /**
          * The configuration of each of the processors. The key is the name of the processor, the value represents the

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -59,7 +59,7 @@ public class EventProcessorControlService implements Lifecycle {
     protected final AxonServerConnectionManager axonServerConnectionManager;
     protected final EventProcessingConfiguration eventProcessingConfiguration;
     protected final String context;
-    protected final Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorConfig;
+    protected final Map<String, AxonServerConfiguration.Eventhandling.ProcessorSettings> processorConfig;
 
     /**
      * Initialize a {@link EventProcessorControlService}.
@@ -84,7 +84,7 @@ public class EventProcessorControlService implements Lifecycle {
         this(axonServerConnectionManager,
              eventProcessingConfiguration,
              axonServerConfiguration.getContext(),
-             axonServerConfiguration.getEventProcessorConfiguration().getProcessors());
+             axonServerConfiguration.getEventhandling().getProcessors());
     }
 
     /**
@@ -132,7 +132,7 @@ public class EventProcessorControlService implements Lifecycle {
     public EventProcessorControlService(AxonServerConnectionManager axonServerConnectionManager,
                                         EventProcessingConfiguration eventProcessingConfiguration,
                                         String context,
-                                        Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorConfig) {
+                                        Map<String, AxonServerConfiguration.Eventhandling.ProcessorSettings> processorConfig) {
         this.axonServerConnectionManager = axonServerConnectionManager;
         this.eventProcessingConfiguration = eventProcessingConfiguration;
         this.context = context;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -201,7 +201,7 @@ public class EventProcessorControlService implements Lifecycle {
                             logger.warn("Requesting to load balance processor [{}] with strategy [{}] failed.",
                                         processorName, strategy, e);
                         });
-            if (processorConfig.get(processorName).shouldAutomaticallyBalance()) {
+            if (processorConfig.get(processorName).isAutomaticBalancing()) {
                 adminChannel.setAutoLoadBalanceStrategy(processorName, tokenStoreIdentifier, strategy)
                             .whenComplete((r, e) -> {
                                 if (e == null) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -49,7 +49,7 @@ class EventProcessorControlServiceTest {
 
     private AxonServerConnectionManager connectionManager;
     private EventProcessingConfiguration processingConfiguration;
-    private Map<String, AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings> processorSettings;
+    private Map<String, AxonServerConfiguration.Eventhandling.ProcessorSettings> processorSettings;
 
     private EventProcessorControlService testSubject;
     private AxonServerConnection connection;
@@ -114,8 +114,8 @@ class EventProcessorControlServiceTest {
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.of(TOKEN_STORE_IDENTIFIER));
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
 
-        AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
-                new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
+                new AxonServerConfiguration.Eventhandling.ProcessorSettings();
         testSetting.setLoadBalancingStrategy(LOAD_BALANCING_STRATEGY);
         processorSettings.put(THIS_PROCESSOR, testSetting);
         processorSettings.put(NON_EXISTING, testSetting);
@@ -147,8 +147,8 @@ class EventProcessorControlServiceTest {
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.of(TOKEN_STORE_IDENTIFIER));
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
 
-        AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
-                new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
+                new AxonServerConfiguration.Eventhandling.ProcessorSettings();
         testSetting.setLoadBalancingStrategy(LOAD_BALANCING_STRATEGY);
         testSetting.setAutomaticBalancing(true);
         processorSettings.put(THIS_PROCESSOR, testSetting);
@@ -187,8 +187,8 @@ class EventProcessorControlServiceTest {
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.empty());
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
 
-        AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings testSetting =
-                new AxonServerConfiguration.EventProcessorConfiguration.ProcessorSettings();
+        AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
+                new AxonServerConfiguration.Eventhandling.ProcessorSettings();
         testSetting.setLoadBalancingStrategy(LOAD_BALANCING_STRATEGY);
         processorSettings.put(THIS_PROCESSOR, testSetting);
         processorSettings.put(THAT_PROCESSOR, testSetting);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/LoadBalancingStrategyAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/LoadBalancingStrategyAutoConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot.autoconfig;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.springboot.utils.GrpcServerStub;
+import org.axonframework.springboot.utils.TcpUtils;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating whether Axon Server's load balancing properties are set as expected.
+ *
+ * @author Steven van Beelen
+ */
+class LoadBalancingStrategyAutoConfigurationTest {
+
+    private ApplicationContextRunner testContext;
+
+    @BeforeEach
+    void setUp() {
+        testContext = new ApplicationContextRunner();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("axon.axonserver.servers", GrpcServerStub.DEFAULT_HOST + ":" + TcpUtils.findFreePort());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("axon.axonserver.servers");
+    }
+
+    @Test
+    void loadBalancingStrategyIsTakenIntoAccount() {
+        testContext.withUserConfiguration(TestContext.class)
+                   .withPropertyValues(
+                           "axon.axonserver.eventhandling.processors.my-processor.load-balancing-strategy=PER_THREAD",
+                           "axon.axonserver.eventhandling.processors.my-processor.automatic-balancing=true"
+                   )
+                   .run(context -> {
+                       AxonServerConfiguration serverConfig = context.getBean(AxonServerConfiguration.class);
+                       assertNotNull(serverConfig);
+
+                       Map<String, AxonServerConfiguration.Eventhandling.ProcessorSettings> processors =
+                               serverConfig.getEventhandling().getProcessors();
+                       assertFalse(processors.isEmpty());
+                       assertTrue(processors.containsKey("my-processor"));
+
+                       AxonServerConfiguration.Eventhandling.ProcessorSettings processorSettings =
+                               processors.get("my-processor");
+                       assertTrue(processorSettings.isAutomaticBalancing());
+                       assertEquals("PER_THREAD", processorSettings.getLoadBalancingStrategy());
+                   });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    private static class TestContext {
+
+        @Bean(initMethod = "start", destroyMethod = "shutdown")
+        public GrpcServerStub grpcServerStub(@Value("${axon.axonserver.servers}") String servers) {
+            return new GrpcServerStub(Integer.parseInt(servers.split(":")[1]));
+        }
+    }
+}


### PR DESCRIPTION
Although Spring resolved the name for the load balancing properties based on the `@ConfigurationProperties` annotation on the getter of the `AxonServerConfiguration.EventHandlingConfiguration`, it was unable to set the properties in this format. 
I assume this has to do with the discrepancy between the defined property and the field and its getter/setter.

To keep the property path name that's already propagated throughout our user base, I've opted to rename the `AxonServerConfigurationEventProcessorConfiguration` to `AxonServerConfiguration`Eventhandling`.
By doing so, we align with the path `"axon.axonserver.eventhandling"`. 

Although we should strictly regard this as a breaking change, I think the chances are minimal somebody interacts with the object, i.o. through a property file.

Next to this, I have renamed the method returning the field `automaticBalancing` from `shouldAutomaticallyBalance` to `isAutomaticBalancing`.
Although this time, the IDE did resolve the `axon.axonserver.eventhandling.processors.[processor-name].automatic-balancing` property, it did complain that it could not resolve it.
After adjusting the getter to align with the property name, the IDE no longer complained.

Similarly, as with the class rename, we should regard this as a breaking change.
But, again, similarly, I do not anticipate users to interact directly with this operation and instead use the property files.