### PR TITLE
Remove all deprecated code from the `config` module

### DIFF
--- a/config/src/main/java/org/axonframework/config/Configurer.java
+++ b/config/src/main/java/org/axonframework/config/Configurer.java
@@ -227,30 +227,6 @@ public interface Configurer extends LifecycleOperations {
     Configurer registerCommandHandler(@Nonnull Function<Configuration, Object> commandHandlerBuilder);
 
     /**
-     * Registers a command handler bean with this {@link Configurer}. The bean may be of any type. The actual command
-     * handler methods will be detected based on the annotations present on the bean's methods. Message handling
-     * functions annotated with {@link org.axonframework.commandhandling.CommandHandler} will be taken into account.
-     * <p>
-     * The builder function receives the {@link Configuration} as input, and is expected to return a fully initialized
-     * instance of the command handler bean.
-     *
-     * @param commandHandlerBuilder the builder function of the command handler bean
-     * @param phase                 defines a phase in which the command handler builder will be invoked during {@link
-     *                              Configuration#start()} and {@link Configuration#shutdown()}. When starting the
-     *                              configuration handlers are ordered in ascending, when shutting down the
-     *                              configuration, descending order is used.
-     * @return the current instance of the {@link Configurer}, for chaining purposes
-     * @deprecated in favor of {@link #registerCommandHandler(Function)}, since the {@code phase} of an annotated
-     * handler should be defined through the {@link org.axonframework.lifecycle.StartHandler}/{@link
-     * org.axonframework.lifecycle.ShutdownHandler} annotation.
-     */
-    @Deprecated
-    default Configurer registerCommandHandler(int phase,
-                                              @Nonnull Function<Configuration, Object> commandHandlerBuilder) {
-        return registerCommandHandler(commandHandlerBuilder);
-    }
-
-    /**
      * Registers a query handler bean with this {@link Configurer}. The bean may be of any type. The actual query
      * handler methods will be detected based on the annotations present on the bean's methods. Message handling
      * functions annotated with {@link org.axonframework.queryhandling.QueryHandler} will be taken into account.
@@ -262,29 +238,6 @@ public interface Configurer extends LifecycleOperations {
      * @return the current instance of the {@link Configurer}, for chaining purposes
      */
     Configurer registerQueryHandler(@Nonnull Function<Configuration, Object> queryHandlerBuilder);
-
-    /**
-     * Registers a query handler bean with this {@link Configurer}. The bean may be of any type. The actual query
-     * handler methods will be detected based on the annotations present on the bean's methods. Message handling
-     * functions annotated with {@link org.axonframework.queryhandling.QueryHandler} will be taken into account.
-     * <p>
-     * The builder function receives the {@link Configuration} as input, and is expected to return a fully initialized
-     * instance of the query handler bean.
-     *
-     * @param queryHandlerBuilder the builder function of the query handler bean
-     * @param phase               defines a phase in which the query handler builder will be invoked during {@link
-     *                            Configuration#start()} and {@link Configuration#shutdown()}. When starting the
-     *                            configuration handlers are ordered in ascending, when shutting down the configuration,
-     *                            descending order is used.
-     * @return the current instance of the {@link Configurer}, for chaining purposes
-     * @deprecated in favor of {@link #registerQueryHandler(Function)}, since the {@code phase} of an annotated handler
-     * should be defined through the {@link org.axonframework.lifecycle.StartHandler}/{@link
-     * org.axonframework.lifecycle.ShutdownHandler} annotation.
-     */
-    @Deprecated
-    default Configurer registerQueryHandler(int phase, @Nonnull Function<Configuration, Object> queryHandlerBuilder) {
-        return registerQueryHandler(queryHandlerBuilder);
-    }
 
     /**
      * Registers a message handler bean with this configuration. The bean may be of any type. The actual message handler

--- a/config/src/main/java/org/axonframework/config/ModuleConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/ModuleConfiguration.java
@@ -37,47 +37,6 @@ public interface ModuleConfiguration {
     void initialize(Configuration config);
 
     /**
-     * Defines a phase in which this module's {@link #initialize(Configuration)}, {@link #start()}, {@link #shutdown()}
-     * will be invoked.
-     *
-     * @return this module's phase
-     * @deprecated a {@link ModuleConfiguration}'s phase is no longer used, as distinct phases might be necessary for
-     * any of the start or shutdown processes added in the {@link #initialize(Configuration)} method
-     */
-    @Deprecated
-    default int phase() {
-        return 0;
-    }
-
-    /**
-     * Invoked when the Configuration is started.
-     *
-     * @see Configuration#start()
-     * @deprecated in favor of maintaining start operations in the {@link Component}. Any lifecycle operations not
-     * covered through the components created by this {@link ModuleConfiguration} should be added to the {@link
-     * Configuration} in {@link #initialize(Configuration)} through {@link Configuration#onStart(int,
-     * LifecycleHandler)}
-     */
-    @Deprecated
-    default void start() {
-        //No-op
-    }
-
-    /**
-     * Invoked prior to shutdown of the application.
-     *
-     * @see Configuration#shutdown()
-     * @deprecated in favor of maintaining shutdown operations in the {@link Component}. Any lifecycle operations not
-     * covered through the components created by this {@link ModuleConfiguration} should be added to the {@link
-     * Configuration} in {@link #initialize(Configuration)} through {@link Configuration#onShutdown(int,
-     * LifecycleHandler)}
-     */
-    @Deprecated
-    default void shutdown() {
-        //No-op
-    }
-
-    /**
      * Returns the actual module configuration instance. Usually, it is the instance itself. However, in case of module
      * configuration wrappers, we would like to provide the wrapped module configuration as the instance.
      *

--- a/config/src/main/java/org/axonframework/config/SagaConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/SagaConfigurer.java
@@ -185,7 +185,6 @@ public class SagaConfigurer<T> {
         }
 
         @Override
-        @Deprecated
         public <T extends EventProcessor> T eventProcessor() {
             ensureInitialized();
             //noinspection unchecked


### PR DESCRIPTION
This pull request removes all deprecated code from the `config` module.
Noteworthy drops are:

* The `registerCommandHandler` and `registerQueryHandler` methods from the `Configurer` using a phase, as lifecycle logic should not reside here.
* The start, shutdown, and phase methods of the `ModuleConfiguration, as lifecycle logic no longer resides here.
* Drop the deprecation mention on a concrete method. The exposed `SagaConfiguration#eventProcessor` still has value. Furthermore, if removing the deprecation warning proves incorrect: the chances are high the configuration will be adjusted quite heavily any how.