### PR TITLE
changed broken xref to broken links - to allow the build process to f…

### DIFF
--- a/docs/old-reference-guide/modules/ROOT/pages/introduction.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/introduction.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-This section of the reference guide intends to cover in detail the capabilities that the Axon Framework provides to help build applications based on xref:../architecture-overview/#ddd-and-cqrs[CQRS/DDD] and xref:../architecture-overview/event-sourcing.adoc[Event Sourcing]
+This section of the reference guide intends to cover in detail the capabilities that the Axon Framework provides to help build applications based on link:../architecture-overview/#ddd-and-cqrs[CQRS/DDD] and link:../architecture-overview/event-sourcing.adoc[Event Sourcing]
 
 ____
 

--- a/docs/old-reference-guide/modules/axon-framework-commands/pages/infrastructure.adoc
+++ b/docs/old-reference-guide/modules/axon-framework-commands/pages/infrastructure.adoc
@@ -461,7 +461,7 @@ The configuration changes slightly per distributed implementation and as such wi
 [[routing-strategy]]
 === Routing strategy
 
-Commands should be xref:../../architecture-overview/README.adoc#explicit-messaging[routed consistently] to the same application, especially those targeted towards a specific Aggregate.
+Commands should be link:../../architecture-overview/README.adoc#explicit-messaging[routed consistently] to the same application, especially those targeted towards a specific Aggregate.
 This ensures a single instance is in charge of the targeted aggregate, resolving the concurrent access issue and allowing for optimization like caching to work as designed.
 The component dealing with the consistent routing in an Axon application is the `RoutingStrategy`.
 
@@ -696,8 +696,8 @@ It defines which segment of the `DistributedCommandBus` should be given a comman
 You can choose different flavors of these components that are available as extension modules.
 Currently, Axon provides two extensions to that end, which are:
 
-. The xref:../../extensions/spring-cloud.adoc[SpringCloud] extension
-. The xref:../../extensions/jgroups.adoc[JGroups] extension
+. The link:../../extensions/spring-cloud.adoc[SpringCloud] extension
+. The link:../../extensions/jgroups.adoc[JGroups] extension
 
 Configuring a distributed command bus can (mostly) be done without any modifications in configuration files.
 The most straightforward approach to this is to include the Spring Boot starter dependency of either the Spring Cloud or JGroups extension.


### PR DESCRIPTION
…inish.

The whole idea is to put those xref as links so that (even though they are still broken links), at least the docs build process can go through and publish the docs.