### PR TITLE
Set axoniq/axonserver:latest as default AxonServer image

### DIFF
--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainer.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  */
 public class AxonServerContainer extends GenericContainer<AxonServerContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver:latest-dev");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("axoniq/axonserver");
 
     private static final int AXON_SERVER_HTTP_PORT = 8024;
     private static final int AXON_SERVER_GRPC_PORT = 8124;

--- a/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
@@ -91,4 +91,11 @@ class AxonServerContainerTest {
             assertTrue(testSubject.isRunning());
         }
     }
+
+    @Test
+    void properlyConfiguredDefaultContainerLabel() {
+        try (AxonServerContainer testSubject = new AxonServerContainer()) {
+            assertEquals("axoniq/axonserver:latest", testSubject.getDockerImageName());
+        }
+    }
 }


### PR DESCRIPTION
Instead of using the latest-dev tag, the testcontainer should use the latest tag. Otherwise, the user wouldn't be able to set their own tag, as they would not be considered compatible with the default container name. Also, all changes are pushed with the "latest" tag.