### PR TITLE
[#3007] Set a SmartLifecycle phase lower than the ones written in the spring WebServer lifecycle ones.

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
@@ -40,6 +40,19 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class SpringAxonConfiguration implements FactoryBean<Configuration>, SmartLifecycle {
 
+    /**
+     * The {@link SmartLifecycle#getPhase()} value of this is set to be safely lower than the typical
+     * values listed in the Spring WebServer lifecycles.
+     *
+     * This means we make sure that:
+     * - Axon is ready when the web server starts
+     * - The web server is stopped before tearing down Axon
+     */
+    public static final int LIFECYCLE_PHASE = SmartLifecycle.DEFAULT_PHASE
+            - 1024 // this puts us next to the "graceful" stop of web servers...
+            - 1024 // this puts us next to the regular, start and non-graceful stop of web servers...
+            - 1024; // we place ourselves healthily below that, starting before web servers and stopping after.
+
     private final Configurer configurer;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final AtomicReference<Configuration> configuration = new AtomicReference<>();
@@ -98,12 +111,6 @@ public class SpringAxonConfiguration implements FactoryBean<Configuration>, Smar
 
     @Override
     public int getPhase() {
-        // Run this with a safely lower phase value than what is set in the spring WebServer start/stop Lifecycle.
-        // This to make sure:
-        // - Axon is ready when the web server starts
-        // - The web server is stopped before tearing down Axon
-        int webServerGracefulShutdownLifecyclePhase = SmartLifecycle.DEFAULT_PHASE - 1024;
-        int webServerDefaultLifecyclePhase = webServerGracefulShutdownLifecyclePhase - 1024;
-        return webServerDefaultLifecyclePhase - 1024;
+        return LIFECYCLE_PHASE;
     }
 }

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
@@ -95,4 +95,15 @@ public class SpringAxonConfiguration implements FactoryBean<Configuration>, Smar
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
+
+    @Override
+    public int getPhase() {
+        // Run this with a safely lower phase value than what is set in the spring WebServer start/stop Lifecycle.
+        // This to make sure:
+        // - Axon is ready when the web server starts
+        // - The web server is stopped before tearing down Axon
+        int webServerGracefulShutdownLifecyclePhase = SmartLifecycle.DEFAULT_PHASE - 1024;
+        int webServerDefaultLifecyclePhase = webServerGracefulShutdownLifecyclePhase - 1024;
+        return webServerDefaultLifecyclePhase - 1024;
+    }
 }

--- a/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/config/SpringAxonConfigurationTest.java
@@ -21,7 +21,9 @@ import org.axonframework.config.Configurer;
 import org.axonframework.spring.event.AxonStartedEvent;
 import org.junit.jupiter.api.*;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.SmartLifecycle;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class SpringAxonConfigurationTest {
@@ -38,5 +40,15 @@ class SpringAxonConfigurationTest {
 
         springAxonConfiguration.start();
         verify(context).publishEvent(isA(AxonStartedEvent.class));
+    }
+
+    @Test
+    void lifecyclePhaseIsLowerThanWebServers() {
+        int webServerGracefulShutdownLifecyclePhase = SmartLifecycle.DEFAULT_PHASE - 1024;
+        int webServerDefaultLifecyclePhase = webServerGracefulShutdownLifecyclePhase - 1024;
+
+        SpringAxonConfiguration springAxonConfiguration = new SpringAxonConfiguration(mock(Configurer.class));
+
+        assertTrue(springAxonConfiguration.getPhase() < webServerDefaultLifecyclePhase);
     }
 }


### PR DESCRIPTION
This means that we "start" Axon before starting the web server and "stop" axon after stopping the web server.

[#3007](https://github.com/AxonFramework/AxonFramework/issues/3007)