### PR TITLE
Instruct compiler to include parameter names metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,7 @@
                     <encoding>UTF-8</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <!-- test -->


### PR DESCRIPTION
This is required for Spring AOT and may also help other cases where reflection is used to retrieve parameter names.