### PR TITLE
Fix inconsistencies around the `AxonServerConfiguration` 

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -202,9 +202,14 @@ public class AxonServerConfiguration {
 
     /**
      * The number of messages that may be in-transit on the network/grpc level when streaming data from the server.
+     * <p>
      * Setting this to 0 (or a negative value) will disable buffering, and requires each message sent by the server to
      * be acknowledged before the next message may be sent. Defaults to 500.
+     *
+     * @deprecated This property is no longer used through adjustments in the <a
+     * href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java Connector</a> project.
      */
+    @Deprecated
     private int maxGrpcBufferedMessages = 500;
 
     /**
@@ -485,10 +490,20 @@ public class AxonServerConfiguration {
         this.commitTimeout = commitTimeout;
     }
 
+    /**
+     * @deprecated This property is no longer used through adjustments in the <a
+     * href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java Connector</a> project.
+     */
+    @Deprecated
     public int getMaxGrpcBufferedMessages() {
         return maxGrpcBufferedMessages;
     }
 
+    /**
+     * @deprecated This property is no longer used through adjustments in the <a
+     * href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java Connector</a> project.
+     */
+    @Deprecated
     public void setMaxGrpcBufferedMessages(int maxGrpcBufferedMessages) {
         this.maxGrpcBufferedMessages = maxGrpcBufferedMessages;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -92,7 +92,7 @@ public class AxonServerConfiguration {
      * @deprecated In favor of {@code permits}.
      */
     @Deprecated
-    private Integer initialNrOfPermits = 5000;
+    private Integer initialNrOfPermits;
 
     /**
      * Initial number of permits send for message streams (events, commands, queries).

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -528,7 +528,7 @@ public class AxonServerConfiguration {
      */
     @Deprecated
     public void setDisableEventBlacklisting(boolean disableEventBlacklisting) {
-        this.disableEventBlacklisting = disableEventBlacklisting;
+        this.eventBlockListingEnabled = !disableEventBlacklisting;
     }
 
     public boolean isEventBlockListingEnabled() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -174,7 +174,11 @@ public class AxonServerConfiguration {
     /**
      * Indicates whether the download advice message should be suppressed, even when default connection properties
      * (which are generally only used in DEV mode) are used. Defaults to false.
+     *
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project, which enables the download message in absence of configured servers.
      */
+    @Deprecated
     private boolean suppressDownloadMessage = false;
 
     /**
@@ -243,12 +247,7 @@ public class AxonServerConfiguration {
      * @return a {@link Builder} to be able to create an {@link AxonServerConfiguration}.
      */
     public static Builder builder() {
-        Builder builder = new Builder();
-        if (Boolean.getBoolean("axon.axonserver.suppressDownloadMessage")) {
-            builder.suppressDownloadMessage();
-        }
-
-        return builder;
+        return new Builder();
     }
 
     /**
@@ -271,7 +270,6 @@ public class AxonServerConfiguration {
 
     public void setServers(String routingServers) {
         this.servers = routingServers;
-        suppressDownloadMessage = true;
     }
 
     public String getClientId() {
@@ -437,10 +435,20 @@ public class AxonServerConfiguration {
         this.keepAliveTime = keepAliveTime;
     }
 
+    /**
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project, which enables the download message in absence of configured servers.
+     */
+    @Deprecated
     public boolean getSuppressDownloadMessage() {
         return suppressDownloadMessage;
     }
 
+    /**
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project, which enables the download message in absence of configured servers.
+     */
+    @Deprecated
     public void setSuppressDownloadMessage(boolean suppressDownloadMessage) {
         this.suppressDownloadMessage = suppressDownloadMessage;
     }
@@ -892,6 +900,11 @@ public class AxonServerConfiguration {
             return this;
         }
 
+        /**
+         * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+         * Connector</a> project, which enables the download message in absence of configured servers.
+         */
+        @Deprecated
         public Builder suppressDownloadMessage() {
             instance.setSuppressDownloadMessage(true);
             return this;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -91,6 +91,7 @@ public class AxonServerConfiguration {
      *
      * @deprecated In favor of {@code permits}.
      */
+    @Deprecated
     private Integer initialNrOfPermits = 5000;
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -88,8 +88,15 @@ public class AxonServerConfiguration {
 
     /**
      * Initial number of permits send for message streams (events, commands, queries).
+     *
+     * @deprecated In favor of {@code permits}.
      */
     private Integer initialNrOfPermits = 5000;
+
+    /**
+     * Initial number of permits send for message streams (events, commands, queries).
+     */
+    private Integer permits = 5000;
 
     /**
      * Additional number of permits send for message streams (events, commands, queries) when application is ready for
@@ -110,18 +117,24 @@ public class AxonServerConfiguration {
     /**
      * Specific flow control settings for the event message stream.
      * <p>
-     * When not specified (null) the default flow control properties initialNrOfPermits, nrOfNewPermits en
-     * newPermitsThreshold will be used.
+     * When not specified (null) the top-level flow control properties {@code permits}, {@code nrOfNewPermits} and
+     * {@code newPermitsThreshold} are used.
      */
     private FlowControlConfiguration eventFlowControl;
 
     /**
      * Specific flow control settings for the queue message stream.
+     * <p>
+     * When not specified (null) the top-level flow control properties {@code permits}, {@code nrOfNewPermits} and
+     * {@code newPermitsThreshold} are used.
      */
     private FlowControlConfiguration queryFlowControl;
 
     /**
      * Specific flow control settings for the command message stream.
+     * <p>
+     * When not specified (null) the top-level flow control properties {@code permits}, {@code nrOfNewPermits} and
+     * {@code newPermitsThreshold} are used.
      */
     private FlowControlConfiguration commandFlowControl;
 
@@ -331,17 +344,32 @@ public class AxonServerConfiguration {
         this.sslEnabled = sslEnabled;
     }
 
+    /**
+     * @deprecated In favor of {@link #getPermits()}
+     */
+    @Deprecated
     public Integer getInitialNrOfPermits() {
         return initialNrOfPermits;
     }
 
+    /**
+     * @deprecated In favor of {@link #setPermits(Integer)}
+     */
     public void setInitialNrOfPermits(Integer initialNrOfPermits) {
-        this.initialNrOfPermits = initialNrOfPermits;
+        this.permits = initialNrOfPermits;
+    }
+
+    public Integer getPermits() {
+        return permits;
+    }
+
+    public void setPermits(Integer permits) {
+        this.permits = permits;
     }
 
     public Integer getNrOfNewPermits() {
         if (nrOfNewPermits == null || nrOfNewPermits <= 0) {
-            return getInitialNrOfPermits() - getNewPermitsThreshold();
+            return getPermits() - getNewPermitsThreshold();
         }
         return nrOfNewPermits;
     }
@@ -352,7 +380,7 @@ public class AxonServerConfiguration {
 
     public Integer getNewPermitsThreshold() {
         if (newPermitsThreshold == null || newPermitsThreshold <= 0) {
-            return initialNrOfPermits / 2;
+            return getPermits() / 2;
         }
         return newPermitsThreshold;
     }
@@ -562,7 +590,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getEventFlowControl() {
         if (eventFlowControl == null) {
-            return new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return eventFlowControl;
     }
@@ -573,7 +601,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getQueryFlowControl() {
         if (queryFlowControl == null) {
-            return new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return queryFlowControl;
     }
@@ -584,7 +612,7 @@ public class AxonServerConfiguration {
 
     public FlowControlConfiguration getCommandFlowControl() {
         if (commandFlowControl == null) {
-            return new FlowControlConfiguration(getInitialNrOfPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
+            return new FlowControlConfiguration(getPermits(), getNrOfNewPermits(), getNewPermitsThreshold());
         }
         return commandFlowControl;
     }
@@ -594,7 +622,7 @@ public class AxonServerConfiguration {
     }
 
     public FlowControlConfiguration getDefaultFlowControlConfiguration() {
-        return new FlowControlConfiguration(initialNrOfPermits, nrOfNewPermits, newPermitsThreshold);
+        return new FlowControlConfiguration(permits, nrOfNewPermits, newPermitsThreshold);
     }
 
     public HeartbeatConfiguration getHeartbeat() {
@@ -633,8 +661,16 @@ public class AxonServerConfiguration {
 
         /**
          * Initial number of permits send for message streams (events, commands, queries).
+         *
+         * @deprecated In favor of {@code permits}.
          */
-        private Integer initialNrOfPermits = 5000;
+        @Deprecated
+        private Integer initialNrOfPermits;
+
+        /**
+         * Initial number of permits send for message streams (events, commands, queries).
+         */
+        private Integer permits;
 
         /**
          * Additional number of permits send for message streams (events, commands, queries) when application is ready
@@ -643,7 +679,7 @@ public class AxonServerConfiguration {
          * A value of {@code null}, 0, and negative values will have the client request the number of permits required
          * to get from the "new-permits-threshold" to "initial-nr-of-permits".
          */
-        private Integer nrOfNewPermits = null;
+        private Integer nrOfNewPermits;
 
         /**
          * Threshold at which application sends new permits to server.
@@ -651,36 +687,49 @@ public class AxonServerConfiguration {
          * A value of {@code null}, 0, and negative values will have the threshold set to 50% of
          * "initial-nr-of-permits".
          */
-        private Integer newPermitsThreshold = null;
-
-        public FlowControlConfiguration() {
-        }
+        private Integer newPermitsThreshold;
 
         /**
          * Construct a {@link FlowControlConfiguration}.
          *
-         * @param initialNrOfPermits  initial nr of new permits
-         * @param nrOfNewPermits      additional number of permits when application is ready for message
-         * @param newPermitsThreshold threshold at which application sends new permits to server
+         * @param permits             Initial nr of new permits.
+         * @param nrOfNewPermits      Additional number of permits when application is ready for message.
+         * @param newPermitsThreshold Threshold at which application sends new permits to server.
          */
-        public FlowControlConfiguration(Integer initialNrOfPermits, Integer nrOfNewPermits,
+        public FlowControlConfiguration(Integer permits,
+                                        Integer nrOfNewPermits,
                                         Integer newPermitsThreshold) {
-            this.initialNrOfPermits = initialNrOfPermits;
+            this.permits = permits;
             this.nrOfNewPermits = nrOfNewPermits;
             this.newPermitsThreshold = newPermitsThreshold;
         }
 
+        /**
+         * @deprecated In favor of {@link #getPermits()}.
+         */
+        @Deprecated
         public Integer getInitialNrOfPermits() {
-            return this.initialNrOfPermits;
+            return this.permits;
         }
 
+        /**
+         * @deprecated In favor of {@link #setPermits(Integer)}.
+         */
         public void setInitialNrOfPermits(Integer initialNrOfPermits) {
-            this.initialNrOfPermits = initialNrOfPermits;
+            this.permits = initialNrOfPermits;
+        }
+
+        public Integer getPermits() {
+            return permits;
+        }
+
+        public void setPermits(Integer permits) {
+            this.permits = permits;
         }
 
         public Integer getNrOfNewPermits() {
             if (this.nrOfNewPermits == null || this.nrOfNewPermits <= 0) {
-                return getInitialNrOfPermits() - getNewPermitsThreshold();
+                return this.getPermits() - this.getNewPermitsThreshold();
             }
             return this.nrOfNewPermits;
         }
@@ -691,7 +740,7 @@ public class AxonServerConfiguration {
 
         public Integer getNewPermitsThreshold() {
             if (this.newPermitsThreshold == null || this.newPermitsThreshold <= 0) {
-                return this.initialNrOfPermits / 2;
+                return this.getPermits() / 2;
             }
             return this.newPermitsThreshold;
         }
@@ -840,9 +889,9 @@ public class AxonServerConfiguration {
 
         public Builder() {
             instance = new AxonServerConfiguration();
-            instance.initialNrOfPermits = 1000;
-            instance.nrOfNewPermits = 500;
-            instance.newPermitsThreshold = 500;
+            instance.permits = 5000;
+            instance.nrOfNewPermits = null;
+            instance.newPermitsThreshold = null;
         }
 
         public Builder ssl(String certFile) {
@@ -866,31 +915,25 @@ public class AxonServerConfiguration {
             return this;
         }
 
-        public Builder flowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
-            instance.initialNrOfPermits = initialNrOfPermits;
+        public Builder flowControl(int permits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.permits = permits;
             instance.nrOfNewPermits = nrOfNewPermits;
             instance.newPermitsThreshold = newPermitsThreshold;
             return this;
         }
 
-        public Builder commandFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
-            instance.setCommandFlowControl(new FlowControlConfiguration(initialNrOfPermits,
-                                                                        nrOfNewPermits,
-                                                                        newPermitsThreshold));
+        public Builder commandFlowControl(int permits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setCommandFlowControl(new FlowControlConfiguration(permits, nrOfNewPermits, newPermitsThreshold));
             return this;
         }
 
-        public Builder queryFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
-            instance.setQueryFlowControl(new FlowControlConfiguration(initialNrOfPermits,
-                                                                      nrOfNewPermits,
-                                                                      newPermitsThreshold));
+        public Builder queryFlowControl(int permits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setQueryFlowControl(new FlowControlConfiguration(permits, nrOfNewPermits, newPermitsThreshold));
             return this;
         }
 
-        public Builder eventFlowControl(int initialNrOfPermits, int nrOfNewPermits, int newPermitsThreshold) {
-            instance.setEventFlowControl(new FlowControlConfiguration(initialNrOfPermits,
-                                                                      nrOfNewPermits,
-                                                                      newPermitsThreshold));
+        public Builder eventFlowControl(int permits, int nrOfNewPermits, int newPermitsThreshold) {
+            instance.setEventFlowControl(new FlowControlConfiguration(permits, nrOfNewPermits, newPermitsThreshold));
             return this;
         }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -356,6 +356,7 @@ public class AxonServerConfiguration {
     /**
      * @deprecated In favor of {@link #setPermits(Integer)}
      */
+    @Deprecated
     public void setInitialNrOfPermits(Integer initialNrOfPermits) {
         this.permits = initialNrOfPermits;
     }
@@ -716,6 +717,7 @@ public class AxonServerConfiguration {
         /**
          * @deprecated In favor of {@link #setPermits(Integer)}.
          */
+        @Deprecated
         public void setInitialNrOfPermits(Integer initialNrOfPermits) {
             this.permits = initialNrOfPermits;
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -149,8 +149,8 @@ public class AxonServerConfiguration {
      * An {@link EventCipher} which is used to encrypt and decrypt events and snapshots. Defaults to
      * {@link EventCipher#EventCipher()}.
      *
-     * @deprecated in through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">AxonServer java
-     * connector</a>
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project.
      */
     @Deprecated
     private EventCipher eventCipher = new EventCipher();
@@ -365,12 +365,22 @@ public class AxonServerConfiguration {
         }).collect(Collectors.toList());
     }
 
+    /**
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project.
+     */
+    @Deprecated
     public EventCipher getEventCipher() {
         return eventCipher;
     }
 
+    /**
+     * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+     * Connector</a> project.
+     */
+    @Deprecated
     private void setEventSecretKey(String key) {
-        if (key != null && key.length() > 0) {
+        if (key != null && !key.isEmpty()) {
             eventCipher = new EventCipher(key.getBytes(StandardCharsets.US_ASCII));
         }
     }
@@ -833,11 +843,21 @@ public class AxonServerConfiguration {
             return this;
         }
 
+        /**
+         * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+         * Connector</a> project.
+         */
+        @Deprecated
         public Builder setEventSecretKey(String key) {
             instance.setEventSecretKey(key);
             return this;
         }
 
+        /**
+         * @deprecated Through use of the <a href="https://github.com/AxonIQ/axonserver-connector-java">Axon Server Java
+         * Connector</a> project.
+         */
+        @Deprecated
         public Builder eventCipher(EventCipher eventCipher) {
             instance.eventCipher = eventCipher;
             return this;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -197,8 +197,20 @@ public class AxonServerConfiguration {
      * message.
      * <p>
      * Default is to have blacklisting enabled.
+     *
+     * @deprecated In favor of the {@code eventBlockListingEnabled} property.
      */
+    @Deprecated
     private boolean disableEventBlacklisting = false;
+
+    /**
+     * Flag that allows block-listing of event types to be enabled.
+     * <p>
+     * Disabling this may have serious performance impact, as it requires all
+     * {@link org.axonframework.eventhandling.EventMessage events} from Axon Server to be sent to clients, even if a
+     * client is unable to process the event. Default is to have block-listing enabled.
+     */
+    private boolean eventBlockListingEnabled = true;
 
     /**
      * The number of messages that may be in-transit on the network/grpc level when streaming data from the server.
@@ -474,12 +486,28 @@ public class AxonServerConfiguration {
         this.snapshotPrefetch = snapshotPrefetch;
     }
 
+    /**
+     * @deprecated In favor of {@link #setEventBlockListingEnabled(boolean)}.
+     */
+    @Deprecated
     public boolean isDisableEventBlacklisting() {
         return disableEventBlacklisting;
     }
 
+    /**
+     * @deprecated In favor of {@link #setEventBlockListingEnabled(boolean)}.
+     */
+    @Deprecated
     public void setDisableEventBlacklisting(boolean disableEventBlacklisting) {
         this.disableEventBlacklisting = disableEventBlacklisting;
+    }
+
+    public boolean isEventBlockListingEnabled() {
+        return eventBlockListingEnabled;
+    }
+
+    public void setEventBlockListingEnabled(boolean eventBlockListingEnabled) {
+        this.eventBlockListingEnabled = eventBlockListingEnabled;
     }
 
     public int getCommitTimeout() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,7 +315,10 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
                 }
             }
 
-            builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS)
+                   .commandPermits(axonServerConfiguration.getCommandFlowControl().getPermits())
+                   .queryPermits(axonServerConfiguration.getQueryFlowControl().getPermits());
+
             if (axonServerConfiguration.getToken() != null) {
                 builder.token(axonServerConfiguration.getToken());
             }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -549,7 +549,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                                                   .eventChannel()
                                                   .openStream(
                                                           nextToken,
-                                                          configuration.getEventFlowControl().getInitialNrOfPermits(),
+                                                          configuration.getEventFlowControl().getPermits(),
                                                           configuration.getEventFlowControl().getNrOfNewPermits(),
                                                           configuration.isForceReadFromLeader()
                                                   );

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -554,7 +554,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                                                           configuration.isForceReadFromLeader()
                                                   );
 
-            return new EventBuffer(stream, upcasterChain, eventSerializer, configuration.isDisableEventBlacklisting());
+            return new EventBuffer(stream, upcasterChain, eventSerializer, configuration.isEventBlockListingEnabled());
         }
 
         public QueryResultStream query(String query, boolean liveUpdates) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -475,7 +475,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                                                .subscriptionQuery(
                                                        subscriptionSerializer.serializeQuery(interceptedQuery),
                                                        subscriptionSerializer.serializeUpdateType(interceptedQuery),
-                                                       configuration.getQueryFlowControl().getInitialNrOfPermits(),
+                                                       configuration.getQueryFlowControl().getPermits(),
                                                        configuration.getQueryFlowControl().getNrOfNewPermits()
                                                );
             return new AxonServerSubscriptionQueryResult<>(

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializer.java
@@ -222,7 +222,7 @@ public class SubscriptionMessageSerializer {
 
         return SubscriptionQuery.newBuilder()
                                 .setSubscriptionIdentifier(subscriptionQueryMessage.getIdentifier())
-                                .setNumberOfPermits(configuration.getInitialNrOfPermits())
+                                .setNumberOfPermits(configuration.getQueryFlowControl().getPermits())
                                 .setUpdateResponseType(
                                         responseTypeSerializer.apply(subscriptionQueryMessage.getUpdateResponseType())
                                 )

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
@@ -33,9 +33,9 @@ class AxonServerConfigurationTest {
         assertEquals(10, axonServerConfiguration.getEventFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getEventFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getEventFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getPermits());
-        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
-        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+        assertEquals(5000, axonServerConfiguration.getPermits());
+        assertEquals(2500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(2500, axonServerConfiguration.getNewPermitsThreshold());
     }
 
     @Test
@@ -45,9 +45,9 @@ class AxonServerConfigurationTest {
         assertEquals(10, axonServerConfiguration.getCommandFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getCommandFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getCommandFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getPermits());
-        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
-        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+        assertEquals(5000, axonServerConfiguration.getPermits());
+        assertEquals(2500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(2500, axonServerConfiguration.getNewPermitsThreshold());
     }
 
     @Test
@@ -57,8 +57,8 @@ class AxonServerConfigurationTest {
         assertEquals(10, axonServerConfiguration.getQueryFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getQueryFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getQueryFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getPermits());
-        assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
-        assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
+        assertEquals(5000, axonServerConfiguration.getPermits());
+        assertEquals(2500, axonServerConfiguration.getNrOfNewPermits());
+        assertEquals(2500, axonServerConfiguration.getNewPermitsThreshold());
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConfigurationTest.java
@@ -16,59 +16,49 @@
 
 package org.axonframework.axonserver.connector;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.axonframework.axonserver.connector.AxonServerConfiguration.builder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test Axon Server Configuration
- * Testing falling back to defaults for Flow Control per message type
- *
+ * Test validating the {@link AxonServerConfiguration}.
  */
 class AxonServerConfigurationTest {
 
-
     @Test
     void eventsFlowControl() {
-
         AxonServerConfiguration axonServerConfiguration = builder().eventFlowControl(10, 20, 30).build();
 
-        assertEquals(10, axonServerConfiguration.getEventFlowControl().getInitialNrOfPermits());
+        assertEquals(10, axonServerConfiguration.getEventFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getEventFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getEventFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(1000, axonServerConfiguration.getPermits());
         assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
         assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
-
     }
 
     @Test
     void commandFlowControl() {
-
         AxonServerConfiguration axonServerConfiguration = builder().commandFlowControl(10, 20, 30).build();
 
-        assertEquals(10, axonServerConfiguration.getCommandFlowControl().getInitialNrOfPermits());
+        assertEquals(10, axonServerConfiguration.getCommandFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getCommandFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getCommandFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(1000, axonServerConfiguration.getPermits());
         assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
         assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
-
     }
 
     @Test
     void queryFlowControl() {
-
         AxonServerConfiguration axonServerConfiguration = builder().queryFlowControl(10, 20, 30).build();
 
-        assertEquals(10, axonServerConfiguration.getQueryFlowControl().getInitialNrOfPermits());
+        assertEquals(10, axonServerConfiguration.getQueryFlowControl().getPermits());
         assertEquals(20, axonServerConfiguration.getQueryFlowControl().getNrOfNewPermits());
         assertEquals(30, axonServerConfiguration.getQueryFlowControl().getNewPermitsThreshold());
-        assertEquals(1000, axonServerConfiguration.getInitialNrOfPermits());
+        assertEquals(1000, axonServerConfiguration.getPermits());
         assertEquals(500, axonServerConfiguration.getNrOfNewPermits());
         assertEquals(500, axonServerConfiguration.getNewPermitsThreshold());
-
     }
-
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -100,7 +100,7 @@ class AxonServerCommandBusTest {
         configuration.setServers(dummyMessagePlatformServer.getAddress());
         configuration.setClientId("JUnit");
         configuration.setComponentName("JUnit");
-        configuration.setInitialNrOfPermits(100);
+        configuration.setPermits(100);
         configuration.setNewPermitsThreshold(10);
         configuration.setNrOfNewPermits(1000);
         configuration.setContext(BOUNDED_CONTEXT);


### PR DESCRIPTION
This pull request resolves numerous minor and greater predicaments found in the `AxonServerConfiguration`.
Some of these may be regarded as bugs, whilst others are more enhancements.

Here's a list of the made adjustments, decreasing in importance:
1. Actually set the `commandPermits` on the `AxonServerConnectionFactory` constructed in the `AxonServerConnectionManager`, based on the command flow control of the `AxonServerConfiguration`.
2. Actually set the `queryPermits` on the `AxonServerConnectionFactory` constructed in the `AxonServerConnectionManager`, based on the command flow control of the `AxonServerConfiguration`.
3. Deprecate the suppress download message property on the `AxonServerConfiguration`, as the control over this message resides fully with the `axonserver-connector-java`.
4. Deprecate the maximum gRPC buffered messages property, as it isn't used with the "new" iteration of the `axonserver-connector-java` (as of AF 4.5.x).
5. Deprecate `eventBlackListingDisabled` to `enableEventBlockListing`.
6. Deprecate remaining methods around the `EventCipher`.
7. Rename `initialNrOfPermits` to `permits`, deprecating the old field/getter/setter and referencing the new format. Renaming the field to `permits` better aligns with how the command and query bus use this property, as the `axonserver-connector-java` does not support defining the threshold, for example.