### PR TITLE
fix(deadletter): NPE on on throwables with null message

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/ThrowableCause.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/ThrowableCause.java
@@ -104,7 +104,8 @@ public class ThrowableCause extends AxonException implements Cause {
     public static ThrowableCause truncated(Throwable throwable, int messageSize) {
         return new ThrowableCause(
                 throwable.getClass().getName(),
-                throwable.getMessage().substring(0, Math.min(throwable.getMessage().length(), messageSize))
+                throwable.getMessage() == null ? null :
+                    throwable.getMessage().substring(0, Math.min(throwable.getMessage().length(), messageSize))
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/ThrowableCauseTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/ThrowableCauseTest.java
@@ -103,6 +103,16 @@ class ThrowableCauseTest {
     }
 
     @Test
+    void truncateCanHandleNullMessages() {
+        Throwable testThrowable = new RuntimeException();
+
+        ThrowableCause result = ThrowableCause.truncated(testThrowable);
+
+        assertEquals(testThrowable.getClass().getName(), result.type());
+        assertNull(result.message());
+    }
+
+    @Test
     void truncateShortensMessageIfItExceedsMessageSize() {
         String textThatShouldBeTruncated = "truncated-text-at-the-end";
         Throwable testThrowable = new RuntimeException(BLOB_OF_TEXT + textThatShouldBeTruncated);


### PR DESCRIPTION
Fixes

```
Error occurred. Starting retry mode.: java.lang.NullPointerException: Cannot invoke "String.length()" because the return value of "java.lang.Throwable.getMessage()" is null
        at org.axonframework.messaging.deadletter.ThrowableCause.truncated(ThrowableCause.java:107)
        at org.axonframework.messaging.deadletter.ThrowableCause.truncated(ThrowableCause.java:90)
        at org.axonframework.config.EventProcessingModule.lambda$null$20(EventProcessingModule.java:181)
        at org.axonframework.eventhandling.deadletter.DeadLetteringEventHandlerInvoker.invokeHandlers(DeadLetteringEventHandlerInvoker.java:177)
        at org.axonframework.eventhandling.deadletter.DeadLetteringEventHandlerInvoker.handle(DeadLetteringEventHandlerInvoker.java:146)
        [...]
```

Rebased version of #2989.