### PR TITLE
[#2955] Fix ability to replay when at least one Event Handling Component supports a reset

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
@@ -153,12 +153,7 @@ public class SimpleEventHandlerInvoker implements EventHandlerInvoker {
 
     @Override
     public boolean supportsReset() {
-        for (EventMessageHandler eventHandler : eventHandlingComponents) {
-            if (!eventHandler.supportsReset()) {
-                return false;
-            }
-        }
-        return true;
+        return eventHandlingComponents.stream().anyMatch(EventMessageHandler::supportsReset);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/SimpleEventHandlerInvokerTest.java
@@ -93,8 +93,8 @@ class SimpleEventHandlerInvokerTest {
 
         testSubject.performReset(resetContext);
 
-        verify(mockHandler1).prepareReset(eq(resetContext));
-        verify(mockHandler2).prepareReset(eq(resetContext));
+        verify(mockHandler1).prepareReset(resetContext);
+        verify(mockHandler2).prepareReset(resetContext);
     }
 
     @Test
@@ -145,5 +145,21 @@ class SimpleEventHandlerInvokerTest {
         SimpleEventHandlerInvoker.Builder<?> builderTestSubject = SimpleEventHandlerInvoker.builder();
         //noinspection ConstantConditions
         assertThrows(AxonConfigurationException.class, () -> builderTestSubject.sequencingPolicy(null));
+    }
+
+    @Test
+    void shouldSupportResetWhenAtLeastOneEventMessageHandlerSupportsReset() {
+        doReturn(true).when(mockHandler1).supportsReset();
+        doReturn(false).when(mockHandler2).supportsReset();
+
+        assertTrue(testSubject.supportsReset());
+    }
+
+    @Test
+    void shouldNotSupportResetWhenNoEventMessageHandlerSupportsReset() {
+        doReturn(false).when(mockHandler1).supportsReset();
+        doReturn(false).when(mockHandler2).supportsReset();
+
+        assertFalse(testSubject.supportsReset());
     }
 }


### PR DESCRIPTION
If an event-processor is used in multiple service-classes and one of those classes is annotated with @AllowReplay(false), the processor is no longer replayable, but it should.

This pull request resolves #2955.