### PR TITLE
Fix SagaTestFixture use DomainEventMessage

### DIFF
--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -373,4 +373,18 @@ class AnnotatedSagaTest {
                        .publishes(new TriggerExceptionWhileHandlingEvent(identifier));
         assertThrows(AxonAssertionError.class, fixtureExecutionResult::expectSuccessfulHandlerExecution);
     }
+
+    @Test
+    void fixtureApi_DomainEventMessageIsAssignableFromMessage() {
+        String aggregate1 = UUID.randomUUID().toString();
+        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
+        FixtureExecutionResult validator = fixture
+                .givenAggregate(aggregate1).published(
+                        GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
+                        new TriggerExistingSagaEvent(aggregate1),
+                        new TriggerAssociationResolverSagaEvent(aggregate1))
+                .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));
+
+        validator.expectActiveSagas(0);
+    }
 }

--- a/test/src/test/java/org/axonframework/test/saga/AssociationResolverStub.java
+++ b/test/src/test/java/org/axonframework/test/saga/AssociationResolverStub.java
@@ -1,0 +1,31 @@
+package org.axonframework.test.saga;
+
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.modelling.saga.AssociationResolver;
+import org.axonframework.modelling.saga.PayloadAssociationResolver;
+import org.jetbrains.annotations.NotNull;
+
+import static org.junit.Assert.*;
+
+public class AssociationResolverStub implements AssociationResolver {
+
+    private final PayloadAssociationResolver defaultResolver = new PayloadAssociationResolver();
+
+    @Override
+    public <T> void validate(@NotNull String associationPropertyName, @NotNull MessageHandlingMember<T> handler) {
+        defaultResolver.validate(associationPropertyName, handler);
+    }
+
+    @Override
+    public <T> Object resolve(@NotNull String associationPropertyName, @NotNull EventMessage<?> message,
+                              @NotNull MessageHandlingMember<T> handler) {
+
+
+        if (!DomainEventMessage.class.isAssignableFrom(message.getClass())) {
+            fail("message is not assignable from DomainEventMessage");
+        }
+        return defaultResolver.resolve(associationPropertyName, message, handler);
+    }
+}

--- a/test/src/test/java/org/axonframework/test/saga/StubSaga.java
+++ b/test/src/test/java/org/axonframework/test/saga/StubSaga.java
@@ -130,6 +130,11 @@ public class StubSaga {
                                    new GenericEventMessage<>(new TimerTriggeredEvent(event.getIdentifier())));
     }
 
+    @SagaEventHandler(associationProperty = "identifier", associationResolver = AssociationResolverStub.class)
+    public void handleTriggerAssociationResolverSagaEvent(TriggerAssociationResolverSagaEvent event) {
+        handledEvents.add(event);
+    }
+
     public EventScheduler getScheduler() {
         return scheduler;
     }

--- a/test/src/test/java/org/axonframework/test/saga/TriggerAssociationResolverSagaEvent.java
+++ b/test/src/test/java/org/axonframework/test/saga/TriggerAssociationResolverSagaEvent.java
@@ -1,0 +1,14 @@
+package org.axonframework.test.saga;
+
+public class TriggerAssociationResolverSagaEvent {
+
+    private String identifier;
+
+    public TriggerAssociationResolverSagaEvent(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+}


### PR DESCRIPTION
Hi,

based on @abuijze commit https://github.com/AxonFramework/AxonFramework/commit/a8ee8f894c03551eb980eb16c03d4b637d23f665 the AssociationResolver does not received a DomainEventMessage.

I used the `EventUtils.asTrackedEventMessage` to receive a `GenericTrackedDomainEventMessage`