### PR TITLE
Ensure insert order is maintained for `SequencedDeadLetterQueue#deadLetterSequence(String)` invocations

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -266,6 +266,7 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
                 + "WHERE " + schema.processingGroupColumn() + "=? "
                 + "AND " + schema.sequenceIdentifierColumn() + "=? "
                 + "AND " + schema.sequenceIndexColumn() + ">=? "
+                + "ORDER BY " + schema.sequenceIndexColumn() + " "
                 + "LIMIT ?";
 
         PreparedStatement statement =

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
@@ -241,16 +241,21 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
     public Iterable<DeadLetter<? extends M>> deadLetterSequence(@Nonnull Object sequenceIdentifier) {
         String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
 
-        return new PagingJpaQueryIterable<>(queryPageSize,
-                                            transactionManager,
-                                            () -> entityManagerProvider
-                                                    .getEntityManager()
-                                                    .createQuery(
-                                                            "select dl from DeadLetterEntry dl where dl.processingGroup=:processingGroup and dl.sequenceIdentifier=:identifier",
-                                                            DeadLetterEntry.class)
-                                                    .setParameter(PROCESSING_GROUP_PARAM, processingGroup)
-                                                    .setParameter("identifier", stringSequenceIdentifier),
-                                            this::toLetter
+        return new PagingJpaQueryIterable<>(
+                queryPageSize,
+                transactionManager,
+                () -> entityManagerProvider
+                        .getEntityManager()
+                        .createQuery(
+                                "select dl from DeadLetterEntry dl "
+                                        + "where dl.processingGroup=:processingGroup "
+                                        + "and dl.sequenceIdentifier=:identifier "
+                                        + "order by dl.sequenceIndex",
+                                DeadLetterEntry.class
+                        )
+                        .setParameter(PROCESSING_GROUP_PARAM, processingGroup)
+                        .setParameter("identifier", stringSequenceIdentifier),
+                this::toLetter
         );
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaSequencedDeadLetterQueue.java
@@ -26,14 +26,18 @@ import org.axonframework.eventhandling.deadletter.jpa.DeadLetterEventEntry;
 import org.axonframework.eventhandling.deadletter.jpa.NoJpaConverterFoundException;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.messaging.deadletter.*;
+import org.axonframework.messaging.deadletter.Cause;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.DeadLetterQueueOverflowException;
+import org.axonframework.messaging.deadletter.EnqueueDecision;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
+import org.axonframework.messaging.deadletter.NoSuchDeadLetterException;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.WrongDeadLetterTypeException;
 import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.time.Instant;
@@ -44,6 +48,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
 
 import static org.axonframework.common.BuilderUtils.*;
 
@@ -246,16 +253,21 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
     public Iterable<DeadLetter<? extends M>> deadLetterSequence(@Nonnull Object sequenceIdentifier) {
         String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
 
-        return new PagingJpaQueryIterable<>(queryPageSize,
-                                            transactionManager,
-                                            () -> entityManagerProvider
-                                                    .getEntityManager()
-                                                    .createQuery(
-                                                            "select dl from DeadLetterEntry dl where dl.processingGroup=:processingGroup and dl.sequenceIdentifier=:identifier",
-                                                            DeadLetterEntry.class)
-                                                    .setParameter(PROCESSING_GROUP_PARAM, processingGroup)
-                                                    .setParameter("identifier", stringSequenceIdentifier),
-                                            this::toLetter
+        return new PagingJpaQueryIterable<>(
+                queryPageSize,
+                transactionManager,
+                () -> entityManagerProvider
+                        .getEntityManager()
+                        .createQuery(
+                                "select dl from DeadLetterEntry dl "
+                                        + "where dl.processingGroup=:processingGroup "
+                                        + "and dl.sequenceIdentifier=:identifier "
+                                        + "order by dl.sequenceIndex",
+                                DeadLetterEntry.class
+                        )
+                        .setParameter(PROCESSING_GROUP_PARAM, processingGroup)
+                        .setParameter("identifier", stringSequenceIdentifier),
+                this::toLetter
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
@@ -16,13 +16,16 @@
 
 package org.axonframework.eventhandling.deadletter.jdbc;
 
+import org.axonframework.common.jdbc.JdbcException;
 import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.deadletter.DeadLetteringEventHandlerInvoker;
 import org.axonframework.eventhandling.deadletter.DeadLetteringEventIntegrationTest;
-import org.axonframework.messaging.deadletter.InMemorySequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.TestSerializer;
 import org.hsqldb.jdbc.JDBCDataSource;
 import org.junit.jupiter.api.*;
@@ -33,9 +36,19 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
 
 import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
+import static org.axonframework.common.jdbc.JdbcUtils.executeUpdate;
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * An implementation of the {@link DeadLetteringEventIntegrationTest} validating the
@@ -50,6 +63,7 @@ class JdbcDeadLetteringEventIntegrationTest extends DeadLetteringEventIntegratio
 
     private DataSource dataSource;
     private TransactionManager transactionManager;
+    private DeadLetterStatementFactory<EventMessage<?>> statementFactory;
     private JdbcSequencedDeadLetterQueue<EventMessage<?>> jdbcDeadLetterQueue;
 
     private final DeadLetterSchema schema = DeadLetterSchema.defaultSchema();
@@ -58,13 +72,22 @@ class JdbcDeadLetteringEventIntegrationTest extends DeadLetteringEventIntegratio
     protected SequencedDeadLetterQueue<EventMessage<?>> buildDeadLetterQueue() {
         dataSource = dataSource();
         transactionManager = transactionManager(dataSource);
+        Serializer eventSerializer = TestSerializer.JACKSON.getSerializer();
+        Serializer genericSerializer = TestSerializer.JACKSON.getSerializer();
+        statementFactory = DefaultDeadLetterStatementFactory.builder()
+                                                            .eventSerializer(eventSerializer)
+                                                            .genericSerializer(genericSerializer)
+                                                            .schema(schema)
+                                                            .build();
+
         jdbcDeadLetterQueue = JdbcSequencedDeadLetterQueue.builder()
                                                           .processingGroup(TEST_PROCESSING_GROUP)
                                                           .connectionProvider(dataSource::getConnection)
                                                           .schema(schema)
+                                                          .statementFactory(statementFactory)
                                                           .transactionManager(transactionManager)
-                                                          .genericSerializer(TestSerializer.JACKSON.getSerializer())
-                                                          .eventSerializer(TestSerializer.JACKSON.getSerializer())
+                                                          .genericSerializer(eventSerializer)
+                                                          .eventSerializer(genericSerializer)
                                                           .build();
         return jdbcDeadLetterQueue;
     }
@@ -113,6 +136,64 @@ class JdbcDeadLetteringEventIntegrationTest extends DeadLetteringEventIntegratio
             }
             // Construct new DLQ
             jdbcDeadLetterQueue.createSchema(new GenericDeadLetterTableFactory());
+        });
+    }
+
+    @Test
+    void deadLetterSequenceReturnsMatchingEnqueuedLettersInInsertOrder() {
+        String aggregateId = UUID.randomUUID().toString();
+        Map<Integer, GenericDeadLetter<EventMessage<?>>> insertedLetters = new HashMap<>();
+
+        Iterator<DeadLetter<? extends EventMessage<?>>> resultIterator =
+                jdbcDeadLetterQueue.deadLetterSequence(aggregateId)
+                                   .iterator();
+        assertFalse(resultIterator.hasNext());
+
+        IntStream.range(0, 64)
+                 .boxed()
+                 .sorted(Collections.reverseOrder())
+                 .forEach(i -> {
+                     GenericDeadLetter<EventMessage<?>> letter =
+                             new GenericDeadLetter<>(aggregateId, asEventMessage(i));
+                     insertLetterAtIndex(aggregateId, letter, i);
+                     insertedLetters.put(i, letter);
+                 });
+
+        resultIterator = jdbcDeadLetterQueue.deadLetterSequence(aggregateId).iterator();
+        for (Map.Entry<Integer, GenericDeadLetter<EventMessage<?>>> entry : insertedLetters.entrySet()) {
+            Integer sequenceIndex = entry.getKey();
+            Supplier<String> assertMessageSupplier = () -> "Failed asserting event [" + sequenceIndex + "]";
+            assertTrue(resultIterator.hasNext(), assertMessageSupplier);
+
+            GenericDeadLetter<EventMessage<?>> expected = entry.getValue();
+            DeadLetter<? extends EventMessage<?>> result = resultIterator.next();
+            assertTrue(result instanceof JdbcDeadLetter);
+            JdbcDeadLetter<? extends EventMessage<?>> actual = ((JdbcDeadLetter<? extends EventMessage<?>>) result);
+
+            assertEquals(expected.getSequenceIdentifier(), actual.getSequenceIdentifier(), assertMessageSupplier);
+            assertEquals(expected.message().getPayload(), actual.message().getPayload(), assertMessageSupplier);
+            assertFalse(result.cause().isPresent(), assertMessageSupplier);
+            assertEquals(expected.diagnostics(), actual.diagnostics(), assertMessageSupplier);
+            assertEquals(sequenceIndex.longValue(), actual.getSequenceIndex(), assertMessageSupplier);
+        }
+    }
+
+    private void insertLetterAtIndex(String aggregateId, DeadLetter<EventMessage<?>> letter, int index) {
+        transactionManager.executeInTransaction(() -> {
+            try (Connection connection = dataSource.getConnection()) {
+                executeUpdate(
+                        connection,
+                        c -> statementFactory.enqueueStatement(
+                                c, TEST_PROCESSING_GROUP, aggregateId, letter, index
+                        ),
+                        e -> new JdbcException(
+                                "Failed to enqueue dead letter with with message id [" +
+                                        letter.message().getIdentifier() + "] during testing", e
+                        )
+                );
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 }

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
@@ -25,13 +25,21 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.deadletter.DeadLetteringEventHandlerInvoker;
 import org.axonframework.eventhandling.deadletter.DeadLetteringEventIntegrationTest;
+import org.axonframework.eventhandling.deadletter.jpa.DeadLetterEntry;
+import org.axonframework.eventhandling.deadletter.jpa.DeadLetterEventEntry;
+import org.axonframework.eventhandling.deadletter.jpa.DeadLetterJpaConverter;
+import org.axonframework.eventhandling.deadletter.jpa.EventMessageDeadLetterJpaConverter;
+import org.axonframework.eventhandling.deadletter.jpa.JpaDeadLetter;
 import org.axonframework.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.TestSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
 import org.axonframework.spring.utils.MysqlTestContainerExtension;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +53,17 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * An implementation of the {@link DeadLetteringEventIntegrationTest} validating the {@link JpaSequencedDeadLetterQueue}
@@ -61,9 +79,11 @@ class SpringJpaDeadLetteringIntegrationTest extends DeadLetteringEventIntegratio
 
     @Autowired
     private PlatformTransactionManager platformTransactionManager;
-
     @Autowired
     private EntityManagerProvider entityManagerProvider;
+    private final Serializer serializer = TestSerializer.JACKSON.getSerializer();
+    private final DeadLetterJpaConverter<EventMessage<?>> converter = new EventMessageDeadLetterJpaConverter();
+    private JpaSequencedDeadLetterQueue<EventMessage<?>> jpaDeadLetterQueue;
 
     @BeforeEach
     public void clear() {
@@ -79,12 +99,69 @@ class SpringJpaDeadLetteringIntegrationTest extends DeadLetteringEventIntegratio
 
     @Override
     protected SequencedDeadLetterQueue<EventMessage<?>> buildDeadLetterQueue() {
-        return JpaSequencedDeadLetterQueue.builder()
-                .processingGroup(PROCESSING_GROUP)
-                .transactionManager(getTransactionManager())
-                .entityManagerProvider(entityManagerProvider)
-                .serializer(TestSerializer.JACKSON.getSerializer())
-                .build();
+        jpaDeadLetterQueue = JpaSequencedDeadLetterQueue.builder()
+                                                        .processingGroup(PROCESSING_GROUP)
+                                                        .entityManagerProvider(entityManagerProvider)
+                                                        .transactionManager(getTransactionManager())
+                                                        .serializer(serializer)
+                                                        .addConverter(converter)
+                                                        .build();
+        return jpaDeadLetterQueue;
+    }
+
+    @Test
+    void deadLetterSequenceReturnsMatchingEnqueuedLettersInInsertOrder() {
+        String aggregateId = UUID.randomUUID().toString();
+        Map<Integer, GenericDeadLetter<EventMessage<?>>> insertedLetters = new HashMap<>();
+
+        Iterator<DeadLetter<? extends EventMessage<?>>> resultIterator =
+                jpaDeadLetterQueue.deadLetterSequence(aggregateId).iterator();
+        assertFalse(resultIterator.hasNext());
+
+        IntStream.range(0, 64)
+                 .boxed()
+                 .sorted(Collections.reverseOrder())
+                 .forEach(i -> {
+                     GenericDeadLetter<EventMessage<?>> letter =
+                             new GenericDeadLetter<>(aggregateId, asEventMessage(i));
+                     insertLetterAtIndex(aggregateId, letter, i);
+                     insertedLetters.put(i, letter);
+                 });
+
+        resultIterator = jpaDeadLetterQueue.deadLetterSequence(aggregateId).iterator();
+        for (Map.Entry<Integer, GenericDeadLetter<EventMessage<?>>> entry : insertedLetters.entrySet()) {
+            Integer sequenceIndex = entry.getKey();
+            Supplier<String> assertMessageSupplier = () -> "Failed asserting event [" + sequenceIndex + "]";
+            assertTrue(resultIterator.hasNext(), assertMessageSupplier);
+
+            GenericDeadLetter<EventMessage<?>> expected = entry.getValue();
+            DeadLetter<? extends EventMessage<?>> result = resultIterator.next();
+            assertTrue(result instanceof JpaDeadLetter);
+            JpaDeadLetter<? extends EventMessage<?>> actual = ((JpaDeadLetter<? extends EventMessage<?>>) result);
+
+            assertEquals(expected.getSequenceIdentifier(), actual.getSequenceIdentifier(), assertMessageSupplier);
+            assertEquals(expected.message().getPayload(), actual.message().getPayload(), assertMessageSupplier);
+            assertFalse(result.cause().isPresent(), assertMessageSupplier);
+            assertEquals(expected.diagnostics(), actual.diagnostics(), assertMessageSupplier);
+            assertEquals(sequenceIndex.longValue(), actual.getIndex(), assertMessageSupplier);
+        }
+    }
+
+    private void insertLetterAtIndex(String aggregateId, DeadLetter<EventMessage<?>> letter, int index) {
+        transactionManager.executeInTransaction(() -> {
+            DeadLetterEventEntry eventEntry = converter.convert(letter.message(), serializer, serializer);
+            DeadLetterEntry deadLetter = new DeadLetterEntry(PROCESSING_GROUP,
+                                                             aggregateId,
+                                                             index,
+                                                             eventEntry,
+                                                             letter.enqueuedAt(),
+                                                             letter.lastTouched(),
+                                                             letter.cause().orElse(null),
+                                                             letter.diagnostics(),
+                                                             serializer);
+            entityManagerProvider.getEntityManager()
+                                 .persist(deadLetter);
+        });
     }
 
     @Configuration


### PR DESCRIPTION
The JavaDoc of the `SequencedDeadLetterQueue#deadLetterSequence(String)` method states the following:

```java
/**
 * Return all the {@link DeadLetter dead letters} for the given {@code sequenceIdentifier} in insert order.
 *
 * @param sequenceIdentifier The identifier of the sequence of {@link DeadLetter dead letters}to return.
 * @return All the {@link DeadLetter dead letters} for the given {@code sequenceIdentifier} in insert order.
 */
```

However, the JPA and JDBC implementations of the `SequencedDeadLetterQueue` did not enforce any ordering open retrieval of the dead letters for a given sequence identifier.
This pull request rectifies that, by adding a test to the unit test suite, and integration tests for the JDBC, JPA, and legacy JPA implementation of the `SequencedDeadLetterQueue`.
Note that the integration tests deliberately insert the dead letters for a given sequence in the reverse order to enforce the scenario that the letters aren't stored in the sequence index ordering that it is intended to be returned in.

The fix itself is minimal, as it is just an `order by` addition to the query.