### PR TITLE
Make a nice link to Token Stealing to refer it in the AxonIQ Console guide

### DIFF
--- a/docs/old-reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -425,7 +425,7 @@ This so-called "claim extension" is, just as updating and saving of tokens, dele
 Hence, the Streaming Processors achieves collaboration among instances/threads through token claims.
 
 In the absence of a claim, a processor will actively try to retrieve one.
-If a token claim is not extended for a configurable amount of time, other processor threads can <<Token stealing,"steal">> the claim.
+If a token claim is not extended for a configurable amount of time, other processor threads can <<token-stealing,"steal">> the claim.
 Token stealing can, for example, happen if event processing is slow or encountered some exceptions.
 
 ____
@@ -669,6 +669,7 @@ public class AxonConfig {
 }
 ----
 
+[[token-stealing]]
 ==== Token stealing
 
 As described at the <<tracking-tokens,start>>, streaming processor threads can "steal" tokens from one another.


### PR DESCRIPTION
I would like to link the AxonIQ Console docs to it, as follows:

```adoc
If the segment claim percentage is higher than 100%, this can mean two things:

- You have an `InMemoryTokenStore` configured with multiple applications deployed, which can be a valid use-case if you want all application instances to process the same events.
- Your applications are xref:xref:axon-framework-reference:events:event-processors/streaming.adoc#token-stealing[stealing tokens from each other] because the work in a batch takes longer than the configured `tokenClaimInterval` of the token store.
```

This way it doesn't have to be explained twice. However, it's missing a nice anchor. This PR adds that. 