### PR TITLE
fixed hasAnnotation test

### DIFF
--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
@@ -38,12 +38,16 @@ class AnnotatedMessageHandlingMemberTest {
 
     @BeforeEach
     void setUp() {
+        try {
         testSubject = new AnnotatedMessageHandlingMember<>(
-                AnnotatedHandler.class.getMethods()[0],
+                AnnotatedHandler.class.getMethod("handlingMethod", String.class),
                 EventMessage.class,
                 String.class,
                 ClasspathParameterResolverFactory.forClass(AnnotatedHandler.class)
-        );
+        ); }
+        catch (NoSuchMethodException e){
+            fail(e.getMessage());
+        }
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedMessageHandlingMemberTest.java
@@ -44,7 +44,8 @@ class AnnotatedMessageHandlingMemberTest {
                 EventMessage.class,
                 String.class,
                 ClasspathParameterResolverFactory.forClass(AnnotatedHandler.class)
-        ); }
+        ); 
+        }
         catch (NoSuchMethodException e){
             fail(e.getMessage());
         }


### PR DESCRIPTION
`hasAnnotation` test within `AnnotatedMessageHandlingMemberTest.java` can fail, if `getMethods` returns a different order. It was expecting a `true` result, but could get `false`.

To fix this test, the `getMethods()[0]` call within the `setUp` was replaced with `getMethod("handlingMessage", String.class)`. A try catch block was added to handle the change to make sure that `EventHandler` was returned.

The change/addition was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

To reproduce the problem, you can run the NonDex tool, using this command:

```
mvn -pl messaging edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.axonframework.messaging.annotation.AnnotatedMessageHandlingMemberTest#hasAnnotation
```