### PR TITLE
Add JDK21 to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           - java-version: 17
             sonar-enabled: true
             deploy-enabled: false
+          - java-version: 21
+            sonar-enabled: false
+            deploy-enabled: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -19,6 +19,8 @@ jobs:
             sonar-enabled: false
           - java-version: 17
             sonar-enabled: true
+          - java-version: 21
+            sonar-enabled: false
 
     steps:
       - name: Checkout code

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <!-- Build / Plugin -->
         <eclipse.transformer-maven-plugin.version>0.5.0</eclipse.transformer-maven-plugin.version>
         <felix.maven-bundle-plugin.version>5.1.9</felix.maven-bundle-plugin.version>
-        <jacoco-maven.version>0.8.8</jacoco-maven.version>
+        <jacoco-maven.version>0.8.11</jacoco-maven.version>
         <maven-assembly.version>3.6.0</maven-assembly.version>
         <maven-clean.version>3.3.1</maven-clean.version>
         <maven-compiler.version>3.11.0</maven-compiler.version>


### PR DESCRIPTION
This pull request adds JDK21 to the GitHub actions for merged code in `master` and pull requests.
In doing so, we keep validating whether Axon Framework works with the most commonly used versions of Java.

Although issue #2710 is specific on Virtual Thread support, I still feel it's feasible to see this PR as part of that effort.