### PR TITLE
Removed requirement for property to disable AxonServer EventStore and enable another one

### DIFF
--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
@@ -92,7 +92,7 @@ import static org.junit.jupiter.api.Assertions.*;
         AxonServerAutoConfiguration.class,
         AxonServerActuatorAutoConfiguration.class
 })
-@TestPropertySource(properties = {"axon.axonserver.enabled=false", "spring.main.banner-mode=off"})
+@TestPropertySource(properties = "spring.main.banner-mode=off")
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class TrackingEventProcessorIntegrationTest {
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -43,10 +43,9 @@ import org.axonframework.springboot.util.DeadLetterQueueProviderConfigurerModule
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -61,7 +60,8 @@ import javax.sql.DataSource;
 @AutoConfiguration
 @ConditionalOnBean(DataSource.class)
 @EnableConfigurationProperties(TokenStoreProperties.class)
-@AutoConfigureAfter(value = {JpaAutoConfiguration.class, JpaEventStoreAutoConfiguration.class})
+@AutoConfigureAfter({JpaAutoConfiguration.class, JpaEventStoreAutoConfiguration.class})
+@AutoConfigureBefore(AxonAutoConfiguration.class)
 public class JdbcAutoConfiguration {
 
     private final TokenStoreProperties tokenStoreProperties;
@@ -71,15 +71,13 @@ public class JdbcAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean({EventStorageEngine.class, EventSchema.class})
-    @ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
+    @ConditionalOnMissingBean({EventStorageEngine.class, EventSchema.class, EventStore.class})
     public EventSchema eventSchema() {
         return new EventSchema();
     }
 
     @Bean
-    @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
-    @ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
+    @ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class, EventStore.class})
     public EventStorageEngine eventStorageEngine(Serializer defaultSerializer,
                                                  PersistenceExceptionResolver persistenceExceptionResolver,
                                                  @Qualifier("eventSerializer") Serializer eventSerializer,

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -22,14 +22,15 @@ import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springboot.util.RegisterDefaultEntities;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
@@ -42,9 +43,9 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration
 @ConditionalOnBean(EntityManagerFactory.class)
-@ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
-@ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
-@AutoConfigureAfter(AxonServerAutoConfiguration.class)
+@ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class, EventStore.class})
+@AutoConfigureAfter(AxonServerBusAutoConfiguration.class)
+@AutoConfigureBefore(AxonAutoConfiguration.class)
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventsourcing.eventstore.jpa"
 })

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/legacyjpa/JpaJavaxEventStoreAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/legacyjpa/JpaJavaxEventStoreAutoConfiguration.java
@@ -21,9 +21,11 @@ import org.axonframework.common.legacyjpa.EntityManagerProvider;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.legacyjpa.JpaEventStorageEngine;
 import org.axonframework.serialization.Serializer;
-import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
+import org.axonframework.springboot.autoconfig.AxonAutoConfiguration;
+import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.axonframework.springboot.autoconfig.JdbcAutoConfiguration;
 import org.axonframework.springboot.autoconfig.JpaEventStoreAutoConfiguration;
 import org.axonframework.springboot.util.RegisterDefaultEntities;
@@ -32,11 +34,12 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import javax.persistence.EntityManagerFactory;
+
+
 
 /**
  * Autoconfiguration class for Axon's JPA specific event store components.
@@ -48,10 +51,9 @@ import javax.persistence.EntityManagerFactory;
 @Deprecated
 @AutoConfiguration
 @ConditionalOnBean(EntityManagerFactory.class)
-@ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class})
-@ConditionalOnExpression("${axon.axonserver.enabled:true} == false")
-@AutoConfigureBefore({JpaEventStoreAutoConfiguration.class, JdbcAutoConfiguration.class})
-@AutoConfigureAfter({AxonServerAutoConfiguration.class, JpaJavaxAutoConfiguration.class})
+@ConditionalOnMissingBean({EventStorageEngine.class, EventBus.class, EventStore.class})
+@AutoConfigureAfter({AxonServerBusAutoConfiguration.class, JpaJavaxAutoConfiguration.class})
+@AutoConfigureBefore({JpaEventStoreAutoConfiguration.class, JdbcAutoConfiguration.class, AxonAutoConfiguration.class})
 @RegisterDefaultEntities(packages = {
         "org.axonframework.eventsourcing.eventstore.jpa"
 })


### PR DESCRIPTION
Fixed the ordering of AutoConfiguration to remove the need of the `axon.axonserver.enabled` property to enable alternatives of AxonServer when the connector is not on the classpath.