### PR TITLE
Introduce the `AxonServerEventStoreFactory`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.command.CommandLoadFactorProvider;
 import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
 import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfiguration;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
@@ -72,6 +73,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
             return new InMemoryTokenStore();
         });
         configurer.registerComponent(TargetContextResolver.class, configuration -> TargetContextResolver.noOp());
+        configurer.registerComponent(AxonServerEventStoreFactory.class, this::buildEventStoreFactory);
     }
 
     private AxonServerConnectionManager buildAxonServerConnectionManager(Configuration c) {
@@ -161,6 +163,23 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                  .targetContextResolver(c.getComponent(TargetContextResolver.class))
                                  .spanFactory(c.spanFactory())
                                  .build();
+    }
+
+    private AxonServerEventStoreFactory buildEventStoreFactory(Configuration config) {
+        return AxonServerEventStoreFactory.builder()
+                                          .configuration(config.getComponent(AxonServerConfiguration.class))
+                                          .connectionManager(
+                                                  config.getComponent(AxonServerConnectionManager.class)
+                                          )
+                                          .snapshotSerializer(config.serializer())
+                                          .eventSerializer(config.eventSerializer())
+                                          .snapshotFilter(config.snapshotFilter())
+                                          .upcasterChain(config.upcasterChain())
+                                          .messageMonitor(
+                                                  config.messageMonitor(AxonServerEventStore.class, "eventStore")
+                                          )
+                                          .spanFactory(config.spanFactory())
+                                          .build();
     }
 
     @Override

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -388,7 +388,7 @@ public class AxonServerEventStore extends AbstractEventStore {
         }
     }
 
-    private static class AxonIQEventStorageEngine extends AbstractEventStorageEngine {
+    static class AxonIQEventStorageEngine extends AbstractEventStorageEngine {
 
         private static final int ALLOW_SNAPSHOTS_MAGIC_VALUE = -42;
         private final String APPEND_EVENT_TRANSACTION = this + "/APPEND_EVENT_TRANSACTION";

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.event.axon;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
+import org.axonframework.monitoring.MessageMonitor;
+import org.axonframework.monitoring.NoOpMessageMonitor;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
+import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.tracing.NoOpSpanFactory;
+import org.axonframework.tracing.SpanFactory;
+
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+
+/**
+ * A factory towards {@link AxonServerEventStore AxonServerEventStores}.
+ * <p>
+ * Especially useful to open a store towards a context differing from the default context. For example, whenever the
+ * application is required to publish "milestone-"/"integration-events" in a common context.
+ *
+ * @author Steven van Beelen
+ * @since 4.9.0
+ */
+public class AxonServerEventStoreFactory {
+
+    private final AxonServerEventStore.Builder base;
+
+    /**
+     * Instantiate a {@link AxonServerEventStoreFactory} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@link AxonServerConfiguration}, {@link AxonServerConnectionManager}, and
+     * {@link SnapshotFilter} are set. If not, an {@link AxonConfigurationException} will be thrown.
+     *
+     * @param builder The {@link Builder} used to instantiate a {@link AxonServerEventStoreFactory} instance
+     */
+    protected AxonServerEventStoreFactory(Builder builder) {
+        builder.validate();
+        base = AxonServerEventStore.builder()
+                                   .configuration(builder.configuration)
+                                   .platformConnectionManager(builder.connectionManager)
+                                   .snapshotSerializer(builder.snapshotSerializer)
+                                   .eventSerializer(builder.eventSerializer)
+                                   .upcasterChain(builder.upcasterChain)
+                                   .snapshotFilter(builder.snapshotFilter)
+                                   .messageMonitor(builder.messageMonitor)
+                                   .spanFactory(builder.spanFactory);
+    }
+
+    /**
+     * Instantiate a builder to construct an {@link AxonServerEventStoreFactory}.
+     * <p>
+     * The following fields have sensible defaults:
+     * <ul>
+     *     <li>The {@link Builder#snapshotSerializer(Serializer) snapshot serializer} defaults to a {@link XStreamSerializer}</li>
+     *     <li>The {@link Builder#eventSerializer(Serializer) event serializer} defaults to a {@link XStreamSerializer}</li>
+     *     <li>The {@link Builder#upcasterChain(EventUpcaster) upcaster chain} defaults to a {@link NoOpEventUpcaster}</li>
+     *     <li>The {@link Builder#messageMonitor(MessageMonitor) message monitor} defaults to a {@link NoOpMessageMonitor}</li>
+     *     <li>The {@link Builder#spanFactory(SpanFactory) span factory} defaults to a {@link NoOpSpanFactory}</li>
+     * </ul>
+     * The {@link AxonServerConfiguration}, {@link AxonServerConnectionManager}, and {@link SnapshotFilter} are <b>hard
+     * requirements</b> and as such should be provided.
+     *
+     * @return A builder to construct an {@link AxonServerEventStoreFactory}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs an {@link AxonServerEventStore} connected to the given {@code context}.
+     * <p>
+     * The other required fields for an {@code AxonServerEventStore} are based on the components configured in this
+     * factory
+     *
+     * @param context The context to construct an {@link AxonServerEventStore} for.
+     * @return A new {@link AxonServerEventStore} connected to the given {@code context}.
+     */
+    public AxonServerEventStore constructFor(@Nonnull String context) {
+        return base.defaultContext(context).build();
+    }
+
+    /**
+     * Constructs an {@link AxonServerEventStore} connected to the given {@code context} with customization based on the
+     * given {@code configuration}.
+     * <p>
+     * The other required fields for an {@code AxonServerEventStore} are based on the components configured in this
+     * factory
+     *
+     * @param context       The context to construct an {@link AxonServerEventStore} for.
+     * @param configuration The customization for the store under construction, deviating from the components set in the
+     *                      {@link AxonServerEventStoreFactory.Builder}.
+     * @return A new {@link AxonServerEventStore} connected to the given {@code context}.
+     */
+    public AxonServerEventStore constructFor(@Nonnull String context,
+                                             @Nonnull AxonServerEventStoreConfiguration configuration) {
+        return configuration.apply(base.defaultContext(context)).build();
+    }
+
+    /**
+     * Builder class to instantiate an {@link AxonServerEventStoreFactory}.
+     * <p>
+     * The following fields have sensible defaults:
+     * <ul>
+     *     <li>The {@link Builder#snapshotSerializer(Serializer) snapshot serializer} defaults to a {@link XStreamSerializer}.</li>
+     *     <li>The {@link Builder#eventSerializer(Serializer) event serializer} defaults to a {@link XStreamSerializer}.</li>
+     *     <li>The {@link Builder#upcasterChain(EventUpcaster) upcaster chain} defaults to a {@link NoOpEventUpcaster}.</li>
+     *     <li>The {@link Builder#messageMonitor(MessageMonitor) message monitor} defaults to a {@link NoOpMessageMonitor}.</li>
+     *     <li>The {@link Builder#spanFactory(SpanFactory) span factory} defaults to a {@link NoOpSpanFactory}.</li>
+     * </ul>
+     * The {@link AxonServerConfiguration}, {@link AxonServerConnectionManager}, and {@link SnapshotFilter} are <b>hard
+     * requirements</b> and as such should be provided.
+     */
+    public static class Builder {
+
+        private AxonServerConfiguration configuration;
+        private AxonServerConnectionManager connectionManager;
+        private Serializer snapshotSerializer;
+        private Serializer eventSerializer;
+        private EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
+        private SnapshotFilter snapshotFilter;
+        private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.INSTANCE;
+        private SpanFactory spanFactory = NoOpSpanFactory.INSTANCE;
+
+        /**
+         * Sets the {@link AxonServerConfiguration} describing the servers to connect with and how to manage flow
+         * control.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param configuration The {@link AxonServerConfiguration} describing the servers to connect with and how to
+         *                      manage flow control.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder configuration(@Nonnull AxonServerConfiguration configuration) {
+            assertNonNull(configuration, "The AxonServerConfiguration may not be null");
+            this.configuration = configuration;
+            return this;
+        }
+
+        /**
+         * Sets the {@link AxonServerConnectionManager} managing the connections to Axon Server.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param connectionManager The {@link AxonServerConnectionManager} managing the connections to Axon Server.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder connectionManager(@Nonnull AxonServerConnectionManager connectionManager) {
+            assertNonNull(connectionManager, "The AxonServerConnectionManager may not be null");
+            this.connectionManager = connectionManager;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} used to serialize and deserialize snapshots.
+         * <p>
+         * Defaults to a {@link XStreamSerializer}.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param snapshotSerializer The {@link Serializer} used to de-/serialize snapshot events.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder snapshotSerializer(@Nonnull Serializer snapshotSerializer) {
+            assertNonNull(snapshotSerializer, "The Snapshot Serializer may not be null");
+            this.snapshotSerializer = snapshotSerializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} used to de-/serialize the {@link EventMessage#getPayload() event payload} and
+         * {@link EventMessage#getMetaData() meta data} with.
+         * <p>
+         * Defaults to a {@link XStreamSerializer}.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param eventSerializer The serializer to de-/serialize the {@link EventMessage#getPayload() event payload}
+         *                        and {@link EventMessage#getMetaData() meta data} with.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder eventSerializer(@Nonnull Serializer eventSerializer) {
+            assertNonNull(eventSerializer, "The Event Serializer may not be null");
+            this.eventSerializer = eventSerializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link SnapshotFilter} used to filter snapshots when returning aggregate events.
+         * <p>
+         * When not set all snapshots are used. Note that {@link SnapshotFilter} instances can be combined and should
+         * return {@code true} if they handle a snapshot they wish to ignore.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param snapshotFilter The {@link SnapshotFilter} used to filter snapshots when returning aggregate events.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder snapshotFilter(@Nonnull SnapshotFilter snapshotFilter) {
+            assertNonNull(snapshotFilter, "The Snapshot filter may not be null");
+            this.snapshotFilter = snapshotFilter;
+            return this;
+        }
+
+        /**
+         * Sets the {@link EventUpcaster upcaster ch ain} used to deserialize events of older revisions.
+         * <p>
+         * Defaults to a {@link NoOpEventUpcaster}.
+         * <p>
+         * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link EventStorageEngine}
+         * implementation.
+         *
+         * @param upcasterChain An {@link EventUpcaster} used to deserialize events of older revisions.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder upcasterChain(@Nonnull EventUpcaster upcasterChain) {
+            assertNonNull(upcasterChain, "EventUpcaster may not be null");
+            this.upcasterChain = upcasterChain;
+            return this;
+        }
+
+        /**
+         * Sets the {@link MessageMonitor} to monitor ingested {@link EventMessage EventMessages}.
+         * <p>
+         * Defaults to a {@link NoOpMessageMonitor}.
+         *
+         * @param messageMonitor A {@link MessageMonitor} to monitor ingested {@link EventMessage EventMessages}.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder messageMonitor(@Nonnull MessageMonitor<? super EventMessage<?>> messageMonitor) {
+            assertNonNull(messageMonitor, "MessageMonitor may not be null");
+            this.messageMonitor = messageMonitor;
+            return this;
+        }
+
+        /**
+         * Sets the {@link SpanFactory} implementation used for providing tracing capabilities.
+         * <p>
+         * Defaults to a {@link NoOpSpanFactory}, which provides no tracing capabilities.
+         *
+         * @param spanFactory The {@link SpanFactory} implementation used for providing tracing capabilities.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            assertNonNull(spanFactory, "SpanFactory may not be null");
+            this.spanFactory = spanFactory;
+            return this;
+        }
+
+        /**
+         * Initializes an {@link AxonServerEventStoreFactory} as specified through this builder.
+         *
+         * @return an {@link AxonServerEventStoreFactory} as specified through this builder.
+         */
+        public AxonServerEventStoreFactory build() {
+            return new AxonServerEventStoreFactory(this);
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException If one field is asserted to be incorrect according to the builder's
+         *                                    specifications.
+         */
+        protected void validate() {
+            assertNonNull(configuration,
+                          "The AxonServerConfiguration is a hard requirement and should be provided");
+            assertNonNull(connectionManager,
+                          "The AxonServerConnectionManager is a hard requirement and should be provided");
+            assertNonNull(snapshotFilter, "The SnapshotFilter is a hard requirement and should be provided");
+        }
+    }
+
+    /**
+     * Contract defining {@link AxonServerEventStore.Builder} based configuration when constructing an
+     * {@link AxonServerEventStore}.
+     */
+    @FunctionalInterface
+    public interface AxonServerEventStoreConfiguration extends
+            Function<AxonServerEventStore.Builder, AxonServerEventStore.Builder> {
+
+        /**
+         * Returns a configuration that applies the given {@code other} configuration after applying {@code this}.
+         * <p>
+         * Any configuration set by the {@code other} will override changes by {@code this} instance.
+         *
+         * @param other The configuration to apply after applying this.
+         * @return A configuration that applies both this and then the other configuration.
+         */
+        default AxonServerEventStoreConfiguration andThen(AxonServerEventStoreConfiguration other) {
+            return builder -> other.apply(this.apply(builder));
+        }
+
+        /**
+         * A {@link AxonServerEventStoreConfiguration} which does not add any configuration.
+         *
+         * @return A {@link AxonServerEventStoreConfiguration} which does not add any configuration.
+         */
+        static AxonServerEventStoreConfiguration noOp() {
+            return builder -> builder;
+        }
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.axonserver.connector;
 import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.command.CommandLoadFactorProvider;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
 import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfiguration;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
@@ -60,6 +61,7 @@ class ServerConnectorConfigurerModuleTest {
         assertTrue(testSubject.eventStore() instanceof AxonServerEventStore);
         assertTrue(testSubject.commandBus() instanceof AxonServerCommandBus);
         assertTrue(testSubject.queryBus() instanceof AxonServerQueryBus);
+        assertNotNull(testSubject.getComponent(AxonServerEventStoreFactory.class));
 
         //noinspection unchecked
         TargetContextResolver<Message<?>> resultTargetContextResolver =

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactoryTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactoryTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.event.axon;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.AbstractEventBus;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.AbstractEventStore;
+import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
+import org.axonframework.monitoring.MessageMonitor;
+import org.axonframework.monitoring.NoOpMessageMonitor;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.TestSerializer;
+import org.axonframework.serialization.upcasting.event.EventUpcaster;
+import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
+import org.axonframework.tracing.NoOpSpanFactory;
+import org.axonframework.tracing.SpanFactory;
+import org.junit.jupiter.api.*;
+
+import static org.axonframework.common.ReflectionUtils.getFieldValue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link AxonServerEventStoreFactory}.
+ *
+ * @author Steven van Beelen
+ */
+class AxonServerEventStoreFactoryTest {
+
+    private static final String TEST_CONTEXT = "my-context";
+
+    private AxonServerConfiguration configuration;
+    private AxonServerConnectionManager connectionManager;
+    private Serializer snapshotSerializer;
+    private Serializer eventSerializer;
+    private SnapshotFilter snapshotFilter;
+    private EventUpcaster upcasterChain;
+    private MessageMonitor<? super EventMessage<?>> messageMonitor;
+    private SpanFactory spanFactory;
+
+    private AxonServerEventStoreFactory testSubject;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new AxonServerConfiguration();
+        connectionManager = AxonServerConnectionManager.builder()
+                                                       .axonServerConfiguration(configuration)
+                                                       .build();
+        snapshotSerializer = TestSerializer.XSTREAM.getSerializer();
+        eventSerializer = TestSerializer.JACKSON.getSerializer();
+        snapshotFilter = SnapshotFilter.allowAll();
+        upcasterChain = new EventUpcasterChain();
+        messageMonitor = NoOpMessageMonitor.INSTANCE;
+        spanFactory = NoOpSpanFactory.INSTANCE;
+
+        testSubject = AxonServerEventStoreFactory.builder()
+                                                 .configuration(configuration)
+                                                 .connectionManager(connectionManager)
+                                                 .snapshotSerializer(snapshotSerializer)
+                                                 .eventSerializer(eventSerializer)
+                                                 .snapshotFilter(snapshotFilter)
+                                                 .upcasterChain(upcasterChain)
+                                                 .messageMonitor(messageMonitor)
+                                                 .spanFactory(spanFactory)
+                                                 .build();
+    }
+
+    @Test
+    void constructForContextUsesFactoryComponents() throws NoSuchFieldException {
+        AxonServerEventStore result = testSubject.constructFor(TEST_CONTEXT);
+
+        AxonServerEventStore.AxonIQEventStorageEngine storageEngine =
+                getFieldValue(AbstractEventStore.class.getDeclaredField("storageEngine"), result);
+
+        String resultContext = getFieldValue(
+                AxonServerEventStore.AxonIQEventStorageEngine.class.getDeclaredField("context"), storageEngine
+        );
+        assertEquals(TEST_CONTEXT, resultContext);
+        AxonServerConfiguration resultConfiguration = getFieldValue(
+                AxonServerEventStore.AxonIQEventStorageEngine.class.getDeclaredField("configuration"), storageEngine
+        );
+        assertEquals(configuration, resultConfiguration);
+        AxonServerConnectionManager resultConnectionManager = getFieldValue(
+                AxonServerEventStore.AxonIQEventStorageEngine.class.getDeclaredField("connectionManager"), storageEngine
+        );
+        assertEquals(connectionManager, resultConnectionManager);
+
+        Serializer resultSnapshotSerializer =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("snapshotSerializer"), storageEngine);
+        assertEquals(snapshotSerializer, resultSnapshotSerializer);
+        Serializer resultEventSerializer =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("eventSerializer"), storageEngine);
+        assertEquals(eventSerializer, resultEventSerializer);
+        EventUpcaster resultUpcasterChain =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("upcasterChain"), storageEngine);
+        assertEquals(upcasterChain, resultUpcasterChain);
+        SnapshotFilter resultSnapshotFilter =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("snapshotFilter"), storageEngine);
+        assertEquals(snapshotFilter, resultSnapshotFilter);
+
+        MessageMonitor<? super EventMessage<?>> resultMessageMonitor =
+                getFieldValue(AbstractEventBus.class.getDeclaredField("messageMonitor"), result);
+        assertEquals(messageMonitor, resultMessageMonitor);
+        SpanFactory resultSpanFactory = getFieldValue(AbstractEventBus.class.getDeclaredField("spanFactory"), result);
+        assertEquals(spanFactory, resultSpanFactory);
+    }
+
+    @Test
+    void constructForContextUsesCustomizations() throws NoSuchFieldException {
+        Serializer expectedSerializer = mock(Serializer.class);
+        AxonServerEventStoreFactory.AxonServerEventStoreConfiguration customization =
+                builder -> builder.snapshotSerializer(expectedSerializer).eventSerializer(expectedSerializer);
+
+        AxonServerEventStore result = testSubject.constructFor(TEST_CONTEXT, customization);
+
+        AxonServerEventStore.AxonIQEventStorageEngine storageEngine =
+                getFieldValue(AbstractEventStore.class.getDeclaredField("storageEngine"), result);
+
+        String resultContext = getFieldValue(
+                AxonServerEventStore.AxonIQEventStorageEngine.class.getDeclaredField("context"), storageEngine
+        );
+        assertEquals(TEST_CONTEXT, resultContext);
+        Serializer resultSnapshotSerializer =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("snapshotSerializer"), storageEngine);
+        assertEquals(expectedSerializer, resultSnapshotSerializer);
+        Serializer resultEventSerializer =
+                getFieldValue(AbstractEventStorageEngine.class.getDeclaredField("eventSerializer"), storageEngine);
+        assertEquals(expectedSerializer, resultEventSerializer);
+    }
+
+    @Test
+    void buildWithoutAxonServerConfigurationThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject =
+                AxonServerEventStoreFactory.builder()
+                                           .connectionManager(connectionManager)
+                                           .snapshotSerializer(snapshotSerializer)
+                                           .eventSerializer(eventSerializer);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void buildWithoutAxonServerConnectionManagerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject =
+                AxonServerEventStoreFactory.builder()
+                                           .configuration(configuration)
+                                           .snapshotSerializer(snapshotSerializer)
+                                           .eventSerializer(eventSerializer);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void buildWithoutSnapshotSerializerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject =
+                AxonServerEventStoreFactory.builder()
+                                           .configuration(configuration)
+                                           .connectionManager(connectionManager)
+                                           .eventSerializer(eventSerializer);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void buildWithoutEventSerializerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject =
+                AxonServerEventStoreFactory.builder()
+                                           .configuration(configuration)
+                                           .connectionManager(connectionManager)
+                                           .snapshotSerializer(snapshotSerializer);
+
+        assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void buildWithNullAxonServerConfigurationThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.configuration(null));
+    }
+
+    @Test
+    void buildWithNullAxonServerConnectionManagerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.connectionManager(null));
+    }
+
+    @Test
+    void buildWithNullSnapshotSerializerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.snapshotSerializer(null));
+    }
+
+    @Test
+    void buildWithNullEventSerializerThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.eventSerializer(null));
+    }
+
+    @Test
+    void buildWithNullSnapshotFilterThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.snapshotFilter(null));
+    }
+
+    @Test
+    void buildWithNullUpcasterChainThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.upcasterChain(null));
+    }
+
+    @Test
+    void buildWithNullMessageMonitorThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.messageMonitor(null));
+    }
+
+    @Test
+    void buildWithNullSpanFactoryThrowsAxonConfigurationException() {
+        AxonServerEventStoreFactory.Builder builderTestSubject = AxonServerEventStoreFactory.builder();
+
+        //noinspection DataFlowIssue
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.spanFactory(null));
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.command.CommandLoadFactorProvider;
 import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
 import org.axonframework.commandhandling.CommandBus;
@@ -144,6 +145,28 @@ public class AxonServerBusAutoConfiguration {
                                    .upcasterChain(configuration.upcasterChain())
                                    .spanFactory(configuration.spanFactory())
                                    .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
+    public AxonServerEventStoreFactory axonServerEventStoreFactory(AxonServerConfiguration axonServerConfig,
+                                                                   AxonServerConnectionManager axonServerConnectionManager,
+                                                                   Serializer snapshotSerializer,
+                                                                   @Qualifier("eventSerializer") Serializer eventSerializer,
+                                                                   org.axonframework.config.Configuration config) {
+        return AxonServerEventStoreFactory.builder()
+                                          .configuration(axonServerConfig)
+                                          .connectionManager(axonServerConnectionManager)
+                                          .snapshotSerializer(snapshotSerializer)
+                                          .eventSerializer(eventSerializer)
+                                          .snapshotFilter(config.snapshotFilter())
+                                          .upcasterChain(config.upcasterChain())
+                                          .messageMonitor(
+                                                  config.messageMonitor(AxonServerEventStore.class, "eventStore")
+                                          )
+                                          .spanFactory(config.spanFactory())
+                                          .build();
     }
 }
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithMetricsWithoutConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.axonframework.springboot;
 
 import com.codahale.metrics.MetricRegistry;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.MessageMonitorFactory;
 import org.axonframework.eventhandling.EventBus;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.*;
 })
 @TestPropertySource("classpath:test.metrics.application.properties")
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
+class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -92,12 +93,14 @@ public class AxonAutoConfigurationWithMetricsWithoutConfigurerTest {
     }
 
     @Test
-    void axonServerEventStoreRequestedMonitor() {
+    void axonServerEventStoreAndFactoryRequestMonitor() {
         assertNotNull(applicationContext.getBean(AxonServerEventStore.class));
+        assertNotNull(applicationContext.getBean(AxonServerEventStoreFactory.class));
 
-        MessageMonitorFactory monitor = applicationContext.getBean("mockMessageMonitorFactory", MessageMonitorFactory.class);
+        MessageMonitorFactory monitor =
+                applicationContext.getBean("mockMessageMonitorFactory", MessageMonitorFactory.class);
 
-        verify(monitor, description("expected MessageMonitorFactory to be retrieved for AxonServerEventStore"))
+        verify(monitor, times(2).description("expected MessageMonitorFactory to be retrieved for AxonServerEventStore"))
                 .create(any(), eq(AxonServerEventStore.class), anyString());
     }
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
 import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventScheduler;
+import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
@@ -235,6 +236,19 @@ class AxonServerAutoConfigurationTest {
                        assertThat(context).getBean(ManagedChannelCustomizer.class)
                                           .isEqualTo(CUSTOM_MANAGED_CHANNEL_CUSTOMIZER);
                    });
+    }
+
+    @Test
+    void axonServerEventStoreFactoryBeanIsConfigured() {
+        testContext.withUserConfiguration(TestContext.class)
+                   .run(context -> assertThat(context).getBeanNames(AxonServerEventStoreFactory.class).hasSize(1));
+    }
+
+    @Test
+    void axonServerEventStoreFactoryBeanIsNotConfiguredWhenEventStoreIsDisabled() {
+        testContext.withUserConfiguration(TestContext.class)
+                .withPropertyValues("axon.axonserver.event-store.enabled=false")
+                   .run(context -> assertThat(context).getBean(AxonServerEventStoreFactory.class).isNull());
     }
 
     @ContextConfiguration


### PR DESCRIPTION
This pull request introduces the so-called `AxonServerEventStoreFactory`.
The intent of this component is to be able to more easily construct a publication path to a different context.

For example, whenever a user utilizes the multi-context feature from Axon Server, there's a chance they use a so-called "integration context."
Without this functionality, you are required to construct an `AxonServerEventStore` instance from scratch, retrieving all the store's components.

The `AxonServerEventStoreFactory` simplifies this by providing the `constructFor(String context)` operation.
By default, the `AxonServerEventStoreFactory` is configured with the same components as the `AxonServerEventStore`.
As such, by invoking `AxonServerEventStoreFactory#constructFor(String context)`, you construct a clone for which only the context field differs.

Next to `constructFor(String context)`, I have added a `constructFor(String context, AxonServerEventStoreConfiguration configuration)` method.
The `AxonServerEventStoreConfiguration` is a functional interface ingesting the `AxonServerEventStore.Builder` and returning an `AxonServerEventStore.Builder`.
Through this approach (which aligns with the approach for the `PooledStreamingEventProcessorConfiguration` and `DeadLetteringEventHandlerInvokerConfiguraiton`), you are able to make a new `AxonServerEventStore` instance that (slightly) deviates from the default `AxonServerEventStore` instance.

This is particularly useful whenever the aforementioned "integration context" uses a different `Serializer` than the rest of the Axon Framework application.

The `AxonServerEventStoreFactory` is configured through the `ServerConnectorConfigurerModule` for pure Java configuration and the `AxonServerBusAutoConfiguration` for Spring Boot users.
Although the approach deviates from the `TargetContextResolver` used for the `AxonServerCommandBus` and `AxonServerQueryBus`, I felt it justified to construct this factory to provide *more* flexibility (`constructFor(context, customization)`), but still keep it simple (`constructFor(context)`).