### PR TITLE
Add additional Axon Server connector configuration to the `AxonServerConfiguration`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -235,6 +235,20 @@ public class AxonServerConfiguration {
     private boolean forceReadFromLeader = false;
 
     /**
+     * Indicates whether the {@link AxonServerConnectionManager} should always reconnect through the
+     * {@link #getServers() servers} or try to reconnect with the server it just lost the connection with.
+     * <p>
+     * When {@code true} (default), the  {@code AxonServerConnectionManager} will contact the servers for a new
+     * destination each time a connection is dropped. When {@code false}, the connector will first attempt to
+     * re-establish a connection to the node it was previously connected to. When that fails, only then will it contact
+     * the servers.
+     * <p>
+     * Default to {@code true}, forcing the failed connection to be abandoned and a new one to be requested via the
+     * routing servers.
+     */
+    private boolean forceReconnectThroughServers = true;
+
+    /**
      * Configuration specifics on sending heartbeat messages to ensure a fully operational end-to-end connection with
      * Axon Server.
      */
@@ -519,6 +533,14 @@ public class AxonServerConfiguration {
 
     public void setForceReadFromLeader(boolean forceReadFromLeader) {
         this.forceReadFromLeader = forceReadFromLeader;
+    }
+
+    public boolean isForceReconnectThroughServers() {
+        return forceReconnectThroughServers;
+    }
+
+    public void setForceReconnectThroughServers(boolean forceReconnectThroughServers) {
+        this.forceReconnectThroughServers = forceReconnectThroughServers;
     }
 
     public FlowControlConfiguration getEventFlowControl() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -216,6 +216,14 @@ public class AxonServerConfiguration {
     private long connectTimeout = 5000;
 
     /**
+     * Sets the amount of time in milliseconds to wait in between attempts to connect to Axon Server. A single attempt
+     * involves connecting to each of the configured {@link #getServers() servers}.
+     * <p>
+     * Defaults to 2000 (2 seconds).
+     */
+    private long reconnectInterval = 2000;
+
+    /**
      * Indicates whether it is OK to query events from the local Axon Server node - the node the client is currently
      * connected to. This means that the client will probably get stale events since all events my not be replicated to
      * this node yet. Can be used when the criteria for eventual consistency is less strict. It will spread the load for
@@ -495,6 +503,14 @@ public class AxonServerConfiguration {
 
     public void setConnectTimeout(long connectTimeout) {
         this.connectTimeout = connectTimeout;
+    }
+
+    public long getReconnectInterval() {
+        return reconnectInterval;
+    }
+
+    public void setReconnectInterval(long reconnectInterval) {
+        this.reconnectInterval = reconnectInterval;
     }
 
     public boolean isForceReadFromLeader() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -249,6 +249,18 @@ public class AxonServerConfiguration {
     private boolean forceReconnectThroughServers = true;
 
     /**
+     * Defines the number of threads that should be used for connection management activities by the
+     * {@link io.axoniq.axonserver.connector.AxonServerConnectionFactory} used by the
+     * {@link AxonServerConnectionManager}.
+     * <p>
+     * This includes activities related to connecting to Axon Server, setting up instruction streams, sending and
+     * validating heartbeats, etc.
+     * <p>
+     * Defaults to a pool size of {@code 2} threads.
+     */
+    private int connectionManagementThreadPoolSize = 2;
+
+    /**
      * Configuration specifics on sending heartbeat messages to ensure a fully operational end-to-end connection with
      * Axon Server.
      */
@@ -541,6 +553,14 @@ public class AxonServerConfiguration {
 
     public void setForceReconnectThroughServers(boolean forceReconnectThroughServers) {
         this.forceReconnectThroughServers = forceReconnectThroughServers;
+    }
+
+    public int getConnectionManagementThreadPoolSize() {
+        return connectionManagementThreadPoolSize;
+    }
+
+    public void setConnectionManagementThreadPoolSize(int connectionManagementThreadPoolSize) {
+        this.connectionManagementThreadPoolSize = connectionManagementThreadPoolSize;
     }
 
     public FlowControlConfiguration getEventFlowControl() {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,7 +315,9 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
                 }
             }
 
-            builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS)
+                   .reconnectInterval(axonServerConfiguration.getReconnectInterval(), TimeUnit.MILLISECONDS);
+
             if (axonServerConfiguration.getToken() != null) {
                 builder.token(axonServerConfiguration.getToken());
             }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -316,7 +316,8 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
             }
 
             builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS)
-                   .reconnectInterval(axonServerConfiguration.getReconnectInterval(), TimeUnit.MILLISECONDS);
+                   .reconnectInterval(axonServerConfiguration.getReconnectInterval(), TimeUnit.MILLISECONDS)
+                   .forceReconnectViaRoutingServers(axonServerConfiguration.isForceReconnectThroughServers());
 
             if (axonServerConfiguration.getToken() != null) {
                 builder.token(axonServerConfiguration.getToken());

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -317,7 +317,8 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
 
             builder.connectTimeout(axonServerConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS)
                    .reconnectInterval(axonServerConfiguration.getReconnectInterval(), TimeUnit.MILLISECONDS)
-                   .forceReconnectViaRoutingServers(axonServerConfiguration.isForceReconnectThroughServers());
+                   .forceReconnectViaRoutingServers(axonServerConfiguration.isForceReconnectThroughServers())
+                   .threadPoolSize(axonServerConfiguration.getConnectionManagementThreadPoolSize());
 
             if (axonServerConfiguration.getToken() != null) {
                 builder.token(axonServerConfiguration.getToken());

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.axonframework.axonserver.connector;
 
 import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
+import io.axoniq.axonserver.connector.impl.ReconnectConfiguration;
 import io.axoniq.axonserver.grpc.control.ClientIdentification;
 import io.axoniq.axonserver.grpc.control.PlatformInfo;
 import io.grpc.CallOptions;
@@ -29,6 +31,7 @@ import org.axonframework.axonserver.connector.event.StubServer;
 import org.axonframework.axonserver.connector.util.TcpUtil;
 import org.axonframework.axonserver.connector.utils.PlatformService;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ReflectionUtils;
 import org.axonframework.config.TagsConfiguration;
 import org.junit.jupiter.api.*;
 
@@ -36,6 +39,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -331,6 +335,29 @@ class AxonServerConnectionManagerTest {
         Boolean someOtherContextConnection = results.get("some-other-context");
         assertNotNull(someOtherContextConnection);
         assertTrue(someOtherContextConnection);
+    }
+
+    @Test
+    void axonServerConfigurationIsSetOnAxonServerConnectionFactoryAsExpected() throws NoSuchFieldException {
+        long expectedReconnectInterval = 1337L;
+
+        AxonServerConfiguration testConfig = new AxonServerConfiguration();
+        testConfig.setReconnectInterval(expectedReconnectInterval);
+        testConfig.setForceReconnectThroughServers(false);
+
+        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+                                                                             .axonServerConfiguration(testConfig)
+                                                                             .build();
+
+        AxonServerConnectionFactory connectionFactory = ReflectionUtils.getFieldValue(
+                AxonServerConnectionManager.class.getDeclaredField("connectionFactory"), testSubject
+        );
+
+        ReconnectConfiguration resultReconnectConfig = ReflectionUtils.getFieldValue(
+                AxonServerConnectionFactory.class.getDeclaredField("reconnectConfiguration"), connectionFactory
+        );
+        assertEquals(expectedReconnectInterval, resultReconnectConfig.getReconnectInterval());
+        assertFalse(resultReconnectConfig.isForcePlatformReconnect());
     }
 
     @Test


### PR DESCRIPTION
This pull request adds three configurable options of the `axonserver-connector-java` that weren't exposed to the `AxonServerConfiguration` yet.
Namely:

1. Reconnect interval - the interval in ms when to attempt a reconnect to the configured servers. Defaults to 2000ms.
2. Force reconnect through servers - boolean whether to enforce a reconnect through the configured servers, yes/no. When false, a reconnect is first attempted over the connection that just failed. Defaults to true
3. Connection management thread pool size - the number of threads used by the `AxonServerConnectionFactory` (connector-specific component) for connection management, instruction stream construction, and heartbeats. Defaults to 2.