### PR TITLE
Github action to build docs uses orgs variable (with default value)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - 'docs/**'
 
+env:
+  VALE_VERSION: ${{ vars.LIBRARY_VALE_VERSION || '3.3.0' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,14 +31,15 @@ jobs:
 
       - name: Install vale
         run: |
-            wget https://github.com/errata-ai/vale/releases/download/v2.23.0/vale_2.23.0_Linux_64-bit.tar.gz
-            sudo tar -xvzf vale_2.23.0_Linux_64-bit.tar.gz -C /usr/local/bin vale
+          wget "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          sudo tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/bin vale
 
       - name: Generate Site
         run: |
           cd docs/_playbook/
           npm install
           export GIT_CREDENTIALS='https://axoniq-devops:${{ secrets.LIBRARY_DEVBOT_TOKEN }}@github.com'
+          echo 'Using' `vale -v`
           npx antora playbook.yaml
 
       - name: Notify AxonIQ Library (if a push to a tracked branch)


### PR DESCRIPTION
To make easier the upgrade of the `vale` version used during docs build to check proselint rules in documentation, I've modified the github action to rely on an org's level `LIBRARY_VALE_VERSION` variable. 

This way, we ensure the proselint validation tool is balanced to the same version that the `axoniq-library-site` is using to build the whole `library` project.

I've set a default value to vale v3.3.0 (current latest version) as a fallback in case that variable is not defined.