### PR TITLE
Updated links to Extensions and appendices

### DIFF
--- a/docs/old-reference-guide/modules/axon-framework-commands/pages/infrastructure.adoc
+++ b/docs/old-reference-guide/modules/axon-framework-commands/pages/infrastructure.adoc
@@ -553,7 +553,7 @@ public class AxonConfig {
 === `AxonServerCommandBus`
 
 The `AxonServerCommandBus` is the _default_ distributed `CommandBus` implementation that is set by the framework.
-It connects to link:../../axon-server-introduction.adoc[AxonServer], with which it can send and receive commands.
+It connects to link:https://www.axoniq.io/products/axon-server[AxonServer,window=_blank,role=external], with which it can send and receive commands.
 
 As it is the default, configuring it is relatively straightforward:
 
@@ -696,8 +696,8 @@ It defines which segment of the `DistributedCommandBus` should be given a comman
 You can choose different flavors of these components that are available as extension modules.
 Currently, Axon provides two extensions to that end, which are:
 
-. The link:../../extensions/spring-cloud.adoc[SpringCloud] extension
-. The link:../../extensions/jgroups.adoc[JGroups] extension
+. The xref:springcloud_extension_guide::index.adoc[SpringCloud] extension
+. The xref:jgroups_extension_guide::index.adoc[JGroups] extension
 
 Configuring a distributed command bus can (mostly) be done without any modifications in configuration files.
 The most straightforward approach to this is to include the Spring Boot starter dependency of either the Spring Cloud or JGroups extension.

--- a/docs/old-reference-guide/modules/events/pages/event-bus-and-event-store.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-bus-and-event-store.adoc
@@ -20,7 +20,7 @@ Additionally, it persists published events and is able to retrieve previous even
 === Axon Server as an event store
 
 Axon provides an event store out of the box, the `AxonServerEventStore`.
-It connects to the link:../../axon-server-introduction.md[AxonIQ AxonServer Server]to store and retrieve Events.
+It connects to the link:https://www.axoniq.io/products/axon-server[AxonIQ AxonServer Server,window=_blank,role=external] to store and retrieve Events.
 
 ==== Axon Configuration API
 
@@ -561,7 +561,7 @@ Applications within the same context "speak the same language." In other words, 
 
 As such, we can share the `EventStore's` data source between these applications.
 We may thus achieve distribution by utilizing the source itself.
-You can use both the <<Embedded event store,`EmbeddedEventStore`>> and link:../../axon-server-introduction.md[Axon Server] for this.
+You can use both the <<Embedded event store,`EmbeddedEventStore`>> and link:https://www.axoniq.io/products/axon-server[Axon Server,window=_blank,role=external] for this.
 The former would require the applications to point to the same data source, whereas the latter would require the applications to partake in the same context.
 
 However, sharing the entire event API is not recommended whenever the applications do not belong to the same context.
@@ -574,7 +574,7 @@ Then, you can open a stream to another context through the `AxonServerEventStore
 With this source in hand, you can configure a xref:event-processors/streaming.adoc[Streaming Processor] to start reading from it.
 
 Alternatively, you can use a message broker to distribute events between contexts.
-Axon provides a couple of these as link:../../extensions[extension modules], for example link:../../extensions/spring-amqp.md[Spring AMQP] or link:../../extensions/kafka.md[Kafka].
+Axon provides a good bunch of these as extension modules, for example xref:amqp_extension_guide::index.adoc[Spring AMQP] or  xref:kafka_extension_guide::index.adoc[Kafka].
 
 Although this allows further event distribution, we still recommend consciously sharing _the correct_ events.
 Ideally, we add a form of context mapping, like an anti-corruption layer, between the contexts.

--- a/docs/old-reference-guide/modules/events/pages/event-processors/README.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/README.adoc
@@ -335,7 +335,7 @@ The JPA dead-letter queue is a suitable option for production environments by pe
 It constructs a `dead_letter_entry` table where it persists failed-events in.
 The JDBC dead-letter queue is a suitable option for production environments by persisting the dead letters.
 
-* `MongoSequencedDeadLetterQueue` - Mongo variant of the dead-letter queue, available via the link:../../../extensions/mongo.md[Mongo Extension].
+* `MongoSequencedDeadLetterQueue` - Mongo variant of the dead-letter queue, available via the xref:mongodb_extension_guide::index.adoc[Mongo Extension].
 
 It constructs a `deadletters` collection where it persists failed-events in.
 The MongoDB dead-letter queue is a suitable option for production environments by persisting the dead letters.

--- a/docs/old-reference-guide/modules/events/pages/event-processors/subscribing.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/subscribing.adoc
@@ -7,7 +7,7 @@ The Subscribing Processor defines itself by receiving the events from a `Subscri
 The `SubscribableMessageSource` is an infrastructure component to register a Subscribing Processor too.
 
 After registration to the `SubscribableMessageSource`, the message source gives the events to the `SubscribingEventProcessor` in the order they are received.
-Examples of a `SubscribableMessageSource` are the `EventBus` or the link:../../../extensions/spring-amqp.md[AMQP Extension].
+Examples of a `SubscribableMessageSource` are the `EventBus` or the xref:amqp_extension_guide::index.adoc[AMQP Extension].
 Both the `EventBus` and AMQP Extension are simple message bus solutions for events.
 
 The simple bus solution makes the `SubscribableMessageSource` and thus the Subscribing Processor an approach to only receive _current_ events.
@@ -30,7 +30,7 @@ ____
 Although the `SubscribingEventProcessor` does not support easy parallelization or replays, there are still scenarios when it is beneficial.
 
 When a model, for example, should be updated within the same thread that published the event, the Subscribing Processor becomes a reasonable solution.
-In combination with Axon's link:../../../extensions/spring-amqp.md[AMQP] or link:../../../extensions/kafka.md[Kafka] extension, some of these concerns are alleviated too, making it a viable option.
+In combination with Axon's xref:amqp_extension_guide::index.adoc[AMQP] or xref:kafka_extension_guide::index.adoc[Kafka] extension, some of these concerns are alleviated too, making it a viable option.
 
 ____
 

--- a/docs/old-reference-guide/modules/messaging-concepts/pages/supported-parameters-annotated-handlers.adoc
+++ b/docs/old-reference-guide/modules/messaging-concepts/pages/supported-parameters-annotated-handlers.adoc
@@ -11,7 +11,7 @@ your annotated handlers.
 You can configure additional `ParameterResolvers` by implementing the `ParameterResolverFactory` interface and
 configuring the new implementation.
 For more specifics on configuring custom `ParameterResolver`s we suggest
-reading link:../../appendices/message-handler-tuning/parameter-resolvers.adoc[this] section.
+reading xref:message-handler-tuning-guide::index.adoc[this] section.
 
 [[supported-parameters-for-command-handlers]]
 == Supported parameters for command handlers

--- a/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
+++ b/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
@@ -7,7 +7,7 @@ ____
 
 *OpenTracing deprecation warning*
 
-The link:../../extensions/tracing.md[OpenTracing extension] works in a different way than described on this page.
+The xref:tracing_extension_guide::index.adoc[OpenTracing extension] works in a different way than described on this page.
 Its functionality is limited and will not be updated to include the additional functionality described on this page.
 The OpenTracing standard itself is deprecated, please consider moving to OpenTelemetry instead.
 
@@ -27,7 +27,7 @@ The following standards are currently supported:
 |Tracing standard |Supported |Description
 
 |OpenTelemetry |Yes |https://opentelemetry.io/docs/concepts/what-is-opentelemetry/[OpenTelemetry] is the successor of OpenTracing, with auto-instrumentation being its most prominent feature.
-|OpenTracing |Limited |https://opentracing.io/[OpenTracing] is supported link:../../extensions/tracing.md[by an extension with limited functionality]. Usage of OpenTelemetry is recommended instead.
+|OpenTracing |Limited |https://opentracing.io/[OpenTracing] is supported xref:tracing_extension_guide::index.adoc[by an extension with limited functionality]. Usage of OpenTelemetry is recommended instead.
 |SLF4j |Yes |If you have no monitoring system in place but want to trace through logging, the framework provides a `LoggingSpanFactory`.
 |===
 
@@ -338,7 +338,7 @@ Note that when not using Spring boot, tracing each message handler invocation is
 == OpenTracing
 
 The OpenTracing standard is deprecated.
-If necessary, you can still use link:../../extensions/tracing.md[the OpenTracing extension of Axon Framework].
+If necessary, you can still use xref:tracing_extension_guide::index.adoc[the OpenTracing extension of Axon Framework].
 
 Note that the functionality of this extension is rather limited compared to the OpenTelemetry integration.
 Because of this, it's recommended to switch to OpenTelemetry if possible.


### PR DESCRIPTION
I've updated a few of the broken links in the Old Axon Framework reference guide to point to the modules corresponding to Extensions and appendices from the old docs moved to the library.