### PR TITLE
Introduce `PersistentStreamScheduledExecutorBuilder`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -1724,6 +1724,11 @@ public class AxonServerConfiguration {
         private int initialSegmentCount = 1;
 
         /**
+         * The number of threads used to process tasks (e.g. event handling) for the persistent stream. Defaults to 1.
+         */
+        private int threadCount = 1;
+
+        /**
          * The sequencing policy to use for the persistent stream.
          * <p>
          * Supported sequencing policies are:
@@ -1780,6 +1785,25 @@ public class AxonServerConfiguration {
          */
         public void setInitialSegmentCount(int initialSegmentCount) {
             this.initialSegmentCount = initialSegmentCount;
+        }
+
+        /**
+         * The number of threads used to process tasks (e.g. event handling) for the persistent stream. Defaults to 1.
+         *
+         * @return The number of threads used to process tasks (e.g. event handling) for the persistent stream.
+         */
+        public int getThreadCount() {
+            return threadCount;
+        }
+
+        /**
+         * Sets the number of threads used to process tasks (e.g. event handling) for the persistent stream.
+         *
+         * @param threadCount The number of threads used to process tasks (e.g. event handling) for the persistent
+         *                    stream.
+         */
+        public void setThreadCount(int threadCount) {
+            this.threadCount = threadCount;
         }
 
         /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamScheduledExecutorBuilder.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamScheduledExecutorBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2024. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.event.axon;
+
+import org.axonframework.common.AxonThreadFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiFunction;
+
+/**
+ * Functional interface towards constructing a {@link ScheduledExecutorService} for a {@link PersistentStreamMessageSource}.
+ *
+ * @author Steven van Beelen
+ * @since 4.10.1
+ */
+@FunctionalInterface
+public interface PersistentStreamScheduledExecutorBuilder
+        extends BiFunction<Integer, String, ScheduledExecutorService> {
+
+    /**
+     * Builds a {@link ScheduledExecutorService} using the given {@code threadCount} and {@code streamName}.
+     *
+     * @param threadCount The requested thread count for the persistent stream. Can for example be used to define the
+     *                    pool size of the {@link ScheduledExecutorService} under construction.
+     * @param streamName The name of the persistent stream. Can, for example, be used to define the name of the
+     * {@link java.util.concurrent.ThreadFactory} given to a {@link ScheduledExecutorService}
+     * @return A {@link ScheduledExecutorService} based on the given {@code threadCount} and {@code streamName}.
+     */
+    default ScheduledExecutorService build(Integer threadCount, String streamName) {
+        return apply(threadCount, streamName);
+    }
+
+    /**
+     * Default {@link PersistentStreamScheduledExecutorBuilder}. Constructs a {@link ScheduledExecutorService} by using
+     * the given {@code threadCount} as the pool size for the executor. Uses the given {@code streamName} to build an
+     * {@link AxonThreadFactory} with the group name {@code "PersistentStream[{streamName}]"}.
+     *
+     * @return The default {@link PersistentStreamScheduledExecutorBuilder}.
+     */
+    static PersistentStreamScheduledExecutorBuilder defaultFactory() {
+        return (threadCount, streamName) -> Executors.newScheduledThreadPool(
+                threadCount, new AxonThreadFactory("PersistentStream[" + streamName + "]")
+        );
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -27,11 +27,11 @@ import org.axonframework.axonserver.connector.event.axon.AxonServerEventSchedule
 import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfiguration;
 import org.axonframework.axonserver.connector.event.axon.PersistentStreamMessageSource;
 import org.axonframework.axonserver.connector.event.axon.PersistentStreamMessageSourceFactory;
+import org.axonframework.axonserver.connector.event.axon.PersistentStreamScheduledExecutorBuilder;
 import org.axonframework.axonserver.connector.event.axon.PersistentStreamSequencingPolicyProvider;
 import org.axonframework.axonserver.connector.query.QueryPriorityCalculator;
 import org.axonframework.commandhandling.distributed.AnnotationRoutingStrategy;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
-import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
@@ -44,6 +44,7 @@ import org.axonframework.springboot.TagsConfigurationProperties;
 import org.axonframework.springboot.service.connection.AxonServerConnectionDetails;
 import org.axonframework.springboot.service.connection.PropertiesAxonServerConnectionDetails;
 import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
+import org.axonframework.springboot.util.ConditionalOnQualifiedBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -60,7 +61,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 
@@ -183,7 +183,8 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
     public EventProcessorInfoConfiguration processorInfoConfiguration(
             EventProcessingConfiguration eventProcessingConfiguration,
             AxonServerConnectionManager connectionManager,
-            AxonServerConfiguration configuration) {
+            AxonServerConfiguration configuration
+    ) {
         return new EventProcessorInfoConfiguration(c -> eventProcessingConfiguration,
                                                    c -> connectionManager,
                                                    c -> configuration);
@@ -201,33 +202,60 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
     }
 
     /**
-     * Create a {@link ScheduledExecutorService} for persistent stream operations.
+     * Creates a {@link PersistentStreamScheduledExecutorBuilder} that constructs
+     * {@link ScheduledExecutorService ScheduledExecutorServices} for each persistent stream.
+     * Defaults to a {@link PersistentStreamScheduledExecutorBuilder#defaultFactory()}.
      *
-     * @return The a {@link ScheduledExecutorService} for persistent stream operations.
+     * @return The a {@link PersistentStreamScheduledExecutorBuilder} that constructs
+     * {@link ScheduledExecutorService ScheduledExecutorServices} for each persistent stream.
      */
     @Bean
-    @ConditionalOnMissingQualifiedBean(qualifier = "persistentStreamScheduler")
+    @ConditionalOnMissingBean
+    @ConditionalOnMissingQualifiedBean(
+            beanClass = ScheduledExecutorService.class,
+            qualifier = "persistentStreamScheduler"
+    )
     @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
-    public ScheduledExecutorService persistentStreamScheduler() {
-        return Executors.newScheduledThreadPool(1, new AxonThreadFactory("persistent-streams"));
+    public PersistentStreamScheduledExecutorBuilder persistentStreamScheduledExecutorBuilder() {
+        return PersistentStreamScheduledExecutorBuilder.defaultFactory();
+    }
+
+    /**
+     * Creates a {@link PersistentStreamScheduledExecutorBuilder} defaulting to the same given
+     * {@code persistentStreamScheduler} on each invocation. This bean-creation method is in place for backwards
+     * compatibility with 4.10.0, which defaulted to this behavior based on a bean of type
+     * {@link ScheduledExecutorService} with qualified {@code persistentStreamScheduler}.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnQualifiedBean(
+            beanClass = ScheduledExecutorService.class,
+            qualifier = "persistentStreamScheduler"
+    )
+    @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
+    public PersistentStreamScheduledExecutorBuilder backwardsCompatiblePersistentStreamScheduledExecutorBuilder(
+         @Qualifier("persistentStreamScheduler") ScheduledExecutorService persistentStreamScheduler
+    ) {
+        return (threadCount, streamName) -> persistentStreamScheduler;
     }
 
     /**
      * Constructs a {@link PersistentStreamMessageSourceRegistrar} to create and register Spring beans for persistent
      * streams.
      *
-     * @param scheduledExecutorService The {@link ScheduledExecutorService} used for persistent stream operations.
-     * @param environment              The Spring {@link Environment}.
+     * @param environment       The Spring {@link Environment}.
+     * @param executorBuilder   The {@link PersistentStreamScheduledExecutorBuilder} used to construct a
+     * {@link ScheduledExecutorService} to perform the persistent stream's tasks with.
      * @return The {@link PersistentStreamMessageSourceRegistrar} to create and register Spring beans for persistent
      * streams.
      */
     @Bean
     @ConditionalOnProperty(name = "axon.axonserver.event-store.enabled", matchIfMissing = true)
     public PersistentStreamMessageSourceRegistrar persistentStreamRegistrar(
-            @Qualifier("persistentStreamScheduler") ScheduledExecutorService scheduledExecutorService,
-            Environment environment
+            Environment environment,
+            PersistentStreamScheduledExecutorBuilder executorBuilder
     ) {
-        return new PersistentStreamMessageSourceRegistrar(environment, scheduledExecutorService);
+        return new PersistentStreamMessageSourceRegistrar(environment, executorBuilder);
     }
 
     /**

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -17,14 +17,17 @@
 package org.axonframework.springboot.autoconfig;
 
 import io.grpc.ManagedChannelBuilder;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
 import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventScheduler;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFactory;
+import org.axonframework.axonserver.connector.event.axon.PersistentStreamScheduledExecutorBuilder;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
+import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.ConfigurerModule;
@@ -52,6 +55,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -270,6 +275,23 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
+    void persistentStreamSettingsArePopulatedAsExpected() {
+        testContext.withPropertyValues("axon.axonserver.persistent-streams[payments-stream].name=My Payments",
+                                       "axon.axonserver.persistent-streams[payments-stream].thread-count=4")
+                   .run(context -> {
+                       assertThat(context).hasSingleBean(AxonServerConfiguration.class);
+                       Map<String, AxonServerConfiguration.PersistentStreamSettings> persistentStreams =
+                               context.getBean(AxonServerConfiguration.class).getPersistentStreams();
+
+                       assertThat(persistentStreams).hasSize(1);
+                       AxonServerConfiguration.PersistentStreamSettings paymentsStreamSettings =
+                               persistentStreams.get("payments-stream");
+                       assertThat(paymentsStreamSettings).isNotNull();
+                       assertThat(paymentsStreamSettings.getThreadCount()).isEqualTo(4);
+                   });
+    }
+
+    @Test
     void persistentStreamProcessorsConfigurerModuleAddsSequencingPolicy() {
         testContext.withPropertyValues("axon.axonserver.persistent-streams[payments-stream].name=My Payments",
                                        "axon.eventhandling.processors.payments.source=payments-stream",
@@ -312,6 +334,35 @@ class AxonServerAutoConfigurationTest {
         testContext.withPropertyValues("axon.axonserver.persistent-streams[payments].name=My Payments",
                                        "axon.axonserver.enabled=false")
                    .run(context -> assertThat(context).getBean("payments").isNull());
+    }
+
+    @Test
+    void persistentStreamScheduledExecutorBuilderConstructsUniqueScheduledExecutorServices() {
+        testContext.withPropertyValues("axon.axonserver.persistent-streams[payments-stream].name=My Payments",
+                                       "axon.eventhandling.processors.payments.source=payments-stream")
+                   .run(context -> {
+                       assertThat(context).hasSingleBean(PersistentStreamScheduledExecutorBuilder.class);
+                       PersistentStreamScheduledExecutorBuilder executorBuilder =
+                               context.getBean(PersistentStreamScheduledExecutorBuilder.class);
+
+                       ScheduledExecutorService fooExecutor = executorBuilder.build(1, "foo");
+                       assertThat(fooExecutor).isNotEqualTo(executorBuilder.build(1, "foo"));
+                   });
+    }
+
+    @Test
+    void persistentStreamScheduledExecutorBuilderReusesScheduledExecutorService() {
+        testContext.withUserConfiguration(SinglePersistentStreamScheduledExecutorServiceConfiguration.class)
+                   .withPropertyValues("axon.axonserver.persistent-streams[payments-stream].name=My Payments",
+                                       "axon.eventhandling.processors.payments.source=payments-stream")
+                   .run(context -> {
+                       assertThat(context).hasSingleBean(PersistentStreamScheduledExecutorBuilder.class);
+                       PersistentStreamScheduledExecutorBuilder executorBuilder =
+                               context.getBean(PersistentStreamScheduledExecutorBuilder.class);
+
+                       ScheduledExecutorService fooExecutor = executorBuilder.build(1, "foo");
+                       assertThat(fooExecutor).isEqualTo(executorBuilder.build(1, "foo"));
+                   });
     }
 
     @ContextConfiguration
@@ -363,6 +414,15 @@ class AxonServerAutoConfigurationTest {
         @Bean
         public ManagedChannelCustomizer customManagedChannelCustomizer() {
             return CUSTOM_MANAGED_CHANNEL_CUSTOMIZER;
+        }
+    }
+
+    private static class SinglePersistentStreamScheduledExecutorServiceConfiguration {
+
+        @Bean
+        @Qualifier("persistentStreamScheduler")
+        public ScheduledExecutorService persistentStreamScheduler() {
+            return Executors.newScheduledThreadPool(1, new AxonThreadFactory("persistent-streams"));
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the `PersistentStreamScheduledExecutorBuilder` functional interface. 
This interface replaces the **single** and, by default, **single-threaded** `ScheduledExecutorService` that Axon Framework's autoconfiguration constructs for **all** Persistent Streams. 

In doing so, we can provide an easier means to configure a `ScheduledExecutorService` per Persistent Stream.
This can be achieved by switching based on the `streamName` provided to the `PersistentStreamScheduledExecutorBuilder#build(Integer,String)` operation. 
Furthermore, the `threadCount` can be adjusted per Persistent Stream through this interface as well.

Lastly, a property is added to the `AxonServerConfiguration`, called `threadCount`.
Through this, an `application.properties`/`application.yml` file can define the following to adjust the thread count for a Persistent Stream:

```properties
axon.axonserver.persistent-streams[{stream-name}].thread-count=4
```

We ensure users that already replaced the previous default `ScheduledExecutorService` bean, qualified under `persistentStreamScheduler`, with their own, by having two bean creation methods in the `AxonServerAutoConfiguration`.
In the presence of a `ScheduledExecutorService` bean qualified with `persistentStreamScheduler`, the old approach is followed.
If this is not the case, Axon Framework will default to constructing a `PersistentStreamScheduledExecutorBuilder` that uses the properties as set in the `AxonServerAutoConfiguration`.

Note there is a single breaking change in this pull request, which is the adjustment of the constructor of the `PersistentStreamMessageSourceRegistrar`.
Given this is a bean post processor, I deemed it safe to be adjusted in a non backwards compatible fashion.