### PR TITLE
Reduce the number of property lookups for matching entities

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
@@ -22,7 +22,9 @@ import org.axonframework.modelling.command.inspection.EntityModel;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
@@ -40,6 +42,12 @@ import static org.axonframework.common.property.PropertyAccessStrategy.getProper
 public class ForwardMatchingInstances<T extends Message<?>> implements ForwardingMode<T> {
 
     private static final String EMPTY_STRING = "";
+    /**
+     * Placeholder value for {@code null} properties, indicating that no property is available
+     */
+    private static final Property<Object> NO_PROPERTY = new NoProperty();
+
+    private final Map<Class, Property> routingProperties = new ConcurrentHashMap<>();
 
     private String routingKey;
     private EntityModel childEntity;
@@ -51,13 +59,16 @@ public class ForwardMatchingInstances<T extends Message<?>> implements Forwardin
                 .map(map -> (String) map.get("routingKey"))
                 .filter(key -> !Objects.equals(key, EMPTY_STRING))
                 .orElse(childEntity.routingKey());
+        routingProperties.clear();
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public <E> Stream<E> filterCandidates(@Nonnull T message, @Nonnull Stream<E> candidates) {
-        Property routingProperty = getProperty(message.getPayloadType(), routingKey);
-        if (routingProperty == null) {
+        Property routingProperty = routingProperties.computeIfAbsent(message.getPayloadType(),
+                                                                     this::resolveProperty);
+
+        if (routingProperty == null || routingProperty == NO_PROPERTY) {
             return Stream.empty();
         }
 
@@ -65,10 +76,27 @@ public class ForwardMatchingInstances<T extends Message<?>> implements Forwardin
         return candidates.filter(candidate -> matchesInstance(candidate, routingValue));
     }
 
+    private Property<?> resolveProperty(Class<?> runtimeType) {
+        Property<?> property = getProperty(runtimeType, routingKey);
+        if (property == null) {
+            return NO_PROPERTY;
+        }
+        return property;
+    }
+
     @SuppressWarnings("unchecked")
     private <E> boolean matchesInstance(E candidate, Object routingValue) {
         Object identifier = childEntity.getIdentifier(candidate);
 
         return Objects.equals(routingValue, identifier);
+    }
+
+    private static class NoProperty implements Property<Object> {
+
+        @Override
+        public <V> V getValue(Object target) {
+            // this code should never be reached
+            throw new UnsupportedOperationException("Property not found on target");
+        }
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/command/ForwardMatchingInstancesTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/ForwardMatchingInstancesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2024. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.modelling.command;
 
 import org.axonframework.common.property.Property;

--- a/modelling/src/test/java/org/axonframework/modelling/command/ForwardMatchingInstancesTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/ForwardMatchingInstancesTest.java
@@ -1,0 +1,183 @@
+package org.axonframework.modelling.command;
+
+import org.axonframework.common.property.Property;
+import org.axonframework.common.property.PropertyAccessStrategy;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.modelling.command.inspection.EntityModel;
+import org.hibernate.EntityMode;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ForwardMatchingInstancesTest {
+
+    EntityModel entityModel = mock();
+
+    ForwardMatchingInstances<Message<?>> testSubject;
+
+    @AggregateMember
+    Object stubEntityWithImplicitRoutingKey = null;
+
+    @AggregateMember(routingKey = "explicitRoutingKey")
+    Object stubEntityWithExplicitRoutingKey = null;
+
+    MockPropertyAccessStrategy mockAccessStrategy = mock();
+
+    @BeforeEach
+    void setUp() {
+        PropertyAccessStrategy.register(mockAccessStrategy);
+        testSubject = new ForwardMatchingInstances<>();
+        when(entityModel.routingKey()).thenReturn("implicitRoutingKey");
+    }
+
+    @AfterEach
+    void tearDown() {
+        PropertyAccessStrategy.unregister(mockAccessStrategy);
+    }
+
+    @Test
+    void useImplicitRoutingKeyWhenNotDefined() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithImplicitRoutingKey");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        Stream<String> result = testSubject.filterCandidates(new GenericMessage<>("Mock"), Stream.of(candidate1));
+
+        verify(mockAccessStrategy).propertyFor(String.class, "implicitRoutingKey");
+        assertEquals(0, result.count());
+    }
+
+    @Test
+    void useExplicitRoutingKeyWhenDefined() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithExplicitRoutingKey");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        Stream<String> result = testSubject.filterCandidates(new GenericMessage<>("Mock"), Stream.of(candidate1));
+
+        verify(mockAccessStrategy).propertyFor(String.class, "explicitRoutingKey");
+        assertEquals(0, result.count());
+    }
+
+    @Test
+    void candidateReturnedWhenPropertyMatchesIdentifier() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithExplicitRoutingKey");
+        Property<String> mockProperty = mock();
+        when(entityModel.getIdentifier(any())).thenReturn("ID");
+        when(mockAccessStrategy.propertyFor(String.class, "explicitRoutingKey")).thenReturn(mockProperty);
+        when(mockProperty.getValue(any())).thenReturn("ID");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        String payload = "Mock";
+        Stream<String> result = testSubject.filterCandidates(new GenericMessage<>(payload), Stream.of(candidate1));
+
+        verify(mockAccessStrategy).propertyFor(String.class, "explicitRoutingKey");
+        verify(mockProperty).getValue(same(payload));
+        assertEquals(1, result.count());
+    }
+
+    @Test
+    void candidateIgnoredWhenPropertyDoesNotMatchIdentifier() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithExplicitRoutingKey");
+        Property<String> mockProperty = mock();
+        when(entityModel.getIdentifier(any())).thenReturn("ID");
+        when(mockAccessStrategy.propertyFor(String.class, "explicitRoutingKey")).thenReturn(mockProperty);
+        when(mockProperty.getValue(any())).thenReturn("ID2");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        String payload = "Mock";
+        Stream<String> result = testSubject.filterCandidates(new GenericMessage<>(payload), Stream.of(candidate1));
+
+        verify(mockAccessStrategy).propertyFor(String.class, "explicitRoutingKey");
+        verify(mockProperty).getValue(same(payload));
+        assertEquals(0, result.count());
+    }
+
+    @Test
+    void secondRequestUsesCachedProperty() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithExplicitRoutingKey");
+        Property<String> mockProperty = mock();
+        when(entityModel.getIdentifier(any())).thenReturn("ID");
+        when(mockAccessStrategy.propertyFor(String.class, "explicitRoutingKey")).thenReturn(mockProperty);
+        when(mockProperty.getValue(any())).thenReturn("ID");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        String payload1 = "Mock1";
+        String payload2 = "Mock2";
+        Stream<String> result1 = testSubject.filterCandidates(new GenericMessage<>(payload1), Stream.of(candidate1));
+        Stream<String> result2 = testSubject.filterCandidates(new GenericMessage<>(payload2), Stream.of(candidate1));
+
+        // the access strategy is only consulted the first time or any payload
+        verify(mockAccessStrategy, times(1)).propertyFor(String.class, "explicitRoutingKey");
+        verify(mockProperty, times(1)).getValue(same(payload1));
+        verify(mockProperty, times(1)).getValue(same(payload2));
+        assertEquals(1, result1.count());
+        assertEquals(1, result2.count());
+    }
+
+    @Test
+    void secondRequestForDifferentPayloadUsesDifferentProperty() throws Exception {
+        Field member = getClass().getDeclaredField("stubEntityWithExplicitRoutingKey");
+        Property<String> mockStringProperty = mock();
+        Property<Long> mockLongProperty = mock();
+        when(entityModel.getIdentifier(any())).thenReturn("ID");
+        when(mockAccessStrategy.propertyFor(String.class, "explicitRoutingKey")).thenReturn(mockStringProperty);
+        when(mockStringProperty.getValue(any())).thenReturn("ID");
+        when(mockAccessStrategy.propertyFor(Long.class, "explicitRoutingKey")).thenReturn(mockLongProperty);
+        when(mockLongProperty.getValue(any())).thenReturn("ID");
+
+        testSubject.initialize(member, entityModel);
+
+        verify(entityModel).routingKey();
+
+        String candidate1 = "Candidate1";
+        String payload1 = "Mock1";
+        Long payload2 = 2L;
+        Stream<String> result1 = testSubject.filterCandidates(new GenericMessage<>(payload1), Stream.of(candidate1));
+        Stream<String> result2 = testSubject.filterCandidates(new GenericMessage<>(payload2), Stream.of(candidate1));
+
+        // the access strategy is only consulted the first time or any payload
+        verify(mockAccessStrategy, times(1)).propertyFor(String.class, "explicitRoutingKey");
+        verify(mockAccessStrategy, times(1)).propertyFor(Long.class, "explicitRoutingKey");
+        verify(mockStringProperty, times(1)).getValue(same(payload1));
+        verify(mockLongProperty, times(1)).getValue(same(payload2));
+        assertEquals(1, result1.count());
+        assertEquals(1, result2.count());
+    }
+
+
+    private abstract class MockPropertyAccessStrategy extends PropertyAccessStrategy {
+
+
+        @Override
+        public int getPriority() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public abstract <T> Property<T> propertyFor(Class<? extends T> targetClass, String property);
+    }
+}


### PR DESCRIPTION
This PR adds a cache to the properties that have been discovered in each of the message payloads that an entity has a handler for.

This prevents lookup of properties to occur for each instance of an event that is applied to an aggregate.

With this optimization, a lookup is only required for each new payload type that is being applied.