### PR TITLE
Add Synchronous queryAndWait Method to QueryGateway

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -26,7 +26,11 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -168,7 +168,7 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
      * @return The result of the query of type {@code R}.
      * @throws QueryExecutionException if an exception occurs during query execution, including cases where a timeout is reached.
      */
-    <R, Q> R queryAndWait(String queryName, Q query, ResponseType<R> responseType, long timeout, TimeUnit unit);
+    <R, Q> R queryAndWait(@Nonnull String queryName, @Nonnull Q query, ResponseType<R> responseType, long timeout, @Nonnull TimeUnit unit);
 
     /**
      * Sends given {@code query} over the {@link org.axonframework.queryhandling.QueryBus}, expecting a response

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -108,6 +108,69 @@ public interface QueryGateway extends MessageDispatchInterceptorSupport<QueryMes
                                       @Nonnull ResponseType<R> responseType);
 
     /**
+     * Sends the specified {@code query} over the {@link QueryBus} and waits for a response synchronously.
+     * This method derives the query name from the provided {@code query} object.
+     *
+     * @param query        The query object containing the details of the request.
+     * @param responseType The {@link ResponseType} describing the expected response type.
+     * @param <R>          The response class contained in the given {@code responseType}.
+     * @param <Q>          The query class.
+     * @return The result of the query of type {@code R}.
+     * @throws QueryExecutionException if an exception occurs during query execution, with the root cause wrapped in the exception.
+     */
+    default <R, Q> R queryAndWait(@Nonnull Q query, @Nonnull ResponseType<R> responseType) {
+        return queryAndWait(queryName(query), query, responseType);
+    }
+
+    /**
+     * Sends the specified {@code query} with a {@code queryName} over the {@link QueryBus} and waits for a response
+     * synchronously.
+     *
+     * @param queryName    A {@link String} describing the query to be executed.
+     * @param query        The query object containing the details of the request.
+     * @param responseType The {@link ResponseType} describing the expected response type.
+     * @param <R>          The response class contained in the given {@code responseType}.
+     * @param <Q>          The query class.
+     * @return The result of the query of type {@code R}.
+     * @throws QueryExecutionException if an exception occurs during query execution, with the root cause wrapped in the exception.
+     */
+    <R, Q> R queryAndWait(@Nonnull String queryName, @Nonnull Q query, @Nonnull ResponseType<R> responseType);
+
+    /**
+     * Sends the specified {@code query} over the {@link QueryBus} and waits for a response synchronously, up to a
+     * maximum period defined by {@code timeout} and {@code unit}. This method derives the query name from the provided
+     * {@code query} object.
+     *
+     * @param query        The query object containing the details of the request.
+     * @param responseType The {@link ResponseType} describing the expected response type.
+     * @param timeout      The maximum time to wait for the response.
+     * @param unit         The {@link TimeUnit} of the timeout value.
+     * @param <R>          The response class contained in the given {@code responseType}.
+     * @param <Q>          The query class.
+     * @return The result of the query of type {@code R}.
+     * @throws QueryExecutionException if an exception occurs during query execution, including cases where a timeout is reached.
+     */
+    default <R, Q> R queryAndWait(@Nonnull Q query, @Nonnull ResponseType<R> responseType, long timeout, @Nonnull TimeUnit unit) {
+        return queryAndWait(queryName(query), query, responseType, timeout, unit);
+    }
+
+    /**
+     * Sends the specified {@code query} with a {@code queryName} over the {@link QueryBus} and waits for a response
+     * synchronously, up to a maximum period defined by {@code timeout} and {@code unit}.
+     *
+     * @param queryName    A {@link String} describing the query to be executed.
+     * @param query        The query object containing the details of the request.
+     * @param responseType The {@link ResponseType} describing the expected response type.
+     * @param timeout      The maximum time to wait for the response.
+     * @param unit         The {@link TimeUnit} of the timeout value.
+     * @param <R>          The response class contained in the given {@code responseType}.
+     * @param <Q>          The query class.
+     * @return The result of the query of type {@code R}.
+     * @throws QueryExecutionException if an exception occurs during query execution, including cases where a timeout is reached.
+     */
+    <R, Q> R queryAndWait(String queryName, Q query, ResponseType<R> responseType, long timeout, TimeUnit unit);
+
+    /**
      * Sends given {@code query} over the {@link org.axonframework.queryhandling.QueryBus}, expecting a response
      * as {@link org.reactivestreams.Publisher} of {@code responseType}.
      * Query is sent once {@link org.reactivestreams.Publisher} is subscribed to.


### PR DESCRIPTION
This PR adds a new synchronous `queryAndWait` method to the `QueryGateway` interface, allowing users to send a query and block until a response is received.

This method is similar to the `sendAndWait` method in `CommandGateway`. It provides a convenient way to perform synchronous queries.

New Methods:

```java
<R, Q> R queryAndWait(@Nonnull Q query, @Nonnull ResponseType<R> responseType);
<R, Q> R queryAndWait(@Nonnull String queryName, @Nonnull Q query, @Nonnull ResponseType<R> responseType);

<R, Q> R queryAndWait(@Nonnull Q query, @Nonnull ResponseType<R> responseType, long timeout, @Nonnull TimeUnit unit);
<R, Q> R queryAndWait(@Nonnull String queryName, @Nonnull Q query, ResponseType<R> responseType, long timeout, @Nonnull TimeUnit unit);
```

Example usage:

```java
String result = queryGateway.queryAndWait("myQuery", "queryPayload", ResponseTypes.instanceOf(String.class));
String resultWithTimeout = queryGateway.queryAndWait("myQuery", "queryPayload", ResponseTypes.instanceOf(String.class), 5, TimeUnit.SECONDS);
```