### PR TITLE
Update index.adoc

### DIFF
--- a/docs/reference/modules/ROOT/pages/index.adoc
+++ b/docs/reference/modules/ROOT/pages/index.adoc
@@ -1,18 +1,14 @@
-= Axon Framework Reference Documentation
+= Axon Framework Documentation 
 
-Welcome to the Axon Framework's reference documentation. It provides information about the modules and components of the framework, their purpose, and their intended use.
+Welcome to the Axon Framework's documentation. It provides information about the modules and components of the framework, their purpose, and their intended use.
 
-== Prerequisite knowledge
+Axon Framework alone significantly simplifies the software development process of JVM-based applications. However, it adds even more value when used in combination with other products of the Axon family.
 
-Axon Framework helps software developers build solutions according to specific software development concepts. While not strictly required, knowing those concepts makes it much easier to understand the framework's principles and the architectural decisions behind it. If you are new to DDD, CQRS, or Event Sourcing, consider reading the "xref:concepts::index.adoc[Software Development Concepts]" first.
+The  documentation is a valuable source of reference during the development process. For step-by-step instructions and examples of how to build Axon-based applications, use the xref:home::tutorials.adoc[].
 
-Axon Framework alone significantly simplifies the software development process of JVM-based applications following the above principles. However, it adds even more value when used in combination with other products of the Axon family. To understand the bigger picture, please refer to "xref:understanding-axon::index.adoc[Understanding Axon]". It explains how individual products complement each other and work together towards a common goal.
+== Documentation structure
 
-The reference documentation is a valuable source during the development process. It assumes the reader is familiar with the underlying software design principles, deployment architectures, etc. To learn more about those, please refer to the relevant xref:home::explanations.adoc[]. For step-by-step instructions and examples of how to build Axon-based applications, use the xref:home::tutorials.adoc[].
-
-== Reference documentation structure
-
-The reference documentation aims to document the specifics of the framework's functionality, objects, interfaces, etc. It's a convenient, quick-access reference answering questions like "What's X?", "What's X used for?", "How's X implemented?" etc. Thus it closely follows the structure of Axon Framework's source code. Such an approach makes it easier to quickly navigate to any specific element.
+The documentation contains the specifics of the framework's functionality, objects, interfaces, etc. It's a convenient, quick-access reference answering questions like "What's X?", "What's X used for?", "How's X implemented?" etc. Thus it closely follows the structure of Axon Framework's source code. Such an approach makes it easier to quickly navigate to any specific element.
 
 == License
 


### PR DESCRIPTION
A shorter version of the index page for the documentation of Axon Framework.  Removed the word "reference". Removed focus on the concepts of DDD, CQRS and Event-Sourcing.  Also removed links to empty pages.