### PR TITLE
Intermediate Span Factory pattern for buses

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfi
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.LoggingDuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.SimpleCommandBus;
@@ -35,10 +36,12 @@ import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.TagsConfiguration;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
 import org.axonframework.queryhandling.SimpleQueryBus;
 import org.slf4j.Logger;
@@ -93,7 +96,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                    .eventSerializer(c.eventSerializer())
                                    .snapshotFilter(c.snapshotFilter())
                                    .upcasterChain(c.upcasterChain())
-                                   .spanFactory(c.spanFactory())
+                                   .spanFactory(c.getComponent(EventBusSpanFactory.class))
                                    .build();
     }
 
@@ -108,7 +111,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                 .transactionManager(c.getComponent(
                                         TransactionManager.class, NoTransactionManager::instance
                                 ))
-                                .spanFactory(c.spanFactory())
+                                .spanFactory(c.getComponent(CommandBusSpanFactory.class))
                                 .build();
         //noinspection unchecked - supresses `c.getComponent(TargetContextResolver.class)`
         return AxonServerCommandBus.builder()
@@ -128,7 +131,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                            () -> command -> CommandLoadFactorProvider.DEFAULT_VALUE
                                    ))
                                    .targetContextResolver(c.getComponent(TargetContextResolver.class))
-                                   .spanFactory(c.spanFactory())
+                                   .spanFactory(c.getComponent(CommandBusSpanFactory.class))
                                    .build();
     }
 
@@ -143,7 +146,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                       () -> LoggingQueryInvocationErrorHandler.builder().build()
                               ))
                               .queryUpdateEmitter(c.queryUpdateEmitter())
-                              .spanFactory(c.spanFactory())
+                              .spanFactory(c.getComponent(QueryBusSpanFactory.class))
                               .messageMonitor(c.messageMonitor(QueryBus.class, "localQueryBus"))
                               .build();
         //noinspection unchecked - supresses `c.getComponent(TargetContextResolver.class)`
@@ -159,7 +162,7 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
                                          QueryPriorityCalculator::defaultQueryPriorityCalculator
                                  ))
                                  .targetContextResolver(c.getComponent(TargetContextResolver.class))
-                                 .spanFactory(c.spanFactory())
+                                 .spanFactory(c.getComponent(QueryBusSpanFactory.class))
                                  .build();
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ import org.axonframework.axonserver.connector.PriorityRunnable;
 import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.util.ExecutorServiceBuilder;
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
 import org.axonframework.commandhandling.GenericCommandResultMessage;
 import org.axonframework.commandhandling.callbacks.NoOpCallback;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
@@ -90,15 +92,16 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
     private final CommandCallback<Object, Object> defaultCommandCallback;
     private final ShutdownLatch shutdownLatch = new ShutdownLatch();
     private final ExecutorService executorService;
-    private final SpanFactory spanFactory;
+    private final CommandBusSpanFactory spanFactory;
 
     /**
      * Instantiate a Builder to be able to create an {@link AxonServerCommandBus}.
      * <p>
      * The {@link CommandPriorityCalculator} is defaulted to
      * {@link CommandPriorityCalculator#defaultCommandPriorityCalculator()}, the {@link TargetContextResolver} defaults
-     * to a lambda returning the {@link AxonServerConfiguration#getContext()} as the context and the {@link SpanFactory}
-     * defaults to a {@link NoOpSpanFactory}. The {@link ExecutorServiceBuilder} defaults to
+     * to a lambda returning the {@link AxonServerConfiguration#getContext()} as the context and the
+     * {@link CommandBusSpanFactory} defaults to a {@link DefaultCommandBusSpanFactory} backed by a
+     * {@link NoOpSpanFactory}. The {@link ExecutorServiceBuilder} defaults to
      * {@link ExecutorServiceBuilder#defaultCommandExecutorServiceBuilder()}. The {@link AxonServerConnectionManager},
      * the {@link AxonServerConfiguration}, the local {@link CommandBus}, {@link Serializer} and the
      * {@link RoutingStrategy} are a <b>hard requirements</b> and as such should be provided.
@@ -167,7 +170,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         shutdownLatch.ifShuttingDown("Cannot dispatch new commands as this bus is being shutdown");
         //noinspection resource
         ShutdownLatch.ActivityHandle commandInTransit = shutdownLatch.registerActivity();
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerCommandBus.dispatch", commandMessage).start();
+        Span span = spanFactory.createDispatchCommandSpan(commandMessage, true).start();
         try (SpanScope unused = span.makeCurrent()) {
             Command command = serializer.serialize(spanFactory.propagateContext(commandMessage),
                                                    routingStrategy.getRoutingKey(commandMessage),
@@ -285,13 +288,13 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         private final CommandBus localSegment;
         private final Command command;
         private final CommandSerializer serializer;
-        private final SpanFactory spanFactory;
+        private final CommandBusSpanFactory spanFactory;
 
         public CommandProcessingTask(Command command,
                                      CommandSerializer serializer,
                                      CompletableFuture<CommandResponse> result,
                                      CommandBus localSegment,
-                                     SpanFactory spanFactory) {
+                                     CommandBusSpanFactory spanFactory) {
             this.command = command;
             this.serializer = serializer;
             this.result = result;
@@ -302,7 +305,7 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         @Override
         public void run() {
             CommandMessage<?> deserializedCommand = serializer.deserialize(command);
-            Span span = spanFactory.createChildHandlerSpan(() -> "AxonServerCommandBus.handle", deserializedCommand);
+            Span span = spanFactory.createHandleCommandSpan(deserializedCommand, true);
             span.run(() -> {
                 try {
                     localSegment.dispatch(
@@ -352,7 +355,8 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
         private String defaultContext;
         private TargetContextResolver<? super CommandMessage<?>> targetContextResolver =
                 c -> StringUtils.nonEmptyOrNull(defaultContext) ? defaultContext : configuration.getContext();
-        private SpanFactory spanFactory = NoOpSpanFactory.INSTANCE;
+        private CommandBusSpanFactory spanFactory = DefaultCommandBusSpanFactory
+                .builder().spanFactory(NoOpSpanFactory.INSTANCE).build();
 
         /**
          * Sets the {@link AxonServerConnectionManager} used to create connections between this application and an Axon
@@ -518,13 +522,28 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
          *
          * @param spanFactory The {@link SpanFactory} implementation
          * @return The current Builder instance, for fluent interfacing.
+         * @deprecated Use {@link #spanFactory(CommandBusSpanFactory)} instead as it provides more configurability.
          */
+        @Deprecated
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            assertNonNull(spanFactory, "SpanFactory may not be null");
+            this.spanFactory = DefaultCommandBusSpanFactory.builder().spanFactory(spanFactory).build();
+            return this;
+        }
+
+        /**
+         * Sets the {@link CommandBusSpanFactory} implementation to use for providing tracing capabilities. Defaults to
+         * a {@link DefaultCommandBusSpanFactory} backed by a {@link NoOpSpanFactory} by default, which provides no
+         * tracing capabilities.
+         *
+         * @param spanFactory The {@link CommandBusSpanFactory} implementation
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(@Nonnull CommandBusSpanFactory spanFactory) {
             assertNonNull(spanFactory, "SpanFactory may not be null");
             this.spanFactory = spanFactory;
             return this;
         }
-
 
         /**
          * Initializes a {@link AxonServerCommandBus} as specified through this Builder.

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerCommandBus.java
@@ -335,9 +335,10 @@ public class AxonServerCommandBus implements CommandBus, Distributed<CommandBus>
      * {@link CommandPriorityCalculator#defaultCommandPriorityCalculator(), and the {@link TargetContextResolver}
      * defaults to a lambda returning the {@link AxonServerConfiguration#getContext()} as the context. The
      * {@link ExecutorServiceBuilder} defaults to {@link ExecutorServiceBuilder#defaultCommandExecutorServiceBuilder()}.
-     * The {@link SpanFactory} defaults to a {@link NoOpSpanFactory}. The {@link AxonServerConnectionManager}, the
-     * {@link AxonServerConfiguration}, the local {@link CommandBus}, {@link Serializer} and the {@link RoutingStrategy}
-     * are <b>hard requirements</b> and as such should be provided.
+     * The {@link CommandBusSpanFactory} defaults to a {@link DefaultCommandBusSpanFactory} backed by a
+     * {@link NoOpSpanFactory}. The {@link AxonServerConnectionManager}, the {@link AxonServerConfiguration}, the local
+     * {@link CommandBus}, {@link Serializer} and the {@link RoutingStrategy} are <b>hard requirements</b> and as such
+     * should be provided.
      */
     public static class Builder {
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.DomainEventData;
 import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
@@ -206,6 +207,12 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         @Override
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            super.spanFactory(spanFactory);
+            return this;
+        }
+
+        @Override
+        public Builder spanFactory(@Nonnull EventBusSpanFactory spanFactory) {
             super.spanFactory(spanFactory);
             return this;
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -32,6 +32,7 @@ import org.axonframework.common.BuilderUtils;
 import org.axonframework.common.StringUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.stream.BlockingStream;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.eventhandling.DomainEventData;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventBusSpanFactory;
@@ -52,11 +53,13 @@ import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.monitoring.MessageMonitor;
+import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.NoOpEventUpcaster;
 import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.SpanFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,11 +106,12 @@ public class AxonServerEventStore extends AbstractEventStore {
      * implementation. An EventStorageEngine may be provided directly however, although we encourage the usage of the
      * {@link Builder#configuration} and {@link Builder#axonServerConnectionManager} functions to let it be created.
      * <p>
-     * The {@link EventUpcaster} is defaulted to a {@link NoOpEventUpcaster} and the {@link SpanFactory} is defaulted
-     * to a {@link org.axonframework.tracing.NoOpSpanFactory}.
+     * The {@link EventUpcaster} is defaulted to a {@link NoOpEventUpcaster} and the {@link EventBusSpanFactory} is
+     * defaulted to a {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a
+     * {@link org.axonframework.tracing.NoOpSpanFactory}.
      * <p>
-     * The event and snapshot {@link Serializer}, {@link AxonServerConfiguration} and {@link
-     * AxonServerConnectionManager} are <b>hard requirements</b> if no EventStorageEngine is provided directly.
+     * The event and snapshot {@link Serializer}, {@link AxonServerConfiguration} and
+     * {@link AxonServerConnectionManager} are <b>hard requirements</b> if no EventStorageEngine is provided directly.
      *
      * @return a Builder to be able to create a {@link AxonServerEventStore}
      */
@@ -178,10 +182,12 @@ public class AxonServerEventStore extends AbstractEventStore {
      * implementation. An EventStorageEngine may be provided directly however, although we encourage the usage of the
      * {@link Builder#configuration} and {@link Builder#axonServerConnectionManager} functions to let it be created.
      * <p>
-     * The {@link EventUpcaster} is defaulted to a {@link NoOpEventUpcaster}.
+     * The {@link EventUpcaster} is defaulted to a {@link NoOpEventUpcaster}. The {@link MessageMonitor} is defaulted to
+     * an {@link NoOpMessageMonitor} and the {@link EventBusSpanFactory} defaults to a
+     * {@link DefaultEventBusSpanFactory} backed by a {@link NoOpSpanFactory}.
      * <p>
-     * The event and snapshot {@link Serializer}, {@link AxonServerConfiguration} and {@link
-     * AxonServerConnectionManager} are <b>hard requirements</b> if no EventStorageEngine is provided directly.
+     * The event and snapshot {@link Serializer}, {@link AxonServerConfiguration} and
+     * {@link AxonServerConnectionManager} are <b>hard requirements</b> if no EventStorageEngine is provided directly.
      */
     public static class Builder extends AbstractEventStore.Builder {
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -210,9 +210,10 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
      * {@link QueryPriorityCalculator#defaultQueryPriorityCalculator()}, the {@link TargetContextResolver} defaults to a
      * lambda returning the {@link AxonServerConfiguration#getContext()} as the context, the
      * {@link ExecutorServiceBuilder} defaults to {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
-     * The {@link AxonServerConnectionManager} and the {@link SpanFactory} defaults to a {@link NoOpSpanFactory}. The
-     * {@link AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and
-     * generic {@link Serializer}s are <b>hard requirements</b> and as such should be provided.
+     * The {@link AxonServerConnectionManager} and the {@link QueryBusSpanFactory} defaults to a
+     * {@link DefaultQueryBusSpanFactory} backed by a {@link NoOpSpanFactory}. The {@link AxonServerConfiguration}, the
+     * local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and generic {@link Serializer}s are
+     * <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link AxonServerQueryBus}
      */
@@ -541,9 +542,10 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
      * {@link QueryPriorityCalculator#defaultQueryPriorityCalculator()} and the {@link TargetContextResolver} defaults
      * to a lambda returning the {@link AxonServerConfiguration#getContext()} as the context. The
      * {@link ExecutorServiceBuilder} defaults to {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
-     * The {@link SpanFactory} defaults to a {@link NoOpSpanFactory}. The {@link AxonServerConnectionManager}, the
-     * {@link AxonServerConfiguration}, the local {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and
-     * generic {@link Serializer}s are <b>hard requirements</b> and as such should be provided.
+     * The {@link QueryBusSpanFactory} defaults to a {@link DefaultQueryBusSpanFactory} backed by a
+     * {@link NoOpSpanFactory}. The {@link AxonServerConnectionManager}, the {@link AxonServerConfiguration}, the local
+     * {@link QueryBus}, the {@link QueryUpdateEmitter}, and the message and generic {@link Serializer}s are <b>hard
+     * requirements</b> and as such should be provided.
      */
     public static class Builder {
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,10 @@ import org.axonframework.messaging.responsetypes.ConvertingResponseMessage;
 import org.axonframework.messaging.responsetypes.InstanceResponseType;
 import org.axonframework.messaging.responsetypes.MultipleInstancesResponseType;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
 import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
@@ -147,7 +149,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
     private final ExecutorService queryExecutor;
     private final LocalSegmentAdapter localSegmentAdapter;
     private final String context;
-    private final SpanFactory spanFactory;
+    private final QueryBusSpanFactory spanFactory;
 
     /**
      * Instantiate a {@link AxonServerQueryBus} based on the fields contained in the {@link Builder}.
@@ -176,7 +178,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
 
     @Override
     public <Q, R> Publisher<QueryResponseMessage<R>> streamingQuery(StreamingQueryMessage<Q, R> query) {
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerQueryBus.streamingQuery", query).start();
+        Span span = spanFactory.createStreamingQuerySpan(query, true).start();
         try (SpanScope unused = span.makeCurrent()) {
             StreamingQueryMessage<Q, R> queryWithContext = spanFactory.propagateContext(query);
             int priority = priorityCalculator.determinePriority(queryWithContext);
@@ -248,7 +250,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
 
     @Override
     public <Q, R> CompletableFuture<QueryResponseMessage<R>> query(@Nonnull QueryMessage<Q, R> queryMessage) {
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerQueryBus.query", queryMessage).start();
+        Span span = spanFactory.createQuerySpan(queryMessage, true).start();
         try (SpanScope unused = span.makeCurrent()) {
             QueryMessage<Q, R> queryWithContext = spanFactory.propagateContext(queryMessage);
             Assert.isFalse(Publisher.class.isAssignableFrom(queryMessage.getResponseType().getExpectedResponseType()),
@@ -264,7 +266,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                 QueryRequest queryRequest = serialize(interceptedQuery, false, priority);
                 ResultStream<QueryResponse> result = sendRequest(interceptedQuery, queryRequest);
                 queryTransaction.whenComplete((r, e) -> result.close());
-                Span responseTaskSpan = spanFactory.createInternalSpan(() -> "AxonServerQueryBus.ResponseProcessingTask");
+                Span responseTaskSpan = spanFactory.createResponseProcessingSpan(interceptedQuery);
                 Runnable responseProcessingTask = new ResponseProcessingTask<>(result,
                                                                                serializer,
                                                                                queryTransaction,
@@ -396,7 +398,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         ));
         ShutdownLatch.ActivityHandle queryInTransit = shutdownLatch.registerActivity();
 
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerQueryBus.scatterGather", queryMessage).start();
+        Span span = spanFactory.createScatterGatherSpan(queryMessage, true).start();
         try(SpanScope unused = span.makeCurrent()) {
             QueryMessage<Q, R> interceptedQuery = dispatchInterceptors.intercept(spanFactory.propagateContext(queryMessage));
             long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
@@ -459,7 +461,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                 "Cannot dispatch new %s as this bus is being shut down", "subscription queries"
         ));
 
-        Span span = spanFactory.createDispatchSpan(() -> "AxonServerQueryBus.subscriptionQuery", query).start();
+        Span span = spanFactory.createSubscriptionQuerySpan(query, true).start();
         try (SpanScope unused = span.makeCurrent()) {
             SubscriptionQueryMessage<Q, I, U> interceptedQuery = dispatchInterceptors.intercept(
                     spanFactory.propagateContext(query)
@@ -557,7 +559,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         private ExecutorServiceBuilder executorServiceBuilder =
                 ExecutorServiceBuilder.defaultQueryExecutorServiceBuilder();
         private String defaultContext;
-        private SpanFactory spanFactory = NoOpSpanFactory.INSTANCE;
+        private QueryBusSpanFactory spanFactory = DefaultQueryBusSpanFactory.builder()
+                                                                            .spanFactory(NoOpSpanFactory.INSTANCE)
+                                                                            .build();
 
         /**
          * Sets the {@link AxonServerConnectionManager} used to create connections between this application and an Axon
@@ -739,9 +743,25 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
          *
          * @param spanFactory The {@link SpanFactory} implementation
          * @return The current Builder instance, for fluent interfacing.
+         * @deprecated Use {@link #spanFactory(QueryBusSpanFactory)} instead as it provides more configurability.
          */
+        @Deprecated
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
             assertNonNull(spanFactory, "The SpanFactory may not be null or empty");
+            this.spanFactory = DefaultQueryBusSpanFactory.builder().spanFactory(spanFactory).build();
+            return this;
+        }
+
+        /**
+         * Sets the {@link QueryBusSpanFactory} implementation to use for providing tracing capabilities. Defaults to a
+         * {@link DefaultQueryBusSpanFactory} backed by a {@link NoOpSpanFactory} by default, which provides no tracing
+         * capabilities.
+         *
+         * @param spanFactory The {@link QueryBusSpanFactory} implementation.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(@Nonnull QueryBusSpanFactory spanFactory) {
+            assertNonNull(spanFactory, "SpanFactory may not be null");
             this.spanFactory = spanFactory;
             return this;
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.axonframework.axonserver.connector.util.ProcessingInstructionHelper;
 import org.axonframework.messaging.responsetypes.MultipleInstancesResponseType;
 import org.axonframework.queryhandling.GenericStreamingQueryMessage;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.queryhandling.StreamingQueryMessage;
@@ -78,7 +79,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
     private final boolean supportsStreaming;
 
     private final Supplier<Boolean> reactorOnClassPath;
-    private final SpanFactory spanFactory;
+    private final QueryBusSpanFactory spanFactory;
 
     /**
      * Instantiates a query processing task.
@@ -89,14 +90,14 @@ class QueryProcessingTask implements Runnable, FlowControl {
      * @param responseHandler The {@link ReplyChannel} used for sending items to the Axon Server.
      * @param serializer      The serializer used to serialize items.
      * @param clientId        The identifier of the client.
-     * @param spanFactory     The {@link SpanFactory} implementation to use to provide tracing capabilities.
+     * @param spanFactory     The {@link QueryBusSpanFactory} implementation to use to provide tracing capabilities.
      */
     QueryProcessingTask(QueryBus localSegment,
                         QueryRequest queryRequest,
                         ReplyChannel<QueryResponse> responseHandler,
                         QuerySerializer serializer,
                         String clientId,
-                        SpanFactory spanFactory) {
+                        QueryBusSpanFactory spanFactory) {
         this(localSegment,
              queryRequest,
              responseHandler,
@@ -116,7 +117,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
      * @param serializer         The serializer used to serialize items.
      * @param clientId           The identifier of the client.
      * @param reactorOnClassPath Indicates whether Project Reactor is on the classpath.
-     * @param spanFactory        The {@link SpanFactory} implementation to use to provide tracing capabilities.
+     * @param spanFactory        The {@link QueryBusSpanFactory} implementation to use to provide tracing capabilities.
      */
     QueryProcessingTask(QueryBus localSegment,
                         QueryRequest queryRequest,
@@ -124,7 +125,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
                         QuerySerializer serializer,
                         String clientId,
                         Supplier<Boolean> reactorOnClassPath,
-                        SpanFactory spanFactory) {
+                        QueryBusSpanFactory spanFactory) {
         this.localSegment = localSegment;
         this.queryRequest = queryRequest;
         this.responseHandler = responseHandler;
@@ -140,7 +141,7 @@ class QueryProcessingTask implements Runnable, FlowControl {
         try {
             logger.debug("Will process query [{}]", queryRequest.getQuery());
             QueryMessage<Object, Object> queryMessage = serializer.deserializeRequest(queryRequest);
-            spanFactory.createChildHandlerSpan(() -> "QueryProcessingTask", queryMessage).run(() -> {
+            spanFactory.createQueryProcessingSpan(queryMessage).run(() -> {
                 if (numberOfResults(queryRequest.getProcessingInstructionsList()) == DIRECT_QUERY_NUMBER_OF_RESULTS) {
                     if (supportsStreaming && reactorOnClassPath.get()) {
                         streamingQuery(queryMessage);

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResult.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/AxonServerSubscriptionQueryResult.java
@@ -61,10 +61,25 @@ public class AxonServerSubscriptionQueryResult<I, U>
     @Deprecated
     public AxonServerSubscriptionQueryResult(final io.axoniq.axonserver.connector.query.SubscriptionQueryResult result,
                                              final SubscriptionMessageSerializer subscriptionSerializer) {
+        this(result, NoOpSpanFactory.INSTANCE, subscriptionSerializer);
+    }
+
+
+    /**
+     * Instantiate a {@link AxonServerSubscriptionQueryResult} which will emit its initial response and the updates of
+     * the subscription query.
+     *
+     * @deprecated Deprecated in favor of constructor with a {@link QueryBusSpanFactory}. This constructor defaults to a
+     * {@link DefaultQueryBusSpanFactory} with the provided {@link SpanFactory}.
+     */
+    @Deprecated
+    public AxonServerSubscriptionQueryResult(final io.axoniq.axonserver.connector.query.SubscriptionQueryResult result,
+                                             final SpanFactory spanFactory,
+                                             final SubscriptionMessageSerializer subscriptionSerializer) {
         this(null,
              result,
              subscriptionSerializer,
-             DefaultQueryBusSpanFactory.builder().spanFactory(NoOpSpanFactory.INSTANCE).build(),
+             DefaultQueryBusSpanFactory.builder().spanFactory(spanFactory).build(),
              new NoOpSpanFactory.NoOpSpan());
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -30,10 +30,12 @@ import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.TestTargetContextResolver;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.common.Registration;
@@ -89,10 +91,12 @@ class AxonServerCommandBusTest {
     private AxonServerConnection mockConnection;
     private CommandChannel mockCommandChannel;
     private TestSpanFactory spanFactory;
+    private CommandBusSpanFactory commandBusSpanFactory;
 
     @BeforeEach
     void setup() throws Exception {
         spanFactory = new TestSpanFactory();
+        commandBusSpanFactory = DefaultCommandBusSpanFactory.builder().spanFactory(spanFactory).build();
         dummyMessagePlatformServer = new DummyMessagePlatformServer();
         dummyMessagePlatformServer.start();
 
@@ -122,7 +126,7 @@ class AxonServerCommandBusTest {
                                           .routingStrategy(command -> "RoutingKey")
                                           .targetContextResolver(targetContextResolver)
                                           .loadFactorProvider(command -> 36)
-                                          .spanFactory(spanFactory)
+                                          .spanFactory(commandBusSpanFactory)
                                           .build();
     }
 
@@ -141,7 +145,7 @@ class AxonServerCommandBusTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
         testSubject.dispatch(commandMessage, (CommandCallback<String, String>) (cm, result) -> {
-            spanFactory.verifySpanActive("AxonServerCommandBus.dispatch", commandMessage);
+            spanFactory.verifySpanActive("dispatchDistributedCommand", commandMessage);
             if (result.isExceptional()) {
                 failure.set(result.exceptionResult());
             } else {
@@ -158,11 +162,11 @@ class AxonServerCommandBusTest {
         verify(axonServerConnectionManager).getConnection(BOUNDED_CONTEXT);
         await().atMost(Duration.ofSeconds(3l))
                 .untilAsserted(
-                        () -> spanFactory.verifySpanCompleted("AxonServerCommandBus.dispatch")
+                        () -> spanFactory.verifySpanCompleted("dispatchDistributedCommand")
                 );
         await().atMost(Duration.ofSeconds(3l))
                 .untilAsserted(
-                        () -> spanFactory.verifySpanPropagated("AxonServerCommandBus.dispatch", commandMessage)
+                        () -> spanFactory.verifySpanPropagated("dispatchDistributedCommand", commandMessage)
                 );
     }
 
@@ -284,7 +288,7 @@ class AxonServerCommandBusTest {
 
         verify(targetContextResolver).resolveContext(commandMessage);
         verify(axonServerConnectionManager).getConnection(BOUNDED_CONTEXT);
-        spanFactory.verifySpanHasException("AxonServerCommandBus.dispatch", RuntimeException.class);
+        spanFactory.verifySpanHasException("dispatchDistributedCommand", RuntimeException.class);
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/AxonServerCommandBusTest.java
@@ -145,7 +145,7 @@ class AxonServerCommandBusTest {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
         testSubject.dispatch(commandMessage, (CommandCallback<String, String>) (cm, result) -> {
-            spanFactory.verifySpanActive("dispatchDistributedCommand", commandMessage);
+            spanFactory.verifySpanActive("CommandBus.dispatchDistributedCommand", commandMessage);
             if (result.isExceptional()) {
                 failure.set(result.exceptionResult());
             } else {
@@ -162,11 +162,11 @@ class AxonServerCommandBusTest {
         verify(axonServerConnectionManager).getConnection(BOUNDED_CONTEXT);
         await().atMost(Duration.ofSeconds(3l))
                 .untilAsserted(
-                        () -> spanFactory.verifySpanCompleted("dispatchDistributedCommand")
+                        () -> spanFactory.verifySpanCompleted("CommandBus.dispatchDistributedCommand")
                 );
         await().atMost(Duration.ofSeconds(3l))
                 .untilAsserted(
-                        () -> spanFactory.verifySpanPropagated("dispatchDistributedCommand", commandMessage)
+                        () -> spanFactory.verifySpanPropagated("CommandBus.dispatchDistributedCommand", commandMessage)
                 );
     }
 
@@ -288,7 +288,7 @@ class AxonServerCommandBusTest {
 
         verify(targetContextResolver).resolveContext(commandMessage);
         verify(axonServerConnectionManager).getConnection(BOUNDED_CONTEXT);
-        spanFactory.verifySpanHasException("dispatchDistributedCommand", RuntimeException.class);
+        spanFactory.verifySpanHasException("CommandBus.dispatchDistributedCommand", RuntimeException.class);
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -129,11 +129,11 @@ class AxonServerEventStoreTest {
                 GenericEventMessage.asEventMessage("Test3")};
         testSubject.publish(eventMessages);
         Arrays.stream(eventMessages).forEach(e -> {
-            testSpanFactory.verifySpanCompleted("publishEvent", e);
+            testSpanFactory.verifySpanCompleted("EventBus.publishEvent", e);
         });
-        testSpanFactory.verifyNotStarted("commitEvents");
+        testSpanFactory.verifyNotStarted("EventBus.commitEvents");
         uow.commit();
-        testSpanFactory.verifySpanCompleted("commitEvents");
+        testSpanFactory.verifySpanCompleted("EventBus.commitEvents");
 
         TrackingEventStream stream = testSubject.openStream(null);
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.axonframework.axonserver.connector.util.TcpUtil;
 import org.axonframework.axonserver.connector.utils.PlatformService;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
@@ -42,6 +43,7 @@ import org.axonframework.serialization.upcasting.event.ContextAwareSingleEventUp
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
 import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation;
 import org.axonframework.serialization.xml.XStreamSerializer;
+import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.TestSpanFactory;
 import org.junit.jupiter.api.*;
 
@@ -107,7 +109,9 @@ class AxonServerEventStoreTest {
                                           .eventSerializer(JacksonSerializer.defaultSerializer())
                                           .snapshotSerializer(TestSerializer.xStreamSerializer())
                                           .snapshotFilter(SnapshotFilter.allowAll())
-                                          .spanFactory(testSpanFactory)
+                                          .spanFactory(DefaultEventBusSpanFactory.builder()
+                                                                                 .spanFactory(testSpanFactory)
+                                                                                 .build())
                                           .build();
     }
 
@@ -125,15 +129,11 @@ class AxonServerEventStoreTest {
                 GenericEventMessage.asEventMessage("Test3")};
         testSubject.publish(eventMessages);
         Arrays.stream(eventMessages).forEach(e -> {
-            testSpanFactory.verifySpanCompleted("AxonServerEventStore.publish", e);
+            testSpanFactory.verifySpanCompleted("publishEvent", e);
         });
-        testSpanFactory.verifyNotStarted("AxonServerEventStore.prepareCommit");
-        testSpanFactory.verifyNotStarted("AxonServerEventStore.commit");
-        testSpanFactory.verifyNotStarted("AxonServerEventStore.afterCommit");
+        testSpanFactory.verifyNotStarted("commitEvents");
         uow.commit();
-        testSpanFactory.verifySpanCompleted("AxonServerEventStore.prepareCommit");
-        testSpanFactory.verifySpanCompleted("AxonServerEventStore.commit");
-        testSpanFactory.verifySpanCompleted("AxonServerEventStore.afterCommit");
+        testSpanFactory.verifySpanCompleted("commitEvents");
 
         TrackingEventStream stream = testSubject.openStream(null);
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -43,6 +43,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.responsetypes.InstanceResponseType;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
 import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.queryhandling.GenericStreamingQueryMessage;
@@ -131,7 +132,11 @@ class AxonServerQueryBusTest {
                                         .messageSerializer(serializer)
                                         .genericSerializer(serializer)
                                         .targetContextResolver(targetContextResolver)
-                                        .spanFactory(spanFactory)
+                                        .spanFactory(
+                                                DefaultQueryBusSpanFactory.builder()
+                                                                          .spanFactory(spanFactory)
+                                                                          .build()
+                                        )
                                         .build();
 
         AxonServerConnection mockConnection = mock(AxonServerConnection.class);
@@ -191,8 +196,8 @@ class AxonServerQueryBusTest {
         assertEquals("test", testSubject.query(testQuery).get().getPayload());
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("AxonServerQueryBus.query");
-        spanFactory.verifySpanPropagated("AxonServerQueryBus.query", testQuery);
+        spanFactory.verifySpanCompleted("queryDistributed");
+        spanFactory.verifySpanPropagated("queryDistributed", testQuery);
     }
 
     @Test
@@ -213,8 +218,8 @@ class AxonServerQueryBusTest {
         }
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("AxonServerQueryBus.query");
-        spanFactory.verifySpanHasException("AxonServerQueryBus.query", AxonServerQueryDispatchException.class);
+        spanFactory.verifySpanCompleted("queryDistributed");
+        spanFactory.verifySpanHasException("queryDistributed", AxonServerQueryDispatchException.class);
     }
 
     @Test
@@ -237,8 +242,8 @@ class AxonServerQueryBusTest {
         assertEquals(ErrorCode.QUERY_EXECUTION_ERROR.errorCode(), remoteQueryHandlingException.getErrorCode());
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("AxonServerQueryBus.query");
-        spanFactory.verifySpanHasException("AxonServerQueryBus.query", QueryExecutionException.class);
+        spanFactory.verifySpanCompleted("queryDistributed");
+        spanFactory.verifySpanHasException("queryDistributed", QueryExecutionException.class);
     }
 
     @Test
@@ -265,8 +270,8 @@ class AxonServerQueryBusTest {
 
         verify(targetContextResolver).resolveContext(testQuery);
         await().untilAsserted(() -> {
-            spanFactory.verifySpanCompleted("AxonServerQueryBus.query");
-            spanFactory.verifySpanHasException("AxonServerQueryBus.query", QueryExecutionException.class);
+            spanFactory.verifySpanCompleted("queryDistributed");
+            spanFactory.verifySpanHasException("queryDistributed", QueryExecutionException.class);
         });
     }
 
@@ -319,8 +324,8 @@ class AxonServerQueryBusTest {
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
                         && -1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            spanFactory.verifySpanCompleted("AxonServerQueryBus.scatterGather", testQuery);
-            spanFactory.verifySpanPropagated("AxonServerQueryBus.scatterGather", testQuery);
+            spanFactory.verifySpanCompleted("scatterGatherQueryDistributed", testQuery);
+            spanFactory.verifySpanPropagated("scatterGatherQueryDistributed", testQuery);
         });
     }
 
@@ -348,8 +353,8 @@ class AxonServerQueryBusTest {
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
-                   spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery", testQuery);
-                   spanFactory.verifySpanPropagated("AxonServerQueryBus.streamingQuery", testQuery);
+                   spanFactory.verifySpanCompleted("streamingQueryDistributed", testQuery);
+                   spanFactory.verifySpanPropagated("streamingQueryDistributed", testQuery);
                });
     }
 
@@ -371,8 +376,8 @@ class AxonServerQueryBusTest {
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
-                   spanFactory.verifySpanCompleted("AxonServerQueryBus.streamingQuery");
-                   spanFactory.verifySpanHasException("AxonServerQueryBus.streamingQuery", RuntimeException.class);
+                   spanFactory.verifySpanCompleted("streamingQueryDistributed");
+                   spanFactory.verifySpanHasException("streamingQueryDistributed", RuntimeException.class);
                });
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -196,8 +196,8 @@ class AxonServerQueryBusTest {
         assertEquals("test", testSubject.query(testQuery).get().getPayload());
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("queryDistributed");
-        spanFactory.verifySpanPropagated("queryDistributed", testQuery);
+        spanFactory.verifySpanCompleted("QueryBus.queryDistributed");
+        spanFactory.verifySpanPropagated("QueryBus.queryDistributed", testQuery);
     }
 
     @Test
@@ -218,8 +218,8 @@ class AxonServerQueryBusTest {
         }
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("queryDistributed");
-        spanFactory.verifySpanHasException("queryDistributed", AxonServerQueryDispatchException.class);
+        spanFactory.verifySpanCompleted("QueryBus.queryDistributed");
+        spanFactory.verifySpanHasException("QueryBus.queryDistributed", AxonServerQueryDispatchException.class);
     }
 
     @Test
@@ -242,8 +242,8 @@ class AxonServerQueryBusTest {
         assertEquals(ErrorCode.QUERY_EXECUTION_ERROR.errorCode(), remoteQueryHandlingException.getErrorCode());
 
         verify(targetContextResolver).resolveContext(testQuery);
-        spanFactory.verifySpanCompleted("queryDistributed");
-        spanFactory.verifySpanHasException("queryDistributed", QueryExecutionException.class);
+        spanFactory.verifySpanCompleted("QueryBus.queryDistributed");
+        spanFactory.verifySpanHasException("QueryBus.queryDistributed", QueryExecutionException.class);
     }
 
     @Test
@@ -270,8 +270,8 @@ class AxonServerQueryBusTest {
 
         verify(targetContextResolver).resolveContext(testQuery);
         await().untilAsserted(() -> {
-            spanFactory.verifySpanCompleted("queryDistributed");
-            spanFactory.verifySpanHasException("queryDistributed", QueryExecutionException.class);
+            spanFactory.verifySpanCompleted("QueryBus.queryDistributed");
+            spanFactory.verifySpanHasException("QueryBus.queryDistributed", QueryExecutionException.class);
         });
     }
 
@@ -324,8 +324,8 @@ class AxonServerQueryBusTest {
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
                         && -1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            spanFactory.verifySpanCompleted("scatterGatherQueryDistributed", testQuery);
-            spanFactory.verifySpanPropagated("scatterGatherQueryDistributed", testQuery);
+            spanFactory.verifySpanCompleted("QueryBus.scatterGatherQueryDistributed", testQuery);
+            spanFactory.verifySpanPropagated("QueryBus.scatterGatherQueryDistributed", testQuery);
         });
     }
 
@@ -353,8 +353,8 @@ class AxonServerQueryBusTest {
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
-                   spanFactory.verifySpanCompleted("streamingQueryDistributed", testQuery);
-                   spanFactory.verifySpanPropagated("streamingQueryDistributed", testQuery);
+                   spanFactory.verifySpanCompleted("QueryBus.streamingQueryDistributed", testQuery);
+                   spanFactory.verifySpanPropagated("QueryBus.streamingQueryDistributed", testQuery);
                });
     }
 
@@ -376,8 +376,8 @@ class AxonServerQueryBusTest {
                         && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
-                   spanFactory.verifySpanCompleted("streamingQueryDistributed");
-                   spanFactory.verifySpanHasException("streamingQueryDistributed", RuntimeException.class);
+                   spanFactory.verifySpanCompleted("QueryBus.streamingQueryDistributed");
+                   spanFactory.verifySpanHasException("QueryBus.streamingQueryDistributed", RuntimeException.class);
                });
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -131,7 +131,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            queryBusSpanFactory);
 
         task.run();
-        spanFactory.verifySpanCompleted("QueryProcessingTask");
+        spanFactory.verifySpanCompleted("QueryBus.processQueryMessage");
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,8 +27,10 @@ import io.axoniq.axonserver.grpc.query.QueryRequest;
 import io.axoniq.axonserver.grpc.query.QueryResponse;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
 import org.axonframework.queryhandling.GenericQueryMessage;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryHandler;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryResponseMessage;
@@ -68,12 +70,16 @@ class QueryProcessingTaskIntegrationTest {
     private CachingReplyChannel<QueryResponse> responseHandler;
     private QuerySerializer querySerializer;
     private TestSpanFactory spanFactory;
+    private QueryBusSpanFactory queryBusSpanFactory;
 
     private QueryHandlingComponent1 queryHandlingComponent1;
 
     @BeforeEach
     void setUp() {
         spanFactory = new TestSpanFactory();
+        queryBusSpanFactory = DefaultQueryBusSpanFactory.builder()
+                                                        .spanFactory(spanFactory)
+                                                        .build();
         localSegment = SimpleQueryBus.builder().build();
         responseHandler = new CachingReplyChannel<>();
         Serializer serializer = XStreamSerializer.builder()
@@ -101,7 +107,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(10);
@@ -122,7 +128,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         spanFactory.verifySpanCompleted("QueryProcessingTask");
@@ -140,7 +146,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.request(10);
         task.run();
@@ -161,7 +167,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.cancel();
         task.run();
@@ -184,7 +190,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.request(10);
         task.run();
@@ -217,7 +223,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.request(10);
         task.run();
@@ -250,7 +256,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           () -> false, spanFactory);
+                                                           () -> false, queryBusSpanFactory);
 
         task.request(10);
         task.run();
@@ -284,7 +290,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           () -> false, spanFactory);
+                                                           () -> false, queryBusSpanFactory);
 
         CountDownLatch latch = new CountDownLatch(101);
         Runnable queryExecutor = () -> {
@@ -334,7 +340,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         CountDownLatch latch = new CountDownLatch(101);
         Runnable queryExecutor = () -> {
@@ -383,7 +389,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.request(10);
         task.run();
@@ -411,7 +417,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(1000);
@@ -440,7 +446,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
         task.run();
         assertTrue(responseHandler.sent().isEmpty());
         task.request(100);
@@ -469,7 +475,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
         task.cancel();
         task.run();
         assertTrue(responseHandler.sent().isEmpty());
@@ -492,7 +498,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           () -> false, spanFactory);
+                                                           () -> false, queryBusSpanFactory);
         task.run();
         assertTrue(responseHandler.sent().isEmpty());
         task.request(100);
@@ -520,7 +526,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           () -> false, spanFactory);
+                                                           () -> false, queryBusSpanFactory);
         task.cancel();
         task.run();
         assertTrue(responseHandler.sent().isEmpty());
@@ -543,7 +549,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(100);
@@ -570,7 +576,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(100);
@@ -596,7 +602,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(100);
@@ -623,7 +629,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(100);
@@ -649,7 +655,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(Long.MAX_VALUE);
@@ -675,7 +681,7 @@ class QueryProcessingTaskIntegrationTest {
                                                            responseHandler,
                                                            querySerializer,
                                                            CLIENT_ID,
-                                                           spanFactory);
+                                                           queryBusSpanFactory);
 
         task.run();
         task.request(Long.MAX_VALUE);

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -540,8 +540,8 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
-     * Returns the default {@link CommandBusSpanFactory}, or a {@link CommandBusSpanFactory} backed by the configured
-     * {@link SpanFactory} if none it set.
+     * Returns the default {@link CommandBusSpanFactory}, or a {@link DefaultCommandBusSpanFactory} backed by the
+     * configured {@link SpanFactory} if none it set.
      *
      * @param config The configuration that supplies the span factory.
      * @return The default {@link CommandBusSpanFactory}.
@@ -555,7 +555,7 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
-     * Returns the default {@link QueryBusSpanFactory}, or a {@link QueryBusSpanFactory} backed by the configured
+     * Returns the default {@link QueryBusSpanFactory}, or a {@link DefaultQueryBusSpanFactory} backed by the configured
      * {@link SpanFactory} if none it set.
      *
      * @param config The configuration that supplies the span factory.
@@ -570,8 +570,8 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
-     * Returns the default {@link QueryUpdateEmitterSpanFactory}, or a {@link QueryUpdateEmitterSpanFactory} backed by the configured
-     * {@link SpanFactory} if none it set.
+     * Returns the default {@link QueryUpdateEmitterSpanFactory}, or a {@link DefaultQueryUpdateEmitterSpanFactory}
+     * backed by the configured {@link SpanFactory} if none it set.
      *
      * @param config The configuration that supplies the span factory.
      * @return The default {@link QueryUpdateEmitterSpanFactory}.
@@ -585,7 +585,7 @@ public class DefaultConfigurer implements Configurer {
     }
 
     /**
-     * Returns the default {@link EventBusSpanFactory}, or a {@link EventBusSpanFactory} backed by the configured
+     * Returns the default {@link EventBusSpanFactory}, or a {@link DefaultEventBusSpanFactory} backed by the configured
      * {@link SpanFactory} if none it set.
      *
      * @param config The configuration that supplies the span factory.

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -18,6 +18,8 @@ package org.axonframework.config;
 
 import org.axonframework.commandhandling.AnnotationCommandHandlerAdapter;
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
 import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.LoggingDuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.SimpleCommandBus;
@@ -31,7 +33,9 @@ import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.deadline.SimpleDeadlineManager;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.gateway.DefaultEventGateway;
 import org.axonframework.eventhandling.gateway.EventGateway;
@@ -60,12 +64,16 @@ import org.axonframework.modelling.saga.ResourceInjector;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.modelling.saga.repository.jpa.JpaSagaStore;
 import org.axonframework.monitoring.MessageMonitor;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
 import org.axonframework.queryhandling.DefaultQueryGateway;
+import org.axonframework.queryhandling.DefaultQueryUpdateEmitterSpanFactory;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
+import org.axonframework.queryhandling.QueryUpdateEmitterSpanFactory;
 import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.queryhandling.SimpleQueryUpdateEmitter;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
@@ -198,6 +206,10 @@ public class DefaultConfigurer implements Configurer {
         components.put(Snapshotter.class, new Component<>(config, "snapshotter", this::defaultSnapshotter));
         components.put(SpanFactory.class, new Component<>(config, "spanFactory", this::defaultSpanFactory));
         components.put(SnapshotterSpanFactory.class, new Component<>(config, "snapshotterSpanFactory", this::defaultSnapshotterSpanFactory));
+        components.put(CommandBusSpanFactory.class, new Component<>(config, "commandBusSpanFactory", this::defaultCommandBusSpanFactory));
+        components.put(QueryBusSpanFactory.class, new Component<>(config, "queryBusSpanFactory", this::defaultQueryBusSpanFactory));
+        components.put(QueryUpdateEmitterSpanFactory.class, new Component<>(config, "queryUpdateEmitterSpanFactory", this::defaultQueryUpdateEmitterSpanFactory));
+        components.put(EventBusSpanFactory.class, new Component<>(config, "eventBusSpanFactory", this::defaultEventBusSpanFactory));
     }
 
     /**
@@ -347,7 +359,7 @@ public class DefaultConfigurer implements Configurer {
                                                               () -> LoggingQueryInvocationErrorHandler.builder().build()
                                                       ))
                                                       .queryUpdateEmitter(config.getComponent(QueryUpdateEmitter.class))
-                                                      .spanFactory(config.spanFactory())
+                                                      .spanFactory(config.getComponent(QueryBusSpanFactory.class))
                                                       .build();
                     queryBus.registerHandlerInterceptor(new CorrelationDataInterceptor<>(config.correlationDataProviders()));
                     return queryBus;
@@ -368,7 +380,7 @@ public class DefaultConfigurer implements Configurer {
                             config.messageMonitor(QueryUpdateEmitter.class, "queryUpdateEmitter");
                     return SimpleQueryUpdateEmitter.builder()
                                                    .updateMessageMonitor(updateMessageMonitor)
-                                                   .spanFactory(config.spanFactory())
+                                                   .spanFactory(config.getComponent(QueryUpdateEmitterSpanFactory.class))
                                                    .build();
                 });
     }
@@ -429,7 +441,7 @@ public class DefaultConfigurer implements Configurer {
                                                     DuplicateCommandHandlerResolver.class,
                                                     LoggingDuplicateCommandHandlerResolver::instance
                                             ))
-                                            .spanFactory(config.spanFactory())
+                                            .spanFactory(config.getComponent(CommandBusSpanFactory.class))
                                             .messageMonitor(config.messageMonitor(SimpleCommandBus.class, "commandBus"))
                                             .build();
                     commandBus.registerHandlerInterceptor(new CorrelationDataInterceptor<>(config.correlationDataProviders()));
@@ -487,7 +499,7 @@ public class DefaultConfigurer implements Configurer {
         return defaultComponent(EventBus.class, config)
                 .orElseGet(() -> SimpleEventBus.builder()
                                                .messageMonitor(config.messageMonitor(EventBus.class, "eventBus"))
-                                               .spanFactory(config.spanFactory())
+                                               .spanFactory(config.getComponent(EventBusSpanFactory.class))
                                                .build());
     }
 
@@ -521,11 +533,70 @@ public class DefaultConfigurer implements Configurer {
      */
     protected SnapshotterSpanFactory defaultSnapshotterSpanFactory(Configuration config) {
         return defaultComponent(SnapshotterSpanFactory.class, this.config)
-                .orElseGet(() -> {
-                    return DefaultSnapshotterSpanFactory.builder()
-                            .spanFactory(config.spanFactory())
-                            .build();
-                });
+                .orElseGet(() -> DefaultSnapshotterSpanFactory
+                        .builder()
+                        .spanFactory(config.spanFactory())
+                        .build());
+    }
+
+    /**
+     * Returns the default {@link CommandBusSpanFactory}, or a {@link CommandBusSpanFactory} backed by the configured
+     * {@link SpanFactory} if none it set.
+     *
+     * @param config The configuration that supplies the span factory.
+     * @return The default {@link CommandBusSpanFactory}.
+     */
+    protected CommandBusSpanFactory defaultCommandBusSpanFactory(Configuration config) {
+        return defaultComponent(CommandBusSpanFactory.class, this.config)
+                .orElseGet(() -> DefaultCommandBusSpanFactory
+                        .builder()
+                        .spanFactory(config.spanFactory())
+                        .build());
+    }
+
+    /**
+     * Returns the default {@link QueryBusSpanFactory}, or a {@link QueryBusSpanFactory} backed by the configured
+     * {@link SpanFactory} if none it set.
+     *
+     * @param config The configuration that supplies the span factory.
+     * @return The default {@link QueryBusSpanFactory}.
+     */
+    protected QueryBusSpanFactory defaultQueryBusSpanFactory(Configuration config) {
+        return defaultComponent(QueryBusSpanFactory.class, this.config)
+                .orElseGet(() -> DefaultQueryBusSpanFactory
+                        .builder()
+                        .spanFactory(config.spanFactory())
+                        .build());
+    }
+
+    /**
+     * Returns the default {@link QueryUpdateEmitterSpanFactory}, or a {@link QueryUpdateEmitterSpanFactory} backed by the configured
+     * {@link SpanFactory} if none it set.
+     *
+     * @param config The configuration that supplies the span factory.
+     * @return The default {@link QueryUpdateEmitterSpanFactory}.
+     */
+    protected QueryUpdateEmitterSpanFactory defaultQueryUpdateEmitterSpanFactory(Configuration config) {
+        return defaultComponent(QueryUpdateEmitterSpanFactory.class, this.config)
+                .orElseGet(() -> DefaultQueryUpdateEmitterSpanFactory
+                        .builder()
+                        .spanFactory(config.spanFactory())
+                        .build());
+    }
+
+    /**
+     * Returns the default {@link EventBusSpanFactory}, or a {@link EventBusSpanFactory} backed by the configured
+     * {@link SpanFactory} if none it set.
+     *
+     * @param config The configuration that supplies the span factory.
+     * @return The default {@link EventBusSpanFactory}.
+     */
+    protected EventBusSpanFactory defaultEventBusSpanFactory(Configuration config) {
+        return defaultComponent(EventBusSpanFactory.class, this.config)
+                .orElseGet(() -> DefaultEventBusSpanFactory
+                        .builder()
+                        .spanFactory(config.spanFactory())
+                        .build());
     }
 
     /**

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,7 +260,7 @@ public class AggregateConfigurerTest {
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
 
-        testSpanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+        testSpanFactory.verifySpanCompleted("dispatchCommand");
 
         config.shutdown();
     }
@@ -309,7 +309,7 @@ public class AggregateConfigurerTest {
         CommandGateway commandGateway = config.commandGateway();
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
-        testSpanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+        testSpanFactory.verifySpanCompleted("dispatchCommand");
 
         config.shutdown();
     }
@@ -356,7 +356,7 @@ public class AggregateConfigurerTest {
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
 
-        testSpanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+        testSpanFactory.verifySpanCompleted("dispatchCommand");
 
         config.shutdown();
     }

--- a/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/AggregateConfigurerTest.java
@@ -260,7 +260,7 @@ public class AggregateConfigurerTest {
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
 
-        testSpanFactory.verifySpanCompleted("dispatchCommand");
+        testSpanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
 
         config.shutdown();
     }
@@ -309,7 +309,7 @@ public class AggregateConfigurerTest {
         CommandGateway commandGateway = config.commandGateway();
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
-        testSpanFactory.verifySpanCompleted("dispatchCommand");
+        testSpanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
 
         config.shutdown();
     }
@@ -356,7 +356,7 @@ public class AggregateConfigurerTest {
         String testAggregateIdentifier = "123";
         commandGateway.sendAndWait(new CreateACommand(testAggregateIdentifier));
 
-        testSpanFactory.verifySpanCompleted("dispatchCommand");
+        testSpanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
 
         config.shutdown();
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactory.java
@@ -51,13 +51,13 @@ public class DefaultSnapshotterSpanFactory implements SnapshotterSpanFactory {
     @Override
     public Span createScheduleSnapshotSpan(String aggregateType, String aggregateIdentifier) {
         return spanFactory
-                .createInternalSpan(() -> createSpanName("scheduleSnapshot", aggregateType))
+                .createInternalSpan(() -> createSpanName("Snapshotter.scheduleSnapshot", aggregateType))
                 .addAttribute("aggregateIdentifier", aggregateIdentifier);
     }
 
     @Override
     public Span createCreateSnapshotSpan(String aggregateType, String aggregateIdentifier) {
-        Supplier<String> spanName = () -> createSpanName("createSnapshot", aggregateType);
+        Supplier<String> spanName = () -> createSpanName("Snapshotter.createSnapshot", aggregateType);
         if (separateTrace) {
             return spanFactory
                     .createRootTrace(spanName)

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,8 +184,10 @@ public abstract class AbstractEventStore extends AbstractEventBus implements Eve
     /**
      * Abstract Builder class to instantiate an {@link AbstractEventStore}.
      * <p>
-     * The {@link MessageMonitor} is defaulted to an {@link NoOpMessageMonitor} and the {@link SpanFactory} defaults to
-     * a {@link NoOpSpanFactory}. The {@link EventStorageEngine} is a
+     * The {@link MessageMonitor} is defaulted to an {@link NoOpMessageMonitor} and the
+     * {@link org.axonframework.eventhandling.EventBusSpanFactory} defaults to a
+     * {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a {@link NoOpSpanFactory}. The
+     * {@link EventStorageEngine} is a
      * <b>hard requirement</b> and as such should be provided.
      */
     public abstract static class Builder extends AbstractEventBus.Builder {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.eventstore;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.io.IOUtils;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
@@ -525,6 +526,12 @@ public class EmbeddedEventStore extends AbstractEventStore implements Lifecycle 
 
         @Override
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            super.spanFactory(spanFactory);
+            return this;
+        }
+
+        @Override
+        public Builder spanFactory(@Nonnull EventBusSpanFactory spanFactory) {
             super.spanFactory(spanFactory);
             return this;
         }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStore.java
@@ -116,7 +116,7 @@ public class EmbeddedEventStore extends AbstractEventStore implements Lifecycle 
      * The following configurable fields have defaults:
      * <ul>
      * <li>The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.</li>
-     * <li>The {@link SpanFactory} is defaulted to a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
+     * <li>The {@link EventBusSpanFactory} is defaulted to a {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
      * <li>The {@code cachedEvents} is defaulted to {@code 10000}.</li>
      * <li>The {@code fetchDelay} is defaulted to {@code 1000}.</li>
      * <li>The {@code cleanupDelay} is defaulted to {@code 10000}.</li>
@@ -484,7 +484,7 @@ public class EmbeddedEventStore extends AbstractEventStore implements Lifecycle 
      * The following configurable fields have defaults:
      * <ul>
      * <li>The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.</li>
-     * <li>The {@link SpanFactory} is defaulted to a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
+     * <li>The {@link EventBusSpanFactory} is defaulted to a {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
      * <li>The {@code cachedEvents} is defaulted to {@code 10000}.</li>
      * <li>The {@code fetchDelay} is defaulted to {@code 1000}.</li>
      * <li>The {@code cleanupDelay} is defaulted to {@code 10000}.</li>

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/legacyjpa/EmbeddedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/legacyjpa/EmbeddedEventStore.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.eventstore.legacyjpa;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.io.IOUtils;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
@@ -517,6 +518,12 @@ public class EmbeddedEventStore extends AbstractEventStore {
 
         @Override
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            super.spanFactory(spanFactory);
+            return this;
+        }
+
+        @Override
+        public Builder spanFactory(@Nonnull EventBusSpanFactory spanFactory) {
             super.spanFactory(spanFactory);
             return this;
         }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/legacyjpa/EmbeddedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/legacyjpa/EmbeddedEventStore.java
@@ -112,7 +112,7 @@ public class EmbeddedEventStore extends AbstractEventStore {
      * The following configurable fields have defaults:
      * <ul>
      * <li>The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.</li>
-     * <li>The {@link SpanFactory} is defaulted to a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
+     * <li>The {@link EventBusSpanFactory} is defaulted to a {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
      * <li>The {@code cachedEvents} is defaulted to {@code 10000}.</li>
      * <li>The {@code fetchDelay} is defaulted to {@code 1000}.</li>
      * <li>The {@code cleanupDelay} is defaulted to {@code 10000}.</li>
@@ -476,7 +476,7 @@ public class EmbeddedEventStore extends AbstractEventStore {
      * The following configurable fields have defaults:
      * <ul>
      * <li>The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}.</li>
-     * <li>The {@link SpanFactory} is defaulted to a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
+     * <li>The {@link EventBusSpanFactory} is defaulted to a {@link org.axonframework.eventhandling.DefaultEventBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}.</li>
      * <li>The {@code cachedEvents} is defaulted to {@code 10000}.</li>
      * <li>The {@code fetchDelay} is defaulted to {@code 1000}.</li>
      * <li>The {@code cleanupDelay} is defaulted to {@code 10000}.</li>

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
@@ -104,16 +104,16 @@ class AbstractSnapshotterTest {
         String aggregateIdentifier = "aggregateIdentifier";
         when(mockEventStore.readEvents(aggregateIdentifier))
                 .thenAnswer(invocation -> {
-                    spanFactory.verifySpanActive("scheduleSnapshot(Object)");
-                    spanFactory.verifySpanActive("createSnapshot(Object)");
+                    spanFactory.verifySpanActive("Snapshotter.scheduleSnapshot(Object)");
+                    spanFactory.verifySpanActive("Snapshotter.createSnapshot(Object)");
                     return DomainEventStream.of(createEvents(2));
                 });
         testSubject.scheduleSnapshot(Object.class, aggregateIdentifier);
         verify(mockEventStore).storeSnapshot(argThat(event(aggregateIdentifier, 1)));
-        spanFactory.verifySpanCompleted("scheduleSnapshot(Object)");
-        spanFactory.verifySpanCompleted("createSnapshot(Object)");
-        spanFactory.verifySpanHasType("scheduleSnapshot(Object)", TestSpanFactory.TestSpanType.INTERNAL);
-        spanFactory.verifySpanHasType("createSnapshot(Object)",
+        spanFactory.verifySpanCompleted("Snapshotter.scheduleSnapshot(Object)");
+        spanFactory.verifySpanCompleted("Snapshotter.createSnapshot(Object)");
+        spanFactory.verifySpanHasType("Snapshotter.scheduleSnapshot(Object)", TestSpanFactory.TestSpanType.INTERNAL);
+        spanFactory.verifySpanHasType("Snapshotter.createSnapshot(Object)",
                                       TestSpanFactory.TestSpanType.INTERNAL);
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
@@ -34,7 +34,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createScheduleSnapshotSpanIncludesAggregateName() {
+    void scheduleSnapshotSpanIncludesAggregateName() {
         test(builder -> builder.aggregateTypeInSpanName(true).separateTrace(false),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("scheduleSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
@@ -43,7 +43,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createScheduleSnapshotSpanDoesntIncludeAggregateName() {
+    void scheduleSnapshotSpanDoesntIncludeAggregateName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(false),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
@@ -52,7 +52,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createScheduleSnapshotSpanIsNotAffectedBySeparateTrace() {
+    void scheduleSnapshotSpanIsNotAffectedBySeparateTrace() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(true),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
@@ -61,7 +61,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createCreateSnapshotSpanWithDefaults() {
+    void createSnapshotSpanWithDefaults() {
         test(spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("createSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
@@ -69,7 +69,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createCreateSnapshotSpanWithSeparateTraceAndWithoutAggregateInSpanName() {
+    void createSnapshotSpanWithSeparateTraceAndWithoutAggregateInSpanName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(true),
              spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("createSnapshot", TestSpanFactory.TestSpanType.ROOT)
@@ -78,7 +78,7 @@ class DefaultSnapshotterSpanFactoryTest
     }
 
     @Test
-    void createCreateSnapshotSpanWithInnerTraceAndWithoutAggregateInSpanName() {
+    void createSnapshotSpanWithInnerTraceAndWithoutAggregateInSpanName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(false),
              spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
              expectedSpan("createSnapshot", TestSpanFactory.TestSpanType.INTERNAL)

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
@@ -46,7 +46,7 @@ class DefaultSnapshotterSpanFactoryTest
     void scheduleSnapshotSpanDoesntIncludeAggregateName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(false),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }
@@ -55,7 +55,7 @@ class DefaultSnapshotterSpanFactoryTest
     void scheduleSnapshotSpanIsNotAffectedBySeparateTrace() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(true),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.scheduleSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }
@@ -72,7 +72,7 @@ class DefaultSnapshotterSpanFactoryTest
     void createSnapshotSpanWithSeparateTraceAndWithoutAggregateInSpanName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(true),
              spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("createSnapshot", TestSpanFactory.TestSpanType.ROOT)
+             expectedSpan("Snapshotter.createSnapshot", TestSpanFactory.TestSpanType.ROOT)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }
@@ -81,7 +81,7 @@ class DefaultSnapshotterSpanFactoryTest
     void createSnapshotSpanWithInnerTraceAndWithoutAggregateInSpanName() {
         test(builder -> builder.aggregateTypeInSpanName(false).separateTrace(false),
              spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("createSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.createSnapshot", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/DefaultSnapshotterSpanFactoryTest.java
@@ -28,7 +28,7 @@ class DefaultSnapshotterSpanFactoryTest
     @Test
     void createScheduleSnapshotSpanWithDefaults() {
         test(spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("scheduleSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.scheduleSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }
@@ -37,7 +37,7 @@ class DefaultSnapshotterSpanFactoryTest
     void scheduleSnapshotSpanIncludesAggregateName() {
         test(builder -> builder.aggregateTypeInSpanName(true).separateTrace(false),
              spanFactory -> spanFactory.createScheduleSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("scheduleSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.scheduleSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }
@@ -63,7 +63,7 @@ class DefaultSnapshotterSpanFactoryTest
     @Test
     void createSnapshotSpanWithDefaults() {
         test(spanFactory -> spanFactory.createCreateSnapshotSpan("MyAggregateType", "3728973982"),
-             expectedSpan("createSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("Snapshotter.createSnapshot(MyAggregateType)", TestSpanFactory.TestSpanType.INTERNAL)
                      .expectAttribute("aggregateIdentifier", "3728973982")
         );
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -388,15 +388,15 @@ public abstract class EmbeddedEventStoreTest {
         DefaultUnitOfWork.startAndGet(null);
         testSubject.publish(events);
         events.forEach(e -> {
-            spanFactory.verifySpanCompleted("publishEvent", e);
-            spanFactory.verifySpanPropagated("publishEvent", e);
-            spanFactory.verifySpanHasType("publishEvent", TestSpanFactory.TestSpanType.DISPATCH);
+            spanFactory.verifySpanCompleted("EventBus.publishEvent", e);
+            spanFactory.verifySpanPropagated("EventBus.publishEvent", e);
+            spanFactory.verifySpanHasType("EventBus.publishEvent", TestSpanFactory.TestSpanType.DISPATCH);
         });
-        spanFactory.verifyNotStarted("commitEvents");
+        spanFactory.verifyNotStarted("EventBus.commitEvents");
 
         CurrentUnitOfWork.commit();
-        spanFactory.verifySpanCompleted("commitEvents");
-        spanFactory.verifySpanHasType("commitEvents", TestSpanFactory.TestSpanType.INTERNAL);
+        spanFactory.verifySpanCompleted("EventBus.commitEvents");
+        spanFactory.verifySpanHasType("EventBus.commitEvents", TestSpanFactory.TestSpanType.INTERNAL);
     }
 
     @Test

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -182,7 +182,11 @@ class TrackingEventProcessorTest {
         }).when(mockTransactionManager).executeInTransaction(any(Runnable.class));
         eventBus = EmbeddedEventStore.builder()
                                      .storageEngine(new InMemoryEventStorageEngine())
-                                     .spanFactory(NoOpSpanFactory.INSTANCE)
+                                     .spanFactory(
+                                             DefaultEventBusSpanFactory.builder()
+                                                                       .spanFactory(spanFactory)
+                                                                       .build()
+                                     )
                                      .build();
         sleepInstructions = new CopyOnWriteArrayList<>();
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,12 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
 
         @Override
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            super.spanFactory(spanFactory);
+            return this;
+        }
+
+        @Override
+        public Builder spanFactory(@Nonnull CommandBusSpanFactory spanFactory) {
             super.spanFactory(spanFactory);
             return this;
         }

--- a/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/AsynchronousCommandBus.java
@@ -74,11 +74,11 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
      * defaulted to a {@link NoOpMessageMonitor}, {@link RollbackConfiguration} defaults to a
      * {@link RollbackConfigurationType#UNCHECKED_EXCEPTIONS}, the {@link DuplicateCommandHandlerResolver} defaults to
      * {@link DuplicateCommandHandlerResolution#logAndOverride()}, the {@link Executor} defaults to a
-     * {@link Executors#newCachedThreadPool} and the {@link SpanFactory} defaults to a
-     * {@link org.axonframework.tracing.NoOpSpanFactory}. The default{@code executor} uses an {@link AxonThreadFactory}
-     * to create threads with a sensible naming scheme. The TransactionManager, MessageMonitor, RollbackConfiguration
-     * and Executor are <b>hard requirements</b>. Thus setting them to {@code null} will result in an
-     * {@link AxonConfigurationException}.
+     * {@link Executors#newCachedThreadPool} and the {@link CommandBusSpanFactory} defaults to a
+     * {@link DefaultCommandBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}. The
+     * default{@code executor} uses an {@link AxonThreadFactory} to create threads with a sensible naming scheme. The
+     * TransactionManager, MessageMonitor, RollbackConfiguration and Executor are <b>hard requirements</b>. Thus setting
+     * them to {@code null} will result in an {@link AxonConfigurationException}.
      *
      * @return a Builder to be able to create a {@link AsynchronousCommandBus}
      */
@@ -113,8 +113,9 @@ public class AsynchronousCommandBus extends SimpleCommandBus {
      * Builder class to instantiate a {@link AsynchronousCommandBus}.
      * <p>
      * The {@link TransactionManager}, {@link MessageMonitor}, {@link RollbackConfiguration},
-     * {@link DuplicateCommandHandlerResolver}, {@link SpanFactory} and {@link Executor} are respectively defaulted to a
-     * {@link NoTransactionManager}, a {@link NoOpMessageMonitor}, a
+     * {@link DuplicateCommandHandlerResolver}, {@link CommandBusSpanFactory} to a {@link DefaultCommandBusSpanFactory}
+     * backed by a {@link org.axonframework.tracing.NoOpSpanFactory}, and {@link Executor} are respectively defaulted to
+     * a {@link NoTransactionManager}, a {@link NoOpMessageMonitor}, a
      * {@link RollbackConfigurationType#UNCHECKED_EXCEPTIONS}, a
      * {@link DuplicateCommandHandlerResolution#logAndOverride()}, {@link org.axonframework.tracing.NoOpSpanFactory} and
      * a {@link Executors#newCachedThreadPool}. The default {@code executor} uses an {@link AxonThreadFactory} to create

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBusSpanFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.tracing.Span;
+
+/**
+ * Span factory that creates spans for the {@link CommandBus}. You can customize the spans of the bus by creating your
+ * own implementation.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public interface CommandBusSpanFactory {
+
+    /**
+     * Creates a span for the dispatching of a command.
+     *
+     * @param commandMessage The command message to create a span for.
+     * @param distributed    Whether the command is distributed or not.
+     * @return The created span.
+     */
+    Span createDispatchCommandSpan(CommandMessage<?> commandMessage, boolean distributed);
+
+    /**
+     * Creates a span for the handling of a command.
+     *
+     * @param commandMessage The command message to create a span for.
+     * @param distributed    Whether the command is distributed or not.
+     * @return The created span.
+     */
+    Span createHandleCommandSpan(CommandMessage<?> commandMessage, boolean distributed);
+
+    /**
+     * Propagates the context of the current span to the given command message.
+     *
+     * @param commandMessage The command message to propagate the context to.
+     * @param <T>            The type of the payload of the command message.
+     * @return The command message with the propagated context.
+     */
+    <T> CommandMessage<T> propagateContext(CommandMessage<T> commandMessage);
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.tracing.Span;
+import org.axonframework.tracing.SpanFactory;
+
+/**
+ * Default implementation of the {@link CommandBusSpanFactory}. Can be configured to include the command handling of a
+ * distributed command in the same trace or not (true by default).
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public class DefaultCommandBusSpanFactory implements CommandBusSpanFactory {
+
+    private final SpanFactory spanFactory;
+    private final boolean distributedInSameTrace;
+
+    /**
+     * Creates a new {@link DefaultCommandBusSpanFactory} using the provided {@code builder}.
+     *
+     * @param builder The builder to build the {@link DefaultCommandBusSpanFactory} from.
+     */
+    protected DefaultCommandBusSpanFactory(Builder builder) {
+        builder.validate();
+        this.spanFactory = builder.builderSpanFactory;
+        this.distributedInSameTrace = builder.distributedInSameTrace;
+    }
+
+    @Override
+    public Span createDispatchCommandSpan(CommandMessage<?> commandMessage, boolean distributed) {
+        if (distributed) {
+            return spanFactory.createDispatchSpan(() -> "dispatchDistributedCommand", commandMessage);
+        }
+        return spanFactory.createInternalSpan(() -> "dispatchCommand", commandMessage);
+    }
+
+    @Override
+    public Span createHandleCommandSpan(CommandMessage<?> commandMessage, boolean distributed) {
+        if (distributed) {
+            if (distributedInSameTrace) {
+                return spanFactory.createChildHandlerSpan(() -> "handleDistributedCommand", commandMessage);
+            }
+            return spanFactory.createLinkedHandlerSpan(() -> "handleDistributedCommand", commandMessage);
+        }
+        return spanFactory.createChildHandlerSpan(() -> "handleCommand", commandMessage);
+    }
+
+    @Override
+    public <T> CommandMessage<T> propagateContext(CommandMessage<T> commandMessage) {
+        return spanFactory.propagateContext(commandMessage);
+    }
+
+    /**
+     * Creates a Builder to be able to create a {@link DefaultCommandBusSpanFactory}. The default values are:
+     * <ul>
+     *     <li>{@code distributedCommandInSameTrace} defaults to {@code true}</li>
+     * </ul>
+     * The {@code spanFactory} is a required field and should be provided.
+     *
+     * @return a Builder to be able to create a {@link DefaultCommandBusSpanFactory}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class to instantiate a {@link DefaultCommandBusSpanFactory}. The default values are:
+     * <ul>
+     *     <li>{@code distributedCommandInSameTrace} defaults to {@code true}</li>
+     * </ul>
+     * The {@code spanFactory} is a required field and should be provided.
+     */
+    public static class Builder {
+
+        private SpanFactory builderSpanFactory;
+        private boolean distributedInSameTrace = true;
+
+        /**
+         * Sets the {@link SpanFactory} to use to create the spans. This is a required field.
+         *
+         * @param spanFactory The {@link SpanFactory} to use to create the spans.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(SpanFactory spanFactory) {
+            BuilderUtils.assertNonNull(spanFactory, "spanFactory may not be null");
+            this.builderSpanFactory = spanFactory;
+            return this;
+        }
+
+        /**
+         * Sets whether the {@link CommandMessage}s should be handled in the same trace as the dispatching span.
+         *
+         * @param distributedInSameTrace whether the {@link CommandMessage}s should be handled in the same trace as the
+         *                               dispatching span.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder distributedInSameTrace(boolean distributedInSameTrace) {
+            this.distributedInSameTrace = distributedInSameTrace;
+            return this;
+        }
+
+        /**
+         * Validates whether the fields contained in this builder are set accordingly.
+         */
+        protected void validate() {
+            BuilderUtils.assertNonNull(builderSpanFactory, "spanFactory may not be null");
+        }
+
+        /**
+         * Initializes a {@link DefaultCommandBusSpanFactory} as specified through this Builder.
+         *
+         * @return The {@link DefaultCommandBusSpanFactory} as specified through this Builder.
+         */
+        public DefaultCommandBusSpanFactory build() {
+            return new DefaultCommandBusSpanFactory(this);
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
@@ -107,7 +107,7 @@ public class DefaultCommandBusSpanFactory implements CommandBusSpanFactory {
         /**
          * Sets whether the {@link CommandMessage}s should be handled in the same trace as the dispatching span.
          *
-         * @param distributedInSameTrace whether the {@link CommandMessage}s should be handled in the same trace as the
+         * @param distributedInSameTrace whether the {@link CommandMessage CommandsMessages} should be handled in the same trace as the
          *                               dispatching span.
          * @return The current Builder instance, for fluent interfacing.
          */

--- a/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactory.java
@@ -46,20 +46,20 @@ public class DefaultCommandBusSpanFactory implements CommandBusSpanFactory {
     @Override
     public Span createDispatchCommandSpan(CommandMessage<?> commandMessage, boolean distributed) {
         if (distributed) {
-            return spanFactory.createDispatchSpan(() -> "dispatchDistributedCommand", commandMessage);
+            return spanFactory.createDispatchSpan(() -> "CommandBus.dispatchDistributedCommand", commandMessage);
         }
-        return spanFactory.createInternalSpan(() -> "dispatchCommand", commandMessage);
+        return spanFactory.createInternalSpan(() -> "CommandBus.dispatchCommand", commandMessage);
     }
 
     @Override
     public Span createHandleCommandSpan(CommandMessage<?> commandMessage, boolean distributed) {
         if (distributed) {
             if (distributedInSameTrace) {
-                return spanFactory.createChildHandlerSpan(() -> "handleDistributedCommand", commandMessage);
+                return spanFactory.createChildHandlerSpan(() -> "CommandBus.handleDistributedCommand", commandMessage);
             }
-            return spanFactory.createLinkedHandlerSpan(() -> "handleDistributedCommand", commandMessage);
+            return spanFactory.createLinkedHandlerSpan(() -> "CommandBus.handleDistributedCommand", commandMessage);
         }
-        return spanFactory.createChildHandlerSpan(() -> "handleCommand", commandMessage);
+        return spanFactory.createChildHandlerSpan(() -> "CommandBus.handleCommand", commandMessage);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -361,7 +361,8 @@ public class DistributedCommandBus implements CommandBus, Distributed<CommandBus
 
         /**
          * Sets the {@link CommandBusSpanFactory} implementation to use for providing tracing capabilities. Defaults to
-         * a {@link CommandBusSpanFactory} by default, which provides no tracing capabilities.
+         * a {@link DefaultCommandBusSpanFactory} backed by a {@link NoOpSpanFactory} by default, which provides no
+         * tracing capabilities.
          *
          * @param spanFactory The {@link CommandBusSpanFactory} implementation
          * @return The current Builder instance, for fluent interfacing.

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.Span;
 import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.SpanScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public abstract class AbstractEventBus implements EventBus {
     private final String eventsKey = this + "_EVENTS";
     private final Set<Consumer<List<? extends EventMessage<?>>>> eventProcessors = new CopyOnWriteArraySet<>();
     private final Set<MessageDispatchInterceptor<? super EventMessage<?>>> dispatchInterceptors = new CopyOnWriteArraySet<>();
-    private final SpanFactory spanFactory;
+    private final EventBusSpanFactory spanFactory;
 
     /**
      * Instantiate an {@link AbstractEventBus} based on the fields contained in the {@link Builder}.
@@ -117,7 +118,7 @@ public abstract class AbstractEventBus implements EventBus {
     public void publish(@Nonnull List<? extends EventMessage<?>> events) {
         List<? extends EventMessage<?>> eventsWithContext = events
                 .stream()
-                .map(e -> spanFactory.createInternalSpan(() -> getClass().getSimpleName() + ".publish", e)
+                .map(e -> spanFactory.createPublishEventSpan(e)
                                      .runSupplier(() -> spanFactory.propagateContext(e)))
                 .collect(Collectors.toList());
         List<MessageMonitor.MonitorCallback> ingested = eventsWithContext.stream()
@@ -140,56 +141,65 @@ public abstract class AbstractEventBus implements EventBus {
 
             eventsQueue(unitOfWork).addAll(eventsWithContext);
         } else {
-            try {
-                prepareCommit(intercept(eventsWithContext));
-                commit(eventsWithContext);
-                afterCommit(eventsWithContext);
-                ingested.forEach(MessageMonitor.MonitorCallback::reportSuccess);
-            } catch (Exception e) {
-                ingested.forEach(m -> m.reportFailure(e));
-                throw e;
-            }
+            spanFactory.createCommitEventsSpan().run(() -> {
+                try {
+                    prepareCommit(intercept(eventsWithContext));
+                    commit(eventsWithContext);
+                    afterCommit(eventsWithContext);
+                    ingested.forEach(MessageMonitor.MonitorCallback::reportSuccess);
+                } catch (Exception e) {
+                    ingested.forEach(m -> m.reportFailure(e));
+                    throw e;
+                }
+            });
         }
     }
 
     private List<EventMessage<?>> eventsQueue(UnitOfWork<?> unitOfWork) {
         return unitOfWork.getOrComputeResource(eventsKey, r -> {
-            String simpleName = getClass().getSimpleName();
-            Span prepareCommitSpan = spanFactory.createInternalSpan(() -> simpleName + ".prepareCommit");
-            Span commitSpan = spanFactory.createInternalSpan(() -> simpleName + ".commit");
-            Span afterCommitSpan = spanFactory.createInternalSpan(() -> simpleName + ".afterCommit");
+            Span commitSpan = spanFactory.createCommitEventsSpan();
             List<EventMessage<?>> eventQueue = new ArrayList<>();
 
-            unitOfWork.onPrepareCommit(prepareCommitSpan.wrapConsumer(u -> {
-                if (u.parent().isPresent() && !u.parent().get().phase().isAfter(PREPARE_COMMIT)) {
-                    eventsQueue(u.parent().get()).addAll(eventQueue);
-                } else {
-                    int processedItems = eventQueue.size();
-                    doWithEvents(this::prepareCommit, intercept(eventQueue));
-                    // Make sure events published during publication prepare commit phase are also published
-                    while (processedItems < eventQueue.size()) {
-                        List<? extends EventMessage<?>> newMessages =
-                                intercept(eventQueue.subList(processedItems, eventQueue.size()));
-                        processedItems = eventQueue.size();
-                        doWithEvents(this::prepareCommit, newMessages);
+            unitOfWork.onPrepareCommit(u -> {
+                commitSpan.start();
+                try (SpanScope unused = commitSpan.makeCurrent()) {
+                    if (u.parent().isPresent() && !u.parent().get().phase().isAfter(PREPARE_COMMIT)) {
+                        eventsQueue(u.parent().get()).addAll(eventQueue);
+                    } else {
+                        int processedItems = eventQueue.size();
+                        doWithEvents(this::prepareCommit, intercept(eventQueue));
+                        // Make sure events published during publication prepare commit phase are also published
+                        while (processedItems < eventQueue.size()) {
+                            List<? extends EventMessage<?>> newMessages =
+                                    intercept(eventQueue.subList(processedItems, eventQueue.size()));
+                            processedItems = eventQueue.size();
+                            doWithEvents(this::prepareCommit, newMessages);
+                        }
                     }
                 }
-            }));
-            unitOfWork.onCommit(commitSpan.wrapConsumer(u -> {
-                if (u.parent().isPresent() && !u.root().phase().isAfter(COMMIT)) {
-                    u.root().onCommit(w -> doWithEvents(this::commit, eventQueue));
-                } else {
-                    doWithEvents(this::commit, eventQueue);
+            });
+            unitOfWork.onCommit(u -> {
+                try (SpanScope unused = commitSpan.makeCurrent()) {
+                    if (u.parent().isPresent() && !u.root().phase().isAfter(COMMIT)) {
+                        u.root().onCommit(w -> doWithEvents(this::commit, eventQueue));
+                    } else {
+                        doWithEvents(this::commit, eventQueue);
+                    }
                 }
-            }));
-            unitOfWork.afterCommit(afterCommitSpan.wrapConsumer(u -> {
-                if (u.parent().isPresent() && !u.root().phase().isAfter(AFTER_COMMIT)) {
-                    u.root().afterCommit(w -> doWithEvents(this::afterCommit, eventQueue));
-                } else {
-                    doWithEvents(this::afterCommit, eventQueue);
+            });
+            unitOfWork.afterCommit(u -> {
+                try (SpanScope unused = commitSpan.makeCurrent()) {
+                    if (u.parent().isPresent() && !u.root().phase().isAfter(AFTER_COMMIT)) {
+                        u.root().afterCommit(w -> doWithEvents(this::afterCommit, eventQueue));
+                    } else {
+                        doWithEvents(this::afterCommit, eventQueue);
+                    }
                 }
-            }));
-            unitOfWork.onCleanup(u -> u.resources().remove(eventsKey));
+            });
+            unitOfWork.onCleanup(u -> {
+                u.resources().remove(eventsKey);
+                commitSpan.end();
+            });
             return eventQueue;
         });
     }
@@ -283,7 +293,8 @@ public abstract class AbstractEventBus implements EventBus {
     public abstract static class Builder {
 
         private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.INSTANCE;
-        private SpanFactory spanFactory = NoOpSpanFactory.INSTANCE;
+        private EventBusSpanFactory spanFactory = DefaultEventBusSpanFactory
+                .builder().spanFactory(NoOpSpanFactory.INSTANCE).build();
 
         /**
          * Sets the {@link MessageMonitor} to monitor ingested {@link EventMessage}s. Defaults to a
@@ -304,8 +315,23 @@ public abstract class AbstractEventBus implements EventBus {
          *
          * @param spanFactory The {@link SpanFactory} implementation
          * @return The current Builder instance, for fluent interfacing.
+         * @deprecated Please use {@link #spanFactory(EventBusSpanFactory)} which is more configurable
          */
+        @Deprecated
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            assertNonNull(spanFactory, "SpanFactory may not be null");
+            this.spanFactory = DefaultEventBusSpanFactory.builder().spanFactory(spanFactory).build();
+            return this;
+        }
+
+        /**
+         * Sets the {@link SpanFactory} implementation to use for providing tracing capabilities. Defaults to a
+         * {@link DefaultEventBusSpanFactory} backed by a {@link NoOpSpanFactory} by default, which provides no tracing capabilities.
+         *
+         * @param spanFactory The {@link EventBusSpanFactory} implementation
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(@Nonnull EventBusSpanFactory spanFactory) {
             assertNonNull(spanFactory, "SpanFactory may not be null");
             this.spanFactory = spanFactory;
             return this;

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
@@ -287,8 +287,8 @@ public abstract class AbstractEventBus implements EventBus {
     /**
      * Abstract Builder class to instantiate {@link AbstractEventBus} implementations.
      * <p>
-     * The {@link MessageMonitor} is defaulted to an {@link NoOpMessageMonitor} and the {@link SpanFactory} defaults to
-     * a {@link NoOpSpanFactory}.
+     * The {@link MessageMonitor} is defaulted to an {@link NoOpMessageMonitor} and the {@link EventBusSpanFactory}
+     * defaults to a {@link DefaultEventBusSpanFactory} backed by a {@link NoOpSpanFactory}.
      */
     public abstract static class Builder {
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/DefaultEventBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DefaultEventBusSpanFactory.java
@@ -44,12 +44,12 @@ public class DefaultEventBusSpanFactory implements EventBusSpanFactory {
 
     @Override
     public Span createPublishEventSpan(EventMessage<?> eventMessage) {
-        return spanFactory.createDispatchSpan(() -> "publishEvent", eventMessage);
+        return spanFactory.createDispatchSpan(() -> "EventBus.publishEvent", eventMessage);
     }
 
     @Override
     public Span createCommitEventsSpan() {
-        return spanFactory.createInternalSpan(() -> "commitEvents");
+        return spanFactory.createInternalSpan(() -> "EventBus.commitEvents");
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/DefaultEventBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DefaultEventBusSpanFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.tracing.Span;
+import org.axonframework.tracing.SpanFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Default implementation of the {@link EventBusSpanFactory}.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public class DefaultEventBusSpanFactory implements EventBusSpanFactory {
+
+    private final SpanFactory spanFactory;
+
+    /**
+     * Creates a new {@link DefaultEventBusSpanFactory} using the provided {@code builder}.
+     *
+     * @param builder The builder to build the {@link DefaultEventBusSpanFactory} from.
+     */
+    protected DefaultEventBusSpanFactory(Builder builder) {
+        builder.validate();
+        this.spanFactory = builder.builderSpanFactory;
+    }
+
+    @Override
+    public Span createPublishEventSpan(EventMessage<?> eventMessage) {
+        return spanFactory.createDispatchSpan(() -> "publishEvent", eventMessage);
+    }
+
+    @Override
+    public Span createCommitEventsSpan() {
+        return spanFactory.createInternalSpan(() -> "commitEvents");
+    }
+
+    @Override
+    public <T> EventMessage<T> propagateContext(EventMessage<T> eventMessage) {
+        return spanFactory.propagateContext(eventMessage);
+    }
+
+    /**
+     * Creates a new {@link Builder} to build a {@link DefaultEventBusSpanFactory} with. The {@code spanFactory} is a
+     * required field and should be provided.
+     *
+     * @return The {@link Builder} to build a {@link DefaultEventBusSpanFactory} with.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class to instantiate a {@link DefaultEventBusSpanFactory}. The {@code spanFactory} is a required field
+     * and should be provided.
+     */
+    public static class Builder {
+
+        private SpanFactory builderSpanFactory;
+
+        /**
+         * Sets the {@link SpanFactory} to use to create the spans. This is a required field.
+         *
+         * @param spanFactory The {@link SpanFactory} to use to create the spans.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(SpanFactory spanFactory) {
+            BuilderUtils.assertNonNull(spanFactory, "spanFactory may not be null");
+            this.builderSpanFactory = spanFactory;
+            return this;
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         */
+        protected void validate() {
+            BuilderUtils.assertNonNull(builderSpanFactory, "spanFactory may not be null");
+        }
+
+        /**
+         * Initializes a {@link DefaultEventBusSpanFactory} as specified through this Builder.
+         *
+         * @return The {@link DefaultEventBusSpanFactory} as specified through this Builder.
+         */
+        public DefaultEventBusSpanFactory build() {
+            return new DefaultEventBusSpanFactory(this);
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventBusSpanFactory.java
@@ -32,7 +32,7 @@ public interface EventBusSpanFactory {
     /**
      * Creates a span for the publishing of an event. This span is created when the event is published on the {@link
      * EventBus}. This span does not include the actual commit of the event, this is represented by the {@link
-     * #createCommitEventsSpan()} and may be later.
+     * #createCommitEventsSpan()} and may occur later.
      *
      * @param eventMessage The event message to create a span for.
      * @return The created span.
@@ -50,7 +50,7 @@ public interface EventBusSpanFactory {
      * Propagates the context of the current span to the given event message.
      *
      * @param eventMessage The event message to propagate the context to.
-     * @param <T>            The type of the payload of the event message.
+     * @param <T>          The type of the payload of the event message.
      * @return The event message with the propagated context.
      */
     <T> EventMessage<T> propagateContext(EventMessage<T> eventMessage);

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventBusSpanFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.tracing.Span;
+
+/**
+ * Span factory that creates spans for the {@link EventBus}. You can customize the spans of the bus by creating your
+ * own implementation.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public interface EventBusSpanFactory {
+
+    /**
+     * Creates a span for the publishing of an event. This span is created when the event is published on the {@link
+     * EventBus}. This span does not include the actual commit of the event, this is represented by the {@link
+     * #createCommitEventsSpan()} and may be later.
+     *
+     * @param eventMessage The event message to create a span for.
+     * @return The created span.
+     */
+    Span createPublishEventSpan(EventMessage<?> eventMessage);
+
+    /**
+     * Creates a span for the committing of events. This is usually batched and done in the commit phase of a UnitOfWork.
+     * If no UnitOfWork is active, the commit is done immediately.
+     * @return The created span.
+     */
+    Span createCommitEventsSpan();
+
+    /**
+     * Propagates the context of the current span to the given event message.
+     *
+     * @param eventMessage The event message to propagate the context to.
+     * @param <T>            The type of the payload of the event message.
+     * @return The event message with the propagated context.
+     */
+    <T> EventMessage<T> propagateContext(EventMessage<T> eventMessage);
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
@@ -35,7 +35,8 @@ public class SimpleEventBus extends AbstractEventBus {
      * Instantiate a Builder to be able to create a {@link SimpleEventBus}.
      * <p>
      * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor}, the {@code queueCapacity} to
-     * {@link Integer#MAX_VALUE} and the {@link SpanFactory} to a {@link org.axonframework.tracing.NoOpSpanFactory}.
+     * {@link Integer#MAX_VALUE} and the {@link EventBusSpanFactory} to a {@link DefaultEventBusSpanFactory} backed by a
+     * {@link org.axonframework.tracing.NoOpSpanFactory}.
      *
      * @return a Builder to be able to create a {@link SimpleEventBus}
      */
@@ -56,7 +57,7 @@ public class SimpleEventBus extends AbstractEventBus {
      * Builder class to instantiate a {@link SimpleEventBus}.
      * <p>
      * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor} and the {@link SpanFactory} is defaulted
-     * to a {@link org.axonframework.tracing.NoOpSpanFactory}.
+     * to {@link DefaultEventBusSpanFactory} backed by a {@link org.axonframework.tracing.NoOpSpanFactory}.
      */
     public static class Builder extends AbstractEventBus.Builder {
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,12 @@ public class SimpleEventBus extends AbstractEventBus {
 
         @Override
         public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            super.spanFactory(spanFactory);
+            return this;
+        }
+
+        @Override
+        public Builder spanFactory(@Nonnull EventBusSpanFactory spanFactory) {
             super.spanFactory(spanFactory);
             return this;
         }

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
@@ -47,57 +47,57 @@ public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
     @Override
     public Span createQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
         if (distributed) {
-            return spanFactory.createDispatchSpan(() -> "queryDistributed", queryMessage);
+            return spanFactory.createDispatchSpan(() -> "QueryBus.queryDistributed", queryMessage);
         }
-        return spanFactory.createInternalSpan(() -> "query", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.query", queryMessage);
     }
 
     @Override
     public Span createSubscriptionQuerySpan(SubscriptionQueryMessage<?, ?, ?> queryMessage, boolean distributed) {
         if (distributed) {
-            return spanFactory.createDispatchSpan(() -> "subscriptionQueryDistributed", queryMessage);
+            return spanFactory.createDispatchSpan(() -> "QueryBus.subscriptionQueryDistributed", queryMessage);
         }
-        return spanFactory.createInternalSpan(() -> "subscriptionQuery", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.subscriptionQuery", queryMessage);
     }
 
     @Override
     public Span createSubscriptionQueryProcessUpdateSpan(SubscriptionQueryUpdateMessage<?> updateMessage,
                                                          SubscriptionQueryMessage<?, ?, ?> queryMessage) {
-        return spanFactory.createChildHandlerSpan(() -> "subscriptionQuery", updateMessage, queryMessage);
+        return spanFactory.createChildHandlerSpan(() -> "QueryBus.subscriptionQuery", updateMessage, queryMessage);
     }
 
     @Override
     public Span createScatterGatherSpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
         if (distributed) {
-            return spanFactory.createDispatchSpan(() -> "scatterGatherQueryDistributed", queryMessage);
+            return spanFactory.createDispatchSpan(() -> "QueryBus.scatterGatherQueryDistributed", queryMessage);
         }
-        return spanFactory.createInternalSpan(() -> "scatterGatherQuery", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.scatterGatherQuery", queryMessage);
     }
 
     @Override
     public Span createScatterGatherHandlerSpan(QueryMessage<?, ?> queryMessage, int handlerIndex) {
-        return spanFactory.createInternalSpan(() -> "scatterGatherQuery-" + handlerIndex, queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.scatterGatherQuery-" + handlerIndex, queryMessage);
     }
 
     @Override
     public Span createStreamingQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
         if (distributed) {
-            return spanFactory.createDispatchSpan(() -> "streamingQueryDistributed", queryMessage);
+            return spanFactory.createDispatchSpan(() -> "QueryBus.streamingQueryDistributed", queryMessage);
         }
-        return spanFactory.createInternalSpan(() -> "streamingQuery", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.streamingQuery", queryMessage);
     }
 
     @Override
     public Span createQueryProcessingSpan(QueryMessage<?, ?> queryMessage) {
         if (distributedInSameTrace) {
-            return spanFactory.createChildHandlerSpan(() -> "processQueryMessage", queryMessage);
+            return spanFactory.createChildHandlerSpan(() -> "QueryBus.processQueryMessage", queryMessage);
         }
-        return spanFactory.createLinkedHandlerSpan(() -> "processQueryMessage", queryMessage);
+        return spanFactory.createLinkedHandlerSpan(() -> "QueryBus.processQueryMessage", queryMessage);
     }
 
     @Override
     public Span createResponseProcessingSpan(QueryMessage<?, ?> queryMessage) {
-        return spanFactory.createInternalSpan(() -> "processQueryResult", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.processQueryResult", queryMessage);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
@@ -63,7 +63,7 @@ public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
     @Override
     public Span createSubscriptionQueryProcessUpdateSpan(SubscriptionQueryUpdateMessage<?> updateMessage,
                                                          SubscriptionQueryMessage<?, ?, ?> queryMessage) {
-        return spanFactory.createChildHandlerSpan(() -> "QueryBus.subscriptionQuery", updateMessage, queryMessage);
+        return spanFactory.createChildHandlerSpan(() -> "QueryBus.queryUpdate", updateMessage, queryMessage);
     }
 
     @Override
@@ -76,7 +76,7 @@ public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
 
     @Override
     public Span createScatterGatherHandlerSpan(QueryMessage<?, ?> queryMessage, int handlerIndex) {
-        return spanFactory.createInternalSpan(() -> "QueryBus.scatterGatherQuery-" + handlerIndex, queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.scatterGatherHandler-" + handlerIndex, queryMessage);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
         if (distributed) {
             return spanFactory.createDispatchSpan(() -> "QueryBus.streamingQueryDistributed", queryMessage);
         }
-        return spanFactory.createInternalSpan(() -> "QueryBus.streamingQuery", queryMessage);
+        return spanFactory.createChildHandlerSpan(() -> "QueryBus.streamingQuery", queryMessage);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
 
     @Override
     public Span createResponseProcessingSpan(QueryMessage<?, ?> queryMessage) {
-        return spanFactory.createInternalSpan(() -> "QueryBus.processQueryResult", queryMessage);
+        return spanFactory.createInternalSpan(() -> "QueryBus.processQueryResponse", queryMessage);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactory.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.tracing.Span;
+import org.axonframework.tracing.SpanFactory;
+
+/**
+ * Default implementation of the {@link QueryBusSpanFactory}. Can be configured to include the query handling of a
+ * distributed query in the same trace or not (true by default).
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public class DefaultQueryBusSpanFactory implements QueryBusSpanFactory {
+
+    private final SpanFactory spanFactory;
+    private final boolean distributedInSameTrace;
+
+    /**
+     * Creates a new {@link DefaultQueryBusSpanFactory} using the provided {@code builder}.
+     *
+     * @param builder The builder to build the {@link DefaultQueryBusSpanFactory} from.
+     */
+    protected DefaultQueryBusSpanFactory(Builder builder) {
+        builder.validate();
+        this.spanFactory = builder.builderSpanFactory;
+        this.distributedInSameTrace = builder.distributedInSameTrace;
+    }
+
+
+    @Override
+    public Span createQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
+        if (distributed) {
+            return spanFactory.createDispatchSpan(() -> "queryDistributed", queryMessage);
+        }
+        return spanFactory.createInternalSpan(() -> "query", queryMessage);
+    }
+
+    @Override
+    public Span createSubscriptionQuerySpan(SubscriptionQueryMessage<?, ?, ?> queryMessage, boolean distributed) {
+        if (distributed) {
+            return spanFactory.createDispatchSpan(() -> "subscriptionQueryDistributed", queryMessage);
+        }
+        return spanFactory.createInternalSpan(() -> "subscriptionQuery", queryMessage);
+    }
+
+    @Override
+    public Span createSubscriptionQueryProcessUpdateSpan(SubscriptionQueryUpdateMessage<?> updateMessage,
+                                                         SubscriptionQueryMessage<?, ?, ?> queryMessage) {
+        return spanFactory.createChildHandlerSpan(() -> "subscriptionQuery", updateMessage, queryMessage);
+    }
+
+    @Override
+    public Span createScatterGatherSpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
+        if (distributed) {
+            return spanFactory.createDispatchSpan(() -> "scatterGatherQueryDistributed", queryMessage);
+        }
+        return spanFactory.createInternalSpan(() -> "scatterGatherQuery", queryMessage);
+    }
+
+    @Override
+    public Span createScatterGatherHandlerSpan(QueryMessage<?, ?> queryMessage, int handlerIndex) {
+        return spanFactory.createInternalSpan(() -> "scatterGatherQuery-" + handlerIndex, queryMessage);
+    }
+
+    @Override
+    public Span createStreamingQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed) {
+        if (distributed) {
+            return spanFactory.createDispatchSpan(() -> "streamingQueryDistributed", queryMessage);
+        }
+        return spanFactory.createInternalSpan(() -> "streamingQuery", queryMessage);
+    }
+
+    @Override
+    public Span createQueryProcessingSpan(QueryMessage<?, ?> queryMessage) {
+        if (distributedInSameTrace) {
+            return spanFactory.createChildHandlerSpan(() -> "processQueryMessage", queryMessage);
+        }
+        return spanFactory.createLinkedHandlerSpan(() -> "processQueryMessage", queryMessage);
+    }
+
+    @Override
+    public Span createResponseProcessingSpan(QueryMessage<?, ?> queryMessage) {
+        return spanFactory.createInternalSpan(() -> "processQueryResult", queryMessage);
+    }
+
+    @Override
+    public <T, R, M extends QueryMessage<T, R>> M propagateContext(M queryMessage) {
+        return spanFactory.propagateContext(queryMessage);
+    }
+
+
+    /**
+     * Creates a Builder to be able to create a {@link DefaultQueryBusSpanFactory}. The default values are:
+     * <ul>
+     *     <li>{@code distributedInSameTrace} defaults to {@code true}</li>
+     * </ul>
+     * The {@code spanFactory} is a required field and should be provided.
+     *
+     * @return a Builder to be able to create a {@link DefaultQueryBusSpanFactory}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class to instantiate a {@link DefaultQueryBusSpanFactory}. The default values are:
+     * <ul>
+     *     <li>{@code distributedInSameTrace} defaults to {@code true}</li>
+     * </ul>
+     * The {@code spanFactory} is a required field and should be provided.
+     */
+    public static class Builder {
+
+        private boolean distributedInSameTrace = true;
+        private SpanFactory builderSpanFactory;
+
+        /**
+         * Sets the {@link SpanFactory} to use to create the spans. This is a required field.
+         *
+         * @param spanFactory The {@link SpanFactory} to use to create the spans.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(SpanFactory spanFactory) {
+            BuilderUtils.assertNonNull(spanFactory, "spanFactory may not be null");
+            this.builderSpanFactory = spanFactory;
+            return this;
+        }
+
+        /**
+         * Sets whether the distributed query should be in the same trace as the parent. Defaults to {@code true}.
+         *
+         * @param distributedInSameTrace whether the distributed query should be in the same trace as the parent.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder distributedInSameTrace(boolean distributedInSameTrace) {
+            this.distributedInSameTrace = distributedInSameTrace;
+            return this;
+        }
+
+        /**
+         * Validates whether the fields contained in this builder are set accordingly.
+         */
+        protected void validate() {
+            BuilderUtils.assertNonNull(builderSpanFactory, "spanFactory may not be null");
+        }
+
+        /**
+         * Initializes a {@link DefaultQueryBusSpanFactory} as specified through this Builder.
+         *
+         * @return The {@link DefaultQueryBusSpanFactory} as specified through this Builder.
+         */
+        public DefaultQueryBusSpanFactory build() {
+            return new DefaultQueryBusSpanFactory(this);
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
@@ -53,12 +53,12 @@ public class DefaultQueryUpdateEmitterSpanFactory implements QueryUpdateEmitterS
 
     @Override
     public Span createUpdateScheduleEmitSpan(SubscriptionQueryUpdateMessage<?> update) {
-        return spanFactory.createInternalSpan(() -> "scheduleQueryUpdateMessage", update);
+        return spanFactory.createInternalSpan(() -> "QueryUpdateEmitter.scheduleQueryUpdateMessage", update);
     }
 
     @Override
     public Span createUpdateEmitSpan(SubscriptionQueryUpdateMessage<?> update) {
-        return spanFactory.createDispatchSpan(() -> "emitQueryUpdateMessage", update);
+        return spanFactory.createDispatchSpan(() -> "QueryUpdateEmitter.emitQueryUpdateMessage", update);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
@@ -86,7 +86,6 @@ public class DefaultQueryUpdateEmitterSpanFactory implements QueryUpdateEmitterS
             return this;
         }
 
-
         /**
          * Validates whether the fields contained in this builder are set accordingly.
          */

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.tracing.Span;
+import org.axonframework.tracing.SpanFactory;
+
+/**
+ * Default implementation of the {@link QueryUpdateEmitterSpanFactory}.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public class DefaultQueryUpdateEmitterSpanFactory implements QueryUpdateEmitterSpanFactory {
+
+    private final SpanFactory spanFactory;
+
+    /**
+     * Creates a new {@link DefaultQueryUpdateEmitterSpanFactory} using the provided {@code builder}.
+     *
+     * @param builder The builder to build the {@link DefaultQueryUpdateEmitterSpanFactory} from.
+     */
+    protected DefaultQueryUpdateEmitterSpanFactory(Builder builder) {
+        builder.validate();
+        this.spanFactory = builder.builderSpanFactory;
+    }
+
+
+    /**
+     * Creates a Builder to be able to create a {@link DefaultQueryUpdateEmitterSpanFactory}.
+     * The {@code spanFactory} is a required field and should be provided.
+     *
+     * @return a Builder to be able to create a {@link DefaultQueryUpdateEmitterSpanFactory}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Span createUpdateScheduleEmitSpan(SubscriptionQueryUpdateMessage<?> update) {
+        return spanFactory.createInternalSpan(() -> "scheduleQueryUpdateMessage", update);
+    }
+
+    @Override
+    public Span createUpdateEmitSpan(SubscriptionQueryUpdateMessage<?> update) {
+        return spanFactory.createDispatchSpan(() -> "emitQueryUpdateMessage", update);
+    }
+
+    @Override
+    public <T, M extends SubscriptionQueryUpdateMessage<T>> M propagateContext(M update) {
+        return spanFactory.propagateContext(update);
+    }
+
+    /**
+     * Builder class to instantiate a {@link DefaultQueryUpdateEmitterSpanFactory}. The {@code spanFactory} is a
+     * required field and should be provided.
+     */
+    public static class Builder {
+
+        private SpanFactory builderSpanFactory;
+
+        /**
+         * Sets the {@link SpanFactory} to use to create the spans. This is a required field.
+         *
+         * @param spanFactory The {@link SpanFactory} to use to create the spans.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder spanFactory(SpanFactory spanFactory) {
+            BuilderUtils.assertNonNull(spanFactory, "spanFactory may not be null");
+            this.builderSpanFactory = spanFactory;
+            return this;
+        }
+
+
+        /**
+         * Validates whether the fields contained in this builder are set accordingly.
+         */
+        protected void validate() {
+            BuilderUtils.assertNonNull(builderSpanFactory, "spanFactory may not be null");
+        }
+
+        /**
+         * Initializes a {@link DefaultQueryUpdateEmitterSpanFactory} as specified through this Builder.
+         *
+         * @return The {@link DefaultQueryUpdateEmitterSpanFactory} as specified through this Builder.
+         */
+        public DefaultQueryUpdateEmitterSpanFactory build() {
+            return new DefaultQueryUpdateEmitterSpanFactory(this);
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.tracing.Span;
+
+/**
+ * Span factory that creates spans for the {@link QueryBus}. You can customize the spans of the bus by creating your own
+ * implementation.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public interface QueryBusSpanFactory {
+
+    /**
+     * Creates a span for a query.
+     *
+     * @param queryMessage The query message being handled.
+     * @param distributed  Whether the query is from a distributed source.
+     * @return The span for the handling of the query.
+     */
+    Span createQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed);
+
+    /**
+     * Creates a span for a subscription query.
+     *
+     * @param queryMessage The subscription query message being handled.
+     * @param distributed  Whether the subscription query is from a distributed source.
+     * @return The span for the handling of the subscription query.
+     */
+    Span createSubscriptionQuerySpan(SubscriptionQueryMessage<?, ?, ?> queryMessage, boolean distributed);
+
+    /**
+     * Creates a span for processing a subscription query update that has been received from the server.
+     *
+     * @param updateMessage The update message being handled.
+     * @param queryMessage  The subscription query message that the update is for.
+     * @return The span for the processing of the subscription query update.
+     */
+    Span createSubscriptionQueryProcessUpdateSpan(SubscriptionQueryUpdateMessage<?> updateMessage,
+                                                  SubscriptionQueryMessage<?, ?, ?> queryMessage);
+
+    /**
+     * Creates a span for a scatter-gather query.
+     *
+     * @param queryMessage The query message being handled.
+     * @param distributed  Whether the query is from a distributed source.
+     * @return The span for the handling of the scatter-gather query.
+     */
+    Span createScatterGatherSpan(QueryMessage<?, ?> queryMessage, boolean distributed);
+
+    /**
+     * Creates a span for one of the handlers of a scatter-gather query. There can be multiple for the same within one
+     * application. The handler index is used to distinguish between them.
+     *
+     * @param queryMessage The query message being handled.
+     * @param handlerIndex The index of the handler. Starts at 0.
+     * @return The span for the handling of the scatter-gather query.
+     */
+    Span createScatterGatherHandlerSpan(QueryMessage<?, ?> queryMessage, int handlerIndex);
+
+    /**
+     * Creates a span for a streaming query.
+     *
+     * @param queryMessage The query message being handled.
+     * @param distributed  Whether the query is from a distributed source.
+     * @return The span for the handling of the streaming query.
+     */
+    Span createStreamingQuerySpan(QueryMessage<?, ?> queryMessage, boolean distributed);
+
+    /**
+     * Creates a span for processing a query. Distributed implementations can use this to create a span for the entire
+     * query processing on the handling side.
+     *
+     * @param queryMessage The query message being handled.
+     * @return The span for the processing of the query.
+     */
+    Span createQueryProcessingSpan(QueryMessage<?, ?> queryMessage);
+
+    /**
+     * Creates a span for processing a response. Distributed implementations can use this to create a span for the
+     * entire response processing on the sending side.
+     *
+     * @param queryMessage The query message the response is for.
+     * @return The span for the processing of the response.
+     */
+    Span createResponseProcessingSpan(QueryMessage<?, ?> queryMessage);
+
+    /**
+     * Propagates the context of the current span to the given {@code queryMessage}.
+     *
+     * @param queryMessage The query message to propagate the context to.
+     * @param <T>          The type of the payload of the query message.
+     * @param <R>          The type of the response of the query message.
+     * @param <M>          The type of the query message.
+     * @return The query message with the context of the current span.
+     */
+    <T, R, M extends QueryMessage<T, R>> M propagateContext(M queryMessage);
+}

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
@@ -30,7 +30,7 @@ public interface QueryBusSpanFactory {
     /**
      * Creates a span for a query.
      *
-     * @param queryMessage The query message being handled.
+     * @param queryMessage The query message being dispatched.
      * @param distributed  Whether the query is from a distributed source.
      * @return The span for the handling of the query.
      */
@@ -39,7 +39,7 @@ public interface QueryBusSpanFactory {
     /**
      * Creates a span for a subscription query.
      *
-     * @param queryMessage The subscription query message being handled.
+     * @param queryMessage The subscription query message being dispatched.
      * @param distributed  Whether the subscription query is from a distributed source.
      * @return The span for the handling of the subscription query.
      */
@@ -68,7 +68,7 @@ public interface QueryBusSpanFactory {
      * Creates a span for one of the handlers of a scatter-gather query. There can be multiple for the same within one
      * application. The handler index is used to distinguish between them.
      *
-     * @param queryMessage The query message being handled.
+     * @param queryMessage The query message being dispatched.
      * @param handlerIndex The index of the handler. Starts at 0.
      * @return The span for the handling of the scatter-gather query.
      */
@@ -77,7 +77,7 @@ public interface QueryBusSpanFactory {
     /**
      * Creates a span for a streaming query.
      *
-     * @param queryMessage The query message being handled.
+     * @param queryMessage The query message being dispatched.
      * @param distributed  Whether the query is from a distributed source.
      * @return The span for the handling of the streaming query.
      */

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBusSpanFactory.java
@@ -68,7 +68,7 @@ public interface QueryBusSpanFactory {
      * Creates a span for one of the handlers of a scatter-gather query. There can be multiple for the same within one
      * application. The handler index is used to distinguish between them.
      *
-     * @param queryMessage The query message being dispatched.
+     * @param queryMessage The query message being handled.
      * @param handlerIndex The index of the handler. Starts at 0.
      * @return The span for the handling of the scatter-gather query.
      */

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitterSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitterSpanFactory.java
@@ -19,7 +19,7 @@ package org.axonframework.queryhandling;
 import org.axonframework.tracing.Span;
 
 /**
- * Span factory that creates spans for the {@link QueryBus}. You can customize the spans of the bus by creating your own
+ * Span factory that creates spans for the {@link QueryUpdateEmitter}. You can customize the spans of the bus by creating your own
  * implementation.
  *
  * @author Mitchell Herrijgers

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitterSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitterSpanFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.tracing.Span;
+
+/**
+ * Span factory that creates spans for the {@link QueryBus}. You can customize the spans of the bus by creating your own
+ * implementation.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.9.0
+ */
+public interface QueryUpdateEmitterSpanFactory {
+
+    /**
+     * Creates a span for the scheduling of emitting a query update. Query updates are scheduled to be emitted in the
+     * commit phase of the UnitOfWork, so these traces are separated to see the proper timings.
+     *
+     * @param update The update to create a span for.
+     * @return The created span.
+     */
+    Span createUpdateScheduleEmitSpan(SubscriptionQueryUpdateMessage<?> update);
+
+    /**
+     * Creates a span for the actual emit of a query update when the UnitOfWork commits (or immediately if no UnitOfWork
+     * is active).
+     *
+     * @param update The update to create a span for.
+     * @return The created span.
+     */
+    Span createUpdateEmitSpan(SubscriptionQueryUpdateMessage<?> update);
+
+    /**
+     * Propagates the context of the current span to the given update message.
+     *
+     * @param update The update message to propagate the context to.
+     * @param <T>    The type of the payload of the update message.
+     * @param <M>    The type of the update message.
+     * @return The update message with the propagated context.
+     */
+    <T, M extends SubscriptionQueryUpdateMessage<T>> M propagateContext(M update);
+}

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
     private static final String QUERY_UPDATE_TASKS_RESOURCE_KEY = "/update-tasks";
 
     private final MessageMonitor<? super SubscriptionQueryUpdateMessage<?>> updateMessageMonitor;
-    private final SpanFactory spanFactory;
+    private final QueryUpdateEmitterSpanFactory spanFactory;
 
     private final ConcurrentMap<SubscriptionQueryMessage<?, ?, ?>, SinkWrapper<?>> updateHandlers =
             new ConcurrentHashMap<>();
@@ -151,9 +151,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
     public <U> void emit(@Nonnull Predicate<SubscriptionQueryMessage<?, ?, U>> filter,
                          @Nonnull SubscriptionQueryUpdateMessage<U> update) {
         SubscriptionQueryUpdateMessage<U> updateMessage = spanFactory.propagateContext(update);
-        Span span = spanFactory.createInternalSpan(() -> "SimpleQueryUpdateEmitter.emit", updateMessage);
+        Span span = spanFactory.createUpdateScheduleEmitSpan(updateMessage);
         span.run(() -> {
-            Span doEmitSpan = spanFactory.createDispatchSpan(() -> "SimpleQueryUpdateEmitter.doEmit", updateMessage);
+            Span doEmitSpan = spanFactory.createUpdateEmitSpan(updateMessage);
             runOnAfterCommitOrNow(doEmitSpan.wrapRunnable(
                     () -> doEmit(filter, intercept(spanFactory.propagateContext(updateMessage)))));
         });
@@ -318,7 +318,10 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
         private MessageMonitor<? super SubscriptionQueryUpdateMessage<?>> updateMessageMonitor =
                 NoOpMessageMonitor.INSTANCE;
-        private SpanFactory spanFactory = NoOpSpanFactory.INSTANCE;
+        private QueryUpdateEmitterSpanFactory spanFactory = DefaultQueryUpdateEmitterSpanFactory
+                .builder()
+                .spanFactory(NoOpSpanFactory.INSTANCE)
+                .build();
 
         /**
          * Sets the {@link MessageMonitor} used to monitor {@link SubscriptionQueryUpdateMessage}s being processed.
@@ -340,10 +343,24 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
          * Sets the {@link SpanFactory} implementation to use for providing tracing capabilities. Defaults to a
          * {@link NoOpSpanFactory} by default, which provides no tracing capabilities.
          *
-         * @param spanFactory The {@link SpanFactory} implementation
+         * @param spanFactory The {@link SpanFactory} implementation.
+         * @return The current Builder instance, for fluent interfacing.
+         * @deprecated Use {@link #spanFactory(QueryUpdateEmitterSpanFactory)}  instead as it provides more configurability.
+         */
+        @Deprecated
+        public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+            assertNonNull(spanFactory, "SpanFactory may not be null");
+            this.spanFactory = DefaultQueryUpdateEmitterSpanFactory.builder().spanFactory(spanFactory).build();
+            return this;
+        }
+        /**
+         * Sets the {@link QueryUpdateEmitterSpanFactory} implementation to use for providing tracing capabilities. Defaults to a
+         * {@link DefaultQueryUpdateEmitterSpanFactory} backed by a {@link NoOpSpanFactory} by default, which provides no tracing capabilities.
+         *
+         * @param spanFactory The {@link QueryUpdateEmitterSpanFactory} implementation.
          * @return The current Builder instance, for fluent interfacing.
          */
-        public Builder spanFactory(@Nonnull SpanFactory spanFactory) {
+        public Builder spanFactory(@Nonnull QueryUpdateEmitterSpanFactory spanFactory) {
             assertNonNull(spanFactory, "SpanFactory may not be null");
             this.spanFactory = spanFactory;
             return this;

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
@@ -86,8 +86,8 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
     /**
      * Instantiate a Builder to be able to create a {@link SimpleQueryUpdateEmitter}.
      * <p>
-     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor} and the {@link SpanFactory} is defauled
-     * to a {@link NoOpSpanFactory}.
+     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor} and the {@link QueryBusSpanFactory}
+     * defaults to a {@link DefaultQueryBusSpanFactory} backed by a {@link NoOpSpanFactory}.
      *
      * @return a Builder to be able to create a {@link SimpleQueryUpdateEmitter}
      */
@@ -311,8 +311,8 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
     /**
      * Builder class to instantiate a {@link SimpleQueryUpdateEmitter}.
      * <p>
-     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor} and the {@link SpanFactory} defaults to a
-     * {@link NoOpSpanFactory}.
+     * The {@link MessageMonitor} is defaulted to a {@link NoOpMessageMonitor} and the {@link QueryBusSpanFactory}
+     * defaults to a {@link DefaultQueryBusSpanFactory} backed by a {@link NoOpSpanFactory}.
      */
     public static class Builder {
 

--- a/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
@@ -77,10 +77,10 @@ class AsynchronousCommandBusTest {
         CommandMessage<Object> command = asCommandMessage(new Object());
         testSubject.dispatch(command, mockCallback);
 
-        spanFactory.verifySpanCompleted("dispatchCommand");
-        spanFactory.verifySpanPropagated("dispatchCommand", command);
+        spanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
+        spanFactory.verifySpanPropagated("CommandBus.dispatchCommand", command);
 
-        spanFactory.verifySpanCompleted("handleCommand");
+        spanFactory.verifySpanCompleted("CommandBus.handleCommand");
 
         InOrder inOrder = inOrder(mockCallback,
                                   executorService,
@@ -107,11 +107,11 @@ class AsynchronousCommandBusTest {
         CommandMessage<Object> command = asCommandMessage(new Object());
         testSubject.dispatch(command, NoOpCallback.INSTANCE);
 
-        spanFactory.verifySpanCompleted("dispatchCommand");
-        spanFactory.verifySpanPropagated("dispatchCommand", command);
+        spanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
+        spanFactory.verifySpanPropagated("CommandBus.dispatchCommand", command);
 
 
-        spanFactory.verifySpanCompleted("handleCommand");
+        spanFactory.verifySpanCompleted("CommandBus.handleCommand");
 
         InOrder inOrder = inOrder(executorService, commandHandler, dispatchInterceptor, handlerInterceptor);
         inOrder.verify(dispatchInterceptor).handle(isA(CommandMessage.class));
@@ -141,7 +141,7 @@ class AsynchronousCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("dispatchCommand", NoHandlerForCommandException.class);
+        spanFactory.verifySpanHasException("CommandBus.dispatchCommand", NoHandlerForCommandException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/AsynchronousCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ class AsynchronousCommandBusTest {
     private ExecutorService executorService;
     private AsynchronousCommandBus testSubject;
     private TestSpanFactory spanFactory;
+    private CommandBusSpanFactory commandBusSpanFactory;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -53,11 +54,12 @@ class AsynchronousCommandBusTest {
         dispatchInterceptor = mock(MessageDispatchInterceptor.class);
         handlerInterceptor = mock(MessageHandlerInterceptor.class);
         spanFactory = new TestSpanFactory();
+        commandBusSpanFactory = DefaultCommandBusSpanFactory.builder().spanFactory(spanFactory).build();
         doAnswer(invocation -> {
             ((Runnable) invocation.getArguments()[0]).run();
             return null;
         }).when(executorService).execute(isA(Runnable.class));
-        testSubject = AsynchronousCommandBus.builder().executor(executorService).spanFactory(spanFactory).build();
+        testSubject = AsynchronousCommandBus.builder().executor(executorService).spanFactory(commandBusSpanFactory).build();
         testSubject.registerDispatchInterceptor(dispatchInterceptor);
         testSubject.registerHandlerInterceptor(handlerInterceptor);
         when(dispatchInterceptor.handle(isA(CommandMessage.class)))
@@ -75,10 +77,10 @@ class AsynchronousCommandBusTest {
         CommandMessage<Object> command = asCommandMessage(new Object());
         testSubject.dispatch(command, mockCallback);
 
-        spanFactory.verifySpanCompleted("AsynchronousCommandBus.dispatch");
-        spanFactory.verifySpanPropagated("AsynchronousCommandBus.dispatch", command);
+        spanFactory.verifySpanCompleted("dispatchCommand");
+        spanFactory.verifySpanPropagated("dispatchCommand", command);
 
-        spanFactory.verifySpanCompleted("AsynchronousCommandBus.handle");
+        spanFactory.verifySpanCompleted("handleCommand");
 
         InOrder inOrder = inOrder(mockCallback,
                                   executorService,
@@ -105,11 +107,11 @@ class AsynchronousCommandBusTest {
         CommandMessage<Object> command = asCommandMessage(new Object());
         testSubject.dispatch(command, NoOpCallback.INSTANCE);
 
-        spanFactory.verifySpanCompleted("AsynchronousCommandBus.dispatch");
-        spanFactory.verifySpanPropagated("AsynchronousCommandBus.dispatch", command);
+        spanFactory.verifySpanCompleted("dispatchCommand");
+        spanFactory.verifySpanPropagated("dispatchCommand", command);
 
 
-        spanFactory.verifySpanCompleted("AsynchronousCommandBus.handle");
+        spanFactory.verifySpanCompleted("handleCommand");
 
         InOrder inOrder = inOrder(executorService, commandHandler, dispatchInterceptor, handlerInterceptor);
         inOrder.verify(dispatchInterceptor).handle(isA(CommandMessage.class));
@@ -139,7 +141,7 @@ class AsynchronousCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("AsynchronousCommandBus.dispatch", NoHandlerForCommandException.class);
+        spanFactory.verifySpanHasException("dispatchCommand", NoHandlerForCommandException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
@@ -24,12 +24,10 @@ import org.junit.jupiter.api.*;
 class DefaultCommandBusSpanFactoryTest
         extends IntermediateSpanFactoryTest<DefaultCommandBusSpanFactory.Builder, DefaultCommandBusSpanFactory> {
 
-
     @Test
     void createLocalDispatchCommand() {
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
-        test(builder -> builder,
-             spanFactory -> spanFactory.createDispatchCommandSpan(command, false),
+        test(spanFactory -> spanFactory.createDispatchCommandSpan(command, false),
              expectedSpan("CommandBus.dispatchCommand", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(command)
         );
@@ -38,8 +36,7 @@ class DefaultCommandBusSpanFactoryTest
     @Test
     void createDistributedDispatchCommand() {
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
-        test(builder -> builder,
-             spanFactory -> spanFactory.createDispatchCommandSpan(command, true),
+        test(spanFactory -> spanFactory.createDispatchCommandSpan(command, true),
              expectedSpan("CommandBus.dispatchDistributedCommand", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(command)
         );
@@ -49,8 +46,7 @@ class DefaultCommandBusSpanFactoryTest
     @Test
     void createLocalHandleCommand() {
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
-        test(builder -> builder,
-             spanFactory -> spanFactory.createHandleCommandSpan(command, false),
+        test(spanFactory -> spanFactory.createHandleCommandSpan(command, false),
              expectedSpan("CommandBus.handleCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(command)
         );
@@ -59,8 +55,7 @@ class DefaultCommandBusSpanFactoryTest
     @Test
     void createDistributedHandleCommandDefault() {
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
-        test(builder -> builder,
-             spanFactory -> spanFactory.createHandleCommandSpan(command, true),
+        test(spanFactory -> spanFactory.createHandleCommandSpan(command, true),
              expectedSpan("CommandBus.handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(command)
         );
@@ -76,6 +71,11 @@ class DefaultCommandBusSpanFactoryTest
         );
     }
 
+    @Test
+    void testPropagateContext() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        testContextPropagation(command, DefaultCommandBusSpanFactory::propagateContext);
+    }
 
     @Override
     protected DefaultCommandBusSpanFactory.Builder createBuilder(SpanFactory spanFactory) {

--- a/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.tracing.IntermediateSpanFactoryTest;
+import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.TestSpanFactory;
+import org.junit.jupiter.api.*;
+
+class DefaultCommandBusSpanFactoryTest
+        extends IntermediateSpanFactoryTest<DefaultCommandBusSpanFactory.Builder, DefaultCommandBusSpanFactory> {
+
+
+    @Test
+    void createLocalDispatchCommand() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        test(builder -> builder,
+             spanFactory -> spanFactory.createDispatchCommandSpan(command, false),
+             expectedSpan("dispatchCommand", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(command)
+        );
+    }
+
+    @Test
+    void createDistributedDispatchCommand() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        test(builder -> builder,
+             spanFactory -> spanFactory.createDispatchCommandSpan(command, true),
+             expectedSpan("dispatchDistributedCommand", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(command)
+        );
+    }
+
+
+    @Test
+    void createLocalHandleCommand() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        test(builder -> builder,
+             spanFactory -> spanFactory.createHandleCommandSpan(command, false),
+             expectedSpan("handleCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+                     .withMessage(command)
+        );
+    }
+
+    @Test
+    void createDistributedHandleCommandDefault() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        test(builder -> builder,
+             spanFactory -> spanFactory.createHandleCommandSpan(command, true),
+             expectedSpan("handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+                     .withMessage(command)
+        );
+    }
+
+    @Test
+    void createDistributedHandleCommandDistributedNotSameTrace() {
+        CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
+        test(builder -> builder.distributedInSameTrace(false),
+             spanFactory -> spanFactory.createHandleCommandSpan(command, true),
+             expectedSpan("handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_LINK)
+                     .withMessage(command)
+        );
+    }
+
+
+    @Override
+    protected DefaultCommandBusSpanFactory.Builder createBuilder(SpanFactory spanFactory) {
+        return DefaultCommandBusSpanFactory.builder().spanFactory(spanFactory);
+    }
+
+    @Override
+    protected DefaultCommandBusSpanFactory createFactoryBasedOnBuilder(DefaultCommandBusSpanFactory.Builder builder) {
+        return builder.build();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/DefaultCommandBusSpanFactoryTest.java
@@ -30,7 +30,7 @@ class DefaultCommandBusSpanFactoryTest
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
         test(builder -> builder,
              spanFactory -> spanFactory.createDispatchCommandSpan(command, false),
-             expectedSpan("dispatchCommand", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("CommandBus.dispatchCommand", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(command)
         );
     }
@@ -40,7 +40,7 @@ class DefaultCommandBusSpanFactoryTest
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
         test(builder -> builder,
              spanFactory -> spanFactory.createDispatchCommandSpan(command, true),
-             expectedSpan("dispatchDistributedCommand", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("CommandBus.dispatchDistributedCommand", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(command)
         );
     }
@@ -51,7 +51,7 @@ class DefaultCommandBusSpanFactoryTest
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
         test(builder -> builder,
              spanFactory -> spanFactory.createHandleCommandSpan(command, false),
-             expectedSpan("handleCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+             expectedSpan("CommandBus.handleCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(command)
         );
     }
@@ -61,7 +61,7 @@ class DefaultCommandBusSpanFactoryTest
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
         test(builder -> builder,
              spanFactory -> spanFactory.createHandleCommandSpan(command, true),
-             expectedSpan("handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+             expectedSpan("CommandBus.handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(command)
         );
     }
@@ -71,7 +71,7 @@ class DefaultCommandBusSpanFactoryTest
         CommandMessage<Object> command = GenericCommandMessage.asCommandMessage("MyCommand");
         test(builder -> builder.distributedInSameTrace(false),
              spanFactory -> spanFactory.createHandleCommandSpan(command, true),
-             expectedSpan("handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_LINK)
+             expectedSpan("CommandBus.handleDistributedCommand", TestSpanFactory.TestSpanType.HANDLER_LINK)
                      .withMessage(command)
         );
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -82,11 +82,11 @@ class SimpleCommandBusTest {
         testSubject.subscribe(String.class.getName(), new MyStringCommandHandler());
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanActive("dispatchCommand");
-                                 spanFactory.verifySpanPropagated("dispatchCommand", command);
-                                 spanFactory.verifySpanCompleted("handleCommand");
+                                 spanFactory.verifySpanActive("CommandBus.dispatchCommand");
+                                 spanFactory.verifySpanPropagated("CommandBus.dispatchCommand", command);
+                                 spanFactory.verifySpanCompleted("CommandBus.handleCommand");
                              });
-        spanFactory.verifySpanCompleted("dispatchCommand");
+        spanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
     }
 
     @Test
@@ -97,11 +97,11 @@ class SimpleCommandBusTest {
         });
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanPropagated("dispatchCommand", command);
-                                 spanFactory.verifySpanCompleted("handleCommand");
+                                 spanFactory.verifySpanPropagated("CommandBus.dispatchCommand", command);
+                                 spanFactory.verifySpanCompleted("CommandBus.handleCommand");
                              });
-        spanFactory.verifySpanCompleted("dispatchCommand");
-        spanFactory.verifySpanHasException("dispatchCommand", RuntimeException.class);
+        spanFactory.verifySpanCompleted("CommandBus.dispatchCommand");
+        spanFactory.verifySpanHasException("CommandBus.dispatchCommand", RuntimeException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,14 @@ class SimpleCommandBusTest {
 
     private TestSpanFactory spanFactory;
     private SimpleCommandBus testSubject;
+    private DefaultCommandBusSpanFactory commandBusSpanFactory;
 
     @BeforeEach
     void setUp() {
         this.spanFactory = new TestSpanFactory();
-        this.testSubject = SimpleCommandBus.builder().spanFactory(spanFactory).build();
+        this.commandBusSpanFactory = DefaultCommandBusSpanFactory.builder().spanFactory(spanFactory).build();
+        this.testSubject = SimpleCommandBus.builder()
+                                           .spanFactory(commandBusSpanFactory).build();
     }
 
     @AfterEach
@@ -79,11 +82,11 @@ class SimpleCommandBusTest {
         testSubject.subscribe(String.class.getName(), new MyStringCommandHandler());
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanActive("SimpleCommandBus.dispatch");
-                                 spanFactory.verifySpanPropagated("SimpleCommandBus.dispatch", command);
-                                 spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+                                 spanFactory.verifySpanActive("dispatchCommand");
+                                 spanFactory.verifySpanPropagated("dispatchCommand", command);
+                                 spanFactory.verifySpanCompleted("handleCommand");
                              });
-        spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
+        spanFactory.verifySpanCompleted("dispatchCommand");
     }
 
     @Test
@@ -94,11 +97,11 @@ class SimpleCommandBusTest {
         });
         testSubject.dispatch(asCommandMessage("Say hi!"),
                              (CommandCallback<String, CommandMessage<String>>) (command, commandResultMessage) -> {
-                                 spanFactory.verifySpanPropagated("SimpleCommandBus.dispatch", command);
-                                 spanFactory.verifySpanCompleted("SimpleCommandBus.handle");
+                                 spanFactory.verifySpanPropagated("dispatchCommand", command);
+                                 spanFactory.verifySpanCompleted("handleCommand");
                              });
-        spanFactory.verifySpanCompleted("SimpleCommandBus.dispatch");
-        spanFactory.verifySpanHasException("SimpleCommandBus.dispatch", RuntimeException.class);
+        spanFactory.verifySpanCompleted("dispatchCommand");
+        spanFactory.verifySpanHasException("dispatchCommand", RuntimeException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
@@ -96,7 +96,7 @@ class DistributedCommandBusTest {
         CountDownLatch waiter = new CountDownLatch(1);
 
         testSubject.dispatch(testCommandMessage, (cm, result) -> {
-            spanFactory.verifySpanActive("dispatchDistributedCommand", testCommandMessage);
+            spanFactory.verifySpanActive("CommandBus.dispatchDistributedCommand", testCommandMessage);
             waiter.countDown();
         });
         waiter.await();
@@ -107,11 +107,11 @@ class DistributedCommandBusTest {
         verify(mockMonitorCallback).reportSuccess();
         await().atMost(Duration.ofSeconds(3l))
                .untilAsserted(
-                       () -> spanFactory.verifySpanCompleted("dispatchDistributedCommand")
+                       () -> spanFactory.verifySpanCompleted("CommandBus.dispatchDistributedCommand")
                );
         await().atMost(Duration.ofSeconds(3l))
                .untilAsserted(
-                       () -> spanFactory.verifySpanPropagated("dispatchDistributedCommand", testCommandMessage)
+                       () -> spanFactory.verifySpanPropagated("CommandBus.dispatchDistributedCommand", testCommandMessage)
                );
     }
 
@@ -190,7 +190,7 @@ class DistributedCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("dispatchDistributedCommand", NoHandlerForCommandException.class);
+        spanFactory.verifySpanHasException("CommandBus.dispatchDistributedCommand", NoHandlerForCommandException.class);
     }
 
     @Test
@@ -233,7 +233,7 @@ class DistributedCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("dispatchDistributedCommand", RuntimeException.class);
+        spanFactory.verifySpanHasException("CommandBus.dispatchDistributedCommand", RuntimeException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/distributed/DistributedCommandBusTest.java
@@ -17,9 +17,11 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.CommandCallback;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.commandhandling.GenericCommandResultMessage;
 import org.axonframework.commandhandling.NoHandlerForCommandException;
@@ -70,15 +72,19 @@ class DistributedCommandBusTest {
     private Member mockMember;
 
     private TestSpanFactory spanFactory;
+    private CommandBusSpanFactory commandBusSpanFactory;
 
     @BeforeEach
     void setUp() {
         spanFactory = new TestSpanFactory();
+        commandBusSpanFactory = DefaultCommandBusSpanFactory.builder()
+                                                            .spanFactory(spanFactory)
+                                                            .build();
         testSubject = DistributedCommandBus.builder()
                                            .commandRouter(mockCommandRouter)
                                            .connector(mockConnector)
                                            .messageMonitor(mockMessageMonitor)
-                                           .spanFactory(spanFactory)
+                                           .spanFactory(commandBusSpanFactory)
                                            .build();
     }
 
@@ -90,7 +96,7 @@ class DistributedCommandBusTest {
         CountDownLatch waiter = new CountDownLatch(1);
 
         testSubject.dispatch(testCommandMessage, (cm, result) -> {
-            spanFactory.verifySpanActive("DistributedCommandBus.dispatch", testCommandMessage);
+            spanFactory.verifySpanActive("dispatchDistributedCommand", testCommandMessage);
             waiter.countDown();
         });
         waiter.await();
@@ -101,11 +107,11 @@ class DistributedCommandBusTest {
         verify(mockMonitorCallback).reportSuccess();
         await().atMost(Duration.ofSeconds(3l))
                .untilAsserted(
-                       () -> spanFactory.verifySpanCompleted("DistributedCommandBus.dispatch")
+                       () -> spanFactory.verifySpanCompleted("dispatchDistributedCommand")
                );
         await().atMost(Duration.ofSeconds(3l))
                .untilAsserted(
-                       () -> spanFactory.verifySpanPropagated("DistributedCommandBus.dispatch", testCommandMessage)
+                       () -> spanFactory.verifySpanPropagated("dispatchDistributedCommand", testCommandMessage)
                );
     }
 
@@ -167,7 +173,7 @@ class DistributedCommandBusTest {
         testSubject = DistributedCommandBus.builder()
                                            .commandRouter(mockCommandRouter)
                                            .connector(mockConnector)
-                                           .spanFactory(spanFactory)
+                                           .spanFactory(commandBusSpanFactory)
                                            .build();
 
         testSubject.dispatch(testCommandMessage, callback);
@@ -184,7 +190,7 @@ class DistributedCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("DistributedCommandBus.dispatch", NoHandlerForCommandException.class);
+        spanFactory.verifySpanHasException("dispatchDistributedCommand", NoHandlerForCommandException.class);
     }
 
     @Test
@@ -227,7 +233,7 @@ class DistributedCommandBusTest {
         assertTrue(commandResultMessageCaptor.getValue().isExceptional());
         assertEquals(NoHandlerForCommandException.class,
                      commandResultMessageCaptor.getValue().exceptionResult().getClass());
-        spanFactory.verifySpanHasException("DistributedCommandBus.dispatch", RuntimeException.class);
+        spanFactory.verifySpanHasException("dispatchDistributedCommand", RuntimeException.class);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
+import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.tracing.IntermediateSpanFactoryTest;
 import org.axonframework.tracing.SpanFactory;
 import org.axonframework.tracing.TestSpanFactory;
@@ -26,8 +29,7 @@ class DefaultEventBusSpanFactoryTest extends IntermediateSpanFactoryTest<Default
 
     @Test
     void createCommitEventsSpan() {
-        test(builder -> builder,
-             DefaultEventBusSpanFactory::createCommitEventsSpan,
+        test(DefaultEventBusSpanFactory::createCommitEventsSpan,
              expectedSpan("EventBus.commitEvents", TestSpanFactory.TestSpanType.INTERNAL)
         );
     }
@@ -35,13 +37,17 @@ class DefaultEventBusSpanFactoryTest extends IntermediateSpanFactoryTest<Default
     @Test
     void createsQuerySpanNonDistributed() {
         EventMessage<?> eventMessage = Mockito.mock(EventMessage.class);
-        test(builder -> builder,
-             factory -> factory.createPublishEventSpan(eventMessage),
+        test(factory -> factory.createPublishEventSpan(eventMessage),
              expectedSpan("EventBus.publishEvent", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(eventMessage)
         );
     }
 
+    @Test
+    void testPropagateContext() {
+        EventMessage<?> eventMessage = Mockito.mock(EventMessage.class);
+        testContextPropagation(eventMessage, DefaultEventBusSpanFactory::propagateContext);
+    }
 
     @Override
     protected DefaultEventBusSpanFactory.Builder createBuilder(SpanFactory spanFactory) {

--- a/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
@@ -28,7 +28,7 @@ class DefaultEventBusSpanFactoryTest extends IntermediateSpanFactoryTest<Default
     void createCommitEventsSpan() {
         test(builder -> builder,
              DefaultEventBusSpanFactory::createCommitEventsSpan,
-             expectedSpan("commitEvents", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("EventBus.commitEvents", TestSpanFactory.TestSpanType.INTERNAL)
         );
     }
 
@@ -37,7 +37,7 @@ class DefaultEventBusSpanFactoryTest extends IntermediateSpanFactoryTest<Default
         EventMessage<?> eventMessage = Mockito.mock(EventMessage.class);
         test(builder -> builder,
              factory -> factory.createPublishEventSpan(eventMessage),
-             expectedSpan("publishEvent", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("EventBus.publishEvent", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(eventMessage)
         );
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/DefaultEventBusSpanFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.axonframework.tracing.IntermediateSpanFactoryTest;
+import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.TestSpanFactory;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+class DefaultEventBusSpanFactoryTest extends IntermediateSpanFactoryTest<DefaultEventBusSpanFactory.Builder, DefaultEventBusSpanFactory> {
+
+    @Test
+    void createCommitEventsSpan() {
+        test(builder -> builder,
+             DefaultEventBusSpanFactory::createCommitEventsSpan,
+             expectedSpan("commitEvents", TestSpanFactory.TestSpanType.INTERNAL)
+        );
+    }
+
+    @Test
+    void createsQuerySpanNonDistributed() {
+        EventMessage<?> eventMessage = Mockito.mock(EventMessage.class);
+        test(builder -> builder,
+             factory -> factory.createPublishEventSpan(eventMessage),
+             expectedSpan("publishEvent", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(eventMessage)
+        );
+    }
+
+
+    @Override
+    protected DefaultEventBusSpanFactory.Builder createBuilder(SpanFactory spanFactory) {
+        return DefaultEventBusSpanFactory.builder().spanFactory(spanFactory);
+    }
+
+    @Override
+    protected DefaultEventBusSpanFactory createFactoryBasedOnBuilder(DefaultEventBusSpanFactory.Builder builder) {
+        return builder.build();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
@@ -16,6 +16,10 @@
 
 package org.axonframework.queryhandling;
 
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
+import org.axonframework.commandhandling.GenericCommandMessage;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.tracing.IntermediateSpanFactoryTest;
 import org.axonframework.tracing.SpanFactory;
 import org.axonframework.tracing.TestSpanFactory;
@@ -29,8 +33,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsQuerySpanNonDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createQuerySpan(queryMessage, false),
+        test(spanFactory -> spanFactory.createQuerySpan(queryMessage, false),
              expectedSpan("QueryBus.query", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
@@ -39,8 +42,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsQuerySpanDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createQuerySpan(queryMessage, true),
+        test(spanFactory -> spanFactory.createQuerySpan(queryMessage, true),
              expectedSpan("QueryBus.queryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
@@ -49,8 +51,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsSubscriptionQuerySpanNonDistributed() {
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, false),
+        test(spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, false),
              expectedSpan("QueryBus.subscriptionQuery", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
@@ -59,8 +60,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsSubscriptionQuerySpanDistributed() {
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, true),
+        test(spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, true),
              expectedSpan("QueryBus.subscriptionQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
@@ -69,8 +69,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsScatterGatherQuerySpanNonDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, false),
+        test(spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, false),
              expectedSpan("QueryBus.scatterGatherQuery", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
@@ -79,8 +78,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsScatterGatherQuerySpanDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, true),
+        test(spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, true),
              expectedSpan("QueryBus.scatterGatherQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
@@ -89,9 +87,8 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsScatterGatherHandlerSpan() {
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createScatterGatherHandlerSpan(queryMessage, 4),
-             expectedSpan("QueryBus.scatterGatherQuery-4", TestSpanFactory.TestSpanType.INTERNAL)
+        test(spanFactory -> spanFactory.createScatterGatherHandlerSpan(queryMessage, 4),
+             expectedSpan("QueryBus.scatterGatherHandler-4", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -99,9 +96,8 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsStreamingQuerySpanNonDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, false),
-             expectedSpan("QueryBus.streamingQuery", TestSpanFactory.TestSpanType.INTERNAL)
+        test(spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, false),
+             expectedSpan("QueryBus.streamingQuery", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(queryMessage)
         );
     }
@@ -109,8 +105,7 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsStreamingQuerySpanDistributed() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, true),
+        test(spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, true),
              expectedSpan("QueryBus.streamingQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
@@ -139,11 +134,16 @@ class DefaultQueryBusSpanFactoryTest extends
     @Test
     void createsResponseProcessingSpan() {
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createResponseProcessingSpan(queryMessage),
-             expectedSpan("QueryBus.processQueryResult", TestSpanFactory.TestSpanType.INTERNAL)
+        test(spanFactory -> spanFactory.createResponseProcessingSpan(queryMessage),
+             expectedSpan("QueryBus.processQueryResponse", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
+    }
+
+    @Test
+    void testPropagateContext() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        testContextPropagation(queryMessage, DefaultQueryBusSpanFactory::propagateContext);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
@@ -31,7 +31,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createQuerySpan(queryMessage, false),
-             expectedSpan("query", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.query", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -41,7 +41,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createQuerySpan(queryMessage, true),
-             expectedSpan("queryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("QueryBus.queryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
     }
@@ -51,7 +51,7 @@ class DefaultQueryBusSpanFactoryTest extends
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, false),
-             expectedSpan("subscriptionQuery", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.subscriptionQuery", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -61,7 +61,7 @@ class DefaultQueryBusSpanFactoryTest extends
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, true),
-             expectedSpan("subscriptionQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("QueryBus.subscriptionQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
     }
@@ -71,7 +71,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, false),
-             expectedSpan("scatterGatherQuery", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.scatterGatherQuery", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -81,7 +81,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, true),
-             expectedSpan("scatterGatherQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("QueryBus.scatterGatherQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
     }
@@ -91,7 +91,7 @@ class DefaultQueryBusSpanFactoryTest extends
         SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createScatterGatherHandlerSpan(queryMessage, 4),
-             expectedSpan("scatterGatherQuery-4", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.scatterGatherQuery-4", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -101,7 +101,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, false),
-             expectedSpan("streamingQuery", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.streamingQuery", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }
@@ -111,7 +111,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, true),
-             expectedSpan("streamingQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("QueryBus.streamingQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(queryMessage)
         );
     }
@@ -121,7 +121,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder.distributedInSameTrace(true),
              spanFactory -> spanFactory.createQueryProcessingSpan(queryMessage),
-             expectedSpan("processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+             expectedSpan("QueryBus.processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_CHILD)
                      .withMessage(queryMessage)
         );
     }
@@ -131,7 +131,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder.distributedInSameTrace(false),
              spanFactory -> spanFactory.createQueryProcessingSpan(queryMessage),
-             expectedSpan("processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_LINK)
+             expectedSpan("QueryBus.processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_LINK)
                      .withMessage(queryMessage)
         );
     }
@@ -141,7 +141,7 @@ class DefaultQueryBusSpanFactoryTest extends
         QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createResponseProcessingSpan(queryMessage),
-             expectedSpan("processQueryResult", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryBus.processQueryResult", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(queryMessage)
         );
     }

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryBusSpanFactoryTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.tracing.IntermediateSpanFactoryTest;
+import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.TestSpanFactory;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+class DefaultQueryBusSpanFactoryTest extends
+        IntermediateSpanFactoryTest<DefaultQueryBusSpanFactory.Builder, DefaultQueryBusSpanFactory> {
+
+
+    @Test
+    void createsQuerySpanNonDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createQuerySpan(queryMessage, false),
+             expectedSpan("query", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsQuerySpanDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createQuerySpan(queryMessage, true),
+             expectedSpan("queryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsSubscriptionQuerySpanNonDistributed() {
+        SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, false),
+             expectedSpan("subscriptionQuery", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsSubscriptionQuerySpanDistributed() {
+        SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createSubscriptionQuerySpan(queryMessage, true),
+             expectedSpan("subscriptionQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsScatterGatherQuerySpanNonDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, false),
+             expectedSpan("scatterGatherQuery", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsScatterGatherQuerySpanDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createScatterGatherSpan(queryMessage, true),
+             expectedSpan("scatterGatherQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsScatterGatherHandlerSpan() {
+        SubscriptionQueryMessage<?, ?, ?> queryMessage = Mockito.mock(SubscriptionQueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createScatterGatherHandlerSpan(queryMessage, 4),
+             expectedSpan("scatterGatherQuery-4", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsStreamingQuerySpanNonDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, false),
+             expectedSpan("streamingQuery", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsStreamingQuerySpanDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createStreamingQuerySpan(queryMessage, true),
+             expectedSpan("streamingQueryDistributed", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsQueryProcessingSpanDistributed() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder.distributedInSameTrace(true),
+             spanFactory -> spanFactory.createQueryProcessingSpan(queryMessage),
+             expectedSpan("processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_CHILD)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsQueryProcessingSpanDistributedButSeparateTrace() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder.distributedInSameTrace(false),
+             spanFactory -> spanFactory.createQueryProcessingSpan(queryMessage),
+             expectedSpan("processQueryMessage", TestSpanFactory.TestSpanType.HANDLER_LINK)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Test
+    void createsResponseProcessingSpan() {
+        QueryMessage<?, ?> queryMessage = Mockito.mock(QueryMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createResponseProcessingSpan(queryMessage),
+             expectedSpan("processQueryResult", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(queryMessage)
+        );
+    }
+
+    @Override
+    protected DefaultQueryBusSpanFactory.Builder createBuilder(SpanFactory spanFactory) {
+        return DefaultQueryBusSpanFactory.builder().spanFactory(spanFactory);
+    }
+
+    @Override
+    protected DefaultQueryBusSpanFactory createFactoryBasedOnBuilder(
+            DefaultQueryBusSpanFactory.Builder builder) {
+        return builder.build();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.axonframework.tracing.IntermediateSpanFactoryTest;
+import org.axonframework.tracing.SpanFactory;
+import org.axonframework.tracing.TestSpanFactory;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+class DefaultQueryUpdateEmitterSpanFactoryTest extends
+        IntermediateSpanFactoryTest<DefaultQueryUpdateEmitterSpanFactory.Builder, DefaultQueryUpdateEmitterSpanFactory> {
+
+    @Test
+    void createsDefaultScheduleSpan() {
+        SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createUpdateScheduleEmitSpan(message),
+             expectedSpan("scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL)
+                     .withMessage(message)
+        );
+    }
+
+    @Test
+    void createsDefaultEmitSpan() {
+        SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
+        test(builder -> builder,
+             spanFactory -> spanFactory.createUpdateEmitSpan(message),
+             expectedSpan("emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH)
+                     .withMessage(message)
+        );
+    }
+
+    @Override
+    protected DefaultQueryUpdateEmitterSpanFactory.Builder createBuilder(SpanFactory spanFactory) {
+        return DefaultQueryUpdateEmitterSpanFactory.builder().spanFactory(spanFactory);
+    }
+
+    @Override
+    protected DefaultQueryUpdateEmitterSpanFactory createFactoryBasedOnBuilder(
+            DefaultQueryUpdateEmitterSpanFactory.Builder builder) {
+        return builder.build();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
@@ -28,8 +28,7 @@ class DefaultQueryUpdateEmitterSpanFactoryTest extends
     @Test
     void createsDefaultScheduleSpan() {
         SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createUpdateScheduleEmitSpan(message),
+        test(spanFactory -> spanFactory.createUpdateScheduleEmitSpan(message),
              expectedSpan("QueryUpdateEmitter.scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(message)
         );
@@ -38,12 +37,18 @@ class DefaultQueryUpdateEmitterSpanFactoryTest extends
     @Test
     void createsDefaultEmitSpan() {
         SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
-        test(builder -> builder,
-             spanFactory -> spanFactory.createUpdateEmitSpan(message),
+        test(spanFactory -> spanFactory.createUpdateEmitSpan(message),
              expectedSpan("QueryUpdateEmitter.emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(message)
         );
     }
+
+    @Test
+    void testPropagateContext() {
+        SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
+        testContextPropagation(message, DefaultQueryUpdateEmitterSpanFactory::propagateContext);
+    }
+
 
     @Override
     protected DefaultQueryUpdateEmitterSpanFactory.Builder createBuilder(SpanFactory spanFactory) {

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryUpdateEmitterSpanFactoryTest.java
@@ -30,7 +30,7 @@ class DefaultQueryUpdateEmitterSpanFactoryTest extends
         SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createUpdateScheduleEmitSpan(message),
-             expectedSpan("scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL)
+             expectedSpan("QueryUpdateEmitter.scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL)
                      .withMessage(message)
         );
     }
@@ -40,7 +40,7 @@ class DefaultQueryUpdateEmitterSpanFactoryTest extends
         SubscriptionQueryUpdateMessage<?> message = Mockito.mock(SubscriptionQueryUpdateMessage.class);
         test(builder -> builder,
              spanFactory -> spanFactory.createUpdateEmitSpan(message),
-             expectedSpan("emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH)
+             expectedSpan("QueryUpdateEmitter.emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH)
                      .withMessage(message)
         );
     }

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -283,13 +283,13 @@ class SimpleQueryBusTest {
         QueryMessage<String, String> testQueryMessage = new GenericQueryMessage<>("hello", singleStringResponse);
         //noinspection resource
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
-            spanFactory.verifySpanActive("SimpleQueryBus.query", testQueryMessage);
+            spanFactory.verifySpanActive("QueryBus.query", testQueryMessage);
             return q.getPayload() + "1234";
         });
 
         testSubject.query(testQueryMessage).get();
 
-        spanFactory.verifySpanCompleted("query", testQueryMessage);
+        spanFactory.verifySpanCompleted("QueryBus.query", testQueryMessage);
     }
 
     @Test
@@ -299,23 +299,23 @@ class SimpleQueryBusTest {
 
         //noinspection resource
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
-            spanFactory.verifySpanActive("scatterGatherQuery", testQueryMessage);
-            spanFactory.verifySpanActive("scatterGatherQuery-0");
+            spanFactory.verifySpanActive("QueryBus.scatterGatherQuery", testQueryMessage);
+            spanFactory.verifySpanActive("QueryBus.scatterGatherQuery-0");
             return q.getPayload() + "1234";
         });
         //noinspection resource
         testSubject.subscribe(String.class.getName(), String.class, (q) -> {
-            spanFactory.verifySpanActive("scatterGatherQuery", testQueryMessage);
-            spanFactory.verifySpanActive("scatterGatherQuery-1");
+            spanFactory.verifySpanActive("QueryBus.scatterGatherQuery", testQueryMessage);
+            spanFactory.verifySpanActive("QueryBus.scatterGatherQuery-1");
             return q.getPayload() + "12345678";
         });
 
         //noinspection ResultOfMethodCallIgnored
         testSubject.scatterGather(testQueryMessage, 500, TimeUnit.MILLISECONDS).collect(Collectors.toList());
 
-        spanFactory.verifySpanCompleted("scatterGatherQuery", testQueryMessage);
-        spanFactory.verifySpanCompleted("scatterGatherQuery-0");
-        spanFactory.verifySpanCompleted("scatterGatherQuery-1");
+        spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery", testQueryMessage);
+        spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery-0");
+        spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery-1");
     }
 
 
@@ -511,7 +511,7 @@ class SimpleQueryBusTest {
         } catch (ExecutionException e) {
             assertEquals(NoHandlerForQueryException.class, e.getCause().getClass());
         }
-        spanFactory.verifySpanHasException("query", NoHandlerForQueryException.class);
+        spanFactory.verifySpanHasException("QueryBus.query", NoHandlerForQueryException.class);
     }
 
     @Test
@@ -840,10 +840,10 @@ class SimpleQueryBusTest {
                                                                              ResponseTypes.instanceOf(Long.class)));
             Mono<QueryResponseMessage<Long>> initialResult = result.initialResult();
             Objects.requireNonNull(initialResult.block()).getPayload();
-            spanFactory.verifySpanCompleted("query");
+            spanFactory.verifySpanCompleted("QueryBus.query");
             updatedLatch.await();
             Objects.requireNonNull(result.updates().next().block()).getPayload();
-            spanFactory.verifySpanCompleted("emitQueryUpdateMessage");
+            spanFactory.verifySpanCompleted("QueryUpdateEmitter.emitQueryUpdateMessage");
         } finally {
             disposable.dispose();
         }

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -314,8 +314,8 @@ class SimpleQueryBusTest {
         testSubject.scatterGather(testQueryMessage, 500, TimeUnit.MILLISECONDS).collect(Collectors.toList());
 
         spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery", testQueryMessage);
-        spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery-0");
-        spanFactory.verifySpanCompleted("QueryBus.scatterGatherQuery-1");
+        spanFactory.verifySpanCompleted("QueryBus.scatterGatherHandler-0");
+        spanFactory.verifySpanCompleted("QueryBus.scatterGatherHandler-1");
     }
 
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class SimpleQueryUpdateEmitterTest {
 
     private final TestSpanFactory spanFactory = new TestSpanFactory();
+    private final QueryUpdateEmitterSpanFactory queryBusSpanFactory = DefaultQueryUpdateEmitterSpanFactory
+            .builder()
+            .spanFactory(spanFactory)
+            .build();
     private final SimpleQueryUpdateEmitter testSubject = SimpleQueryUpdateEmitter.builder()
-                                                                                 .spanFactory(spanFactory)
+                                                                                 .spanFactory(queryBusSpanFactory)
                                                                                  .build();
 
     @Test
@@ -181,10 +185,10 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.complete();
 
-        spanFactory.verifySpanCompleted("SimpleQueryUpdateEmitter.emit");
-        spanFactory.verifySpanHasType("SimpleQueryUpdateEmitter.emit", TestSpanFactory.TestSpanType.INTERNAL);
-        spanFactory.verifySpanCompleted("SimpleQueryUpdateEmitter.doEmit");
-        spanFactory.verifySpanHasType("SimpleQueryUpdateEmitter.doEmit", TestSpanFactory.TestSpanType.DISPATCH);
+        spanFactory.verifySpanCompleted("scheduleQueryUpdateMessage");
+        spanFactory.verifySpanHasType("scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL);
+        spanFactory.verifySpanCompleted("emitQueryUpdateMessage");
+        spanFactory.verifySpanHasType("emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -185,10 +185,10 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.complete();
 
-        spanFactory.verifySpanCompleted("scheduleQueryUpdateMessage");
-        spanFactory.verifySpanHasType("scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL);
-        spanFactory.verifySpanCompleted("emitQueryUpdateMessage");
-        spanFactory.verifySpanHasType("emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH);
+        spanFactory.verifySpanCompleted("QueryUpdateEmitter.scheduleQueryUpdateMessage");
+        spanFactory.verifySpanHasType("QueryUpdateEmitter.scheduleQueryUpdateMessage", TestSpanFactory.TestSpanType.INTERNAL);
+        spanFactory.verifySpanCompleted("QueryUpdateEmitter.emitQueryUpdateMessage");
+        spanFactory.verifySpanHasType("QueryUpdateEmitter.emitQueryUpdateMessage", TestSpanFactory.TestSpanType.DISPATCH);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/tracing/IntermediateSpanFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/IntermediateSpanFactoryTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.tracing;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.messaging.Message;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -129,6 +130,7 @@ public abstract class IntermediateSpanFactoryTest<BI, SI> {
         private final String name;
         private final TestSpanFactory.TestSpanType type;
         private final Map<String, String> attributes = new HashMap<>();
+        private Message<?> message = null;
 
         private ExpectedSpan(String name, TestSpanFactory.TestSpanType type) {
             this.name = name;
@@ -140,10 +142,18 @@ public abstract class IntermediateSpanFactoryTest<BI, SI> {
             return this;
         }
 
+        public ExpectedSpan withMessage(Message<?> message) {
+            this.message = message;
+            return this;
+        }
+
         public void assertSpan(TestSpanFactory.TestSpan span) {
             Assertions.assertEquals(name, span.getName());
             Assertions.assertEquals(type, span.getType());
             attributes.forEach((key, value) -> Assertions.assertEquals(value, span.getAttribute(key)));
+            if(message != null) {
+                Assertions.assertSame(message, span.getMessage());
+            }
         }
 
     }

--- a/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
@@ -356,6 +356,10 @@ public class TestSpanFactory implements SpanFactory {
             return attributes.get(key);
         }
 
+        public Message<?> getMessage() {
+            return message;
+        }
+
         @Override
         public String toString() {
             return "TestSpan{" +

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -328,7 +328,7 @@ public abstract class AbstractSagaManager<T> implements EventHandlerInvoker, Sco
 
         /**
          * Sets the {@link SpanFactory} implementation to use for providing tracing capabilities. Defaults to a
-         * {@link NoOpSpanFactory} by default, which provides no tracing capabilities.
+         * {@link NoOpSpanFactory}, which provides no tracing capabilities.
          *
          * @param spanFactory The {@link SpanFactory} implementation
          * @return The current Builder instance, for fluent interfacing.

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -383,15 +383,15 @@ public abstract class EmbeddedEventStoreTest {
         DefaultUnitOfWork.startAndGet(null);
         testSubject.publish(events);
         events.forEach(e -> {
-            spanFactory.verifySpanCompleted("EmbeddedEventStore.publish", e);
-            spanFactory.verifySpanPropagated("EmbeddedEventStore.publish", e);
-            spanFactory.verifySpanHasType("EmbeddedEventStore.publish", TestSpanFactory.TestSpanType.INTERNAL);
+            spanFactory.verifySpanCompleted("EventBus.publishEvent", e);
+            spanFactory.verifySpanPropagated("EventBus.publishEvent", e);
+            spanFactory.verifySpanHasType("EventBus.publishEvent", TestSpanFactory.TestSpanType.DISPATCH);
         });
-        spanFactory.verifyNotStarted("EmbeddedEventStore.commit");
+        spanFactory.verifyNotStarted("EventBus.commitEvents");
 
         CurrentUnitOfWork.commit();
-        spanFactory.verifySpanCompleted("EmbeddedEventStore.commit");
-        spanFactory.verifySpanHasType("EmbeddedEventStore.commit", TestSpanFactory.TestSpanType.INTERNAL);
+        spanFactory.verifySpanCompleted("EventBus.commitEvents");
+        spanFactory.verifySpanHasType("EventBus.commitEvents", TestSpanFactory.TestSpanType.INTERNAL);
     }
 
     @Test

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
+import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.TestSpanFactory;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.AfterEach;
@@ -111,7 +112,7 @@ public abstract class EmbeddedEventStoreTest {
                 .cleanupDelay(cleanupDelay)
                 .threadFactory(threadFactory)
                 .optimizeEventConsumption(optimizeEventConsumption)
-                .spanFactory(spanFactory)
+                .spanFactory(DefaultEventBusSpanFactory.builder().spanFactory(spanFactory).build())
                 .build();
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.springboot;
 
+import org.axonframework.commandhandling.CommandBus;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
@@ -32,6 +33,16 @@ public class TracingProperties {
      * Properties describing the tracing settings for the {@link org.axonframework.eventsourcing.Snapshotter}.
      */
     private SnapshotterProperties snapshotter = new SnapshotterProperties();
+
+    /**
+     * Properties describing the tracing settings for the {@link CommandBus}.
+     */
+    private CommandBusProperties commandBus = new CommandBusProperties();
+
+    /**
+     * Properties describing the tracing settings for the {@link org.axonframework.queryhandling.QueryBus}.
+     */
+    private QueryBusProperties queryBus = new QueryBusProperties();
 
     /**
      * Whether to show event sourcing handlers in traces. This can be very noisy, especially when larger aggregates are
@@ -76,6 +87,40 @@ public class TracingProperties {
     }
 
     /**
+     * Returns the properties describing the tracing settings for the {@link CommandBus}.
+     *
+     * @return The properties describing the tracing settings for the {@link CommandBus}.
+     */
+    public CommandBusProperties getCommandBus() {
+        return commandBus;
+    }
+
+    /**
+     * Sets the properties describing the tracing settings for the {@link CommandBus}.
+     *
+     * @param commandBus The properties describing the tracing settings for the {@link CommandBus}.
+     */
+    public void setCommandBus(CommandBusProperties commandBus) {
+        this.commandBus = commandBus;
+    }
+
+    /**
+     * Returns the properties describing the tracing settings for the {@link org.axonframework.queryhandling.QueryBus}.
+     * @return the properties describing the tracing settings for the {@link org.axonframework.queryhandling.QueryBus}.
+     */
+    public QueryBusProperties getQueryBus() {
+        return queryBus;
+    }
+
+    /**
+     * Sets the properties describing the tracing settings for the {@link org.axonframework.queryhandling.QueryBus}.
+     * @param queryBus the properties describing the tracing settings for the {@link org.axonframework.queryhandling.QueryBus}.
+     */
+    public void setQueryBus(QueryBusProperties queryBus) {
+        this.queryBus = queryBus;
+    }
+
+    /**
      * Getting value for showing event sourcing handlers in traces.
      *
      * @return Whether event sourcing handlers should show up on traces.
@@ -112,8 +157,8 @@ public class TracingProperties {
     }
 
     /**
-     * The time limit set on nested handlers inside dispatching trace.
-     * Only affects events and deadlines, other messages are always nested.
+     * The time limit set on nested handlers inside dispatching trace. Only affects events and deadlines, other messages
+     * are always nested.
      *
      * @return For how long event messages should be nested in their dispatching trace.
      */
@@ -339,6 +384,73 @@ public class TracingProperties {
          */
         public void setAggregateTypeInSpanName(boolean aggregateTypeInSpanName) {
             this.aggregateTypeInSpanName = aggregateTypeInSpanName;
+        }
+    }
+
+
+    /**
+     * Configuration properties for the behavior of creating tracing spans for the
+     * {@link org.axonframework.commandhandling.CommandBus}.
+     *
+     * @since 4.9.0
+     */
+    public static class CommandBusProperties {
+
+        /**
+         * Whether distributed commands should be part of the same trace.
+         */
+        private boolean distributedInSameTrace = true;
+
+
+        /**
+         * Whether distributed commands should be part of the same trace. Defaults to {@code true}.
+         *
+         * @return whether distributed commands should be part of the same trace.
+         */
+        public boolean isDistributedInSameTrace() {
+            return distributedInSameTrace;
+        }
+
+        /**
+         * Sets whether distributed commands should be part of the same trace.
+         *
+         * @param distributedInSameTrace whether distributed commands should be part of the same trace.
+         */
+        public void setDistributedInSameTrace(boolean distributedInSameTrace) {
+            this.distributedInSameTrace = distributedInSameTrace;
+        }
+    }
+
+    /**
+     * Configuration properties for the behavior of creating tracing spans for the
+     * {@link org.axonframework.queryhandling.QueryBus}.
+     *
+     * @since 4.9.0
+     */
+    public static class QueryBusProperties {
+
+        /**
+         * Whether distributed queries should be part of the same trace.
+         */
+        private boolean distributedInSameTrace = true;
+
+
+        /**
+         * Whether distributed queries should be part of the same trace. Defaults to {@code true}.
+         *
+         * @return whether distributed queries should be part of the same trace.
+         */
+        public boolean isDistributedInSameTrace() {
+            return distributedInSameTrace;
+        }
+
+        /**
+         * Sets whether distributed queries should be part of the same trace.
+         *
+         * @param distributedInSameTrace whether distributed queries should be part of the same trace.
+         */
+        public void setDistributedInSameTrace(boolean distributedInSameTrace) {
+            this.distributedInSameTrace = distributedInSameTrace;
         }
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/TracingProperties.java
@@ -387,7 +387,6 @@ public class TracingProperties {
         }
     }
 
-
     /**
      * Configuration properties for the behavior of creating tracing spans for the
      * {@link org.axonframework.commandhandling.CommandBus}.
@@ -400,7 +399,6 @@ public class TracingProperties {
          * Whether distributed commands should be part of the same trace.
          */
         private boolean distributedInSameTrace = true;
-
 
         /**
          * Whether distributed commands should be part of the same trace. Defaults to {@code true}.
@@ -433,8 +431,7 @@ public class TracingProperties {
          * Whether distributed queries should be part of the same trace.
          */
         private boolean distributedInSameTrace = true;
-
-
+        
         /**
          * Whether distributed queries should be part of the same trace. Defaults to {@code true}.
          *

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.axonframework.springboot.autoconfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thoughtworks.xstream.XStream;
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.DuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.LoggingDuplicateCommandHandlerResolver;
 import org.axonframework.commandhandling.SimpleCommandBus;
@@ -31,6 +32,7 @@ import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.config.TagsConfiguration;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -55,9 +57,11 @@ import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.queryhandling.DefaultQueryGateway;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
+import org.axonframework.queryhandling.QueryUpdateEmitterSpanFactory;
 import org.axonframework.queryhandling.SimpleQueryBus;
 import org.axonframework.queryhandling.SimpleQueryUpdateEmitter;
 import org.axonframework.serialization.AnnotationRevisionResolver;
@@ -73,7 +77,6 @@ import org.axonframework.springboot.EventProcessorProperties;
 import org.axonframework.springboot.SerializerProperties;
 import org.axonframework.springboot.TagsConfigurationProperties;
 import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
-import org.axonframework.tracing.SpanFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -230,7 +233,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
         return EmbeddedEventStore.builder()
                                  .storageEngine(storageEngine)
                                  .messageMonitor(configuration.messageMonitor(EventStore.class, "eventStore"))
-                                 .spanFactory(configuration.spanFactory())
+                                 .spanFactory(configuration.getComponent(EventBusSpanFactory.class))
                                  .build();
     }
 
@@ -251,7 +254,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
     public SimpleEventBus eventBus(Configuration configuration) {
         return SimpleEventBus.builder()
                              .messageMonitor(configuration.messageMonitor(EventStore.class, "eventStore"))
-                             .spanFactory(configuration.spanFactory())
+                             .spanFactory(configuration.getComponent(EventBusSpanFactory.class))
                              .build();
     }
 
@@ -381,7 +384,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
                 SimpleCommandBus.builder()
                                 .transactionManager(txManager)
                                 .duplicateCommandHandlerResolver(duplicateCommandHandlerResolver)
-                                .spanFactory(axonConfiguration.spanFactory())
+                                .spanFactory(axonConfiguration.getComponent(CommandBusSpanFactory.class))
                                 .messageMonitor(axonConfiguration.messageMonitor(CommandBus.class, "commandBus"))
                                 .build();
         commandBus.registerHandlerInterceptor(
@@ -402,7 +405,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
                                      () -> LoggingQueryInvocationErrorHandler.builder().build()
                              ))
                              .queryUpdateEmitter(axonConfiguration.getComponent(QueryUpdateEmitter.class))
-                             .spanFactory(axonConfiguration.spanFactory())
+                             .spanFactory(axonConfiguration.getComponent(QueryBusSpanFactory.class))
                              .build();
     }
 
@@ -412,7 +415,7 @@ public class AxonAutoConfiguration implements BeanClassLoaderAware {
                                        .updateMessageMonitor(configuration.messageMonitor(
                                                QueryUpdateEmitter.class, "queryUpdateEmitter"
                                        ))
-                                       .spanFactory(configuration.spanFactory())
+                                       .spanFactory(configuration.getComponent(QueryUpdateEmitterSpanFactory.class))
                                        .build();
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerBusAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,15 @@ import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
 import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusSpanFactory;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.QueryUpdateEmitter;
@@ -75,7 +78,7 @@ public class AxonServerBusAutoConfiguration {
                                                      CommandPriorityCalculator priorityCalculator,
                                                      CommandLoadFactorProvider loadFactorProvider,
                                                      TargetContextResolver<? super CommandMessage<?>> targetContextResolver,
-                                                     SpanFactory spanFactory) {
+                                                     CommandBusSpanFactory spanFactory) {
         return AxonServerCommandBus.builder()
                                    .axonServerConnectionManager(axonServerConnectionManager)
                                    .configuration(axonServerConfiguration)
@@ -106,7 +109,7 @@ public class AxonServerBusAutoConfiguration {
                               .transactionManager(txManager)
                               .queryUpdateEmitter(axonConfiguration.getComponent(QueryUpdateEmitter.class))
                               .errorHandler(queryInvocationErrorHandler)
-                              .spanFactory(axonConfiguration.spanFactory())
+                              .spanFactory(axonConfiguration.getComponent(QueryBusSpanFactory.class))
                               .build();
         simpleQueryBus.registerHandlerInterceptor(
                 new CorrelationDataInterceptor<>(axonConfiguration.correlationDataProviders())
@@ -121,7 +124,7 @@ public class AxonServerBusAutoConfiguration {
                                  .genericSerializer(genericSerializer)
                                  .priorityCalculator(priorityCalculator)
                                  .targetContextResolver(targetContextResolver)
-                                 .spanFactory(axonConfiguration.spanFactory())
+                                 .spanFactory(axonConfiguration.getComponent(QueryBusSpanFactory.class))
                                  .build();
     }
 
@@ -141,7 +144,7 @@ public class AxonServerBusAutoConfiguration {
                                    .eventSerializer(eventSerializer)
                                    .snapshotFilter(configuration.snapshotFilter())
                                    .upcasterChain(configuration.upcasterChain())
-                                   .spanFactory(configuration.spanFactory())
+                                   .spanFactory(configuration.getComponent(EventBusSpanFactory.class))
                                    .build();
     }
 }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonTracingAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonTracingAutoConfiguration.java
@@ -16,10 +16,18 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import org.axonframework.commandhandling.CommandBusSpanFactory;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
 import org.axonframework.config.ConfigurerModule;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventsourcing.DefaultSnapshotterSpanFactory;
 import org.axonframework.eventsourcing.SnapshotterSpanFactory;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
+import org.axonframework.queryhandling.DefaultQueryUpdateEmitterSpanFactory;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
+import org.axonframework.queryhandling.QueryUpdateEmitterSpanFactory;
 import org.axonframework.springboot.TracingProperties;
 import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.SpanAttributesProvider;
@@ -71,6 +79,42 @@ public class AxonTracingAutoConfiguration {
                                                                                .isAggregateTypeInSpanName())
                                             .separateTrace(properties.getSnapshotter().isSeparateTrace())
                                             .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CommandBusSpanFactory.class)
+    public CommandBusSpanFactory commandBusSpanFactory(SpanFactory spanFactory, TracingProperties properties) {
+        TracingProperties.CommandBusProperties commandBus = properties.getCommandBus();
+        return DefaultCommandBusSpanFactory.builder()
+                                           .spanFactory(spanFactory)
+                                           .distributedInSameTrace(commandBus.isDistributedInSameTrace())
+                                           .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(QueryBusSpanFactory.class)
+    public QueryBusSpanFactory queryBusSpanFactory(SpanFactory spanFactory, TracingProperties properties) {
+        TracingProperties.QueryBusProperties commandBus = properties.getQueryBus();
+        return DefaultQueryBusSpanFactory.builder()
+                                         .spanFactory(spanFactory)
+                                         .distributedInSameTrace(commandBus.isDistributedInSameTrace())
+                                         .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(QueryUpdateEmitterSpanFactory.class)
+    public QueryUpdateEmitterSpanFactory queryUpdateEmitterSpanFactory(SpanFactory spanFactory) {
+        return DefaultQueryUpdateEmitterSpanFactory.builder()
+                                                   .spanFactory(spanFactory)
+                                                   .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EventBusSpanFactory.class)
+    public EventBusSpanFactory eventBusSpanFactory(SpanFactory spanFactory) {
+        return DefaultEventBusSpanFactory.builder()
+                                         .spanFactory(spanFactory)
+                                         .build();
     }
 
     @Bean

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTracingTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTracingTest.java
@@ -16,9 +16,17 @@
 
 package org.axonframework.springboot;
 
+import org.axonframework.commandhandling.CommandBusSpanFactory;
+import org.axonframework.commandhandling.DefaultCommandBusSpanFactory;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventsourcing.DefaultSnapshotterSpanFactory;
 import org.axonframework.eventsourcing.SnapshotterSpanFactory;
 import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.queryhandling.DefaultQueryBusSpanFactory;
+import org.axonframework.queryhandling.DefaultQueryUpdateEmitterSpanFactory;
+import org.axonframework.queryhandling.QueryBusSpanFactory;
+import org.axonframework.queryhandling.QueryUpdateEmitterSpanFactory;
 import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
@@ -265,6 +273,118 @@ class AxonAutoConfigurationWithTracingTest {
                     assertTrue(context.containsBean("snapshotterSpanFactory"));
                     assertNotNull(context.getBean(SnapshotterSpanFactory.class));
                     assertSame(context.getBean(SnapshotterSpanFactory.class), mock);
+                });
+    }
+
+    @Test
+    void eventBusSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("eventBusSpanFactory"));
+                    assertNotNull(context.getBean(EventBusSpanFactory.class));
+                    assertEquals(DefaultEventBusSpanFactory.class, context.getBean(EventBusSpanFactory.class).getClass());
+                });
+    }
+
+    @Test
+    void eventBusSpanFactoryCanBeOverriddenByUser() {
+        EventBusSpanFactory mock = Mockito.mock(EventBusSpanFactory.class);
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean(EventBusSpanFactory.class, () -> mock)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("eventBusSpanFactory"));
+                    assertNotNull(context.getBean(EventBusSpanFactory.class));
+                    assertSame(context.getBean(EventBusSpanFactory.class), mock);
+                });
+    }
+
+    @Test
+    void queryBusSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("queryBusSpanFactory"));
+                    assertNotNull(context.getBean(QueryBusSpanFactory.class));
+                    assertEquals(DefaultQueryBusSpanFactory.class, context.getBean(QueryBusSpanFactory.class).getClass());
+                });
+    }
+
+    @Test
+    void queryBusSpanFactoryCanBeOverriddenByUser() {
+        QueryBusSpanFactory mock = Mockito.mock(QueryBusSpanFactory.class);
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean(QueryBusSpanFactory.class, () -> mock)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("queryBusSpanFactory"));
+                    assertNotNull(context.getBean(QueryBusSpanFactory.class));
+                    assertSame(context.getBean(QueryBusSpanFactory.class), mock);
+                });
+    }
+
+    @Test
+    void queryUpdateEmitterSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("queryUpdateEmitterSpanFactory"));
+                    assertNotNull(context.getBean(QueryUpdateEmitterSpanFactory.class));
+                    assertEquals(DefaultQueryUpdateEmitterSpanFactory.class, context.getBean(QueryUpdateEmitterSpanFactory.class).getClass());
+                });
+    }
+
+    @Test
+    void queryUpdateEmitterSpanFactoryCanBeOverriddenByUser() {
+        QueryUpdateEmitterSpanFactory mock = Mockito.mock(QueryUpdateEmitterSpanFactory.class);
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean(QueryUpdateEmitterSpanFactory.class, () -> mock)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("queryUpdateEmitterSpanFactory"));
+                    assertNotNull(context.getBean(QueryUpdateEmitterSpanFactory.class));
+                    assertSame(context.getBean(QueryUpdateEmitterSpanFactory.class), mock);
+                });
+    }
+
+    @Test
+    void commandBusSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("commandBusSpanFactory"));
+                    assertNotNull(context.getBean(CommandBusSpanFactory.class));
+                    assertEquals(DefaultCommandBusSpanFactory.class, context.getBean(CommandBusSpanFactory.class).getClass());
+                });
+    }
+
+    @Test
+    void commandBusSpanFactoryCanBeOverriddenByUser() {
+        CommandBusSpanFactory mock = Mockito.mock(CommandBusSpanFactory.class);
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withBean(CommandBusSpanFactory.class, () -> mock)
+                .run(context -> {
+                    assertNotNull(context);
+
+                    assertTrue(context.containsBean("commandBusSpanFactory"));
+                    assertNotNull(context.getBean(CommandBusSpanFactory.class));
+                    assertSame(context.getBean(CommandBusSpanFactory.class), mock);
                 });
     }
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTracingTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithTracingTest.java
@@ -305,7 +305,7 @@ class AxonAutoConfigurationWithTracingTest {
     }
 
     @Test
-    void queryBusSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+    void queryBusSpanFactoryDefaultsToDefaultQueryBusSpanFactory() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .run(context -> {
@@ -333,7 +333,7 @@ class AxonAutoConfigurationWithTracingTest {
     }
 
     @Test
-    void queryUpdateEmitterSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+    void queryUpdateEmitterSpanFactoryDefaultsToDefaultQueryUpdateEmitterSpanFactory() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .run(context -> {
@@ -361,7 +361,7 @@ class AxonAutoConfigurationWithTracingTest {
     }
 
     @Test
-    void commandBusSpanFactoryDefaultsToDefaultEventBusSpanFactory() {
+    void commandBusSpanFactoryDefaultsToDefaultCommandBusSpanFactory() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .run(context -> {

--- a/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -24,6 +24,7 @@ import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.deadline.GenericDeadlineMessage;
 import org.axonframework.deadline.annotation.DeadlineHandler;
+import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.Timestamp;
@@ -47,6 +48,7 @@ import org.axonframework.modelling.saga.EndSaga;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
 import org.axonframework.modelling.saga.repository.SagaStore;
+import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.TestSpanFactory;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
@@ -105,7 +107,9 @@ public abstract class AbstractDeadlineManagerTestSuite {
         spanFactory = new TestSpanFactory();
         EventStore eventStore = spy(EmbeddedEventStore.builder()
                                                       .storageEngine(new InMemoryEventStorageEngine())
-                                                      .spanFactory(spanFactory)
+                                                      .spanFactory(DefaultEventBusSpanFactory
+                                                                           .builder()
+                                                                           .spanFactory(spanFactory).build())
                                                       .build());
         List<CorrelationDataProvider> correlationDataProviders = new ArrayList<>();
         correlationDataProviders.add(new MessageOriginProvider());


### PR DESCRIPTION
Updates the following interfaces and adds intermediate span factories for all their implementations:

- CommandBus
- QueryBus
- QueryUpdateEmitter
- EventBus

It also updates the SnapshotterSpanFactory implementation to generate spans with its interface name to make it more clear to users.

This PR currently targets the #2824 branch until it is merged to better reflect the individual changes. Once merged, this PR will target main.