### PR TITLE
Skip jacoco if `sonar-enabled` is false.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Regular Build
         if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true clean verify
 
       - name: Build with Coverage reports
         if: matrix.sonar-enabled

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Regular Build
         if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true clean verify
 
       - name: Build with Coverage reports
         if: matrix.sonar-enabled


### PR DESCRIPTION
Builds are now failing on Java 21 because jacoco isn't working correctly, we don't need to run jacoco for coverage if we don't send the report to sonar.