### PR TITLE
Made test fixture resources available for handlers in spawned aggregates

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1130,7 +1130,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
         @Override
         public Aggregate<R> newInstance(@Nonnull Callable<R> factoryMethod) throws Exception {
-            AggregateModel<R> aggregateModel = AnnotatedAggregateMetaModelFactory.inspectAggregate(aggregateType);
+            AggregateModel<R> aggregateModel = AnnotatedAggregateMetaModelFactory.inspectAggregate(aggregateType, getParameterResolverFactory(), getHandlerDefinition());
             return EventSourcedAggregate.initialize(factoryMethod, aggregateModel, eventStore, repositoryProvider);
         }
 


### PR DESCRIPTION
When spawning an aggregate from another, the test fixtures were unable to resolve custom resources. This change adds support for that.