### PR TITLE
[#3020] Only publish events after EventStore validations in Aggregate Test Fixtures

### DIFF
--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1007,6 +1007,15 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         }
 
         protected void doAppendEvents(List<? extends EventMessage<?>> events) {
+            if (!givenEvents.isEmpty() && !events.isEmpty()) {
+                EventMessage<?> firstEventToAppend = events.get(0);
+                if (DomainEventMessage.class.isAssignableFrom(firstEventToAppend.getClass())) {
+                    if (((DomainEventMessage<?>) firstEventToAppend).getSequenceNumber() == 0) {
+                        throw new FixtureExecutionException("let's try");
+                    }
+                }
+            }
+
             publishedEvents.addAll(events);
             events.stream().filter(DomainEventMessage.class::isInstance).map(e -> (DomainEventMessage<?>) e)
                   .forEach(event -> {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
@@ -216,7 +216,7 @@ class FixtureTest_Annotated {
     @Test
     void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
-        assertThrows(EventStoreException.class, () ->
+        assertThrows(FixtureExecutionException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
                         new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()))
@@ -293,21 +293,23 @@ class FixtureTest_Annotated {
     @Test
     void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenEvents() {
         fixture.registerInjectableResource(new HardToCreateResource());
-        assertThrows(
+        String exceptionMessage = assertThrows(
                 FixtureExecutionException.class,
                 () -> fixture.given(new MyEvent(AGGREGATE_ID, 0))
                              .when(new CreateAggregateCommand(AGGREGATE_ID))
-        );
+        ).getMessage();
+        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
     }
 
     @Test
     void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenCommand() {
         fixture.registerInjectableResource(new HardToCreateResource());
-        assertThrows(
+        String exceptionMessage = assertThrows(
                 FixtureExecutionException.class,
                 () -> fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
                              .when(new CreateAggregateCommand(AGGREGATE_ID))
-        );
+        ).getMessage();
+        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
     }
 
     private static class StubDomainEvent {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
@@ -216,7 +216,7 @@ class FixtureTest_Annotated {
     @Test
     void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
-        assertThrows(FixtureExecutionException.class, () ->
+        assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
                         new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()))
@@ -291,25 +291,21 @@ class FixtureTest_Annotated {
     }
 
     @Test
-    void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenEvents() {
+    void fixtureThrowsEventStoreExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenEvents() {
         fixture.registerInjectableResource(new HardToCreateResource());
-        String exceptionMessage = assertThrows(
-                FixtureExecutionException.class,
-                () -> fixture.given(new MyEvent(AGGREGATE_ID, 0))
-                             .when(new CreateAggregateCommand(AGGREGATE_ID))
-        ).getMessage();
-        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
+        fixture.given(new MyEvent(AGGREGATE_ID, 0))
+               .when(new CreateAggregateCommand(AGGREGATE_ID))
+               .expectException(EventStoreException.class)
+               .expectNoEvents();
     }
 
     @Test
-    void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenCommand() {
+    void fixtureThrowsEventStoreExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenCommand() {
         fixture.registerInjectableResource(new HardToCreateResource());
-        String exceptionMessage = assertThrows(
-                FixtureExecutionException.class,
-                () -> fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
-                             .when(new CreateAggregateCommand(AGGREGATE_ID))
-        ).getMessage();
-        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
+        fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
+               .when(new CreateAggregateCommand(AGGREGATE_ID))
+               .expectException(EventStoreException.class)
+               .expectNoEvents();
     }
 
     private static class StubDomainEvent {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Annotated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,6 +288,26 @@ class FixtureTest_Annotated {
         assertEquals(3, fixture.getEventStore()
                                .readEvents(testAggregateId)
                                .asStream().count());
+    }
+
+    @Test
+    void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenEvents() {
+        fixture.registerInjectableResource(new HardToCreateResource());
+        assertThrows(
+                FixtureExecutionException.class,
+                () -> fixture.given(new MyEvent(AGGREGATE_ID, 0))
+                             .when(new CreateAggregateCommand(AGGREGATE_ID))
+        );
+    }
+
+    @Test
+    void fixtureThrowsFixtureExecutionExceptionWhenHandlingAggregateConstructingCommandWhileThereAreGivenCommand() {
+        fixture.registerInjectableResource(new HardToCreateResource());
+        assertThrows(
+                FixtureExecutionException.class,
+                () -> fixture.givenCommands(new CreateAggregateCommand(AGGREGATE_ID))
+                             .when(new CreateAggregateCommand(AGGREGATE_ID))
+        );
     }
 
     private static class StubDomainEvent {

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
@@ -91,11 +91,10 @@ class FixtureTest_Generic {
     void storingExistingAggregateGeneratesException() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
-        String exceptionMessage = assertThrows(FixtureExecutionException.class, () ->
-                fixture.given(new MyEvent("aggregateId", 1))
-                       .when(new CreateAggregateCommand("aggregateId"))
-        ).getMessage();
-        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
+        fixture.given(new MyEvent("aggregateId", 1))
+               .when(new CreateAggregateCommand("aggregateId"))
+               .expectException(EventStoreException.class)
+               .expectNoEvents();
     }
 
     @Test
@@ -145,7 +144,7 @@ class FixtureTest_Generic {
     @Test
     void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
-        assertThrows(FixtureExecutionException.class, () ->
+        assertThrows(EventStoreException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
                         new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()))

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Generic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.axonframework.eventsourcing.IncompatibleAggregateException;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
-import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.FixtureExecutionException;
 import org.junit.jupiter.api.*;
 
@@ -92,9 +91,11 @@ class FixtureTest_Generic {
     void storingExistingAggregateGeneratesException() {
         fixture.registerAggregateFactory(mockAggregateFactory);
         fixture.registerAnnotatedCommandHandler(new MyCommandHandler(fixture.getRepository(), fixture.getEventBus()));
-        fixture.given(new MyEvent("aggregateId", 1))
-                .when(new CreateAggregateCommand("aggregateId"))
-                .expectException(EventStoreException.class);
+        String exceptionMessage = assertThrows(FixtureExecutionException.class, () ->
+                fixture.given(new MyEvent("aggregateId", 1))
+                       .when(new CreateAggregateCommand("aggregateId"))
+        ).getMessage();
+        assertTrue(exceptionMessage.contains("Unexpected sequence number on stored event."));
     }
 
     @Test
@@ -144,12 +145,11 @@ class FixtureTest_Generic {
     @Test
     void fixtureGeneratesExceptionOnWrongEvents_WrongSequence() {
         String identifier = UUID.randomUUID().toString();
-        assertThrows(EventStoreException.class, () ->
+        assertThrows(FixtureExecutionException.class, () ->
                 fixture.getEventStore().publish(
                         new GenericDomainEventMessage<>("test", identifier, 0, new StubDomainEvent()),
                         new GenericDomainEventMessage<>("test", identifier, 2, new StubDomainEvent()))
         );
-
     }
 
     private class StubDomainEvent {


### PR DESCRIPTION
The `AggregateTestFixture` preemptively added _all_ the events to the `publishedEvents` collection, regardless of any event store exceptions thrown in the `AggregateTestFixture.RecordingEventStore`.
By doing so, this caused test fixtures to succeed on `expectedEvents` even though the event caused an `EventStoreException`.
Hence, a test flow as such was correct:

```java
testFixture.given([some-events])
        .when([aggregate-creation-command])
        .expectedEvents([expected-events])
        .expectedException(EventStoreException.class);
```

This, however, does not represent a production Axon Framework system, as the `EventStoreException` should cause the event not to be published, and stored.

This pull request resolves this predicament through some small changes in the `AggregateTestFixture.RecordingEventStore`.
Through this, this pull request resolves #3020.