### PR TITLE
[#3042] De-/Serialize given `ScopeDescriptor` on each `QuartzDeadlineManager#cancelAllWithinScope` invocation

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/quartz/QuartzDeadlineManagerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/quartz/QuartzDeadlineManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import org.axonframework.config.ConfigurationScopeAwareProvider;
 import org.axonframework.deadline.DeadlineException;
 import org.axonframework.deadline.DeadlineManager;
 import org.axonframework.deadline.DeadlineManagerSpanFactory;
-import org.axonframework.deadline.DefaultDeadlineManagerSpanFactory;
 import org.axonframework.deadline.quartz.QuartzDeadlineManager;
 import org.axonframework.integrationtests.deadline.AbstractDeadlineManagerTestSuite;
-import org.axonframework.integrationtests.utils.TestSerializer;
 import org.axonframework.messaging.ScopeAwareProvider;
+import org.axonframework.serialization.TestSerializer;
+import org.axonframework.serialization.json.JacksonSerializer;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.mockito.*;
@@ -49,7 +49,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
                     QuartzDeadlineManager.builder()
                                          .scheduler(scheduler)
                                          .scopeAwareProvider(new ConfigurationScopeAwareProvider(configuration))
-                                         .serializer(TestSerializer.xStreamSerializer())
+                                         .serializer(TestSerializer.JACKSON.getSerializer())
                                          .spanFactory(configuration.getComponent(DeadlineManagerSpanFactory.class))
                                          .build();
             scheduler.start();
@@ -65,7 +65,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
         QuartzDeadlineManager testSubject = QuartzDeadlineManager.builder()
                                                                  .scopeAwareProvider(scopeAwareProvider)
                                                                  .scheduler(scheduler)
-                                                                 .serializer(TestSerializer.xStreamSerializer())
+                                                                 .serializer(TestSerializer.JACKSON.getSerializer())
                                                                  .build();
 
         testSubject.shutdown();
@@ -83,7 +83,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
         QuartzDeadlineManager testSubject = QuartzDeadlineManager.builder()
                                                                  .scopeAwareProvider(scopeAwareProvider)
                                                                  .scheduler(scheduler)
-                                                                 .serializer(TestSerializer.xStreamSerializer())
+                                                                 .serializer(TestSerializer.JACKSON.getSerializer())
                                                                  .build();
 
         assertThrows(DeadlineException.class, testSubject::shutdown);
@@ -95,7 +95,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
         QuartzDeadlineManager.Builder builderTestSubject =
                 QuartzDeadlineManager.builder()
                                      .scopeAwareProvider(scopeAwareProvider)
-                                     .serializer(TestSerializer.xStreamSerializer());
+                                     .serializer(TestSerializer.JACKSON.getSerializer());
 
         assertThrows(AxonConfigurationException.class, builderTestSubject::build);
     }
@@ -106,7 +106,7 @@ class QuartzDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
         QuartzDeadlineManager.Builder builderTestSubject =
                 QuartzDeadlineManager.builder()
                                      .scheduler(scheduler)
-                                     .serializer(TestSerializer.xStreamSerializer());
+                                     .serializer(TestSerializer.JACKSON.getSerializer());
 
         assertThrows(AxonConfigurationException.class, builderTestSubject::build);
     }


### PR DESCRIPTION
This pull request adjusts the `QuartzDeadlineManager#cancelAllWithinScope` by serializing and immediately deserializing the given `ScopeDescriptor`.
I have introduced this to ensure the outcome of `DeadlineJob.DeadlineJobDataBinder.deadlineScope(Serializer, JobDataMap)`, which similarly has been serialized and deserialized, has the same type for the `ScopeDescriptor#identifier` field.

This, in turn, is done to ensure that non-String aggregate identifiers are correctly recognized in the `QuartzDeadlineManager#cancelAllWithinScope` method.
Without doing so, the `QuartzDeadlineManager#cancelAllWithinScope` would simply not cancel anything, as the `AggregateScopeDescriptor#identifier` (as it's an `Object`) does not match the serialized `identifier` at all.

Another approach to tackle this, is by adjusting the `AggregateScopeDescriptor#equals` method to take the `toString()` result of the `ScopeDescriptor#identifier`.
I have decided against this, for now, as this will require us to use the `org.axonframework.common.IdentifierValidator` to ensure the `ScopeDescriptor#identifier` has a proper `toString` implementation.
Granted, the aggregate meta-model factory code does this, giving us some certainty the `AggregateScopeDescriptor` has an identifier with a proper `toString` implementation.
However, this is an assumption that doesn't hold true when (e.g.) somebody creates the `AggregateScopeDescriptor` manually.

Hence to take the `AggregateScopeDesciptor#equals` solution, the `org.axonframework.common.IdentifierValidator` would need to be introduced to the `QuartzDeadlineManager`, which I decided against.

Regardless, by doing the above, this PR resolves #3042