### PR TITLE
[#2855] Support Hierarchical Spring Contexts within `SpringConfigurer.ComponentLocator`

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.spring.config;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
+import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 import java.util.Arrays;
@@ -59,8 +60,7 @@ public class SpringConfigurer extends DefaultConfigurer {
         }
 
         public <T> Optional<T> findBean(Class<T> componentType) {
-            String[] candidates = beanFactory.getBeanNamesForType(componentType);
-
+            String[] candidates = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, componentType);
             if (candidates.length == 0) {
                 return Optional.empty();
             } else if (candidates.length == 1) {
@@ -77,7 +77,7 @@ public class SpringConfigurer extends DefaultConfigurer {
         private <T> Optional<T> findPrimary(Class<T> componentType, String[] candidates) {
             String primary = null;
             for (String candidate : candidates) {
-                if (beanFactory.getBeanDefinition(candidate).isPrimary()) {
+                if (beanFactory.getMergedBeanDefinition(candidate).isPrimary()) {
                     if (primary != null) {
                         return Optional.empty();
                     } else {

--- a/spring/src/test/java/org/axonframework/spring/config/SpringConfigurerTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringConfigurerTest.java
@@ -20,21 +20,13 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.config.Configuration;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class SpringConfigurerTest {
 
@@ -61,10 +53,10 @@ class SpringConfigurerTest {
     @Test
     void springPrimaryBeanUsedWhenMultipleCandidates() {
         when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
-        when(context.getBeanDefinition(any())).thenReturn(new GenericBeanDefinition());
+        when(context.getMergedBeanDefinition(any())).thenReturn(new GenericBeanDefinition());
         GenericBeanDefinition primary = new GenericBeanDefinition();
         primary.setPrimary(true);
-        when(context.getBeanDefinition("commandBus")).thenReturn(primary);
+        when(context.getMergedBeanDefinition("commandBus")).thenReturn(primary);
         SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
         when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
 
@@ -81,7 +73,7 @@ class SpringConfigurerTest {
         when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
         GenericBeanDefinition primary = new GenericBeanDefinition();
         primary.setPrimary(true);
-        when(context.getBeanDefinition(any())).thenReturn(primary);
+        when(context.getMergedBeanDefinition(any())).thenReturn(primary);
         SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
         when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
 
@@ -98,7 +90,7 @@ class SpringConfigurerTest {
     void failsWhenMultipleNonPrimaryCandidates() {
         when(context.getBeanNamesForType(CommandBus.class)).thenReturn(new String[]{"commandBus", "alternative"});
         GenericBeanDefinition nonPrimary = new GenericBeanDefinition();
-        when(context.getBeanDefinition(any())).thenReturn(nonPrimary);
+        when(context.getMergedBeanDefinition(any())).thenReturn(nonPrimary);
         SimpleCommandBus commandBus = SimpleCommandBus.builder().build();
         when(context.getBean("commandBus", CommandBus.class)).thenReturn(commandBus);
 
@@ -120,5 +112,4 @@ class SpringConfigurerTest {
         //noinspection unchecked
         verify(context, never()).getBean(anyString(), any(Class.class));
     }
-
 }


### PR DESCRIPTION
This pull request adjusts the `SpringConfigurer.ComponentLocator` to take into account beans may originate from ancestor Spring Contexts.
Furthermore, when it has found bean names, it assumes it may need a merged bean definition.

Next to the adjustments in the `SpringConfigurerTest`, I have tested the changes against [my sample project](https://github.com/smcvb/gamerental) and the sample provided in #2855, with success.

In doing the above, this pull request resolves #2855.