### PR TITLE
Fixed messageSerialization test in GenericMessageTest

### DIFF
--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -23,7 +23,6 @@ import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.serialization.CannotConvertBetweenTypesException;
 import org.axonframework.serialization.SerializedObject;
-import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.junit.jupiter.api.*;
 

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -72,21 +72,23 @@ class GenericMessageTest {
 
     @Test
     void messageSerialization() throws IOException{
-        GenericMessage<String> message = new GenericMessage<>("payload", Collections.singletonMap("key", "value"));
-        Serializer jacksonSerializer = JacksonSerializer.builder().build();
+        Map<String, String> metaDataMap = Collections.singletonMap("key", "value");
+
+        GenericMessage<String> message = new GenericMessage<>("payload", metaDataMap);
+     
+        JacksonSerializer jacksonSerializer = JacksonSerializer.builder().build();
+
 
         SerializedObject<String> serializedPayload = message.serializePayload(jacksonSerializer, String.class);
         SerializedObject<String> serializedMetaData = message.serializeMetaData(jacksonSerializer, String.class);
 
         assertEquals("\"payload\"", serializedPayload.getData());
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, String> expectedMetaData = new HashMap<>();
-        expectedMetaData.put("key", "value");
-        expectedMetaData.put("foo", "bar");
+    
+        ObjectMapper objectMapper = jacksonSerializer.getObjectMapper();
         Map<String, String> actualMetaData = objectMapper.readValue(serializedMetaData.getData(), Map.class);
 
-        assertEquals(expectedMetaData, actualMetaData);
+         assertTrue(actualMetaData.entrySet().containsAll(metaDataMap.entrySet()));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -27,6 +27,9 @@ import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.junit.jupiter.api.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +71,7 @@ class GenericMessageTest {
     }
 
     @Test
-    void messageSerialization() {
+    void messageSerialization() throws IOException{
         GenericMessage<String> message = new GenericMessage<>("payload", Collections.singletonMap("key", "value"));
         Serializer jacksonSerializer = JacksonSerializer.builder().build();
 
@@ -76,7 +79,14 @@ class GenericMessageTest {
         SerializedObject<String> serializedMetaData = message.serializeMetaData(jacksonSerializer, String.class);
 
         assertEquals("\"payload\"", serializedPayload.getData());
-        assertEquals("{\"key\":\"value\",\"foo\":\"bar\"}", serializedMetaData.getData());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, String> expectedMetaData = new HashMap<>();
+        expectedMetaData.put("key", "value");
+        expectedMetaData.put("foo", "bar");
+        Map<String, String> actualMetaData = objectMapper.readValue(serializedMetaData.getData(), Map.class);
+
+        assertEquals(expectedMetaData, actualMetaData);
     }
 
     @Test


### PR DESCRIPTION
`messageSerialization` test within `GenericMessageTest.java` can fail based on the order of keys in the JSON output. It was expecting a `<{"key":"value","foo":"bar"}>` but actually returned: `<{"foo":"bar","key":"value"}>`.

To fix this test, the comparison of the raw serialized strings was replaced by parsing the JSON and comparing the actual content of the serialized metadata with the use of a map. The `HashMap` of the `expectedMetaData` and the `Map` of the `actualMetaData` was made and then compared for equality, regardless of key order. A `throws IOException` was added to handle the deserialization process. 

The change/addition was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

To reproduce the problem, you can run the NonDex tool, using this command:

```
mvn -pl messaging edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.axonframework.messaging.GenericMessageTest#messageSerialization
```