### PR TITLE
Changed reference to Home tutorial page with Bike Rental demo tutorial

### DIFF
--- a/docs/reference/modules/ROOT/pages/index.adoc
+++ b/docs/reference/modules/ROOT/pages/index.adoc
@@ -4,7 +4,7 @@ Welcome to the Axon Framework's documentation. It provides information about the
 
 Axon Framework alone significantly simplifies the software development process of JVM-based applications. However, it adds even more value when used in combination with other products of the Axon family.
 
-The  documentation is a valuable source of reference during the development process. For step-by-step instructions and examples of how to build Axon-based applications, use the xref:home::tutorials.adoc[].
+The  documentation is a valuable source of reference during the development process. For step-by-step instructions and examples of how to build Axon-based applications, you can check the xref:bikerental-demo::index.adoc[] tutorial.
 
 == Documentation structure
 


### PR DESCRIPTION
The home for all the tutorials in the doc has been removed, I've changed the reference to that tutorials home page by the link to the specific "Building your first AxonFramework application from scratch" (the Bike Rental demo) tutorial in the index of the AxonFramework Reference guide 
