### PR TITLE
Disable JPA and JDBC `EventStorageEngine` creation when Axon Server is enabled

### DIFF
--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,15 +32,13 @@ import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.serialization.JavaSerializer;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
-import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,18 +50,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest(properties = "axon.axonserver.enabled=false")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = AxonAutoConfigurationWithEventSerializerPropertiesTest.TestContext.class)
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
-        WebClientAutoConfiguration.class,
-        AxonServerBusAutoConfiguration.class,
-        AxonServerAutoConfiguration.class,
-        AxonServerActuatorAutoConfiguration.class
+        WebClientAutoConfiguration.class
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")
-public class AxonAutoConfigurationWithEventSerializerPropertiesTest {
+class AxonAutoConfigurationWithEventSerializerPropertiesTest {
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,6 @@ import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +39,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableMBeanExport;
@@ -52,17 +50,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest(properties = "axon.axonserver.enabled=false")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
-        WebClientAutoConfiguration.class,
-        AxonServerBusAutoConfiguration.class,
-        AxonServerAutoConfiguration.class,
-        AxonServerActuatorAutoConfiguration.class
+        WebClientAutoConfiguration.class
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class AxonAutoConfigurationWithEventSerializerTest {
+class AxonAutoConfigurationWithEventSerializerTest {
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,15 +34,13 @@ import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.Upcaster;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
-import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,17 +57,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@SpringBootTest(properties = "axon.axonserver.enabled=false")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
-        WebClientAutoConfiguration.class,
-        AxonServerBusAutoConfiguration.class,
-        AxonServerAutoConfiguration.class,
-        AxonServerActuatorAutoConfiguration.class
+        WebClientAutoConfiguration.class
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-public class AxonAutoConfigurationWithHibernateTest {
+class AxonAutoConfigurationWithHibernateTest {
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -106,7 +102,7 @@ public class AxonAutoConfigurationWithHibernateTest {
 
     @Transactional
     @Test
-    public void eventStorageEngingeUsesSerializerBean() {
+    public void eventStorageEngineUsesSerializerBean() {
         final Serializer serializer = applicationContext.getBean(Serializer.class);
         final JpaEventStorageEngine engine = applicationContext.getBean(JpaEventStorageEngine.class);
 

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/JpaEventStoreAutoConfigurationWithAxonServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.axonframework.springboot;
 
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.springboot.utils.GrpcServerStub;
 import org.axonframework.springboot.utils.TcpUtils;
@@ -61,6 +62,8 @@ class JpaEventStoreAutoConfigurationWithAxonServerTest {
             Map<String, EventStore> eventStores = context.getBeansOfType(EventStore.class);
             assertTrue(eventStores.containsKey("eventStore"));
             assertEquals(AxonServerEventStore.class, eventStores.get("eventStore").getClass());
+            Map<String, EventStorageEngine> eventStorageEngineBeans = context.getBeansOfType(EventStorageEngine.class);
+            assertTrue(eventStorageEngineBeans.isEmpty());
         });
     }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -44,7 +44,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -70,12 +72,14 @@ public class JdbcAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean({EventStorageEngine.class, EventSchema.class})
+    @ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
     public EventSchema eventSchema() {
         return new EventSchema();
     }
 
     @Bean
     @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
+    @ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
     public EventStorageEngine eventStorageEngine(Serializer defaultSerializer,
                                                  PersistenceExceptionResolver persistenceExceptionResolver,
                                                  @Qualifier("eventSerializer") Serializer eventSerializer,

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,13 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
+
 /**
- * Auto configuration class for Axon's JPA specific event store components.
+ * Autoconfiguration class for Axon's JPA specific event store components.
  *
  * @author Sara Pelligrini
  * @since 4.0
@@ -41,10 +43,11 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration
 @ConditionalOnBean(EntityManagerFactory.class)
 @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
+@ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
+@AutoConfigureAfter(AxonServerAutoConfiguration.class)
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventsourcing.eventstore.jpa"
 })
-@AutoConfigureAfter(AxonServerAutoConfiguration.class)
 public class JpaEventStoreAutoConfiguration {
 
     @Bean

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/legacyjpa/JpaJavaxEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/legacyjpa/JpaJavaxEventStoreAutoConfiguration.java
@@ -32,13 +32,14 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import javax.persistence.EntityManagerFactory;
 
 /**
- * Auto configuration class for Axon's JPA specific event store components.
+ * Autoconfiguration class for Axon's JPA specific event store components.
  *
  * @author Sara Pelligrini
  * @since 4.0
@@ -47,12 +48,13 @@ import javax.persistence.EntityManagerFactory;
 @Deprecated
 @AutoConfiguration
 @ConditionalOnBean(EntityManagerFactory.class)
-@AutoConfigureBefore({JpaEventStoreAutoConfiguration.class, JdbcAutoConfiguration.class})
 @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
+@ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
+@AutoConfigureBefore({JpaEventStoreAutoConfiguration.class, JdbcAutoConfiguration.class})
+@AutoConfigureAfter({AxonServerAutoConfiguration.class, JpaJavaxAutoConfiguration.class})
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventsourcing.eventstore.jpa"
 })
-@AutoConfigureAfter({AxonServerAutoConfiguration.class, JpaJavaxAutoConfiguration.class})
 public class JpaJavaxEventStoreAutoConfiguration {
 
     @Bean

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/RegisterDefaultEntities.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/RegisterDefaultEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation intended for types and methods to trigger the registration of entities found in the given
+ * {@link #packages()} with the {@link DefaultEntityRegistrar}.
+ *
+ * @author Allard Buijze
+ * @since 3.0
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import(DefaultEntityRegistrar.class)
 public @interface RegisterDefaultEntities {
 
+    /**
+     * An array of package names used by the {@link DefaultEntityRegistrar} to collect entities from.
+     *
+     * @return An array of package names used by the {@link DefaultEntityRegistrar} to collect entities from.
+     */
     String[] packages();
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
@@ -28,11 +28,8 @@ import org.axonframework.modelling.saga.StartSaga;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.stereotype.Saga;
 import org.axonframework.springboot.autoconfig.AxonAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
-import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.axonframework.springboot.utils.TestSerializer;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.SpringBootConfiguration;
@@ -41,7 +38,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.jmx.support.RegistrationPolicy;
 
@@ -53,8 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests customization of the event handlers on a Saga, updating the configuration through an autowired method. Ensures
@@ -62,13 +62,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author Marc Gathier
  */
-@SpringBootTest(properties = "spring.main.banner-mode=off")
+@SpringBootTest(properties = {
+        "spring.main.banner-mode=off",
+        "axon.axonserver.enabled=false"
+})
 @SpringBootConfiguration
 @EnableAutoConfiguration(exclude = {
-        AxonServerAutoConfiguration.class,
-        AxonServerBusAutoConfiguration.class,
-        AxonServerActuatorAutoConfiguration.class,
-        AxonServerActuatorAutoConfiguration.class,
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class
 })

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/legacyjpa/JpaEventStoreAutoConfigurationWithAxonServerTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/legacyjpa/JpaEventStoreAutoConfigurationWithAxonServerTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.springboot.legacyjpa;
 
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStore;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.springboot.utils.GrpcServerStub;
 import org.axonframework.springboot.utils.TcpUtils;
@@ -61,6 +62,8 @@ class JpaEventStoreAutoConfigurationWithAxonServerTest {
             Map<String, EventStore> eventStores = context.getBeansOfType(EventStore.class);
             assertTrue(eventStores.containsKey("eventStore"));
             assertEquals(AxonServerEventStore.class, eventStores.get("eventStore").getClass());
+            Map<String, EventStorageEngine> eventStorageEngineBeans = context.getBeansOfType(EventStorageEngine.class);
+            assertTrue(eventStorageEngineBeans.isEmpty());
         });
     }
 


### PR DESCRIPTION
This pull request checks whether the property `axon.axonserver.enabled` is consciously set to `false`.
Only when that is the case will the autoconfiguration try to construct a `JpaEventStorageEngine` bean (either `javax` or `jakarta`, depending on whether the Spring Boot version is 2 or 3 respectively), or a `JdbcEventStorageEngine` whenever the JPA version didn't succeed.

As a side effect, this change ensures that users combining Axon Framework, JPA, and Axon Server, do not automatically receive or have to validate the existence of the `domain_event_entry` and `snapshot_entry` tables.
This follows from the (Axon Framework-specific) `@RegisterDefaultEntities` annotation, that is triggered in conjunction with the introduced `@ConditionalOnExpression("${axon.axonserver.enabled:true} == false")` annotation.

Note that this change has a side effect.
Namely, users that, instead of using properties, decided to exclude `AxonServerAutoConfiguration` and/or `AxonServerBusAutoConfiguration` classes, will no longer receive the `JpaEventStorageEngine`/`JdbcEventStorageEngine` either.
You can see in the PR that this pointer required me to adjust some of our old autoconfiguration tests, which went with the "old -ashioned approach" of disabling Axon Server autoconfiguration.

Hence, this last point is something worth discussing and thus I'd like your insights into this.