### PR TITLE
Resolve warnings within the build

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -764,16 +764,6 @@ class AxonServerQueryBusTest {
         }
 
         @Override
-        public void sendAck() {
-            // Do nothing - no-op implementation
-        }
-
-        @Override
-        public void sendNack(ErrorMessage errorMessage) {
-            // Do nothing - no-op implementation
-        }
-
-        @Override
         public void complete() {
             // Do nothing - no-op implementation
         }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -854,16 +854,6 @@ class QueryProcessingTaskIntegrationTest {
         }
 
         @Override
-        public void sendAck() {
-            // noop
-        }
-
-        @Override
-        public void sendNack(ErrorMessage errorMessage) {
-            // noop
-        }
-
-        @Override
         public void complete() {
             completed = true;
         }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/GenericAggregateFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/GenericAggregateFactory.java
@@ -63,6 +63,7 @@ public class GenericAggregateFactory<T> extends AbstractAggregateFactory<T> {
      *
      * @param aggregateModel the model of aggregate this factory creates instances of
      */
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     public GenericAggregateFactory(AggregateModel<T> aggregateModel) {
         super(aggregateModel);
         aggregateModel.types()

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -142,12 +142,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-xe</artifactId>
             <scope>test</scope>
@@ -168,12 +162,6 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -116,6 +116,7 @@ public class AnnotationRoutingStrategy extends AbstractRoutingStrategy {
                           .identify(command.getPayload());
     }
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     private RoutingKeyResolver createResolver(Class<?> type) {
         for (Method m : methodsOf(type)) {
             if (AnnotationUtils.findAnnotationAttributes(m, annotationType).isPresent()) {

--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -173,7 +173,11 @@ public abstract class ReflectionUtils {
      * @return the given {@code member}, for easier method chaining
      * @throws IllegalStateException if the member is not accessible and the security manager doesn't allow it to be
      *                               made accessible
+     * @deprecated Since the used {@link AccessController} will be removed in future JDK versions. The effort to
+     * implement a workaround is drafted in issue #2901.
      */
+    @SuppressWarnings("removal") // Suppressed AccessController usage
+    @Deprecated
     public static <T extends AccessibleObject> T ensureAccessible(T member) {
         if (!isAccessible(member)) {
             AccessController.doPrivileged(new MemberAccessibilityCallback(member));
@@ -182,12 +186,15 @@ public abstract class ReflectionUtils {
     }
 
     /**
-     * Indicates whether the given {@code member} is accessible. It does so by checking whether the member is
-     * non-final and public, or made accessible via reflection.
+     * Indicates whether the given {@code member} is accessible. It does so by checking whether the member is non-final
+     * and public, or made accessible via reflection.
      *
      * @param member The member (field, method, constructor, etc) to check for accessibility
      * @return {@code true} if the member is accessible, otherwise {@code false}.
+     * @deprecated Since the used {@link AccessibleObject#isAccessible()} should be replaced for
+     * {@link AccessibleObject#canAccess(Object)}. The effort to implement a workaround is drafted in issue #2901.
      */
+    @Deprecated
     public static boolean isAccessible(AccessibleObject member) {
         return member.isAccessible() || (member instanceof Member && isNonFinalPublicMember((Member) member));
     }

--- a/messaging/src/main/java/org/axonframework/common/property/MethodAccessedProperty.java
+++ b/messaging/src/main/java/org/axonframework/common/property/MethodAccessedProperty.java
@@ -42,6 +42,7 @@ public class MethodAccessedProperty<T> implements Property<T> {
      * @param accessorMethod The method providing the property value
      * @param propertyName   The name of the property
      */
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     public MethodAccessedProperty(Method accessorMethod, String propertyName) {
         property = propertyName;
         method = ensureAccessible(accessorMethod);

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -39,11 +39,11 @@ import java.util.OptionalLong;
 public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
 
     private static final long serialVersionUID = -4102464856247630944L;
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
     private final TrackingToken tokenAtReset;
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
     private final TrackingToken currentToken;
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
     private final Object context;
     private final transient boolean lastMessageWasReplay;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/ScheduleToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/ScheduleToken.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
  * @author Allard Buijze
  * @since 0.7
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public interface ScheduleToken extends Serializable {
 
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMember.java
@@ -17,20 +17,17 @@
 package org.axonframework.messaging.annotation;
 
 import org.axonframework.common.ReflectionUtils;
-import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.HandlerAttributes;
 import org.axonframework.messaging.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -62,6 +59,7 @@ public class AnnotatedMessageHandlingMember<T> implements MessageHandlingMember<
      * @param explicitPayloadType      the expected message payload type
      * @param parameterResolverFactory factory used to resolve method parameters
      */
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     public AnnotatedMessageHandlingMember(Executable executable,
                                           @SuppressWarnings("rawtypes") Class<? extends Message> messageType,
                                           Class<?> explicitPayloadType,

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -370,7 +370,8 @@ public class JacksonSerializer implements Serializer {
                 objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
             }
             if (defaultTyping) {
-                objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
+                objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+                                                   ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
             }
             if (classLoader != null) {
                 objectMapper.setTypeFactory(objectMapper.getTypeFactory().withClassLoader(classLoader));

--- a/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -142,6 +142,7 @@ class ReflectionUtilsTest {
         assertEquals(expectedFieldValue, testObject.getField3());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void isAccessible() throws NoSuchFieldException {
         Field field1 = SomeType.class.getDeclaredField("field1");

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -104,7 +104,8 @@ class JacksonSerializerTest {
 
     @Test
     void serializeAndDeserializeList() {
-        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
+        objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(),
+                                           ObjectMapper.DefaultTyping.NON_CONCRETE_AND_ARRAYS);
         SimpleSerializableType toSerialize =
                 new SimpleSerializableType("first", time, new SimpleSerializableType("nested"));
 

--- a/messaging/src/test/java/org/axonframework/serialization/json/MetaDataDeserializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/MetaDataDeserializerTest.java
@@ -52,7 +52,7 @@ class MetaDataDeserializerTest {
                 new SimpleModule("Axon-Jackson Module").addDeserializer(MetaData.class, new MetaDataDeserializer()));
 
         if (defaultTyping != null) {
-            objectMapper.enableDefaultTyping(defaultTyping);
+            objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), defaultTyping);
         }
         return objectMapper;
     }

--- a/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
@@ -110,6 +110,7 @@ public class AnnotationCommandTargetResolver implements CommandTargetResolver {
         return asLong(invokeAnnotated(command, versionAnnotation));
     }
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     private static Object invokeAnnotated(
             Message<?> command, Class<? extends Annotation> annotation
     ) throws InvocationTargetException, IllegalAccessException {

--- a/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
@@ -49,6 +49,7 @@ public class NoArgumentConstructorCreationPolicyAggregateFactory<A> implements C
      * @param identifier The identifier to create the aggregate with. Not used by this factory.
      * @return An aggregate instance.
      */
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     @Nonnull
     @Override
     public A create(@Nullable Object identifier) {

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AbstractResourceInjector.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AbstractResourceInjector.java
@@ -72,6 +72,7 @@ public abstract class AbstractResourceInjector implements ResourceInjector {
      */
     protected abstract <R> Optional<R> findResource(Class<R> requiredType);
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     private void injectFieldResource(Object saga, Field injectField, Object resource) {
         try {
             ReflectionUtils.ensureAccessible(injectField);
@@ -91,6 +92,7 @@ public abstract class AbstractResourceInjector implements ResourceInjector {
                                 }));
     }
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     private void injectMethodResource(Object saga, Method injectMethod, Object resource) {
         try {
             ReflectionUtils.ensureAccessible(injectMethod);

--- a/pom.xml
+++ b/pom.xml
@@ -561,17 +561,6 @@
                     </archiverConfig>
                 </configuration>
             </plugin>
-            <!-- package -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly.version}</version>
-                <configuration>
-                    <descriptorSourceDirectory>assembly</descriptorSourceDirectory>
-                    <archiverConfig>
-                        <duplicateBehavior>skip</duplicateBehavior>
-                    </archiverConfig>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar.version}</version>

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/EventProcessorConfigurationTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class EventProcessorConfigurationTest {
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     @Test
     void processorConfigurationWithCustomPolicy() {
         new ApplicationContextRunner()

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -695,6 +695,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                           fieldFilter);
     }
 
+    @SuppressWarnings("deprecation") // Suppressed ReflectionUtils#ensureAccessible
     private void ensureValuesEqual(Object workingValue,
                                    Object eventSourcedValue,
                                    String propertyPath,

--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +56,7 @@ class AxonServerContainerUtils {
      *                     {@code hostname} and {@code port}.
      */
     static void initCluster(String hostname, int port) throws IOException {
-        final URL url = new URL(String.format("http://%s:%d/v1/context/init", hostname, port));
+        final URL url = URI.create(String.format("http://%s:%d/v1/context/init", hostname, port)).toURL();
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) url.openConnection();
@@ -88,7 +89,7 @@ class AxonServerContainerUtils {
      *                     {@code hostname} and {@code port}.
      */
     static List<String> contexts(String hostname, int port) throws IOException {
-        final URL url = new URL(String.format("http://%s:%d/v1/public/context", hostname, port));
+        final URL url = URI.create(String.format("http://%s:%d/v1/public/context", hostname, port)).toURL();
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) url.openConnection();

--- a/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
+++ b/test/src/test/java/org/axonframework/test/matchers/EqualFieldsMatcherTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test class validating the {@link EqualFieldsMatcher}.
+ * Test class validating the {@link EqualFieldsMatcher}. Use of deprecated code is suppressed as we still have the
+ * responsibility to validate our own code.
  *
  * @author Allard Buijze
  */
+@SuppressWarnings("deprecation")
 class EqualFieldsMatcherTest {
 
     private EqualFieldsMatcher<MyEvent> testSubject;


### PR DESCRIPTION
This pull request resolves warnings that pop up during the build of the project.
The majority of these are deprecation warnings, of which most are resolved.
The noteworthy leftover deprecation in Axon Framework is our own `ReflectionUtils`, which requires some investigation (as drafted up in #2901).