### PR TITLE
Wrap `SinksManyWrapper#performWithBusyWaitSpin` in `ReentrantLock` to improve performance of Subscription Query Updates

### DIFF
--- a/messaging/src/main/java/org/axonframework/queryhandling/SinksManyWrapper.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SinksManyWrapper.java
@@ -77,6 +77,7 @@ class SinksManyWrapper<T> implements SinkWrapper<T> {
         int i = 0;
         Sinks.EmitResult result;
         try {
+            // The lock's in place to have a safe and efficient way to pause a thread before jumping in the while-loop.
             lock.lock();
             while ((result = action.get()) == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
                 // For 100 iterations, just busy-spin. Will resolve most conditions.

--- a/messaging/src/main/java/org/axonframework/queryhandling/SinksManyWrapper.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SinksManyWrapper.java
@@ -19,6 +19,7 @@ package org.axonframework.queryhandling;
 import reactor.core.publisher.Sinks;
 
 import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
@@ -32,6 +33,7 @@ import java.util.function.Supplier;
 class SinksManyWrapper<T> implements SinkWrapper<T> {
 
     private final Sinks.Many<T> fluxSink;
+    private final ReentrantLock lock;
 
     /**
      * Initializes this wrapper with delegate sink.
@@ -40,6 +42,7 @@ class SinksManyWrapper<T> implements SinkWrapper<T> {
      */
     SinksManyWrapper(Sinks.Many<T> fluxSink) {
         this.fluxSink = fluxSink;
+        this.lock = new ReentrantLock();
     }
 
     /**
@@ -73,19 +76,24 @@ class SinksManyWrapper<T> implements SinkWrapper<T> {
     private Sinks.EmitResult performWithBusyWaitSpin(Supplier<Sinks.EmitResult> action) {
         int i = 0;
         Sinks.EmitResult result;
-        while ((result = action.get()) == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
-            // For 100 iterations, just busy-spin. Will resolve most conditions.
-            if (i < 100) {
-                i++;
-                // Busy spin...
-            } else if (i < 200) {
-                // For the next 100 iterations, yield, to force other threads to have a chance.
-                i++;
-                Thread.yield();
-            } else {
-                // Then after, park the thread to force other threads to perform their work.
-                LockSupport.parkNanos(100);
+        try {
+            lock.lock();
+            while ((result = action.get()) == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
+                // For 100 iterations, just busy-spin. Will resolve most conditions.
+                if (i < 100) {
+                    i++;
+                    // Busy spin...
+                } else if (i < 200) {
+                    // For the next 100 iterations, yield, to force other threads to have a chance.
+                    i++;
+                    Thread.yield();
+                } else {
+                    // Then after, park the thread to force other threads to perform their work.
+                    LockSupport.parkNanos(100);
+                }
             }
+        } finally {
+            lock.unlock();
         }
         return result;
     }


### PR DESCRIPTION
After some deep-down discussions with a user of Axon Framework, we discovered a bottleneck in the `SinksManyWrapper` when it was being used very heavily.
The `Thread#yield` and `LockSupport#parkNanos` operations simply take up quite some time when under heavy load, causing a plateau in the flame graph at those points.

After some debate, we figured a `ReentrantLock` would likely improve matters, as it did for the `axonserver-connector-java` (which introduces it in [this](https://github.com/AxonIQ/axonserver-connector-java/pull/390) PR).
We tested this idea, and it had the desired effect.
As such, we are confident this optimization should be included in the `SinksManyWrapper.`

Given the nature of the logic, writing a test for this is, sadly, out of scope.