### PR TITLE
Resolve issue with eager gap cleanup

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GapAwareTrackingToken.java
@@ -122,7 +122,7 @@ public class GapAwareTrackingToken implements TrackingToken, Serializable {
      */
     public GapAwareTrackingToken advanceTo(long index, int maxGapOffset) {
         long newIndex;
-        long smalledAllowedGap = Math.max(gapTruncationIndex, Math.max(index, this.index) - maxGapOffset);
+        long smalledAllowedGap = Math.min(index, Math.max(gapTruncationIndex, Math.max(index, this.index) - maxGapOffset));
         SortedSet<Long> gaps = new TreeSet<>(this.gaps.tailSet(smalledAllowedGap));
         if (gaps.remove(index) || this.gaps.contains(index)) {
             newIndex = this.index;

--- a/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GapAwareTrackingTokenTest.java
@@ -18,7 +18,10 @@ package org.axonframework.eventhandling;
 
 import org.junit.jupiter.api.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -27,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -66,6 +70,17 @@ class GapAwareTrackingTokenTest {
         assertTrue(counter.get() > 0, "The test did not seem to have generated any tokens");
         assertEquals(counter.get() - 1, currentToken.get().getIndex());
         assertEquals(emptySortedSet(), currentToken.get().getGaps());
+    }
+
+    @Test
+    void whenAdvancingToPositionGapsAheadOfThatPositionAreNeverCleanedUp() {
+        List<Long> gaps = asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+        GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(100, gaps);
+
+        GapAwareTrackingToken actual = token.advanceTo(2L, 0);
+        assertTrue(actual.hasGaps());
+        assertIterableEquals(Arrays.asList(3L, 4L, 5L, 6L, 7L, 8L, 9L), actual.getGaps());
+        assertEquals(100, actual.getIndex());
     }
 
     @Test


### PR DESCRIPTION
When a GapAwareTrackingToken advances to a new position, it should never clean up any gaps ahead of that position, even if that means gaps are older than the given "maxGapOffset". Removing these gaps may result in problems with processors not being able to advance.

Resolves #2958