### PR TITLE
Detect empty snapshots due to Serializer misconfiguration

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcedAggregate.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcedAggregate.java
@@ -253,6 +253,12 @@ public class EventSourcedAggregate<T> extends AnnotatedAggregate<T> {
         super.publish(msg);
         snapshotTrigger.eventHandled(msg);
         if (identifierAsString() == null) {
+            if (msg.getPayloadType().equals(getAggregateRoot().getClass())) {
+                throw new IncompatibleAggregateException("Aggregate identifier must be non-null after applying a snapshot. " +
+                        "Make sure the aggregate identifier is included in the snapshot that is used to restore the aggregate from. " +
+                        "This can be missing due to your serializer not being able to find the private fields of your aggregate. "
+                );
+            }
             throw new IncompatibleAggregateException("Aggregate identifier must be non-null after applying an event. " +
                                                              "Make sure the aggregate identifier is initialized at " +
                                                              "the latest when handling the creation event.");

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ import static java.lang.String.format;
  */
 public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggregate<T>, ApplyMore {
 
-    private final AggregateModel<T> inspector;
+    protected final AggregateModel<T> inspector;
     private final RepositoryProvider repositoryProvider;
     private final Queue<Runnable> delayedTasks = new LinkedList<>();
     private final EventBus eventBus;


### PR DESCRIPTION
Work in Progress for discussion.

A customer of ours had difficulties due to Jackson not being able to find the fields of an aggregate for a snapshot. This is the third customer I helped with this, and can cause a lot of confusion.

This PR will extend the `EventSourcedAggregate` exception to throw a more specific exception to the situation if it detects the aggregate identifier to be null if the event that is being applied is a snapshot. 

Tests will be added after we verify the approach. 