### PR TITLE
Integration test should use current Axon version

### DIFF
--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -43,7 +43,7 @@
         <maven-compiler.version>3.11.0</maven-compiler.version>
         <maven-deploy.version>3.1.1</maven-deploy.version>
         <maven-surefire.version>3.1.2</maven-surefire.version>
-        <axon.version>4.9.0-SNAPSHOT</axon.version>
+        <axon.version>${project.version}</axon.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
For some reason, the version was pinned to 4.9.0-SNAPSHOT, causing tests to fail.