### PR TITLE
[#3129] Adjust `MessageStream` to support any type of entry

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -193,6 +193,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Spring - used for testing only! -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -26,7 +26,7 @@ import java.util.function.BiFunction;
  * Implementation of the {@link MessageStream} that invokes the given {@code completeHandler} once the
  * {@code delegate MessageStream} completes.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -37,11 +37,11 @@ class CompletionCallbackMessageStream<E> implements MessageStream<E> {
     private final Runnable completeHandler;
 
     /**
-     * Construct a {@link CompletionCallbackMessageStream} invoking the given {@code completeHandler} when the given
+     * Construct a {@link MessageStream stream} invoking the given {@code completeHandler} when the given
      * {@code delegate} completes.
      *
-     * @param delegate        The {@link MessageStream} that once completed results in the invocation of the given
-     *                        {@code completeHandler}.
+     * @param delegate        The {@link MessageStream stream} that once completed results in the invocation of the
+     *                        given {@code completeHandler}.
      * @param completeHandler The {@link Runnable} to invoke when the given {@code delegate} completes.
      */
     CompletionCallbackMessageStream(@NotNull MessageStream<E> delegate,

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -26,14 +26,14 @@ import java.util.function.BiFunction;
  * Implementation of the {@link MessageStream} that invokes the given {@code completeHandler} once the
  * {@code delegate MessageStream} completes.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class CompletionCallbackMessageStream<M extends Message<?>> implements MessageStream<M> {
+class CompletionCallbackMessageStream<E> implements MessageStream<E> {
 
-    private final MessageStream<M> delegate;
+    private final MessageStream<E> delegate;
     private final Runnable completeHandler;
 
     /**
@@ -44,14 +44,14 @@ class CompletionCallbackMessageStream<M extends Message<?>> implements MessageSt
      *                        {@code completeHandler}.
      * @param completeHandler The {@link Runnable} to invoke when the given {@code delegate} completes.
      */
-    CompletionCallbackMessageStream(@NotNull MessageStream<M> delegate,
+    CompletionCallbackMessageStream(@NotNull MessageStream<E> delegate,
                                     @NotNull Runnable completeHandler) {
         this.delegate = delegate;
         this.completeHandler = completeHandler;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return delegate.asCompletableFuture()
                        .whenComplete((result, exception) -> {
                            if (exception == null) {
@@ -61,14 +61,14 @@ class CompletionCallbackMessageStream<M extends Message<?>> implements MessageSt
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return delegate.asFlux()
                        .doOnComplete(completeHandler);
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return delegate.reduce(identity, accumulator)
                        .whenComplete((result, exception) -> {
                            if (exception == null) {

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -44,8 +44,8 @@ class CompletionCallbackMessageStream<E> implements MessageStream<E> {
      *                        given {@code completeHandler}.
      * @param completeHandler The {@link Runnable} to invoke when the given {@code delegate} completes.
      */
-    CompletionCallbackMessageStream(@NotNull MessageStream<E> delegate,
-                                    @NotNull Runnable completeHandler) {
+    CompletionCallbackMessageStream(@Nonnull MessageStream<E> delegate,
+                                    @Nonnull Runnable completeHandler) {
         this.delegate = delegate;
         this.completeHandler = completeHandler;
     }
@@ -67,8 +67,8 @@ class CompletionCallbackMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return delegate.reduce(identity, accumulator)
                        .whenComplete((result, exception) -> {
                            if (exception == null) {

--- a/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
@@ -25,10 +25,10 @@ import java.util.function.BiFunction;
 /**
  * Implementation of the {@link MessageStream} that concatenates two {@code MessageStreams}.
  * <p>
- * Will only start streaming {@link Message Messages} from the {@code second MessageStream} when the
+ * Will only start streaming entries of type {@code E} from the {@code second MessageStream} when the
  * {@code first MessageStream} completes successfully.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -39,12 +39,12 @@ class ConcatenatingMessageStream<E> implements MessageStream<E> {
     private final MessageStream<E> second;
 
     /**
-     * Construct a {@link ConcatenatingMessageStream} that initially consume from the {@code first MessageStream},
-     * followed by the {@code second} if the {@code first MessageStream} completes successfully
+     * Construct a {@link MessageStream stream} that initially consume from the {@code first MessageStream}, followed by
+     * the {@code second} if the {@code first MessageStream} completes successfully
      *
-     * @param first  The initial {@link MessageStream} to consume {@link Message Messages} from.
-     * @param second The second {@link MessageStream} to start consuming from once the {@code first} stream completes
-     *               successfully.
+     * @param first  The initial {@link MessageStream stream} to consume entries from.
+     * @param second The second {@link MessageStream stream} to start consuming from once the {@code first} stream
+     *               completes successfully.
      */
     ConcatenatingMessageStream(@NotNull MessageStream<E> first,
                                @NotNull MessageStream<E> second) {

--- a/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
@@ -28,15 +28,15 @@ import java.util.function.BiFunction;
  * Will only start streaming {@link Message Messages} from the {@code second MessageStream} when the
  * {@code first MessageStream} completes successfully.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class ConcatenatingMessageStream<M extends Message<?>> implements MessageStream<M> {
+class ConcatenatingMessageStream<E> implements MessageStream<E> {
 
-    private final MessageStream<M> first;
-    private final MessageStream<M> second;
+    private final MessageStream<E> first;
+    private final MessageStream<E> second;
 
     /**
      * Construct a {@link ConcatenatingMessageStream} that initially consume from the {@code first MessageStream},
@@ -46,14 +46,14 @@ class ConcatenatingMessageStream<M extends Message<?>> implements MessageStream<
      * @param second The second {@link MessageStream} to start consuming from once the {@code first} stream completes
      *               successfully.
      */
-    ConcatenatingMessageStream(@NotNull MessageStream<M> first,
-                               @NotNull MessageStream<M> second) {
+    ConcatenatingMessageStream(@NotNull MessageStream<E> first,
+                               @NotNull MessageStream<E> second) {
         this.first = first;
         this.second = second;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return first.asCompletableFuture()
                     .thenCompose(message -> message == null
                             ? second.asCompletableFuture()
@@ -62,14 +62,14 @@ class ConcatenatingMessageStream<M extends Message<?>> implements MessageStream<
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return first.asFlux()
                     .concatWith(second.asFlux());
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return first.reduce(identity, accumulator)
                     .thenCompose(intermediate -> second.reduce(intermediate, accumulator));
     }

--- a/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,8 +46,8 @@ class ConcatenatingMessageStream<E> implements MessageStream<E> {
      * @param second The second {@link MessageStream stream} to start consuming from once the {@code first} stream
      *               completes successfully.
      */
-    ConcatenatingMessageStream(@NotNull MessageStream<E> first,
-                               @NotNull MessageStream<E> second) {
+    ConcatenatingMessageStream(@Nonnull MessageStream<E> first,
+                               @Nonnull MessageStream<E> second) {
         this.first = first;
         this.second = second;
     }
@@ -68,8 +68,8 @@ class ConcatenatingMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return first.reduce(identity, accumulator)
                     .thenCompose(intermediate -> second.reduce(intermediate, accumulator));
     }

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -27,16 +27,16 @@ import java.util.function.BiFunction;
 /**
  * An implementation of the {@link MessageStream} that wraps a stream that will become available asynchronously.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-public class DelayedMessageStream<M extends Message<?>> implements MessageStream<M> {
+public class DelayedMessageStream<E> implements MessageStream<E> {
 
-    private final CompletableFuture<MessageStream<M>> delegate;
+    private final CompletableFuture<MessageStream<E>> delegate;
 
-    private DelayedMessageStream(@NotNull CompletableFuture<MessageStream<M>> delegate) {
+    private DelayedMessageStream(@NotNull CompletableFuture<MessageStream<E>> delegate) {
         this.delegate = delegate;
     }
 
@@ -49,10 +49,10 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
      *
      * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream} to delegate to when it
      *                 becomes available.
-     * @param <M>      The type of {@link Message} carried in this stream.
+     * @param <E>      The type of {@link Message} carried in this stream.
      * @return A {@link MessageStream} that delegates all actions to the {@code delegate} when it becomes available.
      */
-    public static <M extends Message<?>> MessageStream<M> create(CompletableFuture<MessageStream<M>> delegate) {
+    public static <E> MessageStream<E> create(CompletableFuture<MessageStream<E>> delegate) {
         if (delegate.isDone()) {
             try {
                 return delegate.get();
@@ -66,19 +66,19 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return delegate.thenCompose(MessageStream::asCompletableFuture);
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Mono.fromFuture(delegate)
                    .flatMapMany(MessageStream::asFlux);
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return delegate.thenCompose(delegateStream -> delegateStream.reduce(identity, accumulator));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -36,7 +36,7 @@ public class DelayedMessageStream<E> implements MessageStream<E> {
 
     private final CompletableFuture<MessageStream<E>> delegate;
 
-    private DelayedMessageStream(@NotNull CompletableFuture<MessageStream<E>> delegate) {
+    private DelayedMessageStream(@Nonnull CompletableFuture<MessageStream<E>> delegate) {
         this.delegate = delegate;
     }
 
@@ -53,7 +53,7 @@ public class DelayedMessageStream<E> implements MessageStream<E> {
      * @return A {@link MessageStream stream} that delegates all actions to the {@code delegate} when it becomes
      * available.
      */
-    public static <E> MessageStream<E> create(CompletableFuture<MessageStream<E>> delegate) {
+    public static <E> MessageStream<E> create(@Nonnull CompletableFuture<MessageStream<E>> delegate) {
         if (delegate.isDone()) {
             try {
                 return delegate.get();
@@ -78,8 +78,8 @@ public class DelayedMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return delegate.thenCompose(delegateStream -> delegateStream.reduce(identity, accumulator));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -27,7 +27,7 @@ import java.util.function.BiFunction;
 /**
  * An implementation of the {@link MessageStream} that wraps a stream that will become available asynchronously.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -41,16 +41,17 @@ public class DelayedMessageStream<E> implements MessageStream<E> {
     }
 
     /**
-     * Creates a {@link MessageStream} that delays actions to its {@code delegate} when it becomes available.
+     * Creates a {@link MessageStream stream} that delays actions to its {@code delegate} when it becomes available.
      * <p>
      * If the given {@code delegate} has already {@link CompletableFuture#isDone() completed}, it returns the
      * {@code MessageStream} immediately from it. Otherwise, it returns a {@link DelayedMessageStream} instance wrapping
      * the given {@code delegate}.
      *
-     * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream} to delegate to when it
-     *                 becomes available.
-     * @param <E>      The type of {@link Message} carried in this stream.
-     * @return A {@link MessageStream} that delegates all actions to the {@code delegate} when it becomes available.
+     * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream stream} to delegate to
+     *                 when it becomes available.
+     * @param <E>      The type of entry carried in this {@link MessageStream stream}.
+     * @return A {@link MessageStream stream} that delegates all actions to the {@code delegate} when it becomes
+     * available.
      */
     public static <E> MessageStream<E> create(CompletableFuture<MessageStream<E>> delegate) {
         if (delegate.isDone()) {

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -28,12 +28,12 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream} implementation that contains no {@link Message Messages} at all.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
+class EmptyMessageStream<E> implements MessageStream<E> {
 
     @SuppressWarnings("rawtypes")
     private static final EmptyMessageStream INSTANCE = new EmptyMessageStream<>();
@@ -44,48 +44,48 @@ class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
     /**
      * Return a singular instance of the {@link EmptyMessageStream} to be used throughout.
      *
-     * @param <M> The type of {@link Message} carried in this stream.
+     * @param <T> The type of {@link Message} carried in this stream.
      * @return A singular instance of the {@link EmptyMessageStream} to be used throughout.
      */
-    public static <M extends Message<?>> EmptyMessageStream<M> instance() {
+    public static <T> EmptyMessageStream<T> instance() {
         //noinspection unchecked
         return INSTANCE;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return FutureUtils.emptyCompletedFuture();
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Flux.empty();
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(@NotNull Function<M, R> mapper) {
+    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
         //noinspection unchecked
         return (MessageStream<R>) this;
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(identity);
     }
 
     @Override
-    public MessageStream<M> onNextItem(Consumer<M> onNext) {
+    public MessageStream<E> onNextItem(Consumer<E> onNext) {
         return this;
     }
 
     @Override
-    public MessageStream<M> onErrorContinue(Function<Throwable, MessageStream<M>> onError) {
+    public MessageStream<E> onErrorContinue(Function<Throwable, MessageStream<E>> onError) {
         return this;
     }
 
     @Override
-    public MessageStream<M> whenComplete(Runnable completeHandler) {
+    public MessageStream<E> whenComplete(Runnable completeHandler) {
         try {
             completeHandler.run();
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import org.axonframework.common.FutureUtils;
 import reactor.core.publisher.Flux;
 
@@ -64,29 +64,29 @@ class EmptyMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         //noinspection unchecked
         return (MessageStream<R>) this;
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(identity);
     }
 
     @Override
-    public MessageStream<E> onNextItem(Consumer<E> onNext) {
+    public MessageStream<E> onNextItem(@Nonnull Consumer<E> onNext) {
         return this;
     }
 
     @Override
-    public MessageStream<E> onErrorContinue(Function<Throwable, MessageStream<E>> onError) {
+    public MessageStream<E> onErrorContinue(@Nonnull Function<Throwable, MessageStream<E>> onError) {
         return this;
     }
 
     @Override
-    public MessageStream<E> whenComplete(Runnable completeHandler) {
+    public MessageStream<E> whenComplete(@Nonnull Runnable completeHandler) {
         try {
             completeHandler.run();
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -26,9 +26,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * A {@link MessageStream} implementation that contains no {@link Message Messages} at all.
+ * A {@link MessageStream stream} implementation that contains no entries at all.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -39,15 +39,16 @@ class EmptyMessageStream<E> implements MessageStream<E> {
     private static final EmptyMessageStream INSTANCE = new EmptyMessageStream<>();
 
     private EmptyMessageStream() {
+        // No-arg constructor to enforce use of INSTANCE constant.
     }
 
     /**
      * Return a singular instance of the {@link EmptyMessageStream} to be used throughout.
      *
-     * @param <T> The type of {@link Message} carried in this stream.
+     * @param <E> The type of entry carried in this {@link MessageStream stream}.
      * @return A singular instance of the {@link EmptyMessageStream} to be used throughout.
      */
-    public static <T> EmptyMessageStream<T> instance() {
+    public static <E> EmptyMessageStream<E> instance() {
         //noinspection unchecked
         return INSTANCE;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -40,7 +40,7 @@ class FailedMessageStream<E> implements MessageStream<E> {
      *
      * @param error The {@link Throwable} that caused this {@link MessageStream stream} to complete exceptionally.
      */
-    FailedMessageStream(@NotNull Throwable error) {
+    FailedMessageStream(@Nonnull Throwable error) {
         this.error = error;
     }
 
@@ -55,19 +55,19 @@ class FailedMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         //noinspection unchecked
         return (FailedMessageStream<R>) this;
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.failedFuture(error);
     }
 
     @Override
-    public MessageStream<E> whenComplete(Runnable completeHandler) {
+    public MessageStream<E> whenComplete(@Nonnull Runnable completeHandler) {
         return this;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream} implementation that completes exceptionally through the given {@code error}.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -36,9 +36,9 @@ class FailedMessageStream<E> implements MessageStream<E> {
     private final Throwable error;
 
     /**
-     * Constructs a {@link FailedMessageStream} that will complete exceptionally with the given {@code error}.
+     * Constructs a {@link MessageStream stream} that will complete exceptionally with the given {@code error}.
      *
-     * @param error The {@link Throwable} that caused this {@link MessageStream} to complete exceptionally.
+     * @param error The {@link Throwable} that caused this {@link MessageStream stream} to complete exceptionally.
      */
     FailedMessageStream(@NotNull Throwable error) {
         this.error = error;

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -26,12 +26,12 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream} implementation that completes exceptionally through the given {@code error}.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
+class FailedMessageStream<E> implements MessageStream<E> {
 
     private final Throwable error;
 
@@ -45,29 +45,29 @@ class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return CompletableFuture.failedFuture(error);
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Flux.error(error);
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(@NotNull Function<M, R> mapper) {
+    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
         //noinspection unchecked
         return (FailedMessageStream<R>) this;
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.failedFuture(error);
     }
 
     @Override
-    public MessageStream<M> whenComplete(Runnable completeHandler) {
+    public MessageStream<E> whenComplete(Runnable completeHandler) {
         return this;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
@@ -26,49 +26,49 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream} implementation using a {@link Flux} as the {@link Message} source.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class FluxMessageStream<M extends Message<?>> implements MessageStream<M> {
+class FluxMessageStream<E> implements MessageStream<E> {
 
-    private final Flux<M> source;
+    private final Flux<E> source;
 
     /**
      * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
      *
      * @param source The {@link Flux} sourcing the {@link Message Messages} for this {@link MessageStream}.
      */
-    FluxMessageStream(@NotNull Flux<M> source) {
+    FluxMessageStream(@NotNull Flux<E> source) {
         this.source = source;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return source.singleOrEmpty()
                      .toFuture();
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return source;
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(@NotNull Function<M, R> mapper) {
+    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
         return new FluxMessageStream<>(source.map(mapper));
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return source.reduce(identity, accumulator)
                      .toFuture();
     }
 
     @Override
-    public MessageStream<M> onErrorContinue(@NotNull Function<Throwable, MessageStream<M>> onError) {
+    public MessageStream<E> onErrorContinue(@NotNull Function<Throwable, MessageStream<E>> onError) {
         return new FluxMessageStream<>(source.onErrorResume(
                 exception -> onError.apply(exception)
                                     .asFlux()
@@ -76,7 +76,7 @@ class FluxMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public MessageStream<M> whenComplete(@NotNull Runnable completeHandler) {
+    public MessageStream<E> whenComplete(@NotNull Runnable completeHandler) {
         return new FluxMessageStream<>(source.doOnComplete(completeHandler));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +41,7 @@ class FluxMessageStream<E> implements MessageStream<E> {
      *
      * @param source The {@link Flux} providing the entries of type {@code E} for this {@link MessageStream stream}.
      */
-    FluxMessageStream(@NotNull Flux<E> source) {
+    FluxMessageStream(@Nonnull Flux<E> source) {
         this.source = source;
     }
 
@@ -57,19 +57,19 @@ class FluxMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         return new FluxMessageStream<>(source.map(mapper));
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return source.reduce(identity, accumulator)
                      .toFuture();
     }
 
     @Override
-    public MessageStream<E> onErrorContinue(@NotNull Function<Throwable, MessageStream<E>> onError) {
+    public MessageStream<E> onErrorContinue(@Nonnull Function<Throwable, MessageStream<E>> onError) {
         return new FluxMessageStream<>(source.onErrorResume(
                 exception -> onError.apply(exception)
                                     .asFlux()
@@ -77,7 +77,7 @@ class FluxMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public MessageStream<E> whenComplete(@NotNull Runnable completeHandler) {
+    public MessageStream<E> whenComplete(@Nonnull Runnable completeHandler) {
         return new FluxMessageStream<>(source.doOnComplete(completeHandler));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
@@ -24,9 +24,9 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * A {@link MessageStream} implementation using a {@link Flux} as the {@link Message} source.
+ * A {@link MessageStream} implementation using a {@link Flux} as the source.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -36,9 +36,10 @@ class FluxMessageStream<E> implements MessageStream<E> {
     private final Flux<E> source;
 
     /**
-     * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
+     * Constructs a {@link MessageStream stream} using the given {@code source} to provide the entries of type
+     * {@code E}.
      *
-     * @param source The {@link Flux} sourcing the {@link Message Messages} for this {@link MessageStream}.
+     * @param source The {@link Flux} providing the entries of type {@code E} for this {@link MessageStream stream}.
      */
     FluxMessageStream(@NotNull Flux<E> source) {
         this.source = source;

--- a/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
@@ -29,41 +29,41 @@ import java.util.stream.StreamSupport;
 /**
  * A {@link MessageStream} implementation using an {@link Iterable} as the {@link Message} source.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class IterableMessageStream<M extends Message<?>> implements MessageStream<M> {
+class IterableMessageStream<E> implements MessageStream<E> {
 
     private static final boolean NOT_PARALLEL = false;
 
-    private final Iterable<M> source;
+    private final Iterable<E> source;
 
     /**
      * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
      *
      * @param source The {@link Iterable} sourcing the {@link Message Messages} for this {@link MessageStream}.
      */
-    IterableMessageStream(@NotNull Iterable<M> source) {
+    IterableMessageStream(@NotNull Iterable<E> source) {
         this.source = source;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
-        Iterator<M> iterator = source.iterator();
+    public CompletableFuture<E> asCompletableFuture() {
+        Iterator<E> iterator = source.iterator();
         return iterator.hasNext()
                 ? CompletableFuture.completedFuture(iterator.next())
                 : FutureUtils.emptyCompletedFuture();
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Flux.fromIterable(source);
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(Function<M, R> mapper) {
+    public <R> MessageStream<R> map(Function<E, R> mapper) {
         return new IterableMessageStream<>(
                 StreamSupport.stream(source.spliterator(), NOT_PARALLEL)
                              .map(mapper)
@@ -73,7 +73,7 @@ class IterableMessageStream<M extends Message<?>> implements MessageStream<M> {
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(
                 StreamSupport.stream(source.spliterator(), NOT_PARALLEL)
                              .reduce(identity, accumulator, (thisResult, thatResult) -> {

--- a/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import org.axonframework.common.FutureUtils;
 import reactor.core.publisher.Flux;
 
@@ -47,7 +47,7 @@ class IterableMessageStream<E> implements MessageStream<E> {
      * @param source The {@link Iterable} providing the entries of type {@code E} for this
      *               {@link MessageStream stream}.
      */
-    IterableMessageStream(@NotNull Iterable<E> source) {
+    IterableMessageStream(@Nonnull Iterable<E> source) {
         this.source = source;
     }
 
@@ -65,7 +65,7 @@ class IterableMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         return new IterableMessageStream<>(
                 StreamSupport.stream(source.spliterator(), NOT_PARALLEL)
                              .map(mapper)
@@ -74,8 +74,8 @@ class IterableMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(
                 StreamSupport.stream(source.spliterator(), NOT_PARALLEL)
                              .reduce(identity, accumulator, (thisResult, thatResult) -> {

--- a/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/IterableMessageStream.java
@@ -27,9 +27,9 @@ import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 /**
- * A {@link MessageStream} implementation using an {@link Iterable} as the {@link Message} source.
+ * A {@link MessageStream} implementation using an {@link Iterable} as the source.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -41,9 +41,11 @@ class IterableMessageStream<E> implements MessageStream<E> {
     private final Iterable<E> source;
 
     /**
-     * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
+     * Constructs a {@link MessageStream stream} using the given {@code source} to provide the entries of type
+     * {@code E}.
      *
-     * @param source The {@link Iterable} sourcing the {@link Message Messages} for this {@link MessageStream}.
+     * @param source The {@link Iterable} providing the entries of type {@code E} for this
+     *               {@link MessageStream stream}.
      */
     IterableMessageStream(@NotNull Iterable<E> source) {
         this.source = source;

--- a/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -45,8 +45,8 @@ class MappedMessageStream<E, RE> implements MessageStream<RE> {
      *                 {@code mapper}.
      * @param mapper   The {@link Function} mapping entries of type {@code E} to {@code RE}.
      */
-    MappedMessageStream(@NotNull MessageStream<E> delegate,
-                        @NotNull Function<E, RE> mapper) {
+    MappedMessageStream(@Nonnull MessageStream<E> delegate,
+                        @Nonnull Function<E, RE> mapper) {
         this.delegate = delegate;
         this.mapper = mapper;
     }
@@ -65,8 +65,8 @@ class MappedMessageStream<E, RE> implements MessageStream<RE> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, RE, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, RE, R> accumulator) {
         return delegate.reduce(
                 identity,
                 (base, message) -> accumulator.apply(base, mapper.apply(message))

--- a/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
@@ -27,17 +27,17 @@ import java.util.function.Function;
  * Implementation of the {@link MessageStream} that maps the {@link Message Messages} from type {@code M} to type
  * {@code R}.
  *
- * @param <M>  The type of {@link Message} carried as input to this stream.
- * @param <RM> The type of {@link Message} carried as output to this stream as a result of the provided mapper
+ * @param <E>  The type of {@link Message} carried as input to this stream.
+ * @param <RE> The type of {@link Message} carried as output to this stream as a result of the provided mapper
  *             operation.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class MappedMessageStream<M extends Message<?>, RM extends Message<?>> implements MessageStream<RM> {
+class MappedMessageStream<E, RE> implements MessageStream<RE> {
 
-    private final MessageStream<M> delegate;
-    private final Function<M, RM> mapper;
+    private final MessageStream<E> delegate;
+    private final Function<E, RE> mapper;
 
     /**
      * Construct a {@link MappedMessageStream} mapping the {@link Message Messages} of the given {@code delegate}
@@ -47,28 +47,28 @@ class MappedMessageStream<M extends Message<?>, RM extends Message<?>> implement
      *                 {@code mapper}.
      * @param mapper   The {@link Function} mapping {@link Message Messages} of type {@code R} to {@code M}.
      */
-    MappedMessageStream(@NotNull MessageStream<M> delegate,
-                        @NotNull Function<M, RM> mapper) {
+    MappedMessageStream(@NotNull MessageStream<E> delegate,
+                        @NotNull Function<E, RE> mapper) {
         this.delegate = delegate;
         this.mapper = mapper;
     }
 
     @Override
-    public CompletableFuture<RM> asCompletableFuture() {
+    public CompletableFuture<RE> asCompletableFuture() {
         // CompletableFuture doesn't support empty completions, so null is used as placeholder
         return delegate.asCompletableFuture()
                        .thenApply(message -> message == null ? null : mapper.apply(message));
     }
 
     @Override
-    public Flux<RM> asFlux() {
+    public Flux<RE> asFlux() {
         return delegate.asFlux()
                        .map(mapper);
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, RM, R> accumulator) {
+                                           @NotNull BiFunction<R, RE, R> accumulator) {
         return delegate.reduce(
                 identity,
                 (base, message) -> accumulator.apply(base, mapper.apply(message))

--- a/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
@@ -24,12 +24,10 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * Implementation of the {@link MessageStream} that maps the {@link Message Messages} from type {@code M} to type
- * {@code R}.
+ * Implementation of the {@link MessageStream} that maps the entries of type {@code E} to type {@code RE}.
  *
- * @param <E>  The type of {@link Message} carried as input to this stream.
- * @param <RE> The type of {@link Message} carried as output to this stream as a result of the provided mapper
- *             operation.
+ * @param <E>  The type of entry carried in this {@link MessageStream stream}.
+ * @param <RE> The type of entry carried as output to this stream as a result of the provided mapper operation.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -40,12 +38,12 @@ class MappedMessageStream<E, RE> implements MessageStream<RE> {
     private final Function<E, RE> mapper;
 
     /**
-     * Construct a {@link MappedMessageStream} mapping the {@link Message Messages} of the given {@code delegate}
-     * {@link MessageStream} to type {@code M}.
+     * Construct a {@link MessageStream stream} mapping the entries of type {@code E} of the given {@code delegate}
+     * {@code MessageStream} to type {@code RE}.
      *
-     * @param delegate The {@link MessageStream} from which its {@link Message Messages} are mapped with the given
+     * @param delegate The {@link MessageStream stream} who's entries of type {@code E} are mapped with the given
      *                 {@code mapper}.
-     * @param mapper   The {@link Function} mapping {@link Message Messages} of type {@code R} to {@code M}.
+     * @param mapper   The {@link Function} mapping entries of type {@code E} to {@code RE}.
      */
     MappedMessageStream(@NotNull MessageStream<E> delegate,
                         @NotNull Function<E, RE> mapper) {

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -16,7 +16,8 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -50,7 +51,7 @@ public interface MessageStream<E> {
      * @return A {@link MessageStream stream} of entries of type {@code E} that returns the entires provided by the
      * given {@code iterable}.
      */
-    static <E> MessageStream<E> fromIterable(@NotNull Iterable<E> iterable) {
+    static <E> MessageStream<E> fromIterable(@Nonnull Iterable<E> iterable) {
         return new IterableMessageStream<>(iterable);
     }
 
@@ -65,7 +66,7 @@ public interface MessageStream<E> {
      * @return A {@link MessageStream stream} of entries of type {@code E} that returns the entries provided by the
      * given {@code stream}.
      */
-    static <E> MessageStream<E> fromStream(@NotNull Stream<E> stream) {
+    static <E> MessageStream<E> fromStream(@Nonnull Stream<E> stream) {
         return new StreamMessageStream<>(stream);
     }
 
@@ -77,7 +78,7 @@ public interface MessageStream<E> {
      * @return A {@link MessageStream stream} of entries of type {@code E} that returns the entries provided by the
      * given {@code flux}.
      */
-    static <E> MessageStream<E> fromFlux(@NotNull Flux<E> flux) {
+    static <E> MessageStream<E> fromFlux(@Nonnull Flux<E> flux) {
         return new FluxMessageStream<>(flux);
     }
 
@@ -91,7 +92,7 @@ public interface MessageStream<E> {
      * @param <E>    The type of entry carried in this {@link MessageStream stream}.
      * @return A {@link MessageStream stream} containing at most one entry of type {@code E}.
      */
-    static <E> MessageStream<E> fromFuture(@NotNull CompletableFuture<E> future) {
+    static <E> MessageStream<E> fromFuture(@Nonnull CompletableFuture<E> future) {
         return new SingleValueMessageStream<>(future);
     }
 
@@ -104,7 +105,7 @@ public interface MessageStream<E> {
      * @param <E>      The type of entry carried in this {@link MessageStream stream}.
      * @return A {@link MessageStream stream} consisting of a single entry of type {@code E}.
      */
-    static <E> MessageStream<E> just(E instance) {
+    static <E> MessageStream<E> just(@Nullable E instance) {
         return new SingleValueMessageStream<>(instance);
     }
 
@@ -117,7 +118,7 @@ public interface MessageStream<E> {
      * @param <E>     The type of entry carried in this {@link MessageStream stream}.
      * @return A {@link MessageStream stream} that is completed exceptionally.
      */
-    static <E> MessageStream<E> failed(@NotNull Throwable failure) {
+    static <E> MessageStream<E> failed(@Nonnull Throwable failure) {
         return new FailedMessageStream<>(failure);
     }
 
@@ -169,7 +170,7 @@ public interface MessageStream<E> {
      * @return A {@link MessageStream stream} with all entries of type {@code E} mapped according to the {@code mapper}
      * function.
      */
-    default <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
+    default <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         return new MappedMessageStream<>(this, mapper);
     }
 
@@ -190,8 +191,8 @@ public interface MessageStream<E> {
      * @return A {@link CompletableFuture} carrying the result of the given {@code accumulator} that reduced the entire
      * {@link MessageStream stream}.
      */
-    <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                    @NotNull BiFunction<R, E, R> accumulator);
+    <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                    @Nonnull BiFunction<R, E, R> accumulator);
 
     /**
      * Invokes the given {@code onNext} each time an entry of type {@code E} is consumed from this
@@ -204,7 +205,7 @@ public interface MessageStream<E> {
      * @param onNext The {@link Consumer} to invoke for each entry.
      * @return A {@link MessageStream stream} that will invoke the given {@code onNext} for each entry.
      */
-    default MessageStream<E> onNextItem(@NotNull Consumer<E> onNext) {
+    default MessageStream<E> onNextItem(@Nonnull Consumer<E> onNext) {
         return new OnNextMessageStream<>(this, onNext);
     }
 
@@ -214,7 +215,7 @@ public interface MessageStream<E> {
      * @param consumer
      * @return
      */
-    default MessageStream<E> consume(@NotNull Predicate<E> consumer) {
+    default MessageStream<E> consume(@Nonnull Predicate<E> consumer) {
         asFlux().takeWhile(consumer).subscribe().dispose();
         return this;
     }
@@ -228,7 +229,7 @@ public interface MessageStream<E> {
      * @return A {@link MessageStream stream} that continues onto another stream when {@code this} stream completes with
      * an error.
      */
-    default MessageStream<E> onErrorContinue(@NotNull Function<Throwable, MessageStream<E>> onError) {
+    default MessageStream<E> onErrorContinue(@Nonnull Function<Throwable, MessageStream<E>> onError) {
         return new OnErrorContinueMessageStream<>(this, onError);
     }
 
@@ -241,7 +242,7 @@ public interface MessageStream<E> {
      * @param other The {@link MessageStream} to append to this stream.
      * @return A {@link MessageStream stream} concatenating this stream with given {@code other}.
      */
-    default MessageStream<E> concatWith(@NotNull MessageStream<E> other) {
+    default MessageStream<E> concatWith(@Nonnull MessageStream<E> other) {
         return new ConcatenatingMessageStream<>(this, other);
     }
 
@@ -252,7 +253,7 @@ public interface MessageStream<E> {
      * @param completeHandler The {@link Runnable} to invoke when the {@link MessageStream stream} completes normally.
      * @return A {@link MessageStream stream} that invokes the {@code completeHandler} upon normal completion.
      */
-    default MessageStream<E> whenComplete(@NotNull Runnable completeHandler) {
+    default MessageStream<E> whenComplete(@Nonnull Runnable completeHandler) {
         return new CompletionCallbackMessageStream<>(this, completeHandler);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -29,12 +29,12 @@ import java.util.stream.Stream;
 /**
  * Represents a stream of {@link Message Messages} that can be consumed as they become available.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-public interface MessageStream<M extends Message<?>> {
+public interface MessageStream<E> {
 
     /**
      * Create a {@link MessageStream stream} that provides the items returned by the given {@code iterable}.
@@ -43,11 +43,11 @@ public interface MessageStream<M extends Message<?>> {
      * iterable does so.
      *
      * @param iterable The {@link Iterable} providing the {@link Message Messages} to stream.
-     * @param <M>      The declared type of {@link Message} in this stream.
+     * @param <E>      The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} of {@link Message Messages} that returns the messages provided by the
      * given {@code iterable}.
      */
-    static <M extends Message<?>> MessageStream<M> fromIterable(@NotNull Iterable<M> iterable) {
+    static <E> MessageStream<E> fromIterable(@NotNull Iterable<E> iterable) {
         return new IterableMessageStream<>(iterable);
     }
 
@@ -58,11 +58,11 @@ public interface MessageStream<M extends Message<?>> {
      * does so.
      *
      * @param stream The {@link Stream} providing the {@link Message Messages} to stream.
-     * @param <M>    The declared type of {@link Message} in this stream.
+     * @param <E>    The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} of {@link Message Messages} that returns the messages provided by the
      * given {@code stream}.
      */
-    static <M extends Message<?>> MessageStream<M> fromStream(@NotNull Stream<M> stream) {
+    static <E> MessageStream<E> fromStream(@NotNull Stream<E> stream) {
         return new StreamMessageStream<>(stream);
     }
 
@@ -70,11 +70,11 @@ public interface MessageStream<M extends Message<?>> {
      * Create a {@link MessageStream stream} that provides the items returned by the given {@code flux}.
      *
      * @param flux The {@link Flux} providing the {@link Message Messages} to stream.
-     * @param <M>  The declared type of {@link Message} in this stream.
+     * @param <E>  The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} of {@link Message Messages} that returns the messages provided by the
      * given {@code flux}.
      */
-    static <M extends Message<?>> MessageStream<M> fromFlux(@NotNull Flux<M> flux) {
+    static <E> MessageStream<E> fromFlux(@NotNull Flux<E> flux) {
         return new FluxMessageStream<>(flux);
     }
 
@@ -85,10 +85,10 @@ public interface MessageStream<M extends Message<?>> {
      * The stream will complete with an exception when the given {@code future} completes exceptionally.
      *
      * @param future The {@link CompletableFuture} providing the {@link Message} to contain in the stream.
-     * @param <M>    The declared type of {@link Message} in this stream.
+     * @param <E>    The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} containing at most one {@link Message}.
      */
-    static <M extends Message<?>> MessageStream<M> fromFuture(@NotNull CompletableFuture<M> future) {
+    static <E> MessageStream<E> fromFuture(@NotNull CompletableFuture<E> future) {
         return new SingleValueMessageStream<>(future);
     }
 
@@ -98,10 +98,10 @@ public interface MessageStream<M extends Message<?>> {
      * Once the {@code Message} is consumer, the stream is considered completed.
      *
      * @param instance The {@link Message} to return in the stream.
-     * @param <M>      The declared type of {@link Message} in this stream.
+     * @param <E>      The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} consisting of a single {@link Message}.
      */
-    static <M extends Message<?>> MessageStream<M> just(M instance) {
+    static <E> MessageStream<E> just(E instance) {
         return new SingleValueMessageStream<>(instance);
     }
 
@@ -111,10 +111,10 @@ public interface MessageStream<M extends Message<?>> {
      * All attempts to read from this stream will propagate this error.
      *
      * @param failure The {@link Throwable} to propagate to consumers of the stream.
-     * @param <M>     The declared type of {@link Message} in this stream.
+     * @param <E>     The declared type of {@link Message} in this stream.
      * @return A {@link MessageStream stream} that is completed exceptionally.
      */
-    static <M extends Message<?>> MessageStream<M> failed(@NotNull Throwable failure) {
+    static <E> MessageStream<E> failed(@NotNull Throwable failure) {
         return new FailedMessageStream<>(failure);
     }
 
@@ -125,10 +125,10 @@ public interface MessageStream<M extends Message<?>> {
      * Any attempt to convert this stream to a component that requires an item to be returned (such as
      * {@link CompletableFuture}), will have it return {@code null}.
      *
-     * @param <M> The declared type of {@link Message} in this stream.
+     * @param <E> The declared type of {@link Message} in this stream.
      * @return An empty {@link MessageStream stream}.
      */
-    static <M extends Message<?>> MessageStream<M> empty() {
+    static <E> MessageStream<E> empty() {
         return EmptyMessageStream.instance();
     }
 
@@ -142,7 +142,7 @@ public interface MessageStream<M extends Message<?>> {
      * @return A {@link CompletableFuture} that completes with the first item, {@code null} if it is empty, or
      * exceptionally if the {@link MessageStream stream} propagates an error.
      */
-    CompletableFuture<M> asCompletableFuture();
+    CompletableFuture<E> asCompletableFuture();
 
     /**
      * Creates a {@link Flux} that consumes the {@link Message Messages} from this {@link MessageStream stream}.
@@ -152,7 +152,7 @@ public interface MessageStream<M extends Message<?>> {
      *
      * @return A {@link Flux} carrying the {@link Message Messages} of this {@link MessageStream stream}.
      */
-    Flux<M> asFlux();
+    Flux<E> asFlux();
 
     /**
      * Returns a {@link MessageStream stream} that maps each {@link Message} from this stream using given {@code mapper}
@@ -166,7 +166,7 @@ public interface MessageStream<M extends Message<?>> {
      * @return A {@link MessageStream stream} with all {@link Message Messages} mapped according to the {@code mapper}
      * function.
      */
-    default <R extends Message<?>> MessageStream<R> map(@NotNull Function<M, R> mapper) {
+    default <R> MessageStream<R> map(@NotNull Function<E, R> mapper) {
         return new MappedMessageStream<>(this, mapper);
     }
 
@@ -188,7 +188,7 @@ public interface MessageStream<M extends Message<?>> {
      * {@link MessageStream stream}.
      */
     <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                    @NotNull BiFunction<R, M, R> accumulator);
+                                    @NotNull BiFunction<R, E, R> accumulator);
 
     /**
      * Invokes the given {@code onNext} each time a {@link Message} is consumed from this {@link MessageStream stream}.
@@ -200,7 +200,7 @@ public interface MessageStream<M extends Message<?>> {
      * @param onNext The {@link Consumer} to invoke for each item.
      * @return A {@link MessageStream stream} that will invoke the given {@code onNext} for each item.
      */
-    default MessageStream<M> onNextItem(@NotNull Consumer<M> onNext) {
+    default MessageStream<E> onNextItem(@NotNull Consumer<E> onNext) {
         return new OnNextMessageStream<>(this, onNext);
     }
 
@@ -210,7 +210,7 @@ public interface MessageStream<M extends Message<?>> {
      * @param consumer
      * @return
      */
-    default MessageStream<M> consume(@NotNull Predicate<M> consumer) {
+    default MessageStream<E> consume(@NotNull Predicate<E> consumer) {
         asFlux().takeWhile(consumer).subscribe().dispose();
         return this;
     }
@@ -224,7 +224,7 @@ public interface MessageStream<M extends Message<?>> {
      * @return A {@link MessageStream stream} that continues onto another stream when {@code this} stream completes with
      * an error.
      */
-    default MessageStream<M> onErrorContinue(@NotNull Function<Throwable, MessageStream<M>> onError) {
+    default MessageStream<E> onErrorContinue(@NotNull Function<Throwable, MessageStream<E>> onError) {
         return new OnErrorContinueMessageStream<>(this, onError);
     }
 
@@ -237,7 +237,7 @@ public interface MessageStream<M extends Message<?>> {
      * @param other The {@link MessageStream} to append to this stream.
      * @return A {@link MessageStream stream} concatenating this stream with given {@code other}.
      */
-    default MessageStream<M> concatWith(@NotNull MessageStream<M> other) {
+    default MessageStream<E> concatWith(@NotNull MessageStream<E> other) {
         return new ConcatenatingMessageStream<>(this, other);
     }
 
@@ -248,7 +248,7 @@ public interface MessageStream<M extends Message<?>> {
      * @param completeHandler The {@link Runnable} to invoke when the {@link MessageStream stream} completes normally.
      * @return A {@link MessageStream stream} that invokes the {@code completeHandler} upon normal completion.
      */
-    default MessageStream<M> whenComplete(@NotNull Runnable completeHandler) {
+    default MessageStream<E> whenComplete(@NotNull Runnable completeHandler) {
         return new CompletionCallbackMessageStream<>(this, completeHandler);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -48,7 +48,7 @@ public interface MessageStream<E> {
      *
      * @param iterable The {@link Iterable} providing the {@link Message Messages} to stream.
      * @param <E>      The type of entry carried in this {@link MessageStream stream}.
-     * @return A {@link MessageStream stream} of entries of type {@code E} that returns the entires provided by the
+     * @return A {@link MessageStream stream} of entries of type {@code E} that returns the entries provided by the
      * given {@code iterable}.
      */
     static <E> MessageStream<E> fromIterable(@Nonnull Iterable<E> iterable) {

--- a/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
@@ -16,14 +16,13 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
 
 /**
  * Implementation of the {@link MessageStream} that when the stream completes exceptionally will continue on a
@@ -48,8 +47,8 @@ class OnErrorContinueMessageStream<E> implements MessageStream<E> {
      * @param onError  A {@link Function} providing the replacement {@link MessageStream stream} to continue from if the
      *                 given {@code delegate} completes exceptionally.
      */
-    OnErrorContinueMessageStream(@NotNull MessageStream<E> delegate,
-                                 @NotNull Function<Throwable, MessageStream<E>> onError) {
+    OnErrorContinueMessageStream(@Nonnull MessageStream<E> delegate,
+                                 @Nonnull Function<Throwable, MessageStream<E>> onError) {
         this.delegate = delegate;
         this.onError = onError;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
  * Implementation of the {@link MessageStream} that when the stream completes exceptionally will continue on a
  * {@code MessageStream} returned by the given {@code onError} {@link Function}.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -40,13 +40,13 @@ class OnErrorContinueMessageStream<E> implements MessageStream<E> {
     private final Function<Throwable, MessageStream<E>> onError;
 
     /**
-     * Construct an {@link OnErrorContinueMessageStream} that will proceed on the resulting {@link MessageStream} from
-     * the given {@code onError} when the {@code delegate} completes exceptionally
+     * Construct an {@link MessageStream stream} that will proceed on the resulting {@code MessageStream} from the given
+     * {@code onError} when the {@code delegate} completes exceptionally
      *
-     * @param delegate The delegate {@link MessageStream} to proceed from with the result of {@code onError} <em>if</em>
-     *                 it completes exceptionally.
-     * @param onError  A {@link Function} providing the replacement {@link MessageStream} to continue from if the given
-     *                 {@code delegate} completes exceptionally.
+     * @param delegate The delegate {@link MessageStream stream} to proceed from with the result of {@code onError}
+     *                 <em>if</em> it completes exceptionally.
+     * @param onError  A {@link Function} providing the replacement {@link MessageStream stream} to continue from if the
+     *                 given {@code delegate} completes exceptionally.
      */
     OnErrorContinueMessageStream(@NotNull MessageStream<E> delegate,
                                  @NotNull Function<Throwable, MessageStream<E>> onError) {

--- a/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,8 +46,8 @@ class OnNextMessageStream<E> implements MessageStream<E> {
      * @param onNext   The {@link Consumer} to handle each consumed entry of type {@code E} from the given
      *                 {@code delegate}.
      */
-    OnNextMessageStream(@NotNull MessageStream<E> delegate,
-                        @NotNull Consumer<E> onNext) {
+    OnNextMessageStream(@Nonnull MessageStream<E> delegate,
+                        @Nonnull Consumer<E> onNext) {
         this.delegate = delegate;
         this.onNext = onNext;
     }
@@ -68,8 +68,8 @@ class OnNextMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return delegate.reduce(identity, (base, message) -> {
             onNext.accept(message);
             return accumulator.apply(base, message);

--- a/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
@@ -25,9 +25,9 @@ import java.util.function.Consumer;
 
 /**
  * An implementation of the {@link MessageStream} that invokes the given {@code onNext} {@link Consumer} each time a new
- * {@link Message} is consumed from this {@code MessageStream}.
+ * entry of type {@code E} is consumed from this {@code MessageStream}.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -38,12 +38,13 @@ class OnNextMessageStream<E> implements MessageStream<E> {
     private final Consumer<E> onNext;
 
     /**
-     * Construct an {@link OnNextMessageStream} that invokes the given {@code onNext} {@link Consumer} each time a
-     * new {@link Message} is consumed by the given {@code delegate}.
+     * Construct an {@link MessageStream stream} that invokes the given {@code onNext} {@link Consumer} each time a new
+     * entry of type {@code E} is consumed by the given {@code delegate}.
      *
-     * @param delegate The delegate {@link MessageStream} from which each consumed {@link Message} is given to the
-     *                 {@code onNext} {@link Consumer}.
-     * @param onNext   The {@link Consumer} to handle each consumed {@link Message} from the given {@code delegate}.
+     * @param delegate The delegate {@link MessageStream stream} from which each consumed entry of type {@code E} is
+     *                 given to the {@code onNext} {@link Consumer}.
+     * @param onNext   The {@link Consumer} to handle each consumed entry of type {@code E} from the given
+     *                 {@code delegate}.
      */
     OnNextMessageStream(@NotNull MessageStream<E> delegate,
                         @NotNull Consumer<E> onNext) {

--- a/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
@@ -27,15 +27,15 @@ import java.util.function.Consumer;
  * An implementation of the {@link MessageStream} that invokes the given {@code onNext} {@link Consumer} each time a new
  * {@link Message} is consumed from this {@code MessageStream}.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class OnNextMessageStream<M extends Message<?>> implements MessageStream<M> {
+class OnNextMessageStream<E> implements MessageStream<E> {
 
-    private final MessageStream<M> delegate;
-    private final Consumer<M> onNext;
+    private final MessageStream<E> delegate;
+    private final Consumer<E> onNext;
 
     /**
      * Construct an {@link OnNextMessageStream} that invokes the given {@code onNext} {@link Consumer} each time a
@@ -45,14 +45,14 @@ class OnNextMessageStream<M extends Message<?>> implements MessageStream<M> {
      *                 {@code onNext} {@link Consumer}.
      * @param onNext   The {@link Consumer} to handle each consumed {@link Message} from the given {@code delegate}.
      */
-    OnNextMessageStream(@NotNull MessageStream<M> delegate,
-                        @NotNull Consumer<M> onNext) {
+    OnNextMessageStream(@NotNull MessageStream<E> delegate,
+                        @NotNull Consumer<E> onNext) {
         this.delegate = delegate;
         this.onNext = onNext;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return delegate.asCompletableFuture()
                        .thenApply(message -> {
                            onNext.accept(message);
@@ -61,14 +61,14 @@ class OnNextMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return delegate.asFlux()
                        .doOnNext(onNext);
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return delegate.reduce(identity, (base, message) -> {
             onNext.accept(message);
             return accumulator.apply(base, message);

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -16,7 +16,8 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -45,7 +46,7 @@ class SingleValueMessageStream<E> implements MessageStream<E> {
      * @param entry The entry of type {@code E} which is the singular value contained in this
      *              {@link MessageStream stream}.
      */
-    SingleValueMessageStream(E entry) {
+    SingleValueMessageStream(@Nullable E entry) {
         this(CompletableFuture.completedFuture(entry));
     }
 
@@ -56,7 +57,7 @@ class SingleValueMessageStream<E> implements MessageStream<E> {
      * @param source The {@link CompletableFuture} resulting in the singular entry of type {@code E} contained in this
      *               {@link MessageStream stream}.
      */
-    SingleValueMessageStream(@NotNull CompletableFuture<E> source) {
+    SingleValueMessageStream(@Nonnull CompletableFuture<E> source) {
         this.source = source;
     }
 
@@ -71,13 +72,13 @@ class SingleValueMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         return new SingleValueMessageStream<>(source.thenApply(mapper));
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return source.thenApply(message -> accumulator.apply(identity, message));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -28,14 +28,14 @@ import java.util.function.Function;
  * A {@link MessageStream} implementation using a single {@link Message} or {@link CompletableFuture} completing to a
  * {@code Message} as the source.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class SingleValueMessageStream<M extends Message<?>> implements MessageStream<M> {
+class SingleValueMessageStream<E> implements MessageStream<E> {
 
-    private final CompletableFuture<M> source;
+    private final CompletableFuture<E> source;
 
     /**
      * Constructs a {@link MessageStream} wrapping the given {@code message} into a
@@ -45,7 +45,7 @@ class SingleValueMessageStream<M extends Message<?>> implements MessageStream<M>
      * @param message The {@link Message} of type {@code M} which is the singular value contained in this
      *                {@link MessageStream}.
      */
-    SingleValueMessageStream(M message) {
+    SingleValueMessageStream(E message) {
         this(CompletableFuture.completedFuture(message));
     }
 
@@ -56,28 +56,28 @@ class SingleValueMessageStream<M extends Message<?>> implements MessageStream<M>
      * @param source The {@link CompletableFuture} resulting in the singular {@link Message} contained in this
      *               {@link MessageStream}.
      */
-    SingleValueMessageStream(@NotNull CompletableFuture<M> source) {
+    SingleValueMessageStream(@NotNull CompletableFuture<E> source) {
         this.source = source;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return source;
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Flux.from(Mono.fromFuture(source));
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(Function<M, R> mapper) {
+    public <R> MessageStream<R> map(Function<E, R> mapper) {
         return new SingleValueMessageStream<>(source.thenApply(mapper));
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@NotNull R identity,
-                                           @NotNull BiFunction<R, M, R> accumulator) {
+                                           @NotNull BiFunction<R, E, R> accumulator) {
         return source.thenApply(message -> accumulator.apply(identity, message));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -25,10 +25,10 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * A {@link MessageStream} implementation using a single {@link Message} or {@link CompletableFuture} completing to a
- * {@code Message} as the source.
+ * A {@link MessageStream} implementation using a single entry of type {@code E} or {@link CompletableFuture} completing
+ * to an entry of type {@code E} as the source.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -38,23 +38,23 @@ class SingleValueMessageStream<E> implements MessageStream<E> {
     private final CompletableFuture<E> source;
 
     /**
-     * Constructs a {@link MessageStream} wrapping the given {@code message} into a
+     * Constructs a {@link MessageStream stream} wrapping the given {@code entry} into a
      * {@link CompletableFuture#completedFuture(Object) completed CompletableFuture} as the single value in this
      * stream.
      *
-     * @param message The {@link Message} of type {@code M} which is the singular value contained in this
-     *                {@link MessageStream}.
+     * @param entry The entry of type {@code E} which is the singular value contained in this
+     *              {@link MessageStream stream}.
      */
-    SingleValueMessageStream(E message) {
-        this(CompletableFuture.completedFuture(message));
+    SingleValueMessageStream(E entry) {
+        this(CompletableFuture.completedFuture(entry));
     }
 
     /**
-     * Constructs a {@link MessageStream} with the given {@code source} as the provider of the single {@link Message} in
-     * this stream.
+     * Constructs a {@link MessageStream stream} with the given {@code source} as the provider of the single entry of
+     * type {@code E} in this stream.
      *
-     * @param source The {@link CompletableFuture} resulting in the singular {@link Message} contained in this
-     *               {@link MessageStream}.
+     * @param source The {@link CompletableFuture} resulting in the singular entry of type {@code E} contained in this
+     *               {@link MessageStream stream}.
      */
     SingleValueMessageStream(@NotNull CompletableFuture<E> source) {
         this.source = source;

--- a/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
@@ -27,42 +27,42 @@ import java.util.stream.Stream;
 /**
  * A {@link MessageStream} implementation using a {@link Stream} as the {@link Message} source.
  *
- * @param <M> The type of {@link Message} carried in this stream.
+ * @param <E> The type of {@link Message} carried in this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class StreamMessageStream<M extends Message<?>> implements MessageStream<M> {
+class StreamMessageStream<E> implements MessageStream<E> {
 
-    private final Stream<M> source;
+    private final Stream<E> source;
 
     /**
      * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
      *
      * @param source The {@link Stream} sourcing the {@link Message Messages} for this {@link MessageStream}.
      */
-    StreamMessageStream(@NotNull Stream<M> source) {
+    StreamMessageStream(@NotNull Stream<E> source) {
         this.source = source;
     }
 
     @Override
-    public CompletableFuture<M> asCompletableFuture() {
+    public CompletableFuture<E> asCompletableFuture() {
         return CompletableFuture.completedFuture(source.findFirst()
                                                        .orElse(null));
     }
 
     @Override
-    public Flux<M> asFlux() {
+    public Flux<E> asFlux() {
         return Flux.fromStream(source);
     }
 
     @Override
-    public <R extends Message<?>> MessageStream<R> map(Function<M, R> mapper) {
+    public <R> MessageStream<R> map(Function<E, R> mapper) {
         return new StreamMessageStream<>(source.map(mapper));
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity, @NotNull BiFunction<R, M, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@NotNull R identity, @NotNull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(
                 source.sequential()
                       .reduce(identity, accumulator, (thisResult, thatResult) -> {

--- a/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
@@ -25,9 +25,9 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * A {@link MessageStream} implementation using a {@link Stream} as the {@link Message} source.
+ * A {@link MessageStream} implementation using a {@link Stream} as the source.
  *
- * @param <E> The type of {@link Message} carried in this stream.
+ * @param <E> The type of entry carried in this {@link MessageStream stream}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
@@ -37,9 +37,10 @@ class StreamMessageStream<E> implements MessageStream<E> {
     private final Stream<E> source;
 
     /**
-     * Constructs a {@link MessageStream} using the given {@code source} to provide the {@link Message Messages}.
+     * Constructs a {@link MessageStream stream} using the given {@code source} to provide the entries of type
+     * {@code E}.
      *
-     * @param source The {@link Stream} sourcing the {@link Message Messages} for this {@link MessageStream}.
+     * @param source The {@link Stream} providing the entries of type {@code E} for this {@link MessageStream stream}.
      */
     StreamMessageStream(@NotNull Stream<E> source) {
         this.source = source;

--- a/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/StreamMessageStream.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +42,7 @@ class StreamMessageStream<E> implements MessageStream<E> {
      *
      * @param source The {@link Stream} providing the entries of type {@code E} for this {@link MessageStream stream}.
      */
-    StreamMessageStream(@NotNull Stream<E> source) {
+    StreamMessageStream(@Nonnull Stream<E> source) {
         this.source = source;
     }
 
@@ -58,12 +58,13 @@ class StreamMessageStream<E> implements MessageStream<E> {
     }
 
     @Override
-    public <R> MessageStream<R> map(Function<E, R> mapper) {
+    public <R> MessageStream<R> map(@Nonnull Function<E, R> mapper) {
         return new StreamMessageStream<>(source.map(mapper));
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(@NotNull R identity, @NotNull BiFunction<R, E, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
+                                           @Nonnull BiFunction<R, E, R> accumulator) {
         return CompletableFuture.completedFuture(
                 source.sequential()
                       .reduce(identity, accumulator, (thisResult, thatResult) -> {

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import javax.annotation.Nonnull;
 import static org.axonframework.common.annotation.AnnotationUtils.findAnnotationAttributes;
 
 /**
- * The default HandlerDefinition implementation in Axon. It implements the rules of annotated handlers used
- * in all the different types of handlers in Axon.
+ * The default HandlerDefinition implementation in Axon. It implements the rules of annotated handlers used in all the
+ * different types of handlers in Axon.
  * <p>
  * For this implementation to recognize a handler method, it should be (meta)annotated with {@link MessageHandler}. It
  * is recommended to meta-annotated members, and preconfigure the expected {@code messageType}. For example, and event
@@ -46,10 +46,12 @@ public class AnnotatedMessageHandlingMemberDefinition implements HandlerDefiniti
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> Optional<MessageHandlingMember<T>> createHandler(@Nonnull Class<T> declaringType,
-                                                                @Nonnull Method method,
-                                                                @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                                                Function<Object, MessageStream<?>> returnTypeConverter) {
+    public <T> Optional<MessageHandlingMember<T>> createHandler(
+            @Nonnull Class<T> declaringType,
+            @Nonnull Method method,
+            @Nonnull ParameterResolverFactory parameterResolverFactory,
+            Function<Object, MessageStream<? extends Message<?>>> returnTypeConverter
+    ) {
         return findAnnotationAttributes(method, MessageHandler.class)
                 .map(attr -> new MethodInvokingMessageHandlingMember<>(
                         method,

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.annotation;
 
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
 
 import java.lang.reflect.Method;
@@ -44,8 +45,10 @@ public interface HandlerDefinition {
      * @param returnTypeConverter
      * @return An optional containing the handler if the method is suitable, or an empty Nullable otherwise
      */
-    <T> Optional<MessageHandlingMember<T>> createHandler(@Nonnull Class<T> declaringType,
-                                                         @Nonnull Method method,
-                                                         @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                                         Function<Object, MessageStream<?>> returnTypeConverter);
+    <T> Optional<MessageHandlingMember<T>> createHandler(
+            @Nonnull Class<T> declaringType,
+            @Nonnull Method method,
+            @Nonnull ParameterResolverFactory parameterResolverFactory,
+            Function<Object, MessageStream<? extends Message<?>>> returnTypeConverter
+    );
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlerInterceptorMemberChain.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlerInterceptorMemberChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,10 @@ public interface MessageHandlerInterceptorMemberChain<T> {
     Object handleSync(@Nonnull Message<?> message, @Nonnull T target, @Nonnull MessageHandlingMember<? super T> handler)
             throws Exception;
 
-    default MessageStream<?> handle(@Nonnull Message<?> message, @Nonnull ProcessingContext processingContext,
-                                    @Nonnull T target, @Nonnull MessageHandlingMember<? super T> handler) {
+    default MessageStream<? extends Message<?>> handle(@Nonnull Message<?> message,
+                                                       @Nonnull ProcessingContext processingContext,
+                                                       @Nonnull T target,
+                                                       @Nonnull MessageHandlingMember<? super T> handler) {
         try {
             return MessageStream.just(GenericMessage.asMessage(handleSync(message, target, handler)));
         } catch (Exception e) {

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MessageHandlingMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,9 +105,9 @@ public interface MessageHandlingMember<T> {
     @Deprecated
     Object handleSync(@Nonnull Message<?> message, @Nullable T target) throws Exception;
 
-    default MessageStream<?> handle(@Nonnull Message<?> message,
-                                    @Nonnull ProcessingContext processingContext,
-                                    @Nullable T target) {
+    default MessageStream<? extends Message<?>> handle(@Nonnull Message<?> message,
+                                                       @Nonnull ProcessingContext processingContext,
+                                                       @Nullable T target) {
         try {
             // TODO: 24-11-2023 proper impl
             return MessageStream.just(GenericMessage.asMessage(handleSync(message, target)));

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.annotation;
 
 import org.axonframework.common.annotation.PriorityAnnotationComparator;
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
 
 import java.lang.reflect.Method;
@@ -175,10 +176,12 @@ public class MultiHandlerDefinition implements HandlerDefinition {
     }
 
     @Override
-    public <T> Optional<MessageHandlingMember<T>> createHandler(@Nonnull Class<T> declaringType,
-                                                                @Nonnull Method method,
-                                                                @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                                                Function<Object, MessageStream<?>> returnTypeConverter) {
+    public <T> Optional<MessageHandlingMember<T>> createHandler(
+            @Nonnull Class<T> declaringType,
+            @Nonnull Method method,
+            @Nonnull ParameterResolverFactory parameterResolverFactory,
+            Function<Object, MessageStream<? extends Message<?>>> returnTypeConverter
+    ) {
         Optional<MessageHandlingMember<T>> handler = Optional.empty();
         for (HandlerDefinition handlerDefinition : handlerDefinitions) {
             handler = handlerDefinition.createHandler(declaringType,

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/NoMoreInterceptors.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/NoMoreInterceptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,22 +35,25 @@ public class NoMoreInterceptors<T> implements MessageHandlerInterceptorMemberCha
     /**
      * Creates and returns a new instance
      *
-     * @return a new {@link NoMoreInterceptors} instance
      * @param <T> the type of the handlers
+     * @return a new {@link NoMoreInterceptors} instance
      */
     public static <T> MessageHandlerInterceptorMemberChain<T> instance() {
         return new NoMoreInterceptors<>();
     }
 
     @Override
-    public Object handleSync(@Nonnull Message<?> message, @Nonnull T target,
+    public Object handleSync(@Nonnull Message<?> message,
+                             @Nonnull T target,
                              @Nonnull MessageHandlingMember<? super T> handler) throws Exception {
         return handler.handleSync(message, target);
     }
 
     @Override
-    public MessageStream<?> handle(@Nonnull Message<?> message, @Nonnull ProcessingContext processingContext,
-                                   @Nonnull T target, @Nonnull MessageHandlingMember<? super T> handler) {
+    public MessageStream<? extends Message<?>> handle(@Nonnull Message<?> message,
+                                                      @Nonnull ProcessingContext processingContext,
+                                                      @Nonnull T target,
+                                                      @Nonnull MessageHandlingMember<? super T> handler) {
         return handler.handle(message, processingContext, target);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/WrappedMessageHandlingMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ public abstract class WrappedMessageHandlingMember<T> implements MessageHandling
 
     @Override
     public MessageStream<? extends Message<?>> handle(@Nonnull Message<?> message,
-                                @Nonnull ProcessingContext processingContext,
-                                @Nullable T target) {
+                                                      @Nonnull ProcessingContext processingContext,
+                                                      @Nullable T target) {
         return delegate.handle(message, processingContext, target);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
@@ -31,19 +31,19 @@ class CompletionCallbackMessageStreamTest extends MessageStreamTest<String> {
     };
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(messages), NO_OP_COMPLETION_CALLBACK);
+    MessageStream<String> testSubject(List<String> entries) {
+        return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(entries), NO_OP_COMPLETION_CALLBACK);
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(messages)
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(entries)
                                                                   .concatWith(MessageStream.failed(failure)),
                                                      NO_OP_COMPLETION_CALLBACK);
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
@@ -28,23 +28,23 @@ import java.util.concurrent.ThreadLocalRandom;
 class ConcatenatingMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        if (messages.isEmpty()) {
+    MessageStream<String> testSubject(List<String> entries) {
+        if (entries.isEmpty()) {
             return new ConcatenatingMessageStream<>(MessageStream.empty(), MessageStream.empty());
-        } else if (messages.size() == 1) {
-            return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()), MessageStream.empty());
+        } else if (entries.size() == 1) {
+            return new ConcatenatingMessageStream<>(MessageStream.just(entries.getFirst()), MessageStream.empty());
         }
-        return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()),
-                                                MessageStream.fromIterable(messages.subList(1, messages.size())));
+        return new ConcatenatingMessageStream<>(MessageStream.just(entries.getFirst()),
+                                                MessageStream.fromIterable(entries.subList(1, entries.size())));
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return testSubject(messages).concatWith(MessageStream.failed(failure));
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return testSubject(entries).concatWith(MessageStream.failed(failure));
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
@@ -58,8 +58,8 @@ class DelayedMessageStreamTest extends MessageStreamTest<String> {
     void createForExecutionExceptionReturnsFailedMessageStreamWithCause() {
         RuntimeException expected = new RuntimeException("oops");
 
-        CompletableFuture<Message<?>> result = DelayedMessageStream.create(CompletableFuture.failedFuture(expected))
-                                                                   .asCompletableFuture();
+        CompletableFuture<Object> result = DelayedMessageStream.create(CompletableFuture.failedFuture(expected))
+                                                               .asCompletableFuture();
 
         assertTrue(result.isCompletedExceptionally());
         assertEquals(expected, result.exceptionNow());

--- a/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
@@ -33,19 +33,19 @@ import static org.junit.jupiter.api.Assertions.*;
 class EmptyMessageStreamTest extends MessageStreamTest<Void> {
 
     @Override
-    MessageStream<Message<Void>> testSubject(List<Message<Void>> messages) {
-        Assumptions.assumeTrue(messages.isEmpty(), "EmptyMessageStream doesn't support content");
+    MessageStream<Void> testSubject(List<Void> entries) {
+        Assumptions.assumeTrue(entries.isEmpty(), "EmptyMessageStream doesn't support content");
         return MessageStream.empty();
     }
 
     @Override
-    MessageStream<Message<Void>> failingTestSubject(List<Message<Void>> messages, Exception failure) {
+    MessageStream<Void> failingTestSubject(List<Void> entries, Exception failure) {
         Assumptions.abort("EmptyMessageStream doesn't support failed streams");
         return MessageStream.empty();
     }
 
     @Override
-    Void createRandomValidEntry() {
+    Void createRandomEntry() {
         Assumptions.abort("EmptyMessageStream doesn't support content");
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
@@ -54,12 +54,12 @@ class EmptyMessageStreamTest extends MessageStreamTest<Void> {
     void doesNothingOnErrorContinue() {
         AtomicBoolean invoked = new AtomicBoolean(false);
 
-        CompletableFuture<Message<?>> result = MessageStream.empty()
-                                                            .onErrorContinue(e -> {
-                                                                invoked.set(true);
-                                                                return MessageStream.empty();
-                                                            })
-                                                            .asCompletableFuture();
+        CompletableFuture<Object> result = MessageStream.empty()
+                                                        .onErrorContinue(e -> {
+                                                            invoked.set(true);
+                                                            return MessageStream.empty();
+                                                        })
+                                                        .asCompletableFuture();
         assertTrue(result.isDone());
         assertNull(result.join());
         assertFalse(invoked.get());
@@ -69,11 +69,11 @@ class EmptyMessageStreamTest extends MessageStreamTest<Void> {
     void shouldReturnFailedMessageStreamOnFailingCompletionHandler() {
         RuntimeException expected = new RuntimeException("oops");
 
-        CompletableFuture<Message<?>> result = MessageStream.empty()
-                                                            .whenComplete(() -> {
-                                                                throw expected;
-                                                            })
-                                                            .asCompletableFuture();
+        CompletableFuture<Object> result = MessageStream.empty()
+                                                        .whenComplete(() -> {
+                                                            throw expected;
+                                                        })
+                                                        .asCompletableFuture();
 
         assertTrue(result.isCompletedExceptionally());
         assertEquals(expected, result.exceptionNow());

--- a/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
@@ -29,19 +29,19 @@ import java.util.List;
 class FailedMessageStreamTest extends MessageStreamTest<Void> {
 
     @Override
-    MessageStream<Message<Void>> testSubject(List<Message<Void>> messages) {
+    MessageStream<Void> testSubject(List<Void> entries) {
         Assumptions.abort("FailedMessageStream doesn't support successful streams");
         return null;
     }
 
     @Override
-    MessageStream<Message<Void>> failingTestSubject(List<Message<Void>> messages, Exception failure) {
-        Assumptions.assumeTrue(messages.isEmpty(), "FailedMessageStream doesn't support content");
+    MessageStream<Void> failingTestSubject(List<Void> entries, Exception failure) {
+        Assumptions.assumeTrue(entries.isEmpty(), "FailedMessageStream doesn't support content");
         return MessageStream.failed(failure);
     }
 
     @Override
-    Void createRandomValidEntry() {
+    Void createRandomEntry() {
         Assumptions.abort("FailedMessageStream doesn't support content");
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
@@ -31,18 +31,18 @@ import java.util.concurrent.ThreadLocalRandom;
 class FluxMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages));
+    MessageStream<String> testSubject(List<String> entries) {
+        return MessageStream.fromFlux(Flux.fromIterable(entries));
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages)
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return MessageStream.fromFlux(Flux.fromIterable(entries)
                                           .concatWith(Mono.error(failure)));
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/IterableMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/IterableMessageStreamTest.java
@@ -30,18 +30,18 @@ import java.util.concurrent.ThreadLocalRandom;
 class IterableMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return MessageStream.fromIterable(messages);
+    MessageStream<String> testSubject(List<String> entries) {
+        return MessageStream.fromIterable(entries);
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
         Assumptions.abort("IterableMessageStream doesn't support failures");
         return null;
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
@@ -28,22 +28,22 @@ import java.util.function.Function;
  */
 class MappedMessageStreamTest extends MessageStreamTest<String> {
 
-    private static final Function<Message<String>, Message<String>> NO_OP_MAPPER = message -> message;
+    private static final Function<String, String> NO_OP_MAPPER = message -> message;
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return new MappedMessageStream<>(MessageStream.fromIterable(messages), NO_OP_MAPPER);
+    MessageStream<String> testSubject(List<String> entries) {
+        return new MappedMessageStream<>(MessageStream.fromIterable(entries), NO_OP_MAPPER);
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return new MappedMessageStream<>(MessageStream.fromIterable(messages)
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return new MappedMessageStream<>(MessageStream.fromIterable(entries)
                                                       .concatWith(MessageStream.failed(failure)),
                                          NO_OP_MAPPER);
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
@@ -28,19 +28,19 @@ import java.util.concurrent.ThreadLocalRandom;
 class OnErrorContinueMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages), error -> MessageStream.empty());
+    MessageStream<String> testSubject(List<String> entries) {
+        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(entries), error -> MessageStream.empty());
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages)
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(entries)
                                                                .concatWith(MessageStream.failed(failure)),
                                                   error -> MessageStream.failed(failure));
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -60,8 +60,8 @@ class OnNextMessageStreamTest extends MessageStreamTest<String> {
     @Test
     void onNextNotInvokedOnEmptyStream() {
         //noinspection unchecked
-        Consumer<Message<?>> handler = mock();
-        MessageStream<Message<?>> testSubject = MessageStream.empty().onNextItem(handler);
+        Consumer<Object> handler = mock();
+        MessageStream<Object> testSubject = MessageStream.empty().onNextItem(handler);
 
         testSubject.asCompletableFuture().isDone();
         verify(handler, never()).accept(any());

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -37,23 +37,23 @@ import static org.mockito.Mockito.*;
  */
 class OnNextMessageStreamTest extends MessageStreamTest<String> {
 
-    private static final @NotNull Consumer<Message<String>> NO_OP_ON_NEXT = message -> {
+    private static final Consumer<String> NO_OP_ON_NEXT = message -> {
     };
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return new OnNextMessageStream<>(MessageStream.fromIterable(messages), NO_OP_ON_NEXT);
+    MessageStream<String> testSubject(List<String> entries) {
+        return new OnNextMessageStream<>(MessageStream.fromIterable(entries), NO_OP_ON_NEXT);
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        return new OnNextMessageStream<>(MessageStream.fromIterable(messages)
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        return new OnNextMessageStream<>(MessageStream.fromIterable(entries)
                                                       .concatWith(MessageStream.failed(failure)),
                                          NO_OP_ON_NEXT);
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 
@@ -69,21 +69,21 @@ class OnNextMessageStreamTest extends MessageStreamTest<String> {
 
     @Test
     void verifyOnNextInvokedForFirstElementWhenUsingOnCompletableFuture() {
-        List<Message<?>> seen = new ArrayList<>();
-        List<Message<?>> items = List.of(GenericMessage.asMessage("first"), GenericMessage.asMessage("second"));
-        CompletableFuture<Message<?>> actual = MessageStream.fromIterable(items)
-                                                            .onNextItem(seen::add)
-                                                            .asCompletableFuture();
+        List<String> seen = new ArrayList<>();
+        List<String> items = List.of("first", "second");
+        CompletableFuture<String> actual = MessageStream.fromIterable(items)
+                                                        .onNextItem(seen::add)
+                                                        .asCompletableFuture();
 
         assertTrue(actual.isDone());
         assertEquals(1, seen.size());
-        assertEquals("first", seen.getFirst().getPayload());
+        assertEquals("first", seen.getFirst());
     }
 
     @Test
     void verifyOnNextInvokedForAllElementsWhenUsingAsFlux() {
-        List<Message<?>> seen = new ArrayList<>();
-        List<Message<?>> items = List.of(GenericMessage.asMessage("first"), GenericMessage.asMessage("second"));
+        List<String> seen = new ArrayList<>();
+        List<String> items = List.of("first", "second");
         StepVerifier.create(MessageStream.fromIterable(items)
                                          .onNextItem(seen::add)
                                          .asFlux())
@@ -91,7 +91,7 @@ class OnNextMessageStreamTest extends MessageStreamTest<String> {
                     .verifyComplete();
 
         assertEquals(2, seen.size());
-        assertEquals("first", seen.getFirst().getPayload());
-        assertEquals("second", seen.get(1).getPayload());
+        assertEquals("first", seen.getFirst());
+        assertEquals("second", seen.get(1));
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
@@ -31,20 +31,20 @@ import java.util.concurrent.ThreadLocalRandom;
 class SingleValueMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        Assumptions.assumeTrue(messages.size() == 1, "SingleValueMessageStream only supports a single value");
-        return MessageStream.just(messages.getFirst());
+    MessageStream<String> testSubject(List<String> entries) {
+        Assumptions.assumeTrue(entries.size() == 1, "SingleValueMessageStream only supports a single value");
+        return MessageStream.just(entries.getFirst());
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
-        Assumptions.assumeTrue(messages.isEmpty(),
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
+        Assumptions.assumeTrue(entries.isEmpty(),
                                "SingleValueMessageStream only supports failures without regular values");
         return MessageStream.fromFuture(CompletableFuture.failedFuture(failure));
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test-" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
@@ -30,18 +30,18 @@ import java.util.concurrent.ThreadLocalRandom;
 class StreamMessageStreamTest extends MessageStreamTest<String> {
 
     @Override
-    MessageStream<Message<String>> testSubject(List<Message<String>> messages) {
-        return MessageStream.fromStream(messages.stream());
+    MessageStream<String> testSubject(List<String> entries) {
+        return MessageStream.fromStream(entries.stream());
     }
 
     @Override
-    MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages, Exception failure) {
+    MessageStream<String> failingTestSubject(List<String> entries, Exception failure) {
         Assumptions.abort("StreamMessageStream doesn't support failures");
         return null;
     }
 
     @Override
-    String createRandomValidEntry() {
+    String createRandomEntry() {
         return "test--" + ThreadLocalRandom.current().nextInt(10000);
     }
 }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,10 +136,12 @@ public class FixtureTest_RegisteringMethodEnhancements {
         }
 
         @Override
-        public <T> Optional<MessageHandlingMember<T>> createHandler(@Nonnull Class<T> declaringType,
-                                                                    @Nonnull Method method,
-                                                                    @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                                                    Function<Object, MessageStream<?>> returnTypeConverter) {
+        public <T> Optional<MessageHandlingMember<T>> createHandler(
+                @Nonnull Class<T> declaringType,
+                @Nonnull Method method,
+                @Nonnull ParameterResolverFactory parameterResolverFactory,
+                Function<Object, MessageStream<? extends Message<?>>> returnTypeConverter
+        ) {
             assertion.set(true);
             // We do not care about a specific MessageHandlingMember,
             //  only that this method is called to ensure its part of the FixtureConfiguration.

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,10 +143,12 @@ public class FixtureTest_RegisteringMethodEnhancements {
         }
 
         @Override
-        public <T> Optional<MessageHandlingMember<T>> createHandler(@Nonnull Class<T> declaringType,
-                                                                    @Nonnull Method method,
-                                                                    @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                                                    Function<Object, MessageStream<?>> returnTypeConverter) {
+        public <T> Optional<MessageHandlingMember<T>> createHandler(
+                @Nonnull Class<T> declaringType,
+                @Nonnull Method method,
+                @Nonnull ParameterResolverFactory parameterResolverFactory,
+                Function<Object, MessageStream<? extends Message<?>>> returnTypeConverter
+        ) {
             assertion.set(true);
             // We do not care about a specific MessageHandlingMember,
             //  only that this method is called to ensure its part of the FixtureConfiguration.


### PR DESCRIPTION
This pull request adjusts the `MessageStream` to no longer expect a generic that implements the `Message` interface.
Although this merits a rename of the `MessageStream` interface (as well as its implementations), the `MessageStream` is for the time being used around Axon Framework's buses, stores, gateways, and message handlers.

For the buses and message handlers, we expect the generic to still be of type `Message`.
For the stores and gateways, this will likely be different.
The latter would be able to unwrap the `Message` to just return/expect the payload (as is the case with the gateways right now).
For the stores, we expect to use tuples/pairs of `EventMessage` to position (`TrackingToken`, for example) or `EventMessage` to "acknowledgement" (which is mandatory for Persistent Stream support).

The latter requirement to contain tuples was the trigger to work on this issue, was stems from the effort performed for #3101 so far in pull request #3131.

By making this generic shift, some parts of the message handling logic that were already implemented required some changes on their generics too.

Next to switching the generic, this PR adjusts the JavaDoc and tests accordingly. 
Lastly, the `@NotNull` annotation has been replaced for the `@Nonnull` annotation, as this lets the IDE actually validate the APIs and their implementations.

By doing the above, this pull request resolves #3129.