### PR TITLE
Move to JDK21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,18 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java-version: 8
-            sonar-enabled: false
-            deploy-enabled: true
-          - java-version: 11
-            sonar-enabled: false
-            deploy-enabled: false
-          - java-version: 17
-            sonar-enabled: true
-            deploy-enabled: false
           - java-version: 21
-            sonar-enabled: false
-            deploy-enabled: false
+            sonar-enabled: true
+            deploy-enabled: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,14 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java-version: 8
-            sonar-enabled: false
-          - java-version: 11
-            sonar-enabled: false
-          - java-version: 17
-            sonar-enabled: true
           - java-version: 21
-            sonar-enabled: false
+            sonar-enabled: true
 
     steps:
       - name: Checkout code

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/EventProcessorTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/EventProcessorTask.java
@@ -95,7 +95,7 @@ public class EventProcessorTask implements Runnable {
                 processNextTask();
                 processedItems++;
                 // Continue processing if there is no rescheduling involved and there are events in the queue, or if yielding failed
-                mayContinue = (processedItems < itemsAtStart && !taskQueue.isEmpty()) || !yield();
+                mayContinue = (processedItems < itemsAtStart && !taskQueue.isEmpty()) || !yieldProcessing();
             }
         }
     }
@@ -117,7 +117,7 @@ public class EventProcessorTask implements Runnable {
      *
      * @return true if yielding succeeded, false otherwise.
      */
-    private synchronized boolean yield() {
+    private synchronized boolean yieldProcessing() {
         if (taskQueue.isEmpty()) {
             cleanUp();
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
         <module>test</module>
         <module>tracing-opentelemetry</module>
         <module>spring-boot3-dummy</module>
+        <module>hibernate-6-integrationtests</module>
+        <module>spring-boot-3-integrationtests</module>
     </modules>
     <packaging>pom</packaging>
 
@@ -577,8 +579,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
                     <encoding>UTF-8</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -672,7 +674,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.8</version>
+                                    <version>21</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.5</version>
@@ -855,26 +857,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <profile>
-            <id>java11-modules</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <modules>
-                <module>hibernate-6-integrationtests</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>java17-modules</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <modules>
-                <module>spring-boot-3-integrationtests</module>
-            </modules>
         </profile>
 
         <profile>


### PR DESCRIPTION
This pull request adjusts some basic things in Axon Framework to move to JDK21, like:

- Changing the `maven-compiler-plugin` source and target
- Changing the `maven-enforcer-plugin` required version
- Dropping the JDK11 and JDK17 module configuration
- Adjusting the `main` and `pullrequest` GHA to only use JDK21
- Replacing the use of `yield()`, as that's a reserved word (since I believe JDK13)

This PR can be seen as a preparation to remove Javax from the project, as well as **all** deprecated code.