### PR TITLE
Several dependency upgrades

### DIFF
--- a/hibernate-6-integrationtests/pom.xml
+++ b/hibernate-6-integrationtests/pom.xml
@@ -106,11 +106,13 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
+            <version>${hsqldb.with11.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.persistence.with11.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <testcontainers.version>1.19.1</testcontainers.version>
         <!-- Validation -->
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
-        <hibernate-validator.8.version>8.0.0.Final</hibernate-validator.8.version>
+        <hibernate-validator.8.version>8.0.1.Final</hibernate-validator.8.version>
         <!-- Build / Plugin -->
         <eclipse.transformer-maven-plugin.version>0.5.0</eclipse.transformer-maven-plugin.version>
         <felix.maven-bundle-plugin.version>5.1.9</felix.maven-bundle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jackson.version>2.14.3</jackson.version>
         <xstream.version>1.4.20</xstream.version>
         <!-- Scheduling -->
-        <db-scheduler.version>11.7</db-scheduler.version>
+        <db-scheduler.version>12.5.0</db-scheduler.version>
         <jobrunr.version>6.3.2</jobrunr.version>
         <quartz.version>2.3.2</quartz.version>
         <!-- Spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jakarta.el.version>4.0.0</jakarta.el.version>
         <jakarta.el-impl.version>4.0.2</jakarta.el-impl.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
-        <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
+        <jakarta.persistence.version>3.0.0</jakarta.persistence.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <!-- Javax -->
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jakarta.el.version>4.0.0</jakarta.el.version>
         <jakarta.el-impl.version>4.0.2</jakarta.el-impl.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
-        <jakarta.persistence.version>3.0.0</jakarta.persistence.version>
+        <jakarta.persistence.version>3.1.0</jakarta.persistence.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <!-- Javax -->
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <!-- Spring -->
         <spring.version>5.3.30</spring.version>
         <spring.boot.version>2.7.16</spring.boot.version>
-        <spring-security.version>5.7.3</spring-security.version>
+        <spring-security.version>5.8.7</spring-security.version>
         <!-- Testing -->
         <awaitility.version>4.2.0</awaitility.version>
         <hamcrest.version>2.2</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <hsqldb.version>2.7.2</hsqldb.version>
         <hibernate-core.version>5.6.15.Final</hibernate-core.version>
         <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
-        <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
         <postgresql.version>42.6.0</postgresql.version>
         <!-- Jakarta -->
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <ehcache3.version>3.10.8</ehcache3.version>
         <!-- Database -->
         <c3p0.version>0.9.1.2</c3p0.version>
-        <hsqldb.version>2.5.2</hsqldb.version>
+        <hsqldb.version>2.5.2</hsqldb.version><!-- Don't upgrade due to JDK8 -->
         <hibernate-core.version>5.6.15.Final</hibernate-core.version>
         <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
         <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
@@ -87,7 +87,7 @@
         <jakarta.el.version>4.0.0</jakarta.el.version>
         <jakarta.el-impl.version>4.0.2</jakarta.el-impl.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
-        <jakarta.persistence.version>3.0.0</jakarta.persistence.version>
+        <jakarta.persistence.version>3.0.0</jakarta.persistence.version><!-- Don't upgrade due to JDK8 -->
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <!-- Javax -->
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,8 +116,8 @@
         <reactive.streams.spec.version>1.0.4</reactive.streams.spec.version>
         <!-- Serialization -->
         <dom4j.version>2.1.4</dom4j.version>
-        <gson.version>2.8.9</gson.version>
-        <jackson.version>2.13.4</jackson.version>
+        <gson.version>2.10.1</gson.version>
+        <jackson.version>2.14.3</jackson.version>
         <xstream.version>1.4.20</xstream.version>
         <!-- Scheduling -->
         <db-scheduler.version>11.7</db-scheduler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <awaitility.version>4.2.0</awaitility.version>
         <hamcrest.version>2.2</hamcrest.version>
         <junit4.version>4.13.2</junit4.version>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <mockito.version>4.11.0</mockito.version>
         <testcontainers.version>1.19.1</testcontainers.version>
         <!-- Validation -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <ehcache3.version>3.10.8</ehcache3.version>
         <!-- Database -->
         <c3p0.version>0.9.1.2</c3p0.version>
-        <hsqldb.version>2.7.2</hsqldb.version>
+        <hsqldb.version>2.5.2</hsqldb.version>
         <hibernate-core.version>5.6.15.Final</hibernate-core.version>
         <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
         <mysql-connector-java.version>8.0.33</mysql-connector-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         <ehcache3.version>3.10.8</ehcache3.version>
         <!-- Database -->
         <c3p0.version>0.9.1.2</c3p0.version>
-        <hsqldb.version>2.5.2</hsqldb.version>
-        <hibernate-core.version>5.6.14.Final</hibernate-core.version>
-        <hibernate-core.6.version>6.1.6.Final</hibernate-core.6.version>
+        <hsqldb.version>2.7.2</hsqldb.version>
+        <hibernate-core.version>5.6.15.Final</hibernate-core.version>
+        <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
         <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
         <postgresql.version>42.5.1</postgresql.version>
         <!-- Jakarta -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <hibernate-core.version>5.6.15.Final</hibernate-core.version>
         <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
         <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
-        <postgresql.version>42.5.1</postgresql.version>
+        <postgresql.version>42.6.0</postgresql.version>
         <!-- Jakarta -->
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.el.version>4.0.0</jakarta.el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <!-- Database -->
         <c3p0.version>0.9.1.2</c3p0.version>
         <hsqldb.version>2.5.2</hsqldb.version><!-- Don't upgrade due to JDK8 -->
+        <hsqldb.with11.version>2.7.2</hsqldb.with11.version><!-- Don't upgrade due to JDK8 -->
         <hibernate-core.version>5.6.15.Final</hibernate-core.version>
         <hibernate-core.6.version>6.3.1.Final</hibernate-core.6.version>
         <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
@@ -88,6 +89,7 @@
         <jakarta.el-impl.version>4.0.2</jakarta.el-impl.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <jakarta.persistence.version>3.0.0</jakarta.persistence.version><!-- Don't upgrade due to JDK8 -->
+        <jakarta.persistence.with11.version>3.1.0</jakarta.persistence.with11.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <!-- Javax -->
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -153,13 +153,11 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>${hsqldb.with11.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>${jakarta.persistence.with11.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <jobrunr.version>6.3.2</jobrunr.version>
-        <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
         <spring-boot-3.version>3.1.4</spring-boot-3.version>
         <!-- Build / Plugin -->
         <jacoco-maven.version>0.8.8</jacoco-maven.version>

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -145,14 +145,21 @@
         </dependency>
         <!-- Database -->
         <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
             <version>0.9.5.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>${hsqldb.with11.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.persistence.with11.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tracing-opentelemetry/pom.xml
+++ b/tracing-opentelemetry/pom.xml
@@ -33,7 +33,7 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <opentelemetry-api.version>1.19.0</opentelemetry-api.version>
+        <opentelemetry-api.version>1.30.1</opentelemetry-api.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades the following dependencies:

* Update hsqldb from 2.5.2 to 2.7.2 for the hibernate-6 and spring-boot-3 modules **only**
* Update hibernate from 5.6.14 to 5.6.15
* Update hibernate-6 from 6.1.6 to 6.3.1
* Update postgresql from 42.5.1 to 42.6.0
* Update gson from 2.8.9 to 2.10.1
* Update jakarta persistence from 3.0.0 to 3.1.0 for the hibernate-6 and spring-boot-3 modules **only**
* Update jackson from 2.13.4 to 2.14.3
* Update db-scheduler from 11.7 to 12.5.0
* Update spring-security from 5.7.3 to 5.8.7
* Update junit jupiter from 5.9.1 to 5.10.0
* Update hibernate validator from 8.0.0 to 8.0.1
* Update opentelemtry from 1.19.0 to 1.30.1
* Update msql-connector from 8.0.30 to 8.0.33

We would've expected `dependabot` to have made these changes, but for some reason it didn't.
Hence the manual process.