### PR TITLE
Added support for TrackingToken parameter in SagaTestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -174,8 +174,8 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
     private TrackedEventMessage<?> asTrackedEventMessage(EventMessage<?> event) {
         return new GenericTrackedEventMessage<>(
-                new GlobalSequenceTrackingToken(globalSequence.getAndIncrement()),
-                event);
+                new GlobalSequenceTrackingToken(globalSequence.getAndIncrement()), event
+        );
     }
 
     /**

--- a/test/src/test/java/org/axonframework/test/saga/StubSaga.java
+++ b/test/src/test/java/org/axonframework/test/saga/StubSaga.java
@@ -21,6 +21,7 @@ import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.Timestamp;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.messaging.annotation.MetaDataValue;
@@ -64,8 +65,10 @@ public class StubSaga {
     @StartSaga
     @SagaEventHandler(associationProperty = "identifier")
     public void handleSagaStart(TriggerSagaStartEvent event,
+                                TrackingToken trackingToken,
                                 EventMessage<TriggerSagaStartEvent> message,
                                 @MetaDataValue("extraIdentifier") Object extraIdentifier) {
+        assertNotNull(trackingToken);
         handledEvents.add(event);
 
         if (extraIdentifier != null) {


### PR DESCRIPTION
This change allows annotated Sagas that rely on the TrackingToken parameter in their event handler methods to be tested with the Saga Test Fixture. Each event is wrapped in a TrackedEventMessage with a monotonically increasing sequence number.