### PR TITLE
Allow DLQ to handle deserialization errors

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -29,7 +29,6 @@ import org.axonframework.messaging.deadletter.DeadLetter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
-import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -37,6 +36,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
@@ -157,11 +157,11 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
                                       AtomicInteger fieldIndex,
                                       DomainEventMessage<?> eventMessage) throws SQLException {
         statement.setString(fieldIndex.getAndIncrement(),
-                getOrDefault(eventMessage, DomainEventMessage::getType, null));
+                            getOrDefault(eventMessage, DomainEventMessage::getType, null));
         statement.setString(fieldIndex.getAndIncrement(),
-                getOrDefault(eventMessage, DomainEventMessage::getAggregateIdentifier, null));
+                            getOrDefault(eventMessage, DomainEventMessage::getAggregateIdentifier, null));
         statement.setLong(fieldIndex.getAndIncrement(),
-                getOrDefault(eventMessage, DomainEventMessage::getSequenceNumber, -1L));
+                          getOrDefault(eventMessage, DomainEventMessage::getSequenceNumber, -1L));
     }
 
     private void setTrackedEventFields(PreparedStatement statement,
@@ -169,8 +169,8 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
                                        EventMessage<?> eventMessage) throws SQLException {
         boolean isTrackedEvent = eventMessage instanceof TrackedEventMessage;
         setTrackedEventFields(statement,
-                fieldIndex,
-                isTrackedEvent ? ((TrackedEventMessage<?>) eventMessage).trackingToken() : null);
+                              fieldIndex,
+                              isTrackedEvent ? ((TrackedEventMessage<?>) eventMessage).trackingToken() : null);
     }
 
     private void setTrackedEventFields(PreparedStatement statement,

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
@@ -49,8 +49,11 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
         Optional<DomainEventMessage> domainEventMessage = Optional.of(eventMessage).filter(
                 DomainEventMessage.class::isInstance).map(DomainEventMessage.class::cast);
 
+        // Serialize the payload with message.serializePayload to make the deserialization lazy and thus
+        // make us able to store deserialization errors as well.
         SerializedObject<byte[]> serializedPayload = message.serializePayload(eventSerializer, byte[].class);
-        SerializedObject<byte[]> serializedMetadata = message.serializeMetaData(eventSerializer, byte[].class);
+        // For compatibility, we use the serializer directly for the metadata
+        SerializedObject<byte[]> serializedMetadata = eventSerializer.serialize(message.getMetaData(), byte[].class);
         Optional<SerializedObject<byte[]>> serializedToken = trackedEventMessage.map(m -> genericSerializer.serialize(m.trackingToken(),
                                                                                                                byte[].class));
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,7 @@
 
 package org.axonframework.eventhandling.deadletter.jpa;
 
-import org.axonframework.eventhandling.DomainEventMessage;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
-import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
-import org.axonframework.eventhandling.GenericTrackedEventMessage;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.eventhandling.*;
 import org.axonframework.serialization.SerializedMessage;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedType;
@@ -56,8 +49,8 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
         Optional<DomainEventMessage> domainEventMessage = Optional.of(eventMessage).filter(
                 DomainEventMessage.class::isInstance).map(DomainEventMessage.class::cast);
 
-        SerializedObject<byte[]> serializedPayload = eventSerializer.serialize(message.getPayload(), byte[].class);
-        SerializedObject<byte[]> serializedMetadata = eventSerializer.serialize(message.getMetaData(), byte[].class);
+        SerializedObject<byte[]> serializedPayload = message.serializePayload(eventSerializer, byte[].class);
+        SerializedObject<byte[]> serializedMetadata = message.serializeMetaData(eventSerializer, byte[].class);
         Optional<SerializedObject<byte[]>> serializedToken = trackedEventMessage.map(m -> genericSerializer.serialize(m.trackingToken(),
                                                                                                                byte[].class));
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
@@ -16,7 +16,14 @@
 
 package org.axonframework.eventhandling.deadletter.jpa;
 
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.serialization.SerializedMessage;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedType;
@@ -42,7 +49,9 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
 
     @SuppressWarnings("rawtypes")
     @Override
-    public DeadLetterEventEntry convert(EventMessage<?> message, Serializer eventSerializer, Serializer genericSerializer) {
+    public DeadLetterEventEntry convert(EventMessage<?> message,
+                                        Serializer eventSerializer,
+                                        Serializer genericSerializer) {
         GenericEventMessage<?> eventMessage = (GenericEventMessage<?>) message;
         Optional<TrackedEventMessage> trackedEventMessage = Optional.of(eventMessage).filter(
                 TrackedEventMessage.class::isInstance).map(TrackedEventMessage.class::cast);
@@ -54,9 +63,8 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
         SerializedObject<byte[]> serializedPayload = message.serializePayload(eventSerializer, byte[].class);
         // For compatibility, we use the serializer directly for the metadata
         SerializedObject<byte[]> serializedMetadata = eventSerializer.serialize(message.getMetaData(), byte[].class);
-        Optional<SerializedObject<byte[]>> serializedToken = trackedEventMessage.map(m -> genericSerializer.serialize(m.trackingToken(),
-                                                                                                               byte[].class));
-
+        Optional<SerializedObject<byte[]>> serializedToken =
+                trackedEventMessage.map(m -> genericSerializer.serialize(m.trackingToken(), byte[].class));
 
         return new DeadLetterEventEntry(
                 message.getClass().getName(),
@@ -75,7 +83,9 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
     }
 
     @Override
-    public EventMessage<?> convert(DeadLetterEventEntry entry, Serializer eventSerializer, Serializer genericSerializer) {
+    public EventMessage<?> convert(DeadLetterEventEntry entry,
+                                   Serializer eventSerializer,
+                                   Serializer genericSerializer) {
         SerializedMessage<?> serializedMessage = new SerializedMessage<>(entry.getEventIdentifier(),
                                                                          entry.getPayload(),
                                                                          entry.getMetaData(),

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
@@ -18,12 +18,26 @@ package org.axonframework.eventhandling.deadletter.jpa;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.*;
-import org.junit.jupiter.api.Test;
+import org.axonframework.serialization.Revision;
+import org.axonframework.serialization.SerializedMessage;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.SimpleSerializedType;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -54,21 +68,25 @@ class EventMessageDeadLetterJpaConverterTest {
     @Test
     void canConvertTrackedDomainEventMessageWithGlobalSequenceTokenAndBackCorrectly() {
         testConversion(new GenericTrackedDomainEventMessage<>(new GlobalSequenceTrackingToken(232323L),
-                "MyType",
-                "8239081092",
-                25L,
-                new GenericEventMessage<>(event, metaData),
-                Instant::now));
+                                                              "MyType",
+                                                              "8239081092",
+                                                              25L,
+                                                              new GenericEventMessage<>(event, metaData),
+                                                              Instant::now));
     }
 
     @Test
     void canConvertMessagesWithSerializationErrors() {
-        GenericEventMessage<Object> message = new GenericEventMessage<>(new SerializedMessage<>(
+        SerializedType eventType = new SimpleSerializedType(
+                "org.axonframework.eventhandling.deadletter.jpa.EventMessageDeadLetterJpaConverterTest$SerializationErrorClass",
+                null
+        );
+        EventMessage<Object> message = new GenericEventMessage<>(new SerializedMessage<>(
                 "my-identifier",
                 new SimpleSerializedObject<>(
                         "{'my-wrong-payload':'wadawd'}".getBytes(StandardCharsets.UTF_8),
                         byte[].class,
-                        new SimpleSerializedType("org.axonframework.eventhandling.deadletter.jpa.EventMessageDeadLetterJpaConverterTest$SerializationErrorClass", null)
+                        eventType
                 ),
                 new SimpleSerializedObject<>(
                         "{}".getBytes(StandardCharsets.UTF_8),
@@ -84,27 +102,29 @@ class EventMessageDeadLetterJpaConverterTest {
 
     @Test
     void canConvertTrackedDomainEventMessageWithGapAwareTokenAndBackCorrectly() {
-        testConversion(new GenericTrackedDomainEventMessage<>(new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L)),
-                "MyType",
-                "8239081092",
-                25L,
-                new GenericEventMessage<>(event, metaData),
-                Instant::now));
+        TrackingToken testToken = new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L));
+        testConversion(new GenericTrackedDomainEventMessage<>(testToken,
+                                                              "MyType",
+                                                              "8239081092",
+                                                              25L,
+                                                              new GenericEventMessage<>(event, metaData),
+                                                              Instant::now));
     }
 
     @Test
     void canConvertTrackedEventMessageWithGlobalSequenceTokenAndBackCorrectly() {
         testConversion(new GenericTrackedEventMessage<>(new GlobalSequenceTrackingToken(232323L),
-                new GenericEventMessage<>(event, metaData),
-                Instant::now));
+                                                        new GenericEventMessage<>(event, metaData),
+                                                        Instant::now));
     }
 
 
     @Test
     void canConvertTrackedEventMessageWithGapAwareTokenAndBackCorrectly() {
-        testConversion(new GenericTrackedEventMessage<>(new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L)),
-                new GenericEventMessage<>(event, metaData),
-                Instant::now));
+        TrackingToken testToken = new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L));
+        testConversion(new GenericTrackedEventMessage<>(testToken,
+                                                        new GenericEventMessage<>(event, metaData),
+                                                        Instant::now));
     }
 
     private void testConversion(EventMessage<?> message) {
@@ -114,7 +134,8 @@ class EventMessageDeadLetterJpaConverterTest {
         assertCorrectlyMapped(message, deadLetterEventEntry);
         assertTrue(converter.canConvert(deadLetterEventEntry));
 
-        EventMessage<?> restoredEventMessage = converter.convert(deadLetterEventEntry, eventSerializer, genericSerializer);
+        EventMessage<?> restoredEventMessage =
+                converter.convert(deadLetterEventEntry, eventSerializer, genericSerializer);
         assertCorrectlyRestored(message, restoredEventMessage);
     }
 
@@ -146,13 +167,13 @@ class EventMessageDeadLetterJpaConverterTest {
         assertEquals(eventMessage.getIdentifier(), deadLetterEventEntry.getEventIdentifier());
         assertEquals(eventMessage.getTimestamp().toString(), deadLetterEventEntry.getTimeStamp());
         assertEquals(eventMessage.getPayload().getClass().getName(),
-                deadLetterEventEntry.getPayload().getType().getName());
+                     deadLetterEventEntry.getPayload().getType().getName());
         assertEquals(PAYLOAD_REVISION, deadLetterEventEntry.getPayload().getType().getRevision());
         assertEquals(eventSerializer.serialize(event, String.class).getData(),
-                new String(deadLetterEventEntry.getPayload().getData()));
+                     new String(deadLetterEventEntry.getPayload().getData()));
         assertEquals(MetaData.class.getName(), deadLetterEventEntry.getMetaData().getType().getName());
         assertEquals(eventSerializer.serialize(metaData, String.class).getData(),
-                new String(deadLetterEventEntry.getMetaData().getData()));
+                     new String(deadLetterEventEntry.getMetaData().getData()));
 
         if (eventMessage instanceof DomainEventMessage) {
             DomainEventMessage<?> domainEventMessage = (DomainEventMessage<?>) eventMessage;
@@ -167,9 +188,9 @@ class EventMessageDeadLetterJpaConverterTest {
         if (eventMessage instanceof TrackedEventMessage) {
             TrackedEventMessage<?> trackedEventMessage = (TrackedEventMessage<?>) eventMessage;
             assertEquals(trackedEventMessage.trackingToken().getClass().getName(),
-                    deadLetterEventEntry.getTrackingToken().getType().getName());
+                         deadLetterEventEntry.getTrackingToken().getType().getName());
             assertEquals(genericSerializer.serialize(trackedEventMessage.trackingToken(), String.class).getData(),
-                    new String(deadLetterEventEntry.getTrackingToken().getData()));
+                         new String(deadLetterEventEntry.getTrackingToken().getData()));
         } else {
             assertNull(deadLetterEventEntry.getTrackingToken());
         }
@@ -209,7 +230,9 @@ class EventMessageDeadLetterJpaConverterTest {
         }
     }
 
-    class SerializationErrorClass {
+    // Suppressed since it's used for test 'canConvertMessagesWithSerializationErrors'
+    @SuppressWarnings("unused")
+    static class SerializationErrorClass {
         String myValue;
     }
 }


### PR DESCRIPTION
Currently the DLQ does not enqueue messages with deserialization errors, due to the following stack trace:

```
SerializedMessage.getPayload(SerializedMessage.java:81)
MessageDecorator.getPayload(MessageDecorator.java:56)
MessageDecorator.getPayload(MessageDecorator.java:56)
EventMessageDeadLetterJpaConverter.convert(EventMessageDeadLetterJpaConverter.java:59)
```

In this trace the message is first deserialized (if it wasn't yet, through the `LazyDeserializingMessage`) before being serialized again. Besides being inefficient, this causes any deserialization error to occur again during enqueuement in the DLQ, causing the event processor to go into error mode.

This PR switches the call to the `Message.serializePayload` call, which is overridden by the SerializedMessage to not deserialize/serialize if the type matches (or tries to find a converter).