### PR TITLE
[#2966] Add and enhance JavaDoc for the new Unit of Work

### DIFF
--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -14,8 +14,69 @@ Major API Changes
   recommended resolution path in the JavaDoc. It is strongly recommended to (1) upgrade to the latest Axon Framework 4
   version, (2) adjust any deprecations from Axon Framework you are using as recommended, and then (3) to make the change
   towards Axon Framework 5.
+* The entire API of the `UnitOfWork` has been rewritten to (1) construct an " async-native" flow to support both an
+  imperative and reactive style of programming, (2) eliminate the use of `ThreadLocal`, and (3) protect users from
+  internals APIs. This does mean that any direct interaction with the `UnitOfWork` has become a breaking change. Please
+  check the [Unit of Work](#unit-of-work) section for more details if you are facing this predicament.
 * We no longer support message handler annotated constructors. For example, the constructor of an aggregate can no
   longer contain the `@CommandHandler` annotation. Instead, the `@CreationPolicy` should be used.
+
+#### Unit of Work
+
+The `UnitOfWork` interface has been rewritten with roughly three goals in mind:
+
+1. Ensure the API of the `UnitOfWork` easily supports imperative and reactive programming styles.
+2. Remove the use of the `ThreadLocal` entirely. This change is paramount for a reactive programming style.
+3. Guard users from operations they shouldn't touch. The biggest example of this, was the previous `UnitOfWork#commit`
+   operation that **was not** intended to be used by users.
+
+To that end, we broke down the `UnitOfWork` interface into two interfaces and a concrete implementation, being:
+
+1. The `ProcessingLifecycle`, describing methods to register actions into distinct `ProcessingLifeCycle.Phases`, thus
+   managing the "lifecycle of a process."
+2. The `ProcessingContext`, an implementation of the `ProcessingLifecycle` adding resource management.
+3. The `UnitOfWork`, an implementation of the `ProcessingContext` and thus `ProcessingLifecycle`.
+
+The user is intended to interface with the `ProcessingLifecycle` when they need to add actions before/after/during
+pre-defined `ProcessingLifecycle.DefaultPhases`.
+This will allow us, and them, to customize processes like message handling.
+Furthermore, the `ProcessingLifecycle` works with a `CompletableFuture` throughout.
+
+The `ProcessingContext` will in turn provide the space to register resources to be used throughout the
+`ProcessingLifecycle`.
+Although roughly similar to the previous resource management of the old `UnitOfWork`, we intend this format to replace
+the use of the `ThreadLocal`.
+As such, you will notice that the `ProcessingContext` will become a parameter throughout virtually all infrastructure
+interfaces Axon Framework provides.
+
+It is the replacement of the interfaces with the old `UnitOfWork`, and the spreading of the `ProcessingContext`
+instead of the `UnitOfWork` directly, will ensure that operation that are not intended for the end user cannot be
+accessed easily anymore.
+
+To conclude, here is a list of changes to take into account concerning the `UnitOfWork`:
+
+1. Operations like `start()`, `commit()`, and `rollback()` are no longer available for the user directly.
+2. The nesting functionality of the old `UnitOfWork` through operations like `parent()` and `root()` are completely
+   removed.
+3. The `UnitOfWork` used to revolve around a `Message`, which is no longer the case for the `ProcessingContext`/
+   `ProcessingLifeycle`. Instead, the new approach revolves around a generic action, that may or may not return a
+   result.
+4. You are no longer tied to the predefined not-started, started, prepare-commit, commit, after-commit, rollback,
+   clean-up, and closed phases. Instead, the default phases now are pre-invocation, invocation, post-invocation,
+   prepare-commit, commit, and after-commit.
+5. The default phases are ordered through the use of an `int`, with space between them to add action before, after, or
+   during any phase.
+6. The `rollback` logic has been replaced by an on-error, on-complete, and on-finally flow.
+   `ProcessingLifecycle#onError` registers an action to be taken on error, while `whenComplete` registers an action to
+   performed when after worked as intended. `ProcessingLifecycle#doFinally` registers an operation that is performed on
+   success **and** failure of the `ProcessingLifecycle`.
+7. Correlation data management, and thus construction of the initial `MetaData` of any `Message`, is removed entirely.
+   This is inline with the `UnitOfWork` no longer revolving around a `Message`.
+8. The "current" `UnitOfWork` (including the `CurrentUnitOfWork`) is no longer a concept. Instead, all infrastructure
+   components will pass along the current context by containing the `ProcessingContext` as a parameter throughout.
+
+Note that the rewrite of the `UnitOfWork` has caused _a lot_ of API changes and numerous removals. For an exhaustive
+list of the latter, please check [here](#removed).
 
 Other API changes
 =================

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -34,5 +34,11 @@ Moved / Remove Classes
 
 ### Removed
 
-| Class | Why |
-|-------|-----|
+| Class                                                           | Why                                                                                       |
+|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| org.axonframework.messaging.unitofwork.AbstractUnitOfWork       | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |
+| org.axonframework.messaging.unitofwork.BatchingUnitOfWork       | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |
+| org.axonframework.messaging.unitofwork.CurrentUnitOfWork        | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |
+| org.axonframework.messaging.unitofwork.DefaultUnitOfWork        | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |
+| org.axonframework.messaging.unitofwork.ExecutionResult          | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |
+| org.axonframework.messaging.unitofwork.MessageProcessingContext | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work)) |

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -14,7 +14,7 @@ Major API Changes
   recommended resolution path in the JavaDoc. It is strongly recommended to (1) upgrade to the latest Axon Framework 4
   version, (2) adjust any deprecations from Axon Framework you are using as recommended, and then (3) to make the change
   towards Axon Framework 5.
-* The entire API of the `UnitOfWork` has been rewritten to (1) construct an " async-native" flow to support both an
+* The entire API of the `UnitOfWork` has been rewritten to (1) construct an 'async-native' flow to support both an
   imperative and reactive style of programming, (2) eliminate the use of `ThreadLocal`, and (3) protect users from
   internals APIs. This does mean that any direct interaction with the `UnitOfWork` has become a breaking change. Please
   check the [Unit of Work](#unit-of-work) section for more details if you are facing this predicament.

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/StubProcessingContext.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/StubProcessingContext.java
@@ -36,52 +36,6 @@ public class StubProcessingContext implements ProcessingContext {
     private final Map<ResourceKey<?>, Object> resources = new ConcurrentHashMap<>();
 
     @Override
-    public boolean containsResource(ResourceKey<?> key) {
-        return resources.containsKey(key);
-    }
-
-    @Override
-    public <T> T updateResource(ResourceKey<T> key, Function<T, T> updateFunction) {
-        //noinspection unchecked
-        return (T) resources.compute(key, (id, current) -> updateFunction.apply((T) current));
-    }
-
-    @Override
-    public <T> T getResource(ResourceKey<T> key) {
-        //noinspection unchecked
-        return (T) resources.get(key);
-    }
-
-    @Override
-    public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> supplier) {
-        //noinspection unchecked
-        return (T) resources.computeIfAbsent(key, k -> supplier.get());
-    }
-
-    @Override
-    public <T> T putResource(ResourceKey<T> key, T instance) {
-        //noinspection unchecked
-        return (T) resources.put(key, instance);
-    }
-
-    @Override
-    public <T> T putResourceIfAbsent(ResourceKey<T> key, T newValue) {
-        //noinspection unchecked
-        return (T) resources.putIfAbsent(key, newValue);
-    }
-
-    @Override
-    public <T> T removeResource(ResourceKey<T> key) {
-        //noinspection unchecked
-        return (T) resources.remove(key);
-    }
-
-    @Override
-    public <T> boolean removeResource(ResourceKey<T> key, T expectedInstance) {
-        return resources.remove(key, expectedInstance);
-    }
-
-    @Override
     public boolean isStarted() {
         return false;
     }
@@ -103,16 +57,62 @@ public class StubProcessingContext implements ProcessingContext {
 
     @Override
     public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
-        throw new UnsupportedOperationException("Lifecycle handlers not yet supported in StubProcessingContext");
+        throw new UnsupportedOperationException("Lifecycle actions are not yet supported in the StubProcessingContext");
     }
 
     @Override
     public ProcessingLifecycle onError(ErrorHandler action) {
-        throw new UnsupportedOperationException("Lifecycle handlers not yet supported in StubProcessingContext");
+        throw new UnsupportedOperationException("Lifecycle actions are not yet supported in the StubProcessingContext");
     }
 
     @Override
     public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
-        throw new UnsupportedOperationException("Lifecycle handlers not yet supported in StubProcessingContext");
+        throw new UnsupportedOperationException("Lifecycle actions are not yet supported in the StubProcessingContext");
+    }
+
+    @Override
+    public boolean containsResource(ResourceKey<?> key) {
+        return resources.containsKey(key);
+    }
+
+    @Override
+    public <T> T getResource(ResourceKey<T> key) {
+        //noinspection unchecked
+        return (T) resources.get(key);
+    }
+
+    @Override
+    public <T> T putResource(ResourceKey<T> key, T resource) {
+        //noinspection unchecked
+        return (T) resources.put(key, resource);
+    }
+
+    @Override
+    public <T> T updateResource(ResourceKey<T> key, Function<T, T> resourceUpdater) {
+        //noinspection unchecked
+        return (T) resources.compute(key, (id, current) -> resourceUpdater.apply((T) current));
+    }
+
+    @Override
+    public <T> T putResourceIfAbsent(ResourceKey<T> key, T resource) {
+        //noinspection unchecked
+        return (T) resources.putIfAbsent(key, resource);
+    }
+
+    @Override
+    public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> resourceSupplier) {
+        //noinspection unchecked
+        return (T) resources.computeIfAbsent(key, k -> resourceSupplier.get());
+    }
+
+    @Override
+    public <T> T removeResource(ResourceKey<T> key) {
+        //noinspection unchecked
+        return (T) resources.remove(key);
+    }
+
+    @Override
+    public <T> boolean removeResource(ResourceKey<T> key, T expectedResource) {
+        return resources.remove(key, expectedResource);
     }
 }

--- a/messaging/src/main/java/org/axonframework/common/FutureUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/FutureUtils.java
@@ -22,24 +22,26 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 
 /**
- * TODO Add/enhance documentation as described in #2966.
+ * Utility class containing reusable functionality for interacting with the {@link CompletableFuture}.
  *
  * @author Allard Buijze
+ * @since 5.0.0
  */
 public abstract class FutureUtils {
 
     private FutureUtils() {
+        // Utility class
     }
 
     /**
-     * Utility method that doesn't do anything. Its purpose is to simplify conversion of a {@code CompletableFuture}
+     * Utility method that doesn't do anything. Its purpose is to simplify conversion of a {@link CompletableFuture}
      * with any generic type to a {@code CompletableFuture<Void>}.
      * <p>
      * Example: {@code completableFuture.thenApply(FutureUtils::ignoreResult}
      *
-     * @param toIgnore the actual result of the completable future
-     * @param <T>      the declared result of the completable future to ignore the result of
-     * @return {@code null}, as that's the only valid value for Void
+     * @param toIgnore The actual result of the {@link CompletableFuture}.
+     * @param <T>      The declared result of the {@link CompletableFuture} to ignore the result of.
+     * @return {@code null}, as that's the only valid value for {@link Void}.
      */
     @SuppressWarnings("UnusedReturnValue")
     public static <T> Void ignoreResult(@SuppressWarnings("unused") T toIgnore) {
@@ -47,22 +49,23 @@ public abstract class FutureUtils {
     }
 
     /**
-     * Creates a CompletableFuture that was completed with the {@code null} value.
+     * Creates a completed {@link CompletableFuture} with {@code null} as result.
      *
-     * @param <T> The declared type to return in the CompletableFuture
-     * @return a CompletableFuture that is completed with a {@code null} value
+     * @param <T> The declared type to return in the {@link CompletableFuture}.
+     * @return A {@link CompletableFuture} that is completed with {@code null}.
      */
     public static <T> CompletableFuture<T> emptyCompletedFuture() {
         return CompletableFuture.completedFuture(null);
     }
 
     /**
-     * Creates a function that can be passed to a CompletableFuture to complete given {@code future} with the same
-     * result as the CompletableFuture that this function is passed to
+     * Creates a function that can be passed to a {@link CompletableFuture#whenComplete(BiConsumer)} or
+     * {@link CompletableFuture#whenCompleteAsync(BiConsumer)} invocation, to complete the given {@code future} with the
+     * same result as the {@link CompletableFuture} that this function is passed to.
      *
-     * @param future The future to complete
-     * @param <T>    The declared type of result from the CompletableFuture
-     * @return a function that completes another future with the same results
+     * @param future The {@link CompletableFuture} to also complete.
+     * @param <T>    The declared type of result from the {@link CompletableFuture}.
+     * @return A function that completes another {@code future} with the same results.
      */
     public static <T> BiConsumer<T, Throwable> alsoComplete(CompletableFuture<T> future) {
         return (r, e) -> {
@@ -75,17 +78,18 @@ public abstract class FutureUtils {
     }
 
     /**
-     * Unwrap given {@code exception} from wrappers added by CompletableFuture. More specifically, if the given
-     * {@code exception} is a {@link CompletionException} or {@link ExecutionException}, it returns the cause.
-     * Otherwise, it will return the exception as-is.
+     * Unwrap given {@code exception} from the exception-wrappers added by {@link CompletableFuture}.
+     * <p>
+     * More specifically, if the given {@code exception} is a {@link CompletionException} or {@link ExecutionException},
+     * it returns the cause. Otherwise, it will return the exception as-is.
      *
-     * @param exception The exception to unwrap
-     * @return the unwrapped exception
+     * @param exception The exception to unwrap.
+     * @return The unwrapped exception if the given {@code exception} is of type {@link CompletionException} or
+     * {@link ExecutionException}. Otherwise, it is returned as is.
      */
     public static Throwable unwrap(Throwable exception) {
-        if (exception instanceof CompletionException || exception instanceof ExecutionException) {
-            return exception.getCause();
-        }
-        return exception;
+        return exception instanceof CompletionException || exception instanceof ExecutionException
+                ? exception.getCause()
+                : exception;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWork.java
@@ -37,7 +37,7 @@ import java.util.function.Consumer;
  * @author Allard Buijze
  * @since 3.0
  */
-@Deprecated
+@Deprecated // TODO #3064 Remove once old UnitOfWork is removed
 public abstract class AbstractUnitOfWork<T extends Message<?>> implements UnitOfWork<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractUnitOfWork.class);

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWork.java
@@ -22,7 +22,15 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * TODO Add/enhance documentation as described in #2966.
+ * This class represents a Unit of Work that monitors the processing of a task.
+ * <p/>
+ * As an implementation of the {@link ProcessingLifecycle}, steps can be attached in several
+ * {@link ProcessingContext.DefaultPhases phases} of the Unit of Work to ensure the task-to-process is taken care off
+ * correctly. Furthermore, the Unit of Work implements resource management through the {@link ProcessingContext},
+ * providing the possibility to carry along resources throughout the phases.
+ * <p/>
+ * It is strongly recommended to interface with the {@code ProcessingLifecycle} and/or {@code ProcessingContext} instead
+ * of with the {@link AsyncUnitOfWork} directly.
  *
  * @author Allard Buijze
  * @author Gerard Klijs
@@ -30,8 +38,7 @@ import java.util.function.Supplier;
  * @author Mitchell Herrijgers
  * @author Sara Pellegrini
  * @author Steven van Beelen
- * <p>
- * TODO rename class once old UnitOfWork is removed
+ * @since 0.6
  */
 // TODO #3064 - Rename to UnitOfWork once old version is removed.
 public class AsyncUnitOfWork implements ProcessingLifecycle {
@@ -41,22 +48,35 @@ public class AsyncUnitOfWork implements ProcessingLifecycle {
     private final String identifier;
     private final UnitOfWorkProcessingContext context;
 
+
+    /**
+     * Constructs a {@link AsyncUnitOfWork} with a {@link UUID#randomUUID() random UUID String}. Will execute provided
+     * actions on the same thread invoking this Unit of Work.
+     */
     public AsyncUnitOfWork() {
         this(UUID.randomUUID().toString());
     }
 
+    /**
+     * Constructs a {@link AsyncUnitOfWork} with the given {@code identifier}. Will execute provided actions on the same
+     * thread invoking this Unit of Work.
+     *
+     * @param identifier The identifier of this Unit of Work.
+     */
     public AsyncUnitOfWork(String identifier) {
         this(identifier, Runnable::run);
     }
 
+    /**
+     * Constructs a {@link AsyncUnitOfWork} with the given {@code identifier}, processing actions through the given
+     * {@code workScheduler}.
+     *
+     * @param identifier    The identifier of this Unit of Work.
+     * @param workScheduler The {@link Executor} used to process the steps attached to the phases in this Unit of Work
+     */
     public AsyncUnitOfWork(String identifier, Executor workScheduler) {
         this.identifier = identifier;
         this.context = new UnitOfWorkProcessingContext(identifier, workScheduler);
-    }
-
-    @Override
-    public String toString() {
-        return "AsyncUnitOfWork{" + "id='" + identifier + '\'' + "phase='" + context.currentPhase.get() + '\'' + '}';
     }
 
     @Override
@@ -96,56 +116,78 @@ public class AsyncUnitOfWork implements ProcessingLifecycle {
     }
 
     /**
-     * Executes all the registered handlers in their respective phases.
+     * Executes all the registered action in their respective
+     * {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.Phase phases}.
      *
-     * @return a {@link CompletableFuture} that returns normally when the Unit Of Work has been committed or
-     * exceptionally with the exception that caused the Unit of Work to have been rolled back.
+     * @return A {@link CompletableFuture} that returns normally when this Unit Of Work has been committed or
+     * exceptionally with the exception that caused the Unit of Work to fail.
      */
     public CompletableFuture<Void> execute() {
         return context.commit();
     }
 
     /**
-     * Registers the given invocation for the {@link DefaultPhases#INVOCATION Invocation Phase} and executes the Unit of
-     * Work. The return value of the invocation is returned when this Unit of Work is committed.
+     * Registers the given {@code action} for the {@link DefaultPhases#INVOCATION invocation Phase} and executes this
+     * Unit of Work right away.
+     * <p>
+     * The return value of the given {@code action} is returned when this Unit of Work is committed, disregarding
+     * intermittent results of actions registered in other
+     * {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.Phase phases}.
      *
-     * @param invocation The handler to execute in the {@link DefaultPhases#INVOCATION Invocation Phase}
-     * @param <R>        The type of return value returned by the invocation
-     * @return a CompletableFuture that returns normally with the return value of the invocation when the Unit Of Work
-     * has been committed or exceptionally with the exception that caused the Unit of Work to have been rolled back.
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @param <R>    The type of return value returned by the {@code action}.
+     * @return A {@link CompletableFuture} that returns normally with the return value of the given {@code action} when
+     * the Unit Of Work has been committed. Or, an exceptionally completed future with the exception that caused this
+     * Unit of Work to fail.
      */
-    public <R> CompletableFuture<R> executeWithResult(Function<ProcessingContext, CompletableFuture<R>> invocation) {
+    public <R> CompletableFuture<R> executeWithResult(Function<ProcessingContext, CompletableFuture<R>> action) {
         CompletableFuture<R> result = new CompletableFuture<>();
-        onInvocation(p -> safe(() -> invocation.apply(p)).whenComplete(FutureUtils.alsoComplete(result)));
+        onInvocation(context -> safe(() -> action.apply(context)).whenComplete(FutureUtils.alsoComplete(result)));
         return execute().thenCombine(result, (executeResult, invocationResult) -> invocationResult);
     }
 
-    private <R> CompletableFuture<R> safe(Callable<CompletableFuture<R>> apply) {
+    /**
+     * Wraps a given {@code action} in a try-catch block to ensure exceptions are exclusively returned as a failed
+     * {@link CompletableFuture}.
+     *
+     * @param action A {@link Callable} to execute within the try-catch block.
+     * @return A {@link CompletableFuture} wrapping both the successful and exceptional result of the given
+     * {@code action}.
+     */
+    private <R> CompletableFuture<R> safe(Callable<CompletableFuture<R>> action) {
         try {
-            return apply.call();
+            return action.call();
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
+    @Override
+    public String toString() {
+        return "UnitOfWork{" + "identifier='" + identifier + '\'' + "phase='" + context.currentPhase.get() + '\'' + '}';
+    }
+
     private static class UnitOfWorkProcessingContext implements ProcessingContext {
 
-        private final ConcurrentNavigableMap<Phase, Queue<Function<ProcessingContext, CompletableFuture<?>>>> phaseHandlers = new ConcurrentSkipListMap<>(
-                Comparator.comparingInt(Phase::order));
-        private final AtomicReference<Phase> currentPhase = new AtomicReference<>(null);
-        private final ConcurrentMap<ResourceKey<?>, Object> resources = new ConcurrentHashMap<>();
         private final AtomicReference<Status> status = new AtomicReference<>(Status.NOT_STARTED);
-        private final Queue<ErrorHandler> errorHandlers = new ConcurrentLinkedQueue<>();
+        private final AtomicReference<Phase> currentPhase = new AtomicReference<>(null);
+
+        private final ConcurrentNavigableMap<Phase, Queue<Function<ProcessingContext, CompletableFuture<?>>>> phaseActions =
+                new ConcurrentSkipListMap<>(Comparator.comparingInt(Phase::order));
         private final Queue<Consumer<ProcessingContext>> completeHandlers = new ConcurrentLinkedQueue<>();
-        private final String name;
-        private final Executor workScheduler;
+        private final Queue<ErrorHandler> errorHandlers = new ConcurrentLinkedQueue<>();
         private final AtomicReference<CauseAndPhase> errorCause = new AtomicReference<>();
 
-        public UnitOfWorkProcessingContext(String name, Executor workScheduler) {
-            this.name = name;
+        private final ConcurrentMap<ResourceKey<?>, Object> resources = new ConcurrentHashMap<>();
+
+        private final String identifier;
+        private final Executor workScheduler;
+
+        private UnitOfWorkProcessingContext(String identifier, Executor workScheduler) {
+            this.identifier = identifier;
             this.workScheduler = workScheduler;
         }
-
 
         @Override
         public boolean isStarted() {
@@ -165,8 +207,183 @@ public class AsyncUnitOfWork implements ProcessingLifecycle {
         @Override
         public boolean isCompleted() {
             Status currentStatus = status.get();
-            return currentStatus == Status.COMPLETED
-                    || currentStatus == Status.COMPLETED_ERROR;
+            return currentStatus == Status.COMPLETED || currentStatus == Status.COMPLETED_ERROR;
+        }
+
+        @Override
+        public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+            var current = currentPhase.get();
+            if (current != null && phase.order() <= current.order()) {
+                throw new IllegalStateException(
+                        "Failed to register handler in phase " + phase + " (" + phase.order() + "). "
+                                + "ProcessingContext is already in phase " + current + " (" + current.order() + ")."
+                );
+            }
+            phaseActions.computeIfAbsent(phase, p -> new ConcurrentLinkedQueue<>())
+                        .add(safe(phase, action));
+            return this;
+        }
+
+        /**
+         * Wraps a given {@code action}, that is to be executed in the given {@code phase}, in a try-catch block to
+         * ensure exceptions are exclusively returned as a failed {@link CompletableFuture}.
+         *
+         * @param phase  The original phase instance the handler is registered under
+         * @param action The {@link Function} to perform safely. It's given the active {@link ProcessingContext} and
+         *               returns a {@link CompletableFuture} for chaining purposes and to carry the action's result.
+         * @return A {@link CompletableFuture} wrapping both the successful and exceptional result of the given
+         * {@code action}.
+         */
+        private Function<ProcessingContext, CompletableFuture<?>> safe(
+                Phase phase, Function<ProcessingContext, CompletableFuture<?>> action
+        ) {
+            return context -> {
+                CompletableFuture<?> result;
+                try {
+                    result = action.apply(context);
+                } catch (Exception e) {
+                    result = CompletableFuture.failedFuture(e);
+                }
+
+                return result.exceptionallyCompose((e) -> {
+                    if (!errorCause.compareAndSet(null, new CauseAndPhase(phase, e))) {
+                        errorCause.get().cause().addSuppressed(e);
+                    }
+                    return CompletableFuture.failedFuture(e);
+                });
+            };
+        }
+
+        @Override
+        public ProcessingLifecycle onError(ErrorHandler action) {
+            ErrorHandler silentAction = failSilently(action);
+            this.errorHandlers.add(silentAction);
+            var currentStatus = status.get();
+
+            if (currentStatus == Status.COMPLETED_ERROR && errorHandlers.remove(silentAction)) {
+                // When in the COMPLETED_ERROR status, execute immediately.
+                // The removal attempt is to make sure that we aren't concurrently executing from the registering thread
+                // as well as the thread that completed the processing context.
+                CauseAndPhase causeAndPhase = errorCause.get();
+                silentAction.handle(this, causeAndPhase.phase(), causeAndPhase.cause());
+            }
+            return this;
+        }
+
+        private ErrorHandler failSilently(ErrorHandler action) {
+            return (context, phase, exception) -> {
+                try {
+                    action.handle(context, phase, exception);
+                } catch (Throwable ex) {
+                    logger.warn("An onError handler threw an exception.", ex);
+                }
+            };
+        }
+
+        @Override
+        public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+            Consumer<ProcessingContext> silentAction = completeSilently(action);
+            this.completeHandlers.add(silentAction);
+            var currentStatus = status.get();
+
+            if (currentStatus == Status.COMPLETED && completeHandlers.remove(silentAction)) {
+                // When in the COMPLETED status, execute immediately.
+                // The removal attempt is to make sure that we aren't concurrently executing from the registering thread
+                // as well as the thread that completed the processing context.
+                silentAction.accept(this);
+            }
+            return this;
+        }
+
+        private Consumer<ProcessingContext> completeSilently(Consumer<ProcessingContext> action) {
+            return context -> {
+                try {
+                    action.accept(context);
+                } catch (Throwable e) {
+                    logger.warn("A Completion handler threw an exception.", e);
+                }
+            };
+        }
+
+        private CompletableFuture<Void> commit() {
+            if (!status.compareAndSet(Status.NOT_STARTED, Status.STARTED)) {
+                throw new IllegalStateException(
+                        "Cannot switch [" + status.get() + "] to STARTED. "
+                                + "This ProcessingContext cannot be committed (again)."
+                );
+            }
+
+            return executeAllPhaseHandlers()
+                    .thenRun(this::runCompletionHandlers)
+                    .exceptionallyCompose(this::runErrorHandlers);
+        }
+
+        private CompletableFuture<Void> executeAllPhaseHandlers() {
+            if (phaseActions.isEmpty()) {
+                // We're done.
+                return FutureUtils.emptyCompletedFuture();
+            }
+
+            CompletableFuture<Void> nextPhaseResult = runNextPhase().toCompletableFuture();
+            // Avoid stack overflow due to recursion when executed in single thread.
+            while (!phaseActions.isEmpty() && nextPhaseResult.isDone()) {
+                if (nextPhaseResult.isCompletedExceptionally()) {
+                    return nextPhaseResult;
+                } else {
+                    nextPhaseResult = runNextPhase().toCompletableFuture();
+                }
+            }
+            return nextPhaseResult.thenCompose(result -> executeAllPhaseHandlers());
+        }
+
+        private void runCompletionHandlers() {
+            status.set(Status.COMPLETED);
+
+            while (!completeHandlers.isEmpty()) {
+                Consumer<ProcessingContext> nextCompletionHandler = completeHandlers.poll();
+                if (nextCompletionHandler != null) {
+                    workScheduler.execute(() -> nextCompletionHandler.accept(this));
+                }
+            }
+        }
+
+        private CompletionStage<Void> runErrorHandlers(Throwable e) {
+            status.set(Status.COMPLETED_ERROR);
+            CauseAndPhase recordedCause = errorCause.get();
+
+            while (!errorHandlers.isEmpty()) {
+                ErrorHandler nextErrorHandler = errorHandlers.poll();
+                if (nextErrorHandler != null) {
+                    workScheduler.execute(
+                            () -> nextErrorHandler.handle(this, recordedCause.phase(), recordedCause.cause())
+                    );
+                }
+            }
+            return CompletableFuture.failedFuture(e);
+        }
+
+        private CompletableFuture<Void> runNextPhase() {
+            if (phaseActions.isEmpty()) {
+                return FutureUtils.emptyCompletedFuture();
+            }
+            Phase current = phaseActions.firstKey();
+            currentPhase.set(current);
+
+            Queue<Function<ProcessingContext, CompletableFuture<?>>> actionQueue = phaseActions.remove(current);
+            if (actionQueue == null || actionQueue.isEmpty()) {
+                logger.debug("Skipping phase {} (with order [{}]), since no actions are registered.",
+                             current, current.order());
+                return FutureUtils.emptyCompletedFuture();
+            }
+            logger.debug("Calling {}# actions in phase {} (with order {}).",
+                         actionQueue.size(), current, current.order());
+
+            return actionQueue.stream()
+                              .map(handler -> FutureUtils.emptyCompletedFuture()
+                                                         .thenComposeAsync(result -> handler.apply(this), workScheduler)
+                                                         .thenAccept(FutureUtils::ignoreResult))
+                              .reduce(CompletableFuture::allOf)
+                              .orElseGet(FutureUtils::emptyCompletedFuture);
         }
 
         @Override
@@ -181,27 +398,27 @@ public class AsyncUnitOfWork implements ProcessingLifecycle {
         }
 
         @Override
-        public <T> T updateResource(ResourceKey<T> key, Function<T, T> update) {
+        public <T> T putResource(ResourceKey<T> key, T resource) {
             //noinspection unchecked
-            return (T) resources.compute(key, (k, v) -> update.apply((T) v));
+            return (T) resources.put(key, resource);
         }
 
         @Override
-        public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> instance) {
+        public <T> T updateResource(ResourceKey<T> key, Function<T, T> resourceUpdater) {
             //noinspection unchecked
-            return (T) resources.computeIfAbsent(key, t -> instance.get());
+            return (T) resources.compute(key, (k, v) -> resourceUpdater.apply((T) v));
         }
 
         @Override
-        public <T> T putResource(ResourceKey<T> key, T instance) {
+        public <T> T putResourceIfAbsent(ResourceKey<T> key, T resource) {
             //noinspection unchecked
-            return (T) resources.put(key, instance);
+            return (T) resources.putIfAbsent(key, resource);
         }
 
         @Override
-        public <T> T putResourceIfAbsent(ResourceKey<T> key, T newValue) {
+        public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> resourceSupplier) {
             //noinspection unchecked
-            return (T) resources.putIfAbsent(key, newValue);
+            return (T) resources.computeIfAbsent(key, t -> resourceSupplier.get());
         }
 
         @Override
@@ -211,179 +428,29 @@ public class AsyncUnitOfWork implements ProcessingLifecycle {
         }
 
         @Override
-        public <T> boolean removeResource(ResourceKey<T> key, T expectedInstance) {
-            return resources.remove(key, expectedInstance);
-        }
-
-        @Override
-        public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
-            var p = currentPhase.get();
-            if (p != null && phase.order() <= p.order()) {
-                throw new IllegalStateException("Failed to register handler in phase " + phase + " (" + phase.order()
-                                                        + "). ProcessingContext is already in phase " + p + " ("
-                                                        + p.order() + ")");
-            }
-            phaseHandlers.computeIfAbsent(phase, k -> new ConcurrentLinkedQueue<>()).add(safe(phase, action));
-            return this;
-        }
-
-        @Override
-        public ProcessingLifecycle onError(ErrorHandler action) {
-            ErrorHandler silentAction = failSilently(action);
-            this.errorHandlers.add(silentAction);
-            var p = status.get();
-            if (p == Status.COMPLETED_ERROR && errorHandlers.remove(silentAction)) {
-                // when in the completed phase, execute immediately
-                // the removal attempt is to make sure that we aren't concurrently executing from the registering thread
-                // as well as the thread that completed the processing context.
-                CauseAndPhase causeAndPhase = errorCause.get();
-                silentAction.handle(this, causeAndPhase.phase(), causeAndPhase.cause());
-            }
-            return this;
-        }
-
-        @Override
-        public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
-            Consumer<ProcessingContext> silentAction = completeSilently(action);
-            this.completeHandlers.add(silentAction);
-            var p = status.get();
-            if (p == Status.COMPLETED && completeHandlers.remove(silentAction)) {
-                // when in the completed phase, execute immediately
-                // the removal attempt is to make sure that we aren't concurrently executing from the registering thread
-                // as well as the thread that completed the processing context.
-                silentAction.accept(this);
-            }
-            return this;
-        }
-
-        private ErrorHandler failSilently(ErrorHandler action) {
-            return (pc, ph, e) -> {
-                try {
-                    action.handle(pc, ph, e);
-                } catch (Throwable ex) {
-                    logger.warn("An onError handler threw an exception.", ex);
-                }
-            };
-        }
-
-        private Consumer<ProcessingContext> completeSilently(Consumer<ProcessingContext> action) {
-            return p -> {
-                try {
-                    action.accept(p);
-                } catch (Throwable e) {
-                    logger.warn("A Completion handler threw an exception.", e);
-                }
-            };
-        }
-
-        /**
-         * Wraps a given action to ensure exceptions are exclusively returned as a failed CompetableFuture and ensures
-         * any exceptions or failures are registered in the processing context for the error handlers.
-         *
-         * @param phase  The original phase instance the handler is registered under
-         * @param action The action to perform in this phase
-         * @return a safe handler that doesn't throw unchecked exception
-         */
-        private Function<ProcessingContext, CompletableFuture<?>> safe(
-                Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
-            return c -> {
-                CompletableFuture<?> result;
-                try {
-                    result = action.apply(c);
-                } catch (Exception e) {
-                    result = CompletableFuture.failedFuture(e);
-                }
-                return result.exceptionallyCompose((e) -> {
-                    if (!errorCause.compareAndSet(null, new CauseAndPhase(phase, e))) {
-                        errorCause.get().cause().addSuppressed(e);
-                    }
-                    return CompletableFuture.failedFuture(e);
-                });
-            };
-        }
-
-        public CompletableFuture<Void> commit() {
-            if (!status.compareAndSet(Status.NOT_STARTED, Status.STARTED)) {
-                throw new IllegalStateException("ProcessingContext cannot be committed (again)");
-            }
-
-            return executeAllPhaseHandlers()
-                    .thenRun(this::runCompletionHandlers)
-                    .exceptionallyCompose(this::invokeErrorHandlers);
-        }
-
-        private CompletableFuture<Void> executeAllPhaseHandlers() {
-            if (phaseHandlers.isEmpty()) {
-                // we're done
-                return FutureUtils.emptyCompletedFuture();
-            }
-            CompletableFuture<Void> nextPhaseResult = runNextPhase().toCompletableFuture();
-            // Avoid stack overflow due to recursion when executed in single thread
-            while (!phaseHandlers.isEmpty() && nextPhaseResult.isDone()) {
-                if (nextPhaseResult.isCompletedExceptionally()) {
-                    return nextPhaseResult;
-                } else {
-                    nextPhaseResult = runNextPhase().toCompletableFuture();
-                }
-            }
-            return nextPhaseResult.thenCompose(r -> executeAllPhaseHandlers());
-        }
-
-        private void runCompletionHandlers() {
-            status.set(Status.COMPLETED);
-            while (!completeHandlers.isEmpty()) {
-                Consumer<ProcessingContext> next = completeHandlers.poll();
-                if (next != null) {
-                    this.workScheduler.execute(() -> next.accept(this));
-                }
-            }
-        }
-
-        private CompletionStage<Void> invokeErrorHandlers(Throwable e) {
-            CauseAndPhase recordedCause = errorCause.get();
-            status.set(Status.COMPLETED_ERROR);
-            while (!errorHandlers.isEmpty()) {
-                ErrorHandler next = errorHandlers.poll();
-                if (next != null) {
-                    this.workScheduler.execute(() -> next.handle(this, recordedCause.phase(), recordedCause.cause()));
-                }
-            }
-            return CompletableFuture.failedFuture(e);
-        }
-
-        private CompletableFuture<Void> runNextPhase() {
-            if (phaseHandlers.isEmpty()) {
-                return FutureUtils.emptyCompletedFuture();
-            }
-            Phase phase = phaseHandlers.firstKey();
-            currentPhase.set(phase);
-
-            Queue<Function<ProcessingContext, CompletableFuture<?>>> handlers = phaseHandlers.remove(phase);
-            if (handlers == null || handlers.isEmpty()) {
-                logger.debug("Skipping phase {} (seq {}). No handlers registered", phase, phase.order());
-                return FutureUtils.emptyCompletedFuture();
-            }
-            logger.debug("Calling {} handlers in phase {} (seq {}).", handlers.size(), phase, phase.order());
-
-            return handlers.stream()
-                           .map(handler -> FutureUtils.emptyCompletedFuture()
-                                                      .thenComposeAsync(r -> handler.apply(this), workScheduler)
-                                                      .thenAccept(FutureUtils::ignoreResult))
-                           .reduce(CompletableFuture::allOf)
-                           .orElseGet(FutureUtils::emptyCompletedFuture);
+        public <T> boolean removeResource(ResourceKey<T> key, T expectedResource) {
+            return resources.remove(key, expectedResource);
         }
 
         @Override
         public String toString() {
-            return "UnitOfWorkProcessingContext{" + "name='" + name + '\'' + ", currentPhase=" + currentPhase.get()
+            return "UnitOfWorkProcessingContext{"
+                    + "identifier='" + identifier + '\'' + ", currentPhase=" + currentPhase.get()
                     + '}';
         }
 
         private enum Status {
-
             NOT_STARTED, STARTED, COMPLETED_ERROR, COMPLETED
         }
 
+        /**
+         * Tuple combining the given {@code phase} and {@code cause} to be used during the invocation of registered
+         * {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.ErrorHandler ErrorHandlers}.
+         *
+         * @param phase The {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.Phase} in which the given
+         *              {@code cause} was thrown.
+         * @param cause The {@link Throwable} thrown in an action executed in the given {@code phase}.
+         */
         private record CauseAndPhase(Phase phase, Throwable cause) {
 
         }

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWork.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
  * <p>
  * TODO rename class once old UnitOfWork is removed
  */
+// TODO #3064 - Rename to UnitOfWork once old version is removed.
 public class AsyncUnitOfWork implements ProcessingLifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(AsyncUnitOfWork.class);

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWork.java
@@ -42,7 +42,7 @@ import static org.axonframework.messaging.GenericResultMessage.asResultMessage;
  * @author Allard Buijze
  * @since 3.0
  */
-@Deprecated
+@Deprecated // TODO #3064 Remove once old AbstractUnitOfWork is removed
 public class BatchingUnitOfWork<T extends Message<?>> extends AbstractUnitOfWork<T> {
 
     private final List<MessageProcessingContext<T>> processingContexts;

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/CurrentUnitOfWork.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
  * @author Allard Buijze
  * @since 0.6
  */
+@Deprecated // TODO #3064 Remove when AsyncUnitOfWork is fully integrated
 public abstract class CurrentUnitOfWork {
 
     private static final ThreadLocal<Deque<UnitOfWork<?>>> CURRENT = new ThreadLocal<>();

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/DefaultUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/DefaultUnitOfWork.java
@@ -34,7 +34,7 @@ import static org.axonframework.messaging.GenericResultMessage.asResultMessage;
  * @author Allard Buijze
  * @since 0.6
  */
-@Deprecated
+@Deprecated // TODO #3064 Remove once old AbstractUnitOfWork is removed
 public class DefaultUnitOfWork<T extends Message<?>> extends AbstractUnitOfWork<T> {
 
     private final MessageProcessingContext<T> processingContext;

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/ExecutionResult.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/ExecutionResult.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  *
  * @author Rene de Waele
  */
+@Deprecated // TODO #3064 Remove when AsyncUnitOfWork is fully integrated
 public class ExecutionResult {
 
     private final ResultMessage<?> result;

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/MessageProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/MessageProcessingContext.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
  * @author Rene de Waele
  * @since 3.0
  */
+@Deprecated // TODO #3064 Remove when AsyncUnitOfWork is fully integrated
 public class MessageProcessingContext<T extends Message<?>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageProcessingContext.class);

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/NoProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/NoProcessingContext.java
@@ -21,51 +21,21 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * No-op implementation of the {@link ProcessingContext}.
+ *
+ * @author Allard Buijze
+ * @since 5.0.0
+ */
 public class NoProcessingContext implements ProcessingContext {
 
+    /**
+     * Constant of the {@link NoProcessingContext} to be used as a single reference.
+     */
     public static final NoProcessingContext INSTANCE = new NoProcessingContext();
 
     private NoProcessingContext() {
-    }
-
-    @Override
-    public boolean containsResource(ResourceKey<?> key) {
-        return false;
-    }
-
-    @Override
-    public <T> T updateResource(ResourceKey<T> key, Function<T, T> updateFunction) {
-        throw new IllegalStateException("Cannot update resourced in this ProcessingContext");
-    }
-
-    @Override
-    public <T> T getResource(ResourceKey<T> key) {
-        return null;
-    }
-
-    @Override
-    public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> supplier) {
-        throw new IllegalStateException("Cannot update resourced in this ProcessingContext");
-    }
-
-    @Override
-    public <T> T putResource(ResourceKey<T> key, T instance) {
-        throw new IllegalStateException("Cannot update resourced in this ProcessingContext");
-    }
-
-    @Override
-    public <T> T putResourceIfAbsent(ResourceKey<T> key, T newValue) {
-        throw new IllegalStateException("Cannot update resourced in this ProcessingContext");
-    }
-
-    @Override
-    public <T> T removeResource(ResourceKey<T> key) {
-        return null;
-    }
-
-    @Override
-    public <T> boolean removeResource(ResourceKey<T> key, T expectedInstance) {
-        return expectedInstance == null;
+        // No-arg constructor
     }
 
     @Override
@@ -90,16 +60,56 @@ public class NoProcessingContext implements ProcessingContext {
 
     @Override
     public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
-        throw new UnsupportedOperationException("Cannot register lifecycle handlers in this ProcessingContext");
+        throw new UnsupportedOperationException("Cannot register lifecycle actions in this ProcessingContext");
     }
 
     @Override
     public ProcessingLifecycle onError(ErrorHandler action) {
-        throw new UnsupportedOperationException("Cannot register lifecycle handlers in this ProcessingContext");
+        throw new UnsupportedOperationException("Cannot register lifecycle actions in this ProcessingContext");
     }
 
     @Override
     public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
-        throw new UnsupportedOperationException("Cannot register lifecycle handlers in this ProcessingContext");
+        throw new UnsupportedOperationException("Cannot register lifecycle actions in this ProcessingContext");
+    }
+
+    @Override
+    public boolean containsResource(ResourceKey<?> key) {
+        return false;
+    }
+
+    @Override
+    public <T> T getResource(ResourceKey<T> key) {
+        return null;
+    }
+
+    @Override
+    public <T> T putResource(ResourceKey<T> key, T resource) {
+        throw new IllegalArgumentException("Cannot put resources in this ProcessingContext");
+    }
+
+    @Override
+    public <T> T updateResource(ResourceKey<T> key, Function<T, T> resourceUpdater) {
+        throw new IllegalArgumentException("Cannot update resources in this ProcessingContext");
+    }
+
+    @Override
+    public <T> T putResourceIfAbsent(ResourceKey<T> key, T resource) {
+        throw new IllegalArgumentException("Cannot put resources in this ProcessingContext");
+    }
+
+    @Override
+    public <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> resourceSupplier) {
+        throw new IllegalArgumentException("Cannot compute resources in this ProcessingContext");
+    }
+
+    @Override
+    public <T> T removeResource(ResourceKey<T> key) {
+        return null;
+    }
+
+    @Override
+    public <T> boolean removeResource(ResourceKey<T> key, T expectedResource) {
+        return expectedResource == null;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/ProcessingContext.java
@@ -4,7 +4,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * TODO Add/enhance documentation as described in #2966.
+ * Implementation of the {@link ProcessingLifecycle} adding resource management operations.
+ * <p>
+ * It is recommended to construct a {@link ResourceKey} instance when adding/updating/removing resources from the
+ * {@link ProcessingContext} to allow cross-referral by sharing the key or personalization when the resource should be
+ * private to a specific service..
  *
  * @author Allard Buijze
  * @author Gerard Klijs
@@ -12,116 +16,133 @@ import java.util.function.Supplier;
  * @author Mitchell Herrijgers
  * @author Sara Pellegrini
  * @author Steven van Beelen
+ * @since 5.0.0
  */
 public interface ProcessingContext extends ProcessingLifecycle {
 
+    /**
+     * Constant referring to a no-op {@link ProcessingContext} implementation, the {@link NoProcessingContext}.
+     */
     ProcessingContext NONE = NoProcessingContext.INSTANCE;
 
     /**
-     * Indicates whether a resource has been registered with the given {@code key} in this processing context
+     * Indicates whether a resource has been registered with the given {@code key} in this {@link ProcessingContext}.
      *
-     * @param key The key of the resource to check
-     * @return {@code true} if a resource is registered with this key, otherwise {@code false}
+     * @param key The key of the resource to check.
+     * @return {@code true} if a resource is registered with this {@code key}, otherwise {@code false}.
      */
     boolean containsResource(ResourceKey<?> key);
 
     /**
-     * Update the resource with given {@code key} using the given {@code updateFunction} to describe the update. If no
-     * resource is registered with the given {@code key}, the updateFunction is invoked with {@code null}. Otherwise,
-     * the function is called with the currently registered resource under that key.
+     * Returns the resource currently registered under the given {@code key}, or {@code null} if no resource is
+     * present.
+     *
+     * @param key The key to retrieve the resource for.
+     * @param <T> The type of resource registered under the given {@code key}.
+     * @return The resource currently registered under given {@code key}, or {@code null} if not present.
+     */
+    <T> T getResource(ResourceKey<T> key);
+
+    /**
+     * Register the given {@code resource} under the given {@code key}.
+     *
+     * @param key      The key under which to register the {@code resource}.
+     * @param resource The resource to register.
+     * @param <T>      The type of {@code resource} to register under given @code.
+     * @return The previously registered {@code resource}, or {@code null} if none was present.
+     */
+    <T> T putResource(ResourceKey<T> key, T resource);
+
+    /**
+     * Update the resource with given {@code key} using the given {@code resourceUpdater} to describe the update. If no
+     * resource is registered with the given {@code key}, the {@code resourceUpdater} is invoked with {@code null}.
+     * Otherwise, the function is called with the currently registered resource under that key.
      * <p>
      * The resource is replaced with the return value of the function, or removed when the function returns
      * {@code null}.
      * <p>
      * If the function throws an exception, the exception is rethrown to the caller.
      *
-     * @param key            The key to update the resource for
-     * @param updateFunction The function performing the update itself
-     * @param <T>            the type of resource to update
-     * @return the new value associated with the key, or {@code null} when removed
+     * @param key             The key to update the resource for.
+     * @param resourceUpdater The function performing the update itself.
+     * @param <T>             The type of resource to update.
+     * @return The new value associated with the {@code key}, or {@code null} when removed.
      */
-    <T> T updateResource(ResourceKey<T> key, Function<T, T> updateFunction);
-
-    /**
-     * Returns the resource currently registered under given {@code key}, or {@code null} if no resource is present.
-     *
-     * @param key The key to retrieve the resource for
-     * @param <T> The type of resource registered under given key
-     * @return the resource currently registered under given {@code key}, or {@code null} if not present
-     */
-    <T> T getResource(ResourceKey<T> key);
-
-    /**
-     * If no resource is present for the given {@code key}, uses given {@code supplier} to supply the instance to
-     * register.
-     *
-     * @param key      The key to register the resource for
-     * @param supplier The function to supply the instance to register
-     * @param <T>      The type of resource registered under given key
-     * @return the resource associated with the key
-     */
-    <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> supplier);
-
-    /**
-     * Register the given {@code instance} under the given {@code key}.
-     *
-     * @param key      The key under which to register the resource
-     * @param instance The instance to register
-     * @param <T>      The type of resource to register under given key
-     * @return the previously registered instance, or {@code null} if none was present
-     */
-    <T> T putResource(ResourceKey<T> key, T instance);
+    <T> T updateResource(ResourceKey<T> key, Function<T, T> resourceUpdater);
 
     /**
      * Register the given {@code instance} under the given {@code key} if no value is currently present.
      *
-     * @param key      The key under which to register the resource
-     * @param newValue The value to register
-     * @param <T>      The type of resource to register under given key
-     * @return the resource previously associated with given key
+     * @param key      The key under which to register the resource.
+     * @param resource The resource to register when nothing is present for the given {@code key}.
+     * @param <T>      The type of {@code resource} to register under given {@code key}.
+     * @return The resource previously associated with given {@code key}.
      */
-    <T> T putResourceIfAbsent(ResourceKey<T> key, T newValue);
+    <T> T putResourceIfAbsent(ResourceKey<T> key, T resource);
+
+    /**
+     * If no resource is present for the given {@code key}, the given {@code resourceSupplier} is used to supply the
+     * instance to register under this {@code key}.
+     *
+     * @param key              The key to register the resource for.
+     * @param resourceSupplier The function to supply the resource to register.
+     * @param <T>              The type of resource registered under given {@code key}.
+     * @return The resource associated with the {@code key}.
+     */
+    <T> T computeResourceIfAbsent(ResourceKey<T> key, Supplier<T> resourceSupplier);
 
     /**
      * Removes the resource registered under given {@code key}.
      *
-     * @param key The key to remove the registered resource for
-     * @param <T> The type of resource associated with the key
-     * @return the value previously associated with the key
+     * @param key The key to remove the registered resource for.
+     * @param <T> The type of resource associated with the {@code key}.
+     * @return The value previously associated with the {@code key}.
      */
     <T> T removeResource(ResourceKey<T> key);
 
     /**
-     * Remove the resource associated with given {@code key} if the given {@code expectedInstance} is the currently
+     * Remove the resource associated with given {@code key} if the given {@code expectedResource} is the currently
      * associated value.
      *
-     * @param key              The key to remove the registered resource for
-     * @param expectedInstance The expected instance to remove
-     * @param <T>              The type of resource associated with the key
-     * @return {@code true} if the resource has been removed, otherwise {@code false}
+     * @param key              The key to remove the registered resource for.
+     * @param expectedResource The expected resource to remove.
+     * @param <T>              The type of resource associated with the {@code key}.
+     * @return {@code true} if the resource has been removed, otherwise {@code false}.
      */
-    <T> boolean removeResource(ResourceKey<T> key, T expectedInstance);
+    <T> boolean removeResource(ResourceKey<T> key, T expectedResource);
 
-    default <T> ProcessingContext branchedWithResource(ResourceKey<T> resourceKey, T resource) {
-        return new ResourceOverridingProcessingContext<>(this, resourceKey, resource);
+    /**
+     * Constructs a new {@link ProcessingContext}, branching off from {@code this} {@code ProcessingContext}. The given
+     * {@code resource} as added to the branched {@code ProcessingContext} under the given {@code key}.
+     *
+     * @param key      The key under which to register the {@code resource} in the branched {@link ProcessingContext}.
+     * @param resource The resource to register in the branched {@link ProcessingContext}.
+     * @param <T>      The type of resource associated with the {@code key}.
+     * @return A new {@link ProcessingContext}, branched off from {@code this} {@code ProcessingContext}.
+     */
+    default <T> ProcessingContext branchedWithResource(ResourceKey<T> key, T resource) {
+        return new ResourceOverridingProcessingContext<>(this, key, resource);
     }
 
     /**
      * Object that is used as a key to retrieve and register resources of a given type in a processing context.
      * <p>
-     * Implementations are encouraged to override the {@code toString()} method to include some information useful for
+     * Implementations are encouraged to override the {@link #toString()} method to include some information useful for
      * debugging.
      * <p>
-     * Instance of a ResourceKey can be created using {@link ResourceKey#create(String)}
+     * Instance of a {@code ResourceKey} can be created using {@link ResourceKey#create(String)}.
      *
-     * @param <T> The type of resource registered under this key
+     * @param <T> The type of resource registered under this key.
      */
-    @SuppressWarnings("unused") final class ResourceKey<T> {
+    @SuppressWarnings("unused") // Suppresses the warning that the generic type is not used.
+    final class ResourceKey<T> {
+
+        private static final String RESOURCE_KEY_PREFIX = "ResourceKey@";
 
         private final String toString;
 
         private ResourceKey(String debugString) {
-            String keyId = "ResourceKey@" + Integer.toHexString(System.identityHashCode(this));
+            String keyId = RESOURCE_KEY_PREFIX + Integer.toHexString(System.identityHashCode(this));
             if (debugString == null || debugString.isBlank()) {
                 this.toString = keyId;
             } else {
@@ -130,12 +151,13 @@ public interface ProcessingContext extends ProcessingLifecycle {
         }
 
         /**
-         * Create a new Key for a resource of given type {@code T}. The given {@code debugString} is part of the
-         * {@code toString()} of the created key instance and may be used for debugging purposes.
+         * Create a new {@link ResourceKey} for a resource of type {@code T}. The given {@code debugString} is part of
+         * the {@link #toString()} (if not {@code null} or empty) of the created key instance and may be used for
+         * debugging purposes.
          *
-         * @param debugString A String to recognize this key during debugging
-         * @param <T>         The type of resource to register under this key
-         * @return a new key used to register and retrieve resources
+         * @param debugString A {@link String} to recognize this key during debugging.
+         * @param <T>         The type of resource of this key.
+         * @return A new key used to register and retrieve resources.
          */
         public static <T> ResourceKey<T> create(String debugString) {
             return new ResourceKey<>(debugString);

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/ProcessingLifecycle.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/ProcessingLifecycle.java
@@ -7,7 +7,20 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * TODO Add/enhance documentation as described in #2966.
+ * Interface dedicate to managing the lifecycle of any process.
+ * <p/>
+ * Throughout the lifecycle of any process, actions need to be taken in different phases. Numerous
+ * {@link DefaultPhases default phases} are defined that are used throughout the framework for these actions. The
+ * {@link ProcessingLifecycle} has shorthand operations corresponding to these {@code DefaultPhases}. For example, the
+ * {@link #onPreInvocation(Function)} uses the {@link DefaultPhases#PRE_INVOCATION} phase.
+ * <p/>
+ * When the {@link ProcessingLifecycle#isStarted() ProcessingLifecycle is started}, the phases are invoked beginning
+ * with the lowest {@link Phase#order()}, moving up until all phase actions are executed. Note that actions registered
+ * in a {@code Phase} with the same order may be executed in parallel.
+ * <p/>
+ * If necessary, a custom {@link Phase} can be defined that can be invoked before <b>or</b> after any other
+ * {@code Phase}. To ensure it is invoked before/after one of the {@code DefaultPhases}, set the {@link Phase#order()}
+ * to a value higher/lower than the {@code DefaultPhase} you want the step to occur before or after.
  *
  * @author Allard Buijze
  * @author Gerard Klijs
@@ -15,19 +28,64 @@ import java.util.function.Function;
  * @author Mitchell Herrijgers
  * @author Sara Pellegrini
  * @author Steven van Beelen
+ * @since 5.0.0
  */
 public interface ProcessingLifecycle {
 
+    /**
+     * Returns {@code true} when this {@link ProcessingLifecycle} is started, {@code false} otherwise.
+     *
+     * @return {@code true} when this {@link ProcessingLifecycle} is started, {@code false} otherwise.
+     */
     boolean isStarted();
 
+    /**
+     * Returns {@code true} when this {@link ProcessingLifecycle} is in error, {@code false} otherwise.
+     * <p>
+     * When {@code true}, the {@link #onError(ErrorHandler) registered ErrorHandlers} will be invoked.
+     *
+     * @return {@code true} when this {@link ProcessingLifecycle} is in error, {@code false} otherwise.
+     */
     boolean isError();
 
+    /**
+     * Returns {@code true} when this {@link ProcessingLifecycle} is committed, {@code false} otherwise.
+     *
+     * @return {@code true} when this {@link ProcessingLifecycle} is committed, {@code false} otherwise.
+     */
     boolean isCommitted();
 
+    /**
+     * Returns {@code true} when this {@link ProcessingLifecycle} is completed, {@code false} otherwise.
+     * <p>
+     * Note that this {@code ProcessingLifecycle} is marked as completed for a successful and failed completion.
+     *
+     * @return {@code true} when this {@link ProcessingLifecycle} is completed, {@code false} otherwise.
+     */
     boolean isCompleted();
 
+    /**
+     * Registers the provided {@code action} to be executed in the given {@code phase}. Uses the
+     * {@link CompletableFuture} returned by the {@code action} to compose actions and to carry the action's result.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param phase  The {@link Phase} to execute the given {@code action} in.
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action);
 
+    /**
+     * Registers the provided {@code action} to be executed in the given {@code phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param phase  The {@link Phase} to execute the given {@code action} in.
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOn(Phase phase, Consumer<ProcessingContext> action) {
         return on(phase, c -> {
             action.accept(c);
@@ -35,58 +93,197 @@ public interface ProcessingLifecycle {
         });
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#PRE_INVOCATION pre-invocation phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onPreInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PRE_INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#PRE_INVOCATION pre-invocation phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnPreInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PRE_INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the {@link DefaultPhases#INVOCATION invocation phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the {@link DefaultPhases#INVOCATION invocation phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#POST_INVOCATION post invocation phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onPostInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.POST_INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#POST_INVOCATION post invocation phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnPostInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.POST_INVOCATION, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#PREPARE_COMMIT prepare commit phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onPrepareCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PREPARE_COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#PREPARE_COMMIT prepare commit phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnPrepareCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PREPARE_COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the {@link DefaultPhases#COMMIT commit phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the {@link DefaultPhases#COMMIT commit phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#AFTER_COMMIT after commit phase}.
+     * <p>
+     * Use this operation when the return value of the {@code action} is important.
+     *
+     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle onAfterCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.AFTER_COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed in the
+     * {@link DefaultPhases#AFTER_COMMIT after commit phase}.
+     * <p>
+     * Use this operation when there is no need for a return value of the registered {@code action}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle runOnAfterCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.AFTER_COMMIT, action);
     }
 
+    /**
+     * Registers the provided {@code action} to be executed when this {@link ProcessingLifecycle} encounters an error
+     * during the action of any {@link Phase}. This includes failures from actions registered through
+     * {@link #whenComplete(Consumer)}.
+     * <p>
+     * When the given {@link ErrorHandler ErrorHandlers} are invoked {@link #isError()} and {@link #isCompleted()} will
+     * return {@code true}.
+     *
+     * @param action The error handler to execute when this {@link ProcessingLifecycle} encounters an error during phase
+     *               execution.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     ProcessingLifecycle onError(ErrorHandler action);
 
+    /**
+     * Registers the provided {@code action} to be executed when this {@link ProcessingLifecycle} completes <b>all</b>
+     * registered actions.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action);
 
+    /**
+     * Registers the provided {@code action} to be executed {@link #onError(ErrorHandler) on error} of <b>and</b>
+     * {@link #whenComplete(Consumer) when completing} this {@link ProcessingLifecycle}.
+     * <p>
+     * Note that if the given {@code action} throws an exception when completing this {@code ProcessingLifecycle} it
+     * will be invoked <em>again</em> as an on {@link ErrorHandler}.
+     *
+     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
+     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     */
     default ProcessingLifecycle doFinally(Consumer<ProcessingContext> action) {
         onError((c, p, e) -> action.accept(c));
         whenComplete(action);
@@ -94,26 +291,47 @@ public interface ProcessingLifecycle {
     }
 
     /**
-     * Interface describing a component that gets notified when an error is detected within a Processing Context
+     * Functional interface describing an operation that's invoked when an error is detected within the
+     * {@link ProcessingLifecycle}.
+     *
+     * @author Allard Buijze
+     * @author Gerard Klijs
+     * @author Milan Savić
+     * @author Mitchell Herrijgers
+     * @author Sara Pellegrini
+     * @author Steven van Beelen
+     * @since 5.0.0
      */
     @FunctionalInterface
     interface ErrorHandler {
 
         /**
-         * Invoked when an error is detected in a Processing Context and its lifecycle has been aborted. The state of
-         * the lifecycle will always return {@code true} for {@link ProcessingContext#isError()} and
-         * {@link ProcessingContext#isCompleted()}.
+         * Invoked when an error is detected in a {@link ProcessingLifecycle} and it has been aborted.
+         * <p>
+         * In this state, the lifecycle will <b>always</b> return {@code true} for {@link ProcessingContext#isError()}
+         * and {@link ProcessingContext#isCompleted()}.
          *
-         * @param processingContext The context in which the error occurred
-         * @param phase             The phase used to register the handler which caused the ProcessingContext to fail
-         * @param error             The exception or error describing the cause
+         * @param processingContext The context in which the error occurred.
+         * @param phase             The phase used to register the handler which caused the {@link ProcessingLifecycle}
+         *                          to fail.
+         * @param error             The exception or error describing the cause.
          */
         void handle(ProcessingContext processingContext, Phase phase, Throwable error);
     }
 
     /**
-     * Interface describing a possible Phase for a ProcessingLifecycle. Lifecycle handlers are invoked in the order of
-     * their respective phase, where handlers in phases with the same order may be invoked in parallel.
+     * Interface describing a possible phase for the {@link ProcessingLifecycle} to perform steps in.
+     * <p>
+     * Lifecycle actions are invoked in the {@link #order()} of their respective phase, where action in phases with the
+     * same order may be invoked in parallel.
+     *
+     * @author Allard Buijze
+     * @author Gerard Klijs
+     * @author Milan Savić
+     * @author Mitchell Herrijgers
+     * @author Sara Pellegrini
+     * @author Steven van Beelen
+     * @since 5.0.0
      */
     interface Phase {
 
@@ -121,29 +339,75 @@ public interface ProcessingLifecycle {
          * The order of this phase compared to other phases. Phases with the same order are considered "simultaneous"
          * and may have their handlers invoked in parallel.
          *
-         * @return the int describing the relative order of this phase
+         * @return The {@code int} describing the relative order of this phase.
          */
         int order();
 
+        /**
+         * Checks if the {@link Phase#order()} of {@code this Phase} is <b>smaller</b> than the order of the
+         * {@code other}. Returns {@code true} if this is the case and {@code false} otherwise.
+         *
+         * @param other The {@link Phase} to validate if its {@link Phase#order() order} is larger than the order of
+         *              {@code this Phase}.
+         * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>smaller</b> than the order of
+         * the {@code other Phase}.
+         */
         default boolean isBefore(Phase other) {
             return this.order() < other.order();
         }
 
+        /**
+         * Checks if the {@link Phase#order()} of {@code this Phase} is <b>larger</b> than the order of the
+         * {@code other}. Returns {@code true} if this is the case and {@code false} otherwise.
+         *
+         * @param other The {@link Phase} to validate if its {@link Phase#order() order} is smaller than the order of
+         *              {@code this Phase}.
+         * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>larger</b> than the order of
+         * the {@code other Phase}.
+         */
         default boolean isAfter(Phase other) {
             return this.order() > other.order();
         }
     }
 
     /**
-     * Default phases used for the shorthand methods in the ProcessingLifecycle
+     * Default phases used for the shorthand methods in the {@link ProcessingLifecycle}.
+     *
+     * @author Allard Buijze
+     * @author Gerard Klijs
+     * @author Milan Savić
+     * @author Mitchell Herrijgers
+     * @author Sara Pellegrini
+     * @author Steven van Beelen
+     * @since 5.0.0
      */
     enum DefaultPhases implements Phase {
 
+        /**
+         * Phase used to contain actions that occur <b>before</b> the main invocation. Has an order of {@code -10000}.
+         */
         PRE_INVOCATION(-10000),
+        /**
+         * Phase used to contain actions that occur <b>during</b> the main invocation. Has an order of {@code 0}.
+         */
         INVOCATION(0),
+        /**
+         * Phase used to contain actions that occur <b>after</b> the main invocation. Has an order of {@code 10000}.
+         */
         POST_INVOCATION(10000),
+        /**
+         * Phase used to contain actions to prepare the commit of the {@link ProcessingLifecycle}. Has an order of
+         * {@code 20000}.
+         */
         PREPARE_COMMIT(20000),
+        /**
+         * Phase used to contain actions to commit of the {@link ProcessingLifecycle}. Has an order of {@code 30000}.
+         */
         COMMIT(30000),
+        /**
+         * Phase used to contain actions to execute after the commit of the {@link ProcessingLifecycle}. Has an order of
+         * {@code 40000}.
+         */
         AFTER_COMMIT(40000);
 
         private final int order;

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/UnitOfWork.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
  * @author Allard Buijze
  * @since 0.6
  */
-@Deprecated
+@Deprecated // TODO #3064 Remove when AsyncUnitOfWork is fully integrated
 public interface UnitOfWork<T extends Message<?>> {
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/AsyncUnitOfWorkTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Sara Pellegrini
  * @author Steven van Beelen
  */
+// TODO #3064 - Rename to UnitOfWorkTest once old version is removed.
 class AsyncUnitOfWorkTest extends ProcessingLifecycleTest<AsyncUnitOfWork> {
 
     @Override
@@ -97,17 +98,7 @@ class AsyncUnitOfWorkTest extends ProcessingLifecycleTest<AsyncUnitOfWork> {
         }
     }
 
-    private class CustomPhase implements ProcessingLifecycle.Phase {
+    private record CustomPhase(int order) implements ProcessingLifecycle.Phase {
 
-        private final int order;
-
-        public CustomPhase(int order) {
-            this.order = order;
-        }
-
-        @Override
-        public int order() {
-            return order;
-        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/ProcessingLifecycleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/ProcessingLifecycleTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Test suite for implementations of the {@link ProcessingLifecycle}.
  *
  * @param <PL> The implementation of the {@link ProcessingLifecycle} being tested.
+ * @author Allard Buijze
  * @author Gerard Klijs
  * @author Milan Savić
  * @author Sara Pellegrini


### PR DESCRIPTION
This pull request serves as an addition to #2953.
We merged #2953 as it was a very important milestone, mandatory to proceed with working on other infrastructure components.
However, as the Unit of Work rewrite and introduction of the `ProcessingLifecycle` and `ProcessingContext` are extremely central to Axon Framework, I deemed an early revamp of the JavaDoc and API changes documentation to be paramount for further development.

Hence, that is exactly what this pull request does.
It adds JavaDoc, adjusts JavaDoc, renames parameters, reorders variables and methods, and further cleans up any irregularities to provide a strong basis for proceeding with Axon Framework 5's development.

Added, as the `UnitOfWork`, and the other deprecated and soon-to-be-removed implementations of this `UnitOfWork,` are part of the public API, I have drafted an explanation in the `api-changes.md` file.
This file will guide us during the construction of a migration guide and help users who prefer to jump on the bandwagon quickly.

By doing the above, this PR resolves #2966.