### PR TITLE
Add default constructor for the `AxonServerContainer` 

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -76,7 +76,7 @@ class StreamingQueryEndToEndTest {
 
     @Container
     private static final AxonServerContainer axonServerContainer =
-            new AxonServerContainer("axoniq/axonserver:latest-dev")
+            new AxonServerContainer()
                     .withAxonServerName("axonserver")
                     .withAxonServerHostname(HOSTNAME)
                     .withDevMode(true)

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/axonserverconnector/MessagePriorityIntegrationTest.java
@@ -70,7 +70,7 @@ class MessagePriorityIntegrationTest {
 
     @Container
     private static final AxonServerContainer axonServer =
-            new AxonServerContainer(DockerImageName.parse("axoniq/axonserver:latest-dev"))
+            new AxonServerContainer()
                     .withAxonServerName("axonserver")
                     .withAxonServerHostname(HOSTNAME)
                     .withDevMode(true)

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  */
 public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver:latest-dev");
 
     private static final int AXON_SERVER_HTTP_PORT = 8024;
     private static final int AXON_SERVER_GRPC_PORT = 8124;
@@ -64,6 +64,14 @@ public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
     private String axonServerInternalHostname;
     private String axonServerHostname;
     private boolean devMode;
+
+    /**
+     * Initialize an Axon Server {@link GenericContainer test container} using the default image name
+     * {@code "axoniq/axonserver"}.
+     */
+    public AxonServerContainer() {
+        this(DEFAULT_IMAGE_NAME);
+    }
 
     /**
      * Initialize Axon Server with the given {@code dockerImageName}.

--- a/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
@@ -83,4 +83,12 @@ class AxonServerContainerTest {
                          testSubject.getEnvMap().get("AXONIQ_AXONSERVER_DEVMODE_ENABLED"));
         }
     }
+
+    @Test
+    void constructionThroughDefaultConstructorStartsAsExpected() {
+        try (AxonServerContainer testSubject = new AxonServerContainer()) {
+            testSubject.start();
+            assertTrue(testSubject.isRunning());
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds a default constructor for the `AxonServerContainer`.
In doing so, users can base themselves on the default container the Axon Server team provides for their tests.
Next to adding the container, the Framework's tests using the container are adjusted to use the default constructor, too (where feasible).