### PR TITLE
Adjust the `AbstractMethodPropertyAccessStrategy` to filter better on none-matching methods 

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
@@ -54,8 +54,18 @@ public abstract class AbstractMethodPropertyAccessStrategy extends PropertyAcces
         return Arrays.stream(targetClass.getMethods())
                      .filter(method -> method.getName().equals(methodName))
                      .filter(method -> method.getParameterCount() == 0)
-                     .filter(method -> !method.getReturnType().equals(Void.TYPE))
+                     .filter(this::isNotReturningVoid)
                      .findFirst();
+    }
+
+    private boolean isNotReturningVoid(Method method) {
+        boolean returnsVoid = method.getReturnType().equals(Void.TYPE);
+        if (returnsVoid && logger.isDebugEnabled()) {
+            logger.debug(
+                    "Method with name '{}' in '{}' cannot be accepted as a property accessor, as it returns void",
+                    method.getName(), method.getDeclaringClass().getName());
+        }
+        return !returnsVoid;
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
@@ -39,28 +39,23 @@ public abstract class AbstractMethodPropertyAccessStrategy extends PropertyAcces
     @Override
     public <T> Property<T> propertyFor(Class<? extends T> targetClass, String property) {
         String methodName = getterName(property);
-        try {
-            final Method method = targetClass.getMethod(methodName);
-            if (!Void.TYPE.equals(method.getReturnType())) {
-                return new MethodAccessedProperty<>(method, property);
-            }
-            logger.debug(
-                    "Method with name '{}' in '{}' cannot be accepted as a property accessor, as it returns void",
-                    methodName, targetClass.getName());
-        } catch (NoSuchMethodException e) {
+        Optional<Method> method = getMethod(targetClass, methodName);
+        if (!method.isPresent()) {
             logger.debug("No method with name '{}' found in {} to use as property accessor. " +
                                  "Attempting to fall back to other strategies.",
                          methodName, targetClass.getName());
+            return null;
+        } else {
+            return new MethodAccessedProperty<>(method.get(), property);
         }
-        return null;
     }
 
     private <T> Optional<Method> getMethod(Class<T> targetClass, String methodName) {
         return Arrays.stream(targetClass.getMethods())
-                .filter(method -> method.getName().equals(methodName))
-                .filter(method -> method.getParameterCount() == 0)
-                .filter(method -> !method.getReturnType().equals(Void.TYPE))
-                .findFirst();
+                     .filter(method -> method.getName().equals(methodName))
+                     .filter(method -> method.getParameterCount() == 0)
+                     .filter(method -> !method.getReturnType().equals(Void.TYPE))
+                     .findFirst();
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/AbstractMethodPropertyAccessStrategy.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Abstract implementation of the PropertyAccessStrategy that uses a no-arg, public method to access the property
@@ -51,6 +53,14 @@ public abstract class AbstractMethodPropertyAccessStrategy extends PropertyAcces
                          methodName, targetClass.getName());
         }
         return null;
+    }
+
+    private <T> Optional<Method> getMethod(Class<T> targetClass, String methodName) {
+        return Arrays.stream(targetClass.getMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .filter(method -> method.getParameterCount() == 0)
+                .filter(method -> !method.getReturnType().equals(Void.TYPE))
+                .findFirst();
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
@@ -16,10 +16,19 @@
 
 package org.axonframework.common.property;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BeanPropertyAccessStrategyTest extends
         AbstractPropertyAccessStrategyTest<BeanPropertyAccessStrategyTest.TestMessage> {
+
+    private static final Logger log = LoggerFactory.getLogger(BeanPropertyAccessStrategyTest.class);
 
     @Override
     protected String exceptionPropertyName() {

--- a/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
@@ -55,6 +55,33 @@ public class BeanPropertyAccessStrategyTest extends
         return new BeanPropertyAccessStrategy().propertyFor(TestMessage.class, property);
     }
 
+    /**
+     * Before the Performance optimization(avoiding exceptions) for each event a lot of events were thrown, if the
+     * accessors the access do not follow the Bean Standard, but follows the Record Standard. Furthermore, for
+     * aggregateId-Properties will be scanned, which also caused exceptions. The performance optimization decreased the
+     * CPU time by 65 %.
+     * <p/>
+     * Before the optimization 100,000 executions had a duration of around 355ms.</br> After the optimization 100,000
+     * executions had a duration of around 116ms.
+     * <p/>
+     * On a MacBook Pro M1 using jdk 21 the duration is around 105-130ms. I am not sure if this test can be used,
+     * because I don't know about the build environment and other developer environments.
+     */
+    @Test
+    @Timeout(value = 200, unit = TimeUnit.MILLISECONDS)
+    void testPerformanceWhenMethodNotExisting() {
+        BeanPropertyAccessStrategy beanPropertyAccess = new BeanPropertyAccessStrategy();
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 100000; i++) {
+            beanPropertyAccess.propertyFor(TestMessage.class, "notExistingProperty" + i);
+        }
+        long end = System.currentTimeMillis();
+        log.info("Used time: {} nanos", (end - start));
+        // 100,000 requests
+        // with exception -> 357 millis
+        // without exception -> 113 millis
+    }
+
     protected String voidPropertyName() {
         return "voidMethod";
     }

--- a/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
@@ -77,7 +77,7 @@ public class BeanPropertyAccessStrategyTest extends
             beanPropertyAccess.propertyFor(TestMessage.class, "notExistingProperty" + i);
         }
         long end = System.currentTimeMillis();
-        log.info("Used time: {} nanos", (end - start));
+        log.info("Used time: {} millis", (end - start));
     }
 
     protected String voidPropertyName() {

--- a/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,19 +56,24 @@ public class BeanPropertyAccessStrategyTest extends
     }
 
     /**
-     * Before the Performance optimization(avoiding exceptions) for each event a lot of events were thrown, if the
-     * accessors the access do not follow the Bean Standard, but follows the Record Standard. Furthermore, for
-     * aggregateId-Properties will be scanned, which also caused exceptions. The performance optimization decreased the
-     * CPU time by 65 %.
+     * The build server environment is very slow. Currently there is no strategy when and how to test the
+     * performance of this class. However, maybe in the future this code will be helpfull for someone.
      * <p/>
-     * Before the optimization 100,000 executions had a duration of around 355ms.</br> After the optimization 100,000
-     * executions had a duration of around 116ms.
+     * The suggested way to disable this test for the moment was to drop the test annotation.
      * <p/>
-     * On a MacBook Pro M1 using jdk 21 the duration is around 105-130ms. I am not sure if this test can be used,
-     * because I don't know about the build environment and other developer environments.
+     * The goal this test should be to keep the code fast. This can currently not be achieved, because
+     * the build servers are "slow".
+     * <p/>
+     * Facts on a MacBook Pro M1:<p/>
+     * Duration of the Test
+     * <ul>
+     *     <li>before the performance fix: 355ms<p/></li>
+     *     <li>after the performance fix: 116ms<p/></li>
+     * </ul>
      */
-    @Test
-    @Timeout(value = 200, unit = TimeUnit.MILLISECONDS)
+//    @Test
+//    @Timeout(value = 200, unit = TimeUnit.MILLISECONDS)
+    @SuppressWarnings("unused")
     void testPerformanceWhenMethodNotExisting() {
         BeanPropertyAccessStrategy beanPropertyAccess = new BeanPropertyAccessStrategy();
         long start = System.currentTimeMillis();
@@ -77,9 +82,6 @@ public class BeanPropertyAccessStrategyTest extends
         }
         long end = System.currentTimeMillis();
         log.info("Used time: {} nanos", (end - start));
-        // 100,000 requests
-        // with exception -> 357 millis
-        // without exception -> 113 millis
     }
 
     protected String voidPropertyName() {

--- a/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
+++ b/messaging/src/test/java/org/axonframework/common/property/BeanPropertyAccessStrategyTest.java
@@ -16,14 +16,10 @@
 
 package org.axonframework.common.property;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BeanPropertyAccessStrategyTest extends
         AbstractPropertyAccessStrategyTest<BeanPropertyAccessStrategyTest.TestMessage> {


### PR DESCRIPTION
This is a new merge request for the change already requested with pull request 3113.
It contains already changes based on the comments from Steven.

Following is the original description of the pull request 3113

___

In our project we are applying around 1,9 billion events in around 21 hours.
This is a migration of an old system, which happens weekly, as long as we are in developing the product. At least one additional year. In this migration only events are applied.

While applying events, I was wondering why the client uses 50 % of the CPU, while the Axon Server only needs around 5 %.
After profiling the client, I realized that about 65 % of the CPU Time was used for throwing exceptions while applying events.

This should be a fix, which decrease the CPU time and the duration of a property access by around 65 %.

One debug log message was removed in the case if the accessor method returns void. It is already filtered before, when getting the method. I hope the log message wasn't that important.

Concerning the test method for the performance:
I don't know your strategy for performance and also not about the build environment. The test works on my machine. Feel free to remove or adapt it to your needs.