### PR TITLE
[#3123] Introduce `SubscriptionQueryResult#handle` default implementation that expects a `Consumer<Throwable>`

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryResult.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryResult.java
@@ -95,23 +95,23 @@ public interface SubscriptionQueryResult<I, U> extends Registration {
                                     try {
                                         updateConsumer.accept(update);
                                     } catch (Exception e) {
-                                        errorConsumer.accept(e);
                                         cancel();
+                                        errorConsumer.accept(e);
                                     }
                                 },
                                 throwable -> {
-                                    errorConsumer.accept(throwable);
                                     cancel();
+                                    errorConsumer.accept(throwable);
                                 }
                         );
                     } catch (Exception e) {
-                        errorConsumer.accept(e);
                         cancel();
+                        errorConsumer.accept(e);
                     }
                 },
                 throwable -> {
-                    errorConsumer.accept(throwable);
                     cancel();
+                    errorConsumer.accept(throwable);
                 }
         );
     }

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryResult.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@
 package org.axonframework.queryhandling;
 
 import org.axonframework.common.Registration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 
 /**
@@ -31,6 +34,8 @@ import java.util.function.Consumer;
  * @since 3.3
  */
 public interface SubscriptionQueryResult<I, U> extends Registration {
+
+    Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Subscribing to this mono will trigger invocation of query handler. The return value of that query handler will be
@@ -48,27 +53,66 @@ public interface SubscriptionQueryResult<I, U> extends Registration {
     Flux<U> updates();
 
     /**
-     * Delegates handling of initial result and incremental updates to the provided consumers. Subscription to the
-     * incremental updates is done after the initial result is retrieved and its consumer is invoked. If anything goes
-     * wrong during invoking or consuming initial result or incremental updates, subscription is cancelled.
+     * Delegates handling of initial result and incremental updates to the provided consumers.
+     * <p>
+     * Subscription to the incremental updates is done after the initial result is retrieved and its consumer is
+     * invoked. If anything goes wrong during invoking or consuming initial result or incremental updates, subscription
+     * is cancelled.
      *
-     * @param initialResultConsumer The consumer to be invoked when the initial result is retrieved
-     * @param updateConsumer        The consumer to be invoked when incremental updates are emitted
+     * @param initialResultConsumer The {@link Consumer} to be invoked when the initial result is retrieved.
+     * @param updateConsumer        The {@link Consumer} to be invoked when incremental updates are emitted.
+     * @deprecated Please use {@link #handle(Consumer, Consumer, Consumer)} instead, to consciously deal with any
+     * exceptions with the {@code errorConsumer}.
      */
+    @Deprecated
     default void handle(Consumer<? super I> initialResultConsumer, Consumer<? super U> updateConsumer) {
-        initialResult().subscribe(initialResult -> {
-            try {
-                initialResultConsumer.accept(initialResult);
-                updates().subscribe(i -> {
+        handle(initialResultConsumer, updateConsumer,
+               error -> logger.warn("Failed handle the initial result or an update", error));
+    }
+
+    /**
+     * Delegates handling of initial result and incremental updates to the provided consumers.
+     * <p>
+     * Subscription to the incremental updates is done after the initial result is retrieved and its consumer is
+     * invoked. If anything goes wrong during invoking or consuming initial result or incremental updates, subscription
+     * is cancelled <em>after</em> invoking the given {@code errorConsumer}.
+     *
+     * @param initialResultConsumer The {@link Consumer} to be invoked when the initial result is retrieved.
+     * @param updateConsumer        The {@link Consumer} to be invoked when incremental updates are emitted.
+     * @param errorConsumer         A {@link Consumer} of {@link Exception} used to react to an exception resulting from
+     *                              the {@link #initialResult()} or {@link #updates()}.
+     */
+    default void handle(Consumer<? super I> initialResultConsumer,
+                        Consumer<? super U> updateConsumer,
+                        Consumer<Throwable> errorConsumer) {
+        initialResult().subscribe(
+                initialResult -> {
                     try {
-                        updateConsumer.accept(i);
+                        initialResultConsumer.accept(initialResult);
+
+                        updates().subscribe(
+                                update -> {
+                                    try {
+                                        updateConsumer.accept(update);
+                                    } catch (Exception e) {
+                                        errorConsumer.accept(e);
+                                        cancel();
+                                    }
+                                },
+                                throwable -> {
+                                    errorConsumer.accept(throwable);
+                                    cancel();
+                                }
+                        );
                     } catch (Exception e) {
+                        errorConsumer.accept(e);
                         cancel();
                     }
-                });
-            } catch (Exception e) {
-                cancel();
-            }
-        }, t -> cancel());
+                },
+                throwable -> {
+                    errorConsumer.accept(throwable);
+                    cancel();
+                }
+        );
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultSubscriptionQueryResultTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultSubscriptionQueryResultTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2010-2024. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import org.junit.jupiter.api.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link DefaultSubscriptionQueryResult}.
+ *
+ * @author Steven van Beelen
+ */
+class DefaultSubscriptionQueryResultTest {
+
+    @Test
+    void handleInvokesErrorConsumerOnExceptionInTheInitialResult() {
+        AtomicBoolean canceled = new AtomicBoolean(false);
+        AtomicBoolean initialResultConsumed = new AtomicBoolean(false);
+        AtomicBoolean updateConsumed = new AtomicBoolean(false);
+        AtomicBoolean errorConsumed = new AtomicBoolean(false);
+
+        DefaultSubscriptionQueryResult<Object, Object> testSubject = new DefaultSubscriptionQueryResult<>(
+                Mono.error(new RuntimeException("oops")),
+                Flux.empty(),
+                () -> {
+                    canceled.set(true);
+                    return true;
+                }
+        );
+
+        testSubject.handle(initialResult -> initialResultConsumed.set(true),
+                           update -> updateConsumed.set(true),
+                           error -> errorConsumed.set(true));
+
+        assertTrue(canceled.get());
+        assertFalse(initialResultConsumed.get());
+        assertFalse(updateConsumed.get());
+        assertTrue(errorConsumed.get());
+    }
+
+    @Test
+    void handleInvokesErrorConsumerOnExceptionsInTheUpdates() {
+        AtomicBoolean canceled = new AtomicBoolean(false);
+        AtomicBoolean initialResultConsumed = new AtomicBoolean(false);
+        AtomicBoolean updateConsumed = new AtomicBoolean(false);
+        AtomicBoolean errorConsumed = new AtomicBoolean(false);
+
+        DefaultSubscriptionQueryResult<Object, Object> testSubject = new DefaultSubscriptionQueryResult<>(
+                Mono.just("some-initial-result"),
+                Flux.error(new RuntimeException("oops")),
+                () -> {
+                    canceled.set(true);
+                    return true;
+                }
+        );
+
+        testSubject.handle(initialResult -> initialResultConsumed.set(true),
+                           update -> updateConsumed.set(true),
+                           error -> errorConsumed.set(true));
+
+        assertTrue(canceled.get());
+        assertTrue(initialResultConsumed.get());
+        assertFalse(updateConsumed.get());
+        assertTrue(errorConsumed.get());
+    }
+
+    @Test
+    void handleInvokesErrorConsumerOnExceptionThrownByTheInitialResultConsumer() {
+        AtomicBoolean canceled = new AtomicBoolean(false);
+        AtomicBoolean updateConsumed = new AtomicBoolean(false);
+        AtomicBoolean errorConsumed = new AtomicBoolean(false);
+
+        DefaultSubscriptionQueryResult<Object, Object> testSubject = new DefaultSubscriptionQueryResult<>(
+                Mono.just("some-initial-result"),
+                Flux.just("some-update"),
+                () -> {
+                    canceled.set(true);
+                    return true;
+                }
+        );
+
+        testSubject.handle(initialResult -> {
+                               throw new RuntimeException("oops");
+                           },
+                           update -> updateConsumed.set(true),
+                           error -> errorConsumed.set(true));
+
+        assertTrue(canceled.get());
+        assertFalse(updateConsumed.get());
+        assertTrue(errorConsumed.get());
+    }
+
+    @Test
+    void handleInvokesErrorConsumerOnExceptionThrownByTheUpdateConsumer() {
+        AtomicBoolean canceled = new AtomicBoolean(false);
+        AtomicBoolean initialResultConsumed = new AtomicBoolean(false);
+        AtomicBoolean errorConsumed = new AtomicBoolean(false);
+
+        DefaultSubscriptionQueryResult<Object, Object> testSubject = new DefaultSubscriptionQueryResult<>(
+                Mono.just("some-initial-result"),
+                Flux.just("some-update"),
+                () -> {
+                    canceled.set(true);
+                    return true;
+                }
+        );
+
+        testSubject.handle(initialResult -> initialResultConsumed.set(true),
+                           update -> {
+                               throw new RuntimeException("oops");
+                           },
+                           error -> errorConsumed.set(true));
+
+        assertTrue(canceled.get());
+        assertTrue(initialResultConsumed.get());
+        assertTrue(errorConsumed.get());
+    }
+}


### PR DESCRIPTION
The `SubscriptionQueryResult#handle(Consumer<? super I>, Consumer<? super U>)` would swallow exceptions that reside in the `Mono<I> initialResult`.
As this is not helpful to the end user, this pull request provides an implementation of `SubscriptionQueryResult#handle(...)` that expects a `Consumer<Throwable>` to be given.

This so-called `errorConsumer` is invoked when subscribing the `initialResult()` generates an exception, when subscribing to the `updates()` generates an exception, and when the `initialResultConsumer` or `updateConsumer` throw an exception.
As such, the `errorConsumer` is invoked each time the `SubscriptionQueryResult#cancel` would be triggered.

Lastly, this PR deprecates `SubscriptionQueryResult#handle(Consumer<? super I>, Consumer<? super U>)` in favor of  `SubscriptionQueryResult#handle(Consumer<? super I>, Consumer<? super U>, Consumer<Throwable>)` to ensure users think consciously about dealing with exceptions.

By doing the above, this pull request resolves #3123.