### PR TITLE
Automate migration to Axon 4.9+

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -1,35 +1,35 @@
 # Migration
 Module containing [OpenRewrite](https://docs.openrewrite.org/) recipes for migrating Axon Framework applications.
 
-## Migrate to Axon Framework 4.7 Javax
+## Migrate to Axon Framework 4.x Javax
 ### Maven
 ```bash
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.axonframework:axon-migration:LATEST \
-  -DactiveRecipes=org.axonframework.migration.UpgradeAxonFramework_4_7_Javax
+  -DactiveRecipes=org.axonframework.migration.UpgradeAxonFramework_4_Javax
 ```
 
 #### Gradle
 Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).
 
-## Migrate to Axon Framework 4.7 Jakarta
+## Migrate to Axon Framework 4.x Jakarta
 ### Maven
 ```bash
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.axonframework:axon-migration:LATEST \
-  -DactiveRecipes=org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta
+  -DactiveRecipes=org.axonframework.migration.UpgradeAxonFramework_4_Jakarta
 ```
 
 #### Gradle
 Requires a custom [Gradle init script](https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-gradle-project-without-modifying-the-build).
 
 
-## Migrate to Axon Framework 4.7 Jakarta and Spring Boot 3.0
+## Migrate to Axon Framework 4.x Jakarta and Spring Boot 3.2
 ### Maven
 ```bash
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
   -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:LATEST,org.axonframework:axon-migration:LATEST \
-  -DactiveRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0,org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta
+  -DactiveRecipes=org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_2,org.axonframework.migration.UpgradeAxonFramework_4_Jakarta
 ```
 
 #### Gradle

--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -35,7 +35,7 @@
             <groupId>org.axonframework</groupId>
             <artifactId>axon-messaging</artifactId>
             <!-- Version is intended as the recipe is to migrate to AF 4.7 -->
-            <version>4.7.3</version>
+            <version>4.7.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/migration/src/main/resources/META-INF/rewrite/axon-jakarta-4.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon-jakarta-4.yml
@@ -1,12 +1,12 @@
 type: specs.openrewrite.org/v1beta/recipe
-name: org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta
-displayName: Upgrade to Axonframework 4.7 Jakarta
+name: org.axonframework.migration.UpgradeAxonFramework_4_Jakarta
+displayName: Upgrade to Axonframework 4.x Jakarta
 description: Migration file to upgrade from an Axon Framework Javax-specific project to Jakarta.
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.axonframework
       artifactId: "*"
-      newVersion: 4.7.x
+      newVersion: 4.x
   # Include the Jakarta migration recipe
   - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
   # Swap 4.6 dependencies for 4.7 dependencies
@@ -14,22 +14,22 @@ recipeList:
       oldGroupId: org.axonframework
       oldArtifactId: axon-configuration-jakarta
       newArtifactId: axon-configuration
-      newVersion: 4.7.x
+      newVersion: 4.x
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.axonframework
       oldArtifactId: axon-eventsourcing-jakarta
       newArtifactId: axon-eventsourcing
-      newVersion: 4.7.x
+      newVersion: 4.x
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.axonframework
       oldArtifactId: axon-messaging-jakarta
       newArtifactId: axon-messaging
-      newVersion: 4.7.x
+      newVersion: 4.x
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.axonframework
       oldArtifactId: axon-modelling-jakarta
       newArtifactId: axon-modelling
-      newVersion: 4.7.x
+      newVersion: 4.x
   # Convert legacy JPA packages to Jakarta JPA packages
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.axonframework.common.legacyjpa

--- a/migration/src/main/resources/META-INF/rewrite/axon-javax-4.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon-javax-4.yml
@@ -1,12 +1,12 @@
 type: specs.openrewrite.org/v1beta/recipe
-name: org.axonframework.migration.UpgradeAxonFramework_4_7_Javax
-displayName: Upgrade to Axonframework 4.7 Javax
+name: org.axonframework.migration.UpgradeAxonFramework_4_Javax
+displayName: Upgrade to Axonframework 4.x Javax
 description: Migration file to upgrade an Axon Framework Javax-specific project and remain on Javax.
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.axonframework
       artifactId: "*"
-      newVersion: 4.7.x
+      newVersion: 4.x
   # Move all classes from org.axonframework.common.jpa to org.axonframework.common.legacyjpa
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.axonframework.common.jpa

--- a/migration/src/test/java/org/axonframework/migration/AxonJakartaTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AxonJakartaTest.java
@@ -41,7 +41,7 @@ class AxonJakartaTest implements RewriteTest {
                 .recipe(Environment.builder()
                         .scanRuntimeClasspath()
                         .build()
-                        .activateRecipes("org.axonframework.migration.UpgradeAxonFramework_4_7_Jakarta"));
+                        .activateRecipes("org.axonframework.migration.UpgradeAxonFramework_4_Jakarta"));
     }
 
     @Test
@@ -69,7 +69,6 @@ class AxonJakartaTest implements RewriteTest {
         rewriteRun(
                 mavenProject("any-project",
                         pomXml(
-
                                 "    <project>\n" +
                                         "        <modelVersion>4.0.0</modelVersion>\n" +
                                         "        <groupId>com.example</groupId>\n" +
@@ -84,8 +83,8 @@ class AxonJakartaTest implements RewriteTest {
                                         "        </dependencies>\n" +
                                         "    </project>\n",
                                 spec -> spec.after(pom -> {
-                                    Matcher version = Pattern.compile("4.[7-9].\\d+").matcher(pom);
-                                    assertThat(version.find()).describedAs("Expected 4.7.x in %s", pom).isTrue();
+                                    Matcher version = Pattern.compile("4\\.[^06]\\d?.\\d+").matcher(pom);
+                                    assertThat(version.find()).describedAs("Expected 4.x in %s", pom).isTrue();
                                     return String.format(
                                             "    <project>\n" +
                                             "        <modelVersion>4.0.0</modelVersion>\n" +

--- a/migration/src/test/java/org/axonframework/migration/AxonJavaxTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AxonJavaxTest.java
@@ -31,7 +31,7 @@ class AxonJavaxTest implements RewriteTest {
                 .parser(JavaParser.fromJavaVersion()
                         .logCompilationWarningsAndErrors(true)
                         .classpath("axon-messaging"))
-                .recipe("/META-INF/rewrite/axon-javax-47.yml", "org.axonframework.migration.UpgradeAxonFramework_4_7_Javax");
+                .recipe("/META-INF/rewrite/axon-javax-4.yml", "org.axonframework.migration.UpgradeAxonFramework_4_Javax");
     }
 
     @Test


### PR DESCRIPTION
Seeing how there's been no breaking changes, yet still quite some releases on 4.x since 4.7, I figured update the existing recipes to pick up any 4.x version going forward. 