### PR TITLE
Account for contexts call on un-initialized containers

### DIFF
--- a/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
+++ b/test/src/main/java/org/axonframework/test/server/AxonServerContainerUtils.java
@@ -164,7 +164,11 @@ class AxonServerContainerUtils {
     }
 
     private static boolean initialized(String hostname, int port) throws IOException {
-        List<String> cont = contexts(hostname, port);
-        return cont.contains("_admin") && cont.contains("default");
+        try {
+            List<String> cont = contexts(hostname, port);
+            return cont.contains("_admin") && cont.contains("default");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
+++ b/test/src/test/java/org/axonframework/test/server/AxonServerContainerTest.java
@@ -98,4 +98,16 @@ class AxonServerContainerTest {
             assertEquals("axoniq/axonserver:latest", testSubject.getDockerImageName());
         }
     }
+
+    @Test
+    void constructionWithReuseEnabledStartsMultipleTimesAsExpected() {
+        try (AxonServerContainer testSubject = new AxonServerContainer().withReuse(true)) {
+
+            testSubject.doStart();
+            assertTrue(testSubject.isRunning());
+
+            testSubject.doStart();
+            assertTrue(testSubject.isRunning());
+        }
+    }
 }


### PR DESCRIPTION
When a container is not initialized (first run), the method to check if it's initialized hits the endpoint...

`/v1/public/context`

this fails with a `400` and subsequently the `contexts` method throws an IllegalArgumentException using this we can draw the conclusion that the container is not yet initialized. (This assumption needs to be verified)

Also added a test that calls the doStart method twice to test that we do not try to initialize a container that has been initialized and that the reuse works.
