### PR TITLE
Resolved MySQL startup problems in integration tests

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/MysqlJdbcEventStorageEngineTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MysqlJdbcEventStorageEngineTest {
 
     @Container
-    private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql")
+    private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
             .withDatabaseName("axon")
             .withUsername("admin")
             .withPassword("some-password");

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <junit4.version>4.13.2</junit4.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <mockito.version>4.11.0</mockito.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
         <!-- Validation -->
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hibernate-validator.8.version>8.0.1.Final</hibernate-validator.8.version>

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.2.2</version>
         <relativePath/>
     </parent>
 
@@ -37,7 +37,7 @@
     <properties>
         <jobrunr.version>6.3.2</jobrunr.version>
         <mysql-connector-java.version>8.0.33</mysql-connector-java.version>
-        <spring-boot-3.version>3.1.6</spring-boot-3.version>
+        <spring-boot-3.version>3.2.2</spring-boot-3.version>
         <!-- Build / Plugin -->
         <jacoco-maven.version>0.8.8</jacoco-maven.version>
         <maven-compiler.version>3.11.0</maven-compiler.version>

--- a/spring/src/test/java/org/axonframework/spring/utils/MysqlTestContainerExtension.java
+++ b/spring/src/test/java/org/axonframework/spring/utils/MysqlTestContainerExtension.java
@@ -34,7 +34,7 @@ public class MysqlTestContainerExtension extends MySQLContainer<MysqlTestContain
     private static MysqlTestContainerExtension container;
 
     public MysqlTestContainerExtension() {
-        super("mysql:latest");
+        super("mysql:8.0");
     }
 
     public static MysqlTestContainerExtension getInstance() {


### PR DESCRIPTION
The docker container with the latest release has problems starting. This PR pins the version of mysql to 8.0, which doesn't seem to have that problem.

Included other version updates of related libraries for integration tests.