### PR TITLE
Fix Exception on using OpenTelemetry and ScatterGather queries

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,9 +414,12 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                                                                                  .queryChannel()
                                                                                  .query(queryRequest);
 
+            AtomicBoolean closed = new AtomicBoolean(false);
             Runnable closeHandler = () -> {
-                queryInTransit.end();
-                span.end();
+                if(closed.compareAndSet(false, true)) {
+                    queryInTransit.end();
+                    span.end();
+                }
             };
             return StreamSupport.stream(
                     new QueryResponseSpliterator<>(queryMessage,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -327,6 +327,21 @@ class AxonServerQueryBusTest {
             spanFactory.verifySpanCompleted("QueryBus.scatterGatherQueryDistributed", testQuery);
             spanFactory.verifySpanPropagated("QueryBus.scatterGatherQueryDistributed", testQuery);
         });
+    }
+
+    @Test
+    void scatterGatherCloseStreamDoesNotThrowExceptionOnCloseMethod() {
+        QueryMessage<String, String> testQuery = new GenericQueryMessage<>("Hello, World", instanceOf(String.class));
+
+        when(mockQueryChannel.query(any())).thenReturn(new StubResultStream<>(stubResponse("<string>1</string>"),
+                                                                              stubResponse("<string>2</string>"),
+                                                                              stubResponse("<string>3</string>")));
+
+        Stream<QueryResponseMessage<String>> stream = testSubject.scatterGather(testQuery,
+                                                                                                    12,
+                                                                                                    TimeUnit.SECONDS);
+        assertEquals(3, stream.count());
+        stream.close();
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/tracing/TestSpanFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -328,6 +328,9 @@ public class TestSpanFactory implements SpanFactory {
 
         @Override
         public void end() {
+            if(ended) {
+                throw new IllegalStateException("Span already ended!");
+            }
             ended = true;
             if (scopes.size() > 0) {
                 throw new IllegalStateException("All scopes should be closed! Still have " + scopes.size() + " open!");


### PR DESCRIPTION
The onClose handler on ScatterGather queries calls the `end` operation on Spans a second time. This, however, has been restricted by an exception as this can indicate thread leaks.

However, calling the `Span.end` on both `close` and finishing of advancing the stream is necessary, as users might not always close a stream explicitly. Likewise, the stream may be closed without reading it completely.

I have added an AtomicBoolean as close gate on the closeHandler, so it's always called exactly once.

The TestSpanFactory has been extended with the same behavior as the OpenTelemetrySpan to catch any other instances of this happening during the tests