### PR TITLE
Fix rescheduling of failed Persistent Streams

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamConnection.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamConnection.java
@@ -184,7 +184,7 @@ public class PersistentStreamConnection {
         if (throwable != null) {
             logger.info("{}: Rescheduling persistent stream", streamId, throwable);
             scheduler.schedule(this::start,
-                               retrySeconds.getAndUpdate(current -> Math.max(60, current * 2)),
+                               retrySeconds.getAndUpdate(current -> Math.min(60, current * 2)),
                                TimeUnit.SECONDS);
         }
     }


### PR DESCRIPTION
The back-off rescheduling of a failed Persistent Stream picked the maximum value between `60` and `current * 2`, causing the value to increase indefinitely.
This PR corrects that behavior to pick the minium value, ensuring the back-off rescheduling "maxes out" at 60 (seconds).