### PR TITLE
Enhancement/test container reuse

### DIFF
--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -115,7 +115,7 @@ public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
     protected void doStart() {
         super.doStart();
         try {
-            AxonServerContainerUtils.initCluster(getHost(), getHttpPort());
+            AxonServerContainerUtils.initCluster(getHost(), getHttpPort(), isShouldBeReused());
         } catch (IOException e) {
             throw new ContainerLaunchException("Axon Server cluster initialization failed.", e);
         }

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -54,7 +54,10 @@ class AxonServerContainerUtils {
      * @throws IOException When there are issues with the HTTP connection to the Axon Server instance at the given
      *                     {@code hostname} and {@code port}.
      */
-    static void initCluster(String hostname, int port) throws IOException {
+    static void initCluster(String hostname, int port, boolean shouldBeReused) throws IOException {
+        if (shouldBeReused && initialized(hostname, port)){
+            return;
+        }
         final URL url = new URL(String.format("http://%s:%d/v1/context/init", hostname, port));
         HttpURLConnection connection = null;
         try {
@@ -158,5 +161,10 @@ class AxonServerContainerUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static boolean initialized(String hostname, int port) throws IOException {
+        List<String> cont = contexts(hostname, port);
+        return cont.contains("_admin") && cont.contains("default");
     }
 }

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -55,7 +55,7 @@ class AxonServerContainerUtils {
      *                     {@code hostname} and {@code port}.
      */
     static void initCluster(String hostname, int port, boolean shouldBeReused) throws IOException {
-        if (shouldBeReused && initialized(hostname, port)){
+        if (shouldBeReused && initialized(hostname, port)) {
             return;
         }
         final URL url = new URL(String.format("http://%s:%d/v1/context/init", hostname, port));


### PR DESCRIPTION
When using the Axon test container, if you set the reuse flag to true, the current setup always tries to initialize the container contexts, we should check if reuse has been set to true and also if the container has already been initialized before re-initializing