### PR TITLE
Use `TransactionManager` in the `EventProcessorControlService` to invoke `TokenStore#retrieveStorageIdentifier`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
+import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
@@ -219,8 +220,9 @@ public class EventProcessorControlService implements Lifecycle {
     }
 
     private Optional<String> tokenStoreIdentifierFor(String processorName) {
-        return eventProcessingConfiguration.tokenStore(processorName)
-                                           .retrieveStorageIdentifier();
+        TokenStore tokenStore = eventProcessingConfiguration.tokenStore(processorName);
+        return eventProcessingConfiguration.transactionManager(processorName)
+                                           .fetchInTransaction(tokenStore::retrieveStorageIdentifier);
     }
 
     private void registerInstructionHandlers(AxonServerConnection connection,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/processor/EventProcessorControlServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import io.axoniq.axonserver.connector.admin.AdminChannel;
 import io.axoniq.axonserver.connector.control.ControlChannel;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static org.mockito.Mockito.*;
 
@@ -113,6 +115,10 @@ class EventProcessorControlServiceTest {
         TokenStore tokenStore = mock(TokenStore.class);
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.of(TOKEN_STORE_IDENTIFIER));
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
+        TransactionManager transactionManager = mock(TransactionManager.class);
+        when(transactionManager.fetchInTransaction(any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(0)).get());
+        when(processingConfiguration.transactionManager(anyString())).thenReturn(transactionManager);
 
         AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
                 new AxonServerConfiguration.Eventhandling.ProcessorSettings();
@@ -146,6 +152,10 @@ class EventProcessorControlServiceTest {
         TokenStore tokenStore = mock(TokenStore.class);
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.of(TOKEN_STORE_IDENTIFIER));
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
+        TransactionManager transactionManager = mock(TransactionManager.class);
+        when(transactionManager.fetchInTransaction(any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(0)).get());
+        when(processingConfiguration.transactionManager(anyString())).thenReturn(transactionManager);
 
         AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
                 new AxonServerConfiguration.Eventhandling.ProcessorSettings();
@@ -186,6 +196,10 @@ class EventProcessorControlServiceTest {
         TokenStore tokenStore = mock(TokenStore.class);
         when(tokenStore.retrieveStorageIdentifier()).thenReturn(Optional.empty());
         when(processingConfiguration.tokenStore(anyString())).thenReturn(tokenStore);
+        TransactionManager transactionManager = mock(TransactionManager.class);
+        when(transactionManager.fetchInTransaction(any()))
+                .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(0)).get());
+        when(processingConfiguration.transactionManager(anyString())).thenReturn(transactionManager);
 
         AxonServerConfiguration.Eventhandling.ProcessorSettings testSetting =
                 new AxonServerConfiguration.Eventhandling.ProcessorSettings();


### PR DESCRIPTION
This pull request adds usage of the `TransactionManager` to the `TokenStore#retrieveStorageIdentifier` operation in the `EventProcessorControlService`.
Without wrapping this task in a transaction, some databases will throw exceptions.
Thus, for users of databases with this requirement, load balancing simply doesn't occur at all through the load balancing strategy properties.
