### PR TITLE
Align the `TrackingToken` assert for JPA, JDBC, and AxonServer

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -37,6 +37,7 @@ import org.axonframework.eventhandling.DomainEventData;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackedEventData;
@@ -552,8 +553,11 @@ public class AxonServerEventStore extends AbstractEventStore {
         }
 
         public TrackingEventStream openStream(TrackingToken trackingToken) {
-            Assert.isTrue(trackingToken == null || trackingToken instanceof GlobalSequenceTrackingToken,
-                          () -> "Invalid tracking token type. Must be GlobalSequenceTrackingToken.");
+            Assert.isTrue(
+                    trackingToken == null || trackingToken instanceof GlobalSequenceTrackingToken,
+                    () -> String.format("Token [%s] is of the wrong type. Expected [%s]",
+                                        trackingToken, GlobalSequenceTrackingToken.class.getSimpleName())
+            );
             long nextToken = trackingToken == null
                     ? -1
                     : ((GlobalSequenceTrackingToken) trackingToken).getGlobalIndex();

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore.jdbc;
 
+import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.common.jdbc.ConnectionProvider;
@@ -504,8 +505,11 @@ public class JdbcEventStorageEngine extends BatchingEventStorageEngine {
 
     @Override
     protected List<? extends TrackedEventData<?>> fetchTrackedEvents(TrackingToken lastToken, int batchSize) {
-        isTrue(lastToken == null || lastToken instanceof GapAwareTrackingToken,
-               () -> "Unsupported token format: " + lastToken);
+        Assert.isTrue(
+                lastToken == null || lastToken instanceof GapAwareTrackingToken,
+                () -> String.format("Token [%s] is of the wrong type. Expected [%s]",
+                                    lastToken, GapAwareTrackingToken.class.getSimpleName())
+        );
 
         return transactionManager.fetchInTransaction(() -> {
             // If there are many gaps, it worthwhile checking if it is possible to clean them up.


### PR DESCRIPTION
This pull request ensures that the assertion done in the `JpaEventStorageEngine`, `JdbcEventStorageEngine`, and `AxonServerEventStore.AxonIQEventStorageEngine` all three do a similar assert.
Although the JPA and JDBC versions already shared the "wrong" token they received, the Axon Server version did not.
With this change, all three share what they expect and what they got, in similar wording.