### PR TITLE
Implement StreamingEventProcessor.claimSegment

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
@@ -79,6 +79,26 @@ public interface StreamingEventProcessor extends EventProcessor {
     void releaseSegment(int segmentId, long releaseDuration, TimeUnit unit);
 
     /**
+     * Instructs the processor to claim the segment with given {@code segmentId} and start processing it as soon as
+     * possible.
+     * <p>
+     * The given {@code segmentId} must not be currently processed by a different processor instance, as that will
+     * have an active claim on the token. Claiming a segment that is already being processed will have no effect
+     * and return {@code true}.
+     * <p>
+     * A {@code true} return value indicates that the segment has been claimed and will be processed by this processor.
+     * The {@link StreamingEventProcessor} may postpone start of work until after completion of this task, as long as
+     * the token has been claimed so work can be started. A return value of {@code false} indicates that the segment
+     * has not been claimed due to the token for that segment not being available.
+     *
+     * @param segmentId the identifier of the segment to claim and start processing
+     * @return a {@link CompletableFuture} providing the result of the claim operation
+     */
+    default CompletableFuture<Boolean> claimSegment(int segmentId) {
+        return CompletableFuture.completedFuture(false);
+    }
+
+    /**
      * Instruct the processor to split the segment with given {@code segmentId} into two segments, allowing an
      * additional process to start processing events from it.
      * <p>
@@ -90,22 +110,6 @@ public interface StreamingEventProcessor extends EventProcessor {
      * @return a {@link CompletableFuture} providing the result of the split operation
      */
     CompletableFuture<Boolean> splitSegment(int segmentId);
-
-    /**
-     * Instructs the processor to claim the segment with given {@code segmentId} and start processing it as soon as
-     * possible.
-     * <p>
-     * The given {@code segmentId} must not be currently processed by a different processor instance, as that will
-     * have an active claim on the token. Claiming a segment that is already being processed will have no effect
-     * and return {@code true}.
-     * <p>
-     * The {@link StreamingEventProcessor} may postpone start of work until after completion of this task, as long as
-     * the token has been claimed so work can be started.
-     *
-     * @param segmentId the identifier of the segment to claim and start processing
-     * @return a {@link CompletableFuture} providing the result of the claim operation
-     */
-    CompletableFuture<Boolean> claimSegment(int segmentId);
 
     /**
      * Instruct the processor to merge the segment with given {@code segmentId} back with the segment that it was

--- a/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
@@ -92,6 +92,22 @@ public interface StreamingEventProcessor extends EventProcessor {
     CompletableFuture<Boolean> splitSegment(int segmentId);
 
     /**
+     * Instructs the processor to claim the segment with given {@code segmentId} and start processing it as soon as
+     * possible.
+     * <p>
+     * The given {@code segmentId} must not be currently processed by a different processor instance, as that will
+     * have an active claim on the token. Claiming a segment that is already being processed will have no effect
+     * and return {@code true}.
+     * <p>
+     * The {@link StreamingEventProcessor} may postpone start of work until after completion of this task, as long as
+     * the token has been claimed so work can be started.
+     *
+     * @param segmentId the identifier of the segment to claim and start processing
+     * @return a {@link CompletableFuture} providing the result of the claim operation
+     */
+    CompletableFuture<Boolean> claimSegment(int segmentId);
+
+    /**
      * Instruct the processor to merge the segment with given {@code segmentId} back with the segment that it was
      * originally split from. The processor must be able to claim the other segment, in order to merge it. Therefore,
      * this other segment must not have any active claims in the {@link TokenStore}.

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -118,6 +118,8 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
     private final int maxThreadCount;
 
     private final ConcurrentMap<Integer, List<Instruction>> instructions = new ConcurrentHashMap<>();
+    private final List<Instruction> launcherInstructions = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean shouldRunLauncherImmediately = new AtomicBoolean(false);
     private final boolean storeTokenBeforeProcessing;
     private final int eventAvailabilityTimeout;
     private final EventTrackerStatusChangeListener trackerStatusChangeListener;
@@ -256,6 +258,18 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
 
         this.instructions.computeIfAbsent(segmentId, i -> new CopyOnWriteArrayList<>())
                          .add(new SplitSegmentInstruction(result, segmentId));
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> claimSegment(int segmentId) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        if (this.activeSegments.containsKey(segmentId)) {
+            return CompletableFuture.completedFuture(true);
+        }
+
+        shouldRunLauncherImmediately.set(true);
+        this.launcherInstructions.add(new ClaimSegmentInstruction(result, segmentId));
         return result;
     }
 
@@ -612,6 +626,14 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
         releaseSegment(segmentId, tokenClaimInterval * 2, MILLISECONDS);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method will put the segment on a non-claim map. During the next iteration of the {@link #processingLoop(Segment)}
+     * the segments will be unclaimed and the worker stopped if it is found to be in this map. This means it can take
+     * up to the batch processing time, or up to the {@link #eventAvailabilityTimeout} if there are no events in the stream
+     * for the segment to be unclaimed.
+     */
     @Override
     public void releaseSegment(int segmentId, long releaseDuration, TimeUnit unit) {
         segmentReleaseDeadlines.put(segmentId, System.currentTimeMillis() + unit.toMillis(releaseDuration));
@@ -828,10 +850,27 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
      * @param millisToSleep The number of milliseconds to sleep
      */
     protected void doSleepFor(long millisToSleep) {
+        doSleepFor(millisToSleep, new AtomicBoolean(false));
+    }
+
+    /**
+     * Instructs the current Thread to sleep until the given deadline. This method may be overridden to check for flags
+     * that have been set to return earlier than the given deadline.
+     * <p>
+     * The default implementation will sleep in blocks of 100ms, intermittently checking for the processor's state. Once
+     * the processor stops running, this method will return immediately (after detecting the state change).
+     * <p>
+     * This method will also return when the given interruptFlag is set to {@code true}. This can facilitate immediately
+     * needed actions for the sleeping thread.
+     *
+     * @param millisToSleep The number of milliseconds to sleep
+     * @param interruptFlag A flag that is set when the thread should stop sleeping
+     */
+    protected void doSleepFor(long millisToSleep, AtomicBoolean interruptFlag) {
         long deadline = System.currentTimeMillis() + millisToSleep;
         try {
             long timeLeft;
-            while (getState().isRunning() && (timeLeft = deadline - System.currentTimeMillis()) > 0) {
+            while (getState().isRunning() &&  (timeLeft = deadline - System.currentTimeMillis()) > 0) {
                 Thread.sleep(Math.min(timeLeft, 100));
             }
         } catch (InterruptedException e) {
@@ -1205,6 +1244,13 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                 String processorName = TrackingEventProcessor.this.getName();
                 while (getState().isRunning()) {
                     List<Segment> segmentsToClaim;
+                    shouldRunLauncherImmediately.set(false);
+
+                    while (!launcherInstructions.isEmpty()) {
+                        Instruction instruction = launcherInstructions.get(0);
+                        launcherInstructions.remove(instruction);
+                        instruction.run();
+                    }
 
                     try {
                         int[] tokenStoreCurrentSegments = transactionManager.fetchInTransaction(
@@ -1234,7 +1280,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                                     processorName, e.getMessage(), waitTime
                             );
                         }
-                        doSleepFor(SECONDS.toMillis(waitTime));
+                        doSleepFor(SECONDS.toMillis(waitTime), shouldRunLauncherImmediately);
                         waitTime = Math.min(waitTime * 2, 60);
 
                         continue;
@@ -1311,7 +1357,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                             }
                         }
                     }
-                    doSleepFor(tokenClaimInterval);
+                    doSleepFor(tokenClaimInterval, shouldRunLauncherImmediately);
                 }
             } finally {
                 cleanUp();
@@ -1348,6 +1394,30 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                 workLauncherRunning.set(false);
             }
         }
+
+    }
+
+
+    private class ClaimSegmentInstruction extends Instruction {
+
+        private final int segmentId;
+
+        public ClaimSegmentInstruction(CompletableFuture<Boolean> result, int segmentId) {
+            super(result);
+            this.segmentId = segmentId;
+        }
+
+        @Override
+        protected boolean runSafe() {
+            logger.info("Processing claim instruction for segment [{}] in processor [{}]", segmentId, getName());
+            if (availableThreads.get() == 0) {
+                logger.info("Cannot claim segment [{}] in processor [{}] due to not enough threads being available", segmentId, getName());
+                return false;
+            }
+            segmentReleaseDeadlines.remove(segmentId);
+            tokenStore.fetchToken(getName(), segmentId);
+            return true;
+        }
     }
 
     private class SplitSegmentInstruction extends Instruction {
@@ -1369,6 +1439,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
             activeSegments.put(segmentId, newStatus[0]);
             // We don't invoke the trackerStatusChangeListener because the segment's size changes
             //  are not taken into account, which is the sole thing changing when doing a split.
+            shouldRunLauncherImmediately.set(true);
             return true;
         }
     }
@@ -1409,6 +1480,7 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                                         : new MergedTrackingToken(status.getInternalTrackingToken(), otherToken);
 
             tokenStore.storeToken(mergedToken, getName(), newSegment.getSegmentId());
+            shouldRunLauncherImmediately.set(true);
             return true;
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.pooled;
+
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.MergedTrackingToken;
+import org.axonframework.eventhandling.Segment;
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+/**
+ * A {@link CoordinatorTask} implementation dedicated to claiming a token so that the {@link Coordinator} can
+ * start a new {@link WorkPackage} in its next cycle.
+ * <p>
+ * It achieves this by removing the segment from the {@code releasesDeadlines} map which prevent the segment from
+ * being claimed if a previous release operation was done, and claiming the token in the store.
+ * Upon the next iteration of the {@link Coordinator}, it will see the segment is claimed and will start a new
+ * {@link WorkPackage} for it.
+ *
+ * @author Mitchell Herrijgers
+ * @see Coordinator
+ * @since 4.9.0
+ */
+class ClaimTask extends CoordinatorTask {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final String name;
+    private final int segmentId;
+    private final Map<Integer, WorkPackage> workPackages;
+    private final Map<Integer, Instant> releasesDeadlines;
+    private final TokenStore tokenStore;
+    private final TransactionManager transactionManager;
+
+    /**
+     * Constructs a {@link ClaimTask}.
+     *
+     * @param result             the {@link CompletableFuture} to {@link #complete(Boolean, Throwable)} once {@link
+     *                           #run()} has finalized
+     * @param name               the name of the {@link Coordinator} this instruction will be ran in. Used to correctly
+     *                           deal with the {@code tokenStore}
+     * @param segmentId          the identifier of the {@link Segment} this instruction should merge
+     * @param workPackages       the collection of {@link WorkPackage}s controlled by the {@link Coordinator}. Will be
+     *                           queried for the presence of the given {@code segmentId} and the segment to merge it
+     *                           with
+     * @param releasesDeadlines  the map of release deadlines for each segment
+     * @param tokenStore         the storage solution for {@link TrackingToken}s. Used to claim the {@code segmentId} if
+     *                           it is not present in the {@code workPackages}, to remove one of the segments and merge
+     *                           the merged token
+     * @param transactionManager a {@link TransactionManager} used to invoke all {@link TokenStore} operations inside a
+     */
+    ClaimTask(CompletableFuture<Boolean> result,
+              String name,
+              int segmentId,
+              Map<Integer, WorkPackage> workPackages,
+              Map<Integer, Instant> releasesDeadlines,
+              TokenStore tokenStore,
+              TransactionManager transactionManager) {
+        super(result, name);
+        this.name = name;
+        this.segmentId = segmentId;
+        this.workPackages = workPackages;
+        this.releasesDeadlines = releasesDeadlines;
+        this.transactionManager = transactionManager;
+        this.tokenStore = tokenStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Performs a {@link Segment} claim. Will succeed if the {@link TrackingToken} respective for that segment is
+     * claimable and has been successfully claimed.
+     */
+    @Override
+    protected CompletableFuture<Boolean> task() {
+        logger.debug("Processor [{}] will perform claim instruction for segment {}.", name, segmentId);
+
+        if (workPackages.containsKey(segmentId)) {
+            return CompletableFuture.completedFuture(true);
+        }
+        releasesDeadlines.remove(segmentId);
+        List<Segment> segments = transactionManager.fetchInTransaction(() -> tokenStore.fetchAvailableSegments(name));
+
+        Optional<Segment> segmentToClaim = segments.stream()
+                .filter(segment -> segment.getSegmentId() == segmentId)
+                .findFirst();
+        if (!segmentToClaim.isPresent()) {
+            logger.info("Processor [{}] cannot claim segment {}. It is not available.", name, segmentId);
+            return CompletableFuture.completedFuture(false);
+        }
+
+        try {
+            transactionManager.fetchInTransaction(() -> tokenStore.fetchToken(name, segmentId));
+        } catch (Exception e) {
+            logger.warn("Processor [{}] cannot claim segment {} due to an error.", name, segmentId, e);
+            return CompletableFuture.completedFuture(false);
+        }
+
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    String getDescription() {
+        return "Claim Task for segment " + segmentId;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
@@ -17,7 +17,6 @@
 package org.axonframework.eventhandling.pooled;
 
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.eventhandling.MergedTrackingToken;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
@@ -30,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
 
 /**
  * A {@link CoordinatorTask} implementation dedicated to claiming a token so that the {@link Coordinator} can

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/ClaimTask.java
@@ -63,7 +63,7 @@ class ClaimTask extends CoordinatorTask {
      *                           #run()} has finalized
      * @param name               the name of the {@link Coordinator} this instruction will be ran in. Used to correctly
      *                           deal with the {@code tokenStore}
-     * @param segmentId          the identifier of the {@link Segment} this instruction should merge
+     * @param segmentId          the identifier of the {@link Segment} this instruction should claim
      * @param workPackages       the collection of {@link WorkPackage}s controlled by the {@link Coordinator}. Will be
      *                           queried for the presence of the given {@code segmentId} and the segment to merge it
      *                           with
@@ -72,6 +72,7 @@ class ClaimTask extends CoordinatorTask {
      *                           it is not present in the {@code workPackages}, to remove one of the segments and merge
      *                           the merged token
      * @param transactionManager a {@link TransactionManager} used to invoke all {@link TokenStore} operations inside a
+     *                           transaction
      */
     ClaimTask(CompletableFuture<Boolean> result,
               String name,

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -262,6 +262,13 @@ class Coordinator {
         return result;
     }
 
+    public CompletableFuture<Boolean> claimSegment(int segmentId) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        coordinatorTasks.add(new ClaimTask(result, name, segmentId, workPackages, releasesDeadlines, tokenStore, transactionManager));
+        scheduleCoordinator();
+        return result;
+    }
+
     private boolean initializeTokenStore() {
         AtomicBoolean tokenStoreInitialized = new AtomicBoolean(false);
         transactionManager.executeInTransaction(() -> {

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -262,6 +262,19 @@ class Coordinator {
         return result;
     }
 
+    /**
+     * Instructs this coordinator to claim the segment for the given {@code segmentId}.
+     * <p>
+     * If this coordinator is already processing the segment, it will have a successful result. If the segment's token
+     * is currently taken by another processor instance, the result will be unsuccessful.
+     * <p>
+     * The token will immediately be claimed, but processing of the token will start after the invocation of this
+     * instruction has been completed successfully by scheduling the coordinator. This will see the claimed token
+     * and start a {@link WorkPackage} for it.
+     *
+     * @param segmentId the identifier of the segment to claim
+     * @return a {@link CompletableFuture} indicating whether the claim was executed successfully
+     */
     public CompletableFuture<Boolean> claimSegment(int segmentId) {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         coordinatorTasks.add(new ClaimTask(result, name, segmentId, workPackages, releasesDeadlines, tokenStore, transactionManager));

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -269,6 +269,11 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
     }
 
     @Override
+    public CompletableFuture<Boolean> claimSegment(int segmentId) {
+        return coordinator.claimSegment(segmentId);
+    }
+
+    @Override
     public CompletableFuture<Boolean> mergeSegment(int segmentId) {
         if (!tokenStore.requiresExplicitSegmentInitialization()) {
             CompletableFuture<Boolean> result = new CompletableFuture<>();

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -256,6 +256,11 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
     }
 
     @Override
+    public CompletableFuture<Boolean> claimSegment(int segmentId) {
+        return coordinator.claimSegment(segmentId);
+    }
+
+    @Override
     public CompletableFuture<Boolean> splitSegment(int segmentId) {
         if (!tokenStore.requiresExplicitSegmentInitialization()) {
             CompletableFuture<Boolean> result = new CompletableFuture<>();
@@ -266,11 +271,6 @@ public class PooledStreamingEventProcessor extends AbstractEventProcessor implem
         }
 
         return coordinator.splitSegment(segmentId);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> claimSegment(int segmentId) {
-        return coordinator.claimSegment(segmentId);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -816,6 +816,32 @@ class PooledStreamingEventProcessorTest {
     }
 
     @Test
+    void releaseAndClaimSegment() {
+        int testSegmentId = 0;
+        int testTokenClaimInterval = 5000;
+
+        setTestSubject(createTestSubject(builder -> builder.initialSegmentCount(2)
+                .tokenClaimInterval(testTokenClaimInterval)));
+        testSubject.start();
+        // Assert the single WorkPackage is in progress prior to invoking the merge.
+        assertWithin(
+                testTokenClaimInterval, TimeUnit.MILLISECONDS,
+                () -> assertNotNull(testSubject.processingStatus().get(testSegmentId))
+        );
+
+        // When...
+        testSubject.releaseSegment(testSegmentId, 180, TimeUnit.SECONDS);
+
+        // Assert the MergeTask is done and completed successfully.
+        assertWithin(testTokenClaimInterval, TimeUnit.MILLISECONDS, () -> assertEquals(1, testSubject.processingStatus().size()));
+
+        testSubject.claimSegment(testSegmentId);
+
+        // Assert the Coordinator has only one WorkPackage at work now.
+        assertWithin(testTokenClaimInterval, TimeUnit.MILLISECONDS, () -> assertEquals(2, testSubject.processingStatus().size()));
+    }
+
+    @Test
     void supportReset() {
         when(stubEventHandler.supportsReset()).thenReturn(true);
 


### PR DESCRIPTION
In order to provide smoother Event Processor operations in the Framework going forward, we have decided to implement a specific action that claims a token for a processor.

Previously, moving processing from one instance to another could only be done by releasing the segment on all instances but the desired, and awaiting the token claim interval of the desired instance. This led to a prolonged period of not processing of events, which is undesirable.

The action will be handled in the context of the processor and claim the token in the store. Then upon the next WorkerLauncher/Coordinator operation (which is queued at the same time) processing of it will start. This works both for the PSEP and the TEP.

Fixes #2803 