### PR TITLE
[#3022] Introduce `PropertiesAxonServerConnectionDetails` to ensure expected property ordering with `ConnectionDetails`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -439,6 +439,11 @@ public class AxonServerConfiguration {
         this.context = context;
     }
 
+    /**
+     * @deprecated In favor of the {@link AxonServerConnectionManager} itself being in charge of parsing the
+     * {@link #getServers()} list into a {@link NodeInfo} collection.
+     */
+    @Deprecated
     public List<NodeInfo> routingServers() {
         String[] serverArr = servers.split(",");
         return Arrays.stream(serverArr).map(server -> {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -25,6 +25,7 @@ import io.grpc.Channel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.config.TagsConfiguration;
 import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
@@ -217,7 +218,7 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
      */
     public static class Builder {
 
-        private String routingServers = "localhost:8024";
+        private String routingServers;
         private AxonServerConfiguration axonServerConfiguration;
         private TagsConfiguration tagsConfiguration = new TagsConfiguration();
         private UnaryOperator<ManagedChannelBuilder<?>> channelCustomization;
@@ -307,6 +308,8 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
             AxonServerConnectionFactory.Builder builder = AxonServerConnectionFactory.forClient(
                     axonServerConfiguration.getComponentName(), axonServerConfiguration.getClientId()
             );
+
+            this.routingServers = ObjectUtils.getOrDefault(routingServers, axonServerConfiguration.getServers());
             List<NodeInfo> nodeInfos = mapToNodeInfos(routingServers);
             if (!nodeInfos.isEmpty()) {
                 ServerAddress[] addresses = new ServerAddress[nodeInfos.size()];

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
 
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
@@ -50,6 +52,8 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @since 4.0
  */
 public class AxonServerConnectionManager implements Lifecycle, ConnectionManager {
+
+    private static final int DEFAULT_GRPC_PORT = 8124;
 
     private final Map<String, AxonServerConnection> connections = new ConcurrentHashMap<>();
     private final AxonServerConnectionFactory connectionFactory;
@@ -78,7 +82,8 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
     /**
      * Instantiate a Builder to be able to create an {@link AxonServerConnectionManager}.
      * <p>
-     * The {@link TagsConfiguration} is defaulted to {@link TagsConfiguration#TagsConfiguration()}. The
+     * The {@link Builder#routingServers(String) routingServers} default to {@code "localhost:8024"} and the
+     * {@link TagsConfiguration} is defaulted to {@link TagsConfiguration#TagsConfiguration()}. The
      * {@link AxonServerConfiguration} is a <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link AxonServerConnectionManager}
@@ -138,7 +143,7 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
     /**
      * Returns {@code true} if a gRPC channel for the specific context is opened between client and AxonServer.
      *
-     * @param context the (Bounded) Context for for which is verified the AxonServer connection through the gRPC
+     * @param context the (Bounded) Context for which is verified the AxonServer connection through the gRPC
      *                channel
      * @return if the gRPC channel is opened, false otherwise
      */
@@ -206,14 +211,29 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
     /**
      * Builder class to instantiate an {@link AxonServerConnectionManager}.
      * <p>
-     * The {@link TagsConfiguration} is defaulted to {@link TagsConfiguration#TagsConfiguration()}. The
+     * The {@link Builder#routingServers(String) routingServers} default to {@code "localhost:8024"} and the
+     * {@link TagsConfiguration} is defaulted to {@link TagsConfiguration#TagsConfiguration()}. The
      * {@link AxonServerConfiguration} is a <b>hard requirements</b> and as such should be provided.
      */
     public static class Builder {
 
+        private String routingServers = "localhost:8024";
         private AxonServerConfiguration axonServerConfiguration;
         private TagsConfiguration tagsConfiguration = new TagsConfiguration();
         private UnaryOperator<ManagedChannelBuilder<?>> channelCustomization;
+
+        /**
+         * Comma separated list of Axon Server locations. Each element is hostname or hostname:grpcPort. Defaults to
+         * {@code "localhost:8024"}.
+         *
+         * @param routingServers Comma separated list of Axon Server locations.
+         * @return The current Builder instance, for fluent interfacing.
+         */
+        public Builder routingServers(String routingServers) {
+            assertNonEmpty(routingServers, "");
+            this.routingServers = routingServers;
+            return this;
+        }
 
         /**
          * Sets the {@link AxonServerConfiguration} used to correctly configure connections between Axon clients and
@@ -284,11 +304,11 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
             AxonServerConnectionFactory.Builder builder = AxonServerConnectionFactory.forClient(
                     axonServerConfiguration.getComponentName(), axonServerConfiguration.getClientId()
             );
-            List<NodeInfo> routingServers = axonServerConfiguration.routingServers();
-            if (!routingServers.isEmpty()) {
-                ServerAddress[] addresses = new ServerAddress[routingServers.size()];
+            List<NodeInfo> nodeInfos = mapToNodeInfos(routingServers);
+            if (!nodeInfos.isEmpty()) {
+                ServerAddress[] addresses = new ServerAddress[nodeInfos.size()];
                 for (int i = 0; i < addresses.length; i++) {
-                    NodeInfo routingServer = routingServers.get(i);
+                    NodeInfo routingServer = nodeInfos.get(i);
                     addresses[i] = new ServerAddress(routingServer.getHostName(), routingServer.getGrpcPort());
                 }
                 builder.routingServers(addresses);
@@ -341,6 +361,24 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
 
             AxonServerConnectionFactory connectionFactory = builder.build();
             return new AxonServerConnectionManager(this, connectionFactory);
+        }
+
+        private static List<NodeInfo> mapToNodeInfos(String servers) {
+            String[] serverArray = servers.split(",");
+            return Arrays.stream(serverArray)
+                         .map(server -> {
+                             String[] s = server.trim().split(":");
+                             return s.length > 1
+                                     ? NodeInfo.newBuilder()
+                                               .setHostName(s[0])
+                                               .setGrpcPort(Integer.parseInt(s[1]))
+                                               .build()
+                                     : NodeInfo.newBuilder()
+                                               .setHostName(s[0])
+                                               .setGrpcPort(DEFAULT_GRPC_PORT)
+                                               .build();
+                         })
+                         .collect(Collectors.toList());
         }
 
         /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -230,7 +230,10 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
          * @return The current Builder instance, for fluent interfacing.
          */
         public Builder routingServers(String routingServers) {
-            assertNonEmpty(routingServers, "");
+            assertNonEmpty(
+                    routingServers,
+                    "Routing Servers should be a non-empty String of a comma-separated [hostname:grpcPort] entries"
+            );
             this.routingServers = routingServers;
             return this;
         }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,10 @@ public class ServerConnectorConfigurerModule implements ConfigurerModule {
     }
 
     private AxonServerConnectionManager buildAxonServerConnectionManager(Configuration c) {
+        AxonServerConfiguration axonServerConfiguration = c.getComponent(AxonServerConfiguration.class);
         return AxonServerConnectionManager.builder()
-                                          .axonServerConfiguration(c.getComponent(AxonServerConfiguration.class))
+                                          .routingServers(axonServerConfiguration.getServers())
+                                          .axonServerConfiguration(axonServerConfiguration)
                                           .tagsConfiguration(
                                                   c.getComponent(TagsConfiguration.class, TagsConfiguration::new)
                                           )

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -376,5 +376,17 @@ class AxonServerConnectionManagerTest {
     void buildWithoutAxonServerConfigurationThrowsAxonConfigurationException() {
         AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
         assertThrows(AxonConfigurationException.class, builderTestSubject::build);
+    }
+
+    @Test
+    void buildWithNullRoutingServersThrowsAxonConfigurationException() {
+        AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.routingServers(null));
+    }
+
+    @Test
+    void buildWithEmptyRoutingServersThrowsAxonConfigurationException() {
+        AxonServerConnectionManager.Builder builderTestSubject = AxonServerConnectionManager.builder();
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.routingServers(""));
     }
 }

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootDockerComposeIntegrationTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootDockerComposeIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,14 +47,9 @@ class SpringBootDockerComposeIntegrationTest {
     @Test
     void verifyApplicationRunsAndConnectsToAxonServerDefinedInDockerComposeFile() {
         assertTrue(application.isRunning());
-        AxonServerConfiguration config = application.getBean(AxonServerConfiguration.class);
 
         assertNotNull(application.getBean(AxonServerConnectionDetails.class),
                       "Expected an AxonServerConnectionDetails bean pointing to Axon Server in Docker");
-
-        assertNotNull(config);
-        assertNotEquals("localhost:8124", config.getServers());
-        assertNotEquals("localhost", config.getServers());
 
         AxonServerConnectionManager connectionFactory = application.getBean(AxonServerConnectionManager.class);
         AxonServerConnection connection = connectionFactory.getConnection();

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -35,9 +36,17 @@ import java.util.concurrent.ExecutionException;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating that the constructed {@link AxonServerConnectionDetails} from the {@link ServiceConnection}
+ * annotated test container take precedence over the properties (in this scenario provided through the {@code custom}
+ * profile).
+ *
+ * @author Steven van Beelen
+ */
 @SpringBootTest
 @Testcontainers
-class SpringBootTestContainerIntegrationTest {
+@ActiveProfiles("custom")
+class SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest {
 
     @Container
     @ServiceConnection

--- a/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest.java
+++ b/spring-boot-3-integrationtests/src/test/java/org/axonframework/springboot/service/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.springboot.service.connection;
 
-import io.axoniq.axonserver.grpc.admin.ContextOverview;
+import io.axoniq.axonserver.connector.AxonServerConnection;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.test.server.AxonServerContainer;
@@ -29,9 +29,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
@@ -62,7 +59,7 @@ class SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest {
     private AxonServerConnectionManager axonServerConnectionManager;
 
     @Test
-    void verifyApplicationStartsNormallyWithAxonServerInstance() throws ExecutionException, InterruptedException {
+    void verifyApplicationStartsNormallyWithAxonServerInstance() {
         assertTrue(axonServer.isRunning());
         assertNotNull(connectionDetails);
         assertTrue(connectionDetails.routingServers().endsWith("" + axonServer.getGrpcPort()));
@@ -70,12 +67,9 @@ class SpringBootTestContainerIntegrationWithAxonServerPropertiesFileTest {
 
         assertNotEquals("localhost:8024", axonServerConfiguration.getServers());
 
-        // Retrieving all contexts will try to establish a connection with the container
-        CompletableFuture<List<ContextOverview>> allContexts = axonServerConnectionManager.getConnection()
-                                                                                          .adminChannel()
-                                                                                          .getAllContexts();
-        await().atMost(Duration.ofMillis(500))
-               .until(allContexts::isDone);
-        assertFalse(allContexts.get().isEmpty());
+        AxonServerConnection connection = axonServerConnectionManager.getConnection();
+
+        await().atMost(Duration.ofSeconds(5))
+               .untilAsserted(() -> assertTrue(connection.isConnected()));
     }
 }

--- a/spring-boot-3-integrationtests/src/test/resources/application-custom.properties
+++ b/spring-boot-3-integrationtests/src/test/resources/application-custom.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2024. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+axon.axonserver.servers=unknown

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -36,11 +36,11 @@ import org.axonframework.queryhandling.QueryInvocationErrorHandler;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springboot.TagsConfigurationProperties;
 import org.axonframework.springboot.service.connection.AxonServerConnectionDetails;
+import org.axonframework.springboot.service.connection.PropertiesAxonServerConnectionDetails;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -65,53 +65,16 @@ import javax.annotation.Nonnull;
 @ConditionalOnClass(AxonServerConfiguration.class)
 @EnableConfigurationProperties(TagsConfigurationProperties.class)
 @ConditionalOnProperty(name = "axon.axonserver.enabled", matchIfMissing = true)
-public class AxonServerAutoConfiguration {
+public class AxonServerAutoConfiguration implements ApplicationContextAware {
 
-    @Configuration
-    @ConditionalOnMissingClass("org.springframework.boot.autoconfigure.service.connection.ConnectionDetails")
-    public static class ConnectionConfiguration implements ApplicationContextAware {
+    private ApplicationContext applicationContext;
 
-        private ApplicationContext applicationContext;
-        @Bean
-        public AxonServerConfiguration axonServerConfiguration() {
-            AxonServerConfiguration configuration = new AxonServerConfiguration();
-            configuration.setComponentName(clientName(applicationContext.getId()));
-            return configuration;
-        }
-        @Override
-        public void setApplicationContext(@Nonnull ApplicationContext applicationContext) throws BeansException {
-            this.applicationContext = applicationContext;
-        }
+    @Bean
+    public AxonServerConfiguration axonServerConfiguration() {
+        AxonServerConfiguration configuration = new AxonServerConfiguration();
+        configuration.setComponentName(clientName(applicationContext.getId()));
+        return configuration;
     }
-
-    @Configuration
-    @ConditionalOnClass(name = "org.springframework.boot.autoconfigure.service.connection.ConnectionDetails")
-    public static class ConnectionDetailsConfiguration implements ApplicationContextAware{
-        private ApplicationContext applicationContext;
-
-        @ConditionalOnMissingBean(AxonServerConnectionDetails.class)
-        @Bean
-        public AxonServerConfiguration axonServerConfiguration() {
-            AxonServerConfiguration configuration = new AxonServerConfiguration();
-            configuration.setComponentName(clientName(applicationContext.getId()));
-            return configuration;
-        }
-
-        @ConditionalOnBean(type = "org.axonframework.springboot.service.connection.AxonServerConnectionDetails")
-        @Bean
-        public AxonServerConfiguration axonServerConfigurationWithConnectionDetails(AxonServerConnectionDetails connectionDetails) {
-            AxonServerConfiguration configuration = new AxonServerConfiguration();
-            configuration.setComponentName(clientName(applicationContext.getId()));
-            configuration.setServers(connectionDetails.routingServers());
-            return configuration;
-        }
-
-        @Override
-        public void setApplicationContext(@Nonnull ApplicationContext applicationContext) throws BeansException {
-            this.applicationContext = applicationContext;
-        }
-    }
-
 
     private static String clientName(@Nullable String id) {
         if (id == null) {
@@ -120,6 +83,17 @@ public class AxonServerAutoConfiguration {
             return id.substring(0, id.indexOf(":"));
         }
         return id;
+    }
+
+    @Configuration
+    @ConditionalOnClass(name = "org.springframework.boot.autoconfigure.service.connection.ConnectionDetails")
+    public static class ConnectionDetailsConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(AxonServerConnectionDetails.class)
+        PropertiesAxonServerConnectionDetails axonServerConnectionDetails(AxonServerConfiguration configuration) {
+            return new PropertiesAxonServerConnectionDetails(configuration);
+        }
     }
 
     @Bean
@@ -195,6 +169,11 @@ public class AxonServerAutoConfiguration {
                                        .eventSerializer(eventSerializer)
                                        .connectionManager(connectionManager)
                                        .build();
+    }
+
+    @Override
+    public void setApplicationContext(@Nonnull ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
     }
 }
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,10 +103,12 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
     }
 
     @Bean
-    public AxonServerConnectionManager platformConnectionManager(AxonServerConfiguration axonServerConfiguration,
+    public AxonServerConnectionManager platformConnectionManager(AxonServerConnectionDetails connectionDetails,
+                                                                 AxonServerConfiguration axonServerConfiguration,
                                                                  TagsConfigurationProperties tagsConfigurationProperties,
                                                                  ManagedChannelCustomizer managedChannelCustomizer) {
         return AxonServerConnectionManager.builder()
+                                          .routingServers(connectionDetails.routingServers())
                                           .axonServerConfiguration(axonServerConfiguration)
                                           .tagsConfiguration(tagsConfigurationProperties.toTagsConfiguration())
                                           .channelCustomizer(managedChannelCustomizer)

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/service/connection/PropertiesAxonServerConnectionDetails.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/service/connection/PropertiesAxonServerConnectionDetails.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2024. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.springboot.service.connection;
+
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+
+/**
+ * An {@link AxonServerConnectionDetails} implementation based on a given {@link AxonServerConfiguration} bean.
+ * <p>
+ * Used to ensure the properties from an {@code ServiceConnection} annotated test container take precedence over
+ * property-based configuration, as this would trigger the {@link AxonServerTestContainerConnectionDetailsFactory} to
+ * construct a {@link AxonServerConnectionDetails} object first. Due to this ordering, the property-based format,
+ * inserted through this class, is no longer able to override the properties, like the
+ * {@link AxonServerConfiguration#getServers()}.
+ *
+ * @author Steven van Beelen
+ * @since 4.9.4
+ */
+public class PropertiesAxonServerConnectionDetails implements AxonServerConnectionDetails {
+
+    private final String routingServers;
+
+    /**
+     * Constructs a {@link PropertiesAxonServerConnectionDetails} instance based on the given {@code configuration}.
+     *
+     * @param configuration An {@link AxonServerConfiguration} to base this
+     *                      {@link PropertiesAxonServerConnectionDetails} instance on.
+     */
+    public PropertiesAxonServerConnectionDetails(AxonServerConfiguration configuration) {
+        this.routingServers = configuration.getServers();
+    }
+
+    @Override
+    public String routingServers() {
+        return routingServers;
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/service/connection/PropertiesAxonServerConnectionDetails.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/service/connection/PropertiesAxonServerConnectionDetails.java
@@ -21,11 +21,9 @@ import org.axonframework.axonserver.connector.AxonServerConfiguration;
 /**
  * An {@link AxonServerConnectionDetails} implementation based on a given {@link AxonServerConfiguration} bean.
  * <p>
- * Used to ensure the properties from an {@code ServiceConnection} annotated test container take precedence over
- * property-based configuration, as this would trigger the {@link AxonServerTestContainerConnectionDetailsFactory} to
- * construct a {@link AxonServerConnectionDetails} object first. Due to this ordering, the property-based format,
- * inserted through this class, is no longer able to override the properties, like the
- * {@link AxonServerConfiguration#getServers()}.
+ * Ensures there will be a {@code AxonServerConnectionDetails} instance in the absence of the container-based version
+ * constructed by the {@link AxonServerTestContainerConnectionDetailsFactory}. The container-based version only exists
+ * if there is a {@code ServiceConnection} annotated bean in the context, which is not a guarantee.
  *
  * @author Steven van Beelen
  * @since 4.9.4


### PR DESCRIPTION
This pull request introduces the `PropertiesAxonServerConnectionDetails` object.
This object implements the `AxonServerConnectionDetails` interface and is constructed in the absence of an `AxonServerConnectionDetails` instance.

Furthermore, this introduces the `AxonServerConnectionManager.Builder#routingServers` as a means to set the routing servers separately from the `AxonServerConfiguration` object.
Whenever Axon Framework constructs the `AxonServerConnectionManager` for a user, we ensure `AxonServerConnectionManager.Builder#routingServers` is invoked.
The occasions are:
1. In the `ServerConnectorConfigurerModule`, which defaults to providing the `AxonServerConfiguration#getServers` output.
2. In the `AxonServerAutoConfiguration`, which uses the `AxonServerConnectionDetails#routingServers` input instead.

Whereas point 1 is covered to comply with non-Spring environments, the latter ensures Spring applications utilizing `ConnectionDetails` will follow the expected ordering of properties.
Furthermore, point 2 resolves the issues mentioned in #3022.