### PR TITLE
Inject multiple test resources

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -249,6 +249,13 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     @Override
+    public FixtureConfiguration<T> registerInjectableResources(Object... resources) {
+        for (Object resource : resources)
+            registerInjectableResource(resource);
+        return this;
+    }
+
+    @Override
     public FixtureConfiguration<T> registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory) {
         if (repository != null) {
             throw new FixtureExecutionException(

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -249,13 +249,6 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     @Override
-    public FixtureConfiguration<T> registerInjectableResources(Object... resources) {
-        for (Object resource : resources)
-            registerInjectableResource(resource);
-        return this;
-    }
-
-    @Override
     public FixtureConfiguration<T> registerParameterResolverFactory(ParameterResolverFactory parameterResolverFactory) {
         if (repository != null) {
             throw new FixtureExecutionException(

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -189,6 +189,17 @@ public interface FixtureConfiguration<T> {
     FixtureConfiguration<T> registerInjectableResource(Object resource);
 
     /**
+     * Registers resources that are eligible for injection in handler method (e.g. methods annotated with {@link
+     * CommandHandler @CommandHandler}, {@link EventSourcingHandler @EventSourcingHandler} and {@link EventHandler}.
+     * These resource must be registered <em>before</em> registering any command handler.
+     * Internally this method calls {@link #registerInjectableResource(Object) for each object.
+     *
+     * @param resources collection of resources eligible for injection
+     * @return the current FixtureConfiguration, for fluent interfacing
+     */
+    FixtureConfiguration<T> registerInjectableResources(Object... resources);
+
+    /**
      * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
      * will be added to the other parameter resolver factories introduced through {@link
      * org.axonframework.messaging.annotation.ClasspathParameterResolverFactory#forClass(Class)} and the {@link

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -287,6 +287,7 @@ public interface FixtureConfiguration<T> {
      * @param declaringClass The class declaring the field
      * @param fieldName      The name of the field
      * @return the current FixtureConfiguration, for fluent interfacing
+     *
      * @throws FixtureExecutionException when no such field is declared
      */
     FixtureConfiguration<T> registerIgnoredField(Class<?> declaringClass, String fieldName);

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -195,7 +195,7 @@ public interface FixtureConfiguration<T> {
      * Internally this method calls {@link #registerInjectableResource(Object) for each resource.
      *
      * @param resources collection of resources eligible for injection
-     * @return the current FixtureConfiguration, for fluent interfacing.
+     * @return the current FixtureConfiguration, for fluent interfacing
      */
     default FixtureConfiguration<T> registerInjectableResources(Object... resources) {
         for (Object resource : resources) {

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -195,7 +195,7 @@ public interface FixtureConfiguration<T> {
      * Internally this method calls {@link #registerInjectableResource(Object) for each resource.
      *
      * @param resources collection of resources eligible for injection
-     * @return the current FixtureConfiguration, for fluent interfacing
+     * @return the current FixtureConfiguration, for fluent interfacing.
      */
     default FixtureConfiguration<T> registerInjectableResources(Object... resources) {
         for (Object resource : resources) {

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -189,15 +189,20 @@ public interface FixtureConfiguration<T> {
     FixtureConfiguration<T> registerInjectableResource(Object resource);
 
     /**
-     * Registers resources that are eligible for injection in handler method (e.g. methods annotated with {@link
+     * Default implementation to register multiple resources in handler method (e.g. methods annotated with {@link
      * CommandHandler @CommandHandler}, {@link EventSourcingHandler @EventSourcingHandler} and {@link EventHandler}.
      * These resource must be registered <em>before</em> registering any command handler.
-     * Internally this method calls {@link #registerInjectableResource(Object) for each object.
+     * Internally this method calls {@link #registerInjectableResource(Object) for each resource.
      *
      * @param resources collection of resources eligible for injection
      * @return the current FixtureConfiguration, for fluent interfacing
      */
-    FixtureConfiguration<T> registerInjectableResources(Object... resources);
+    default FixtureConfiguration<T> registerInjectableResources(Object... resources) {
+        for (Object resource : resources) {
+            registerInjectableResource(resource);
+        }
+        return this;
+    }
 
     /**
      * Registers a {@link ParameterResolverFactory} within this fixture. The given {@code parameterResolverFactory}
@@ -282,7 +287,6 @@ public interface FixtureConfiguration<T> {
      * @param declaringClass The class declaring the field
      * @param fieldName      The name of the field
      * @return the current FixtureConfiguration, for fluent interfacing
-     *
      * @throws FixtureExecutionException when no such field is declared
      */
     FixtureConfiguration<T> registerIgnoredField(Class<?> declaringClass, String fieldName);


### PR DESCRIPTION
I provided a version of `registerInjectableResource` with collection of resources as parameters.
The method will call the original method on a simple iteration.