### PR TITLE
fix: log statement issue with logback classic

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueue.java
@@ -203,7 +203,8 @@ public class JdbcSequencedDeadLetterQueue<E extends EventMessage<?>> implements 
             Optional<Cause> optionalCause = letter.cause();
             if (optionalCause.isPresent()) {
                 logger.info("Adding dead letter with message id [{}] because [{}].",
-                            letter.message().getIdentifier(), optionalCause.get());
+                            letter.message().getIdentifier(),
+                            optionalCause.get().type());
             } else {
                 logger.info(
                         "Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
@@ -138,10 +138,14 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
 
         Optional<Cause> optionalCause = letter.cause();
         if (optionalCause.isPresent()) {
-            logger.info("Adding dead letter with message id [{}] because [{}].", letter.message().getIdentifier(), optionalCause.get());
+            logger.info("Adding dead letter with message id [{}] because [{}].",
+                        letter.message().getIdentifier(),
+                        optionalCause.get().type());
         } else {
-            logger.info("Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",
-                        letter.message().getIdentifier(), stringSequenceIdentifier);
+            logger.info(
+                    "Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",
+                    letter.message().getIdentifier(),
+                    stringSequenceIdentifier);
         }
 
         DeadLetterEventEntry entry = converters

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/legacyjpa/JpaSequencedDeadLetterQueue.java
@@ -147,7 +147,7 @@ public class JpaSequencedDeadLetterQueue<M extends EventMessage<?>> implements S
         if (optionalCause.isPresent()) {
             logger.info("Adding dead letter with message id [{}] because [{}].",
                         letter.message().getIdentifier(),
-                        optionalCause.get());
+                        optionalCause.get().type());
         } else {
             logger.info(
                     "Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/InMemorySequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/InMemorySequencedDeadLetterQueue.java
@@ -113,10 +113,14 @@ public class InMemorySequencedDeadLetterQueue<M extends Message<?>> implements S
         if (logger.isDebugEnabled()) {
             Optional<Cause> optionalCause = letter.cause();
             if (optionalCause.isPresent()) {
-                logger.debug("Adding dead letter with message id [{}] because [{}].", letter.message().getIdentifier(), optionalCause.get());
+                logger.debug("Adding dead letter with message id [{}] because [{}].",
+                             letter.message().getIdentifier(),
+                             optionalCause.get().type());
             } else {
-                logger.debug("Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",
-                             letter.message().getIdentifier(), sequenceIdentifier);
+                logger.debug(
+                        "Adding dead letter with message id [{}] because the sequence identifier [{}] is already present.",
+                        letter.message().getIdentifier(),
+                        sequenceIdentifier);
             }
         }
 


### PR DESCRIPTION
Resolves #3160

@smcvb I saw the `Cause` interface exposes the original exception `type()`, so instinctively I went for that. Though, the exception message might be interesting in some cases, e.g. the JSR303 constraint violation I referred to in the issue, because it prints all offending fields helping in debugging. So, alternatively we could go for `Cause#toString()`, which can produce very long outputs if the exception message is long, that's the downside. Your call.

https://github.com/AxonFramework/AxonFramework/blob/d7c6fcd7216558d9d90107e1ef77c0ae81530cb3/messaging/src/main/java/org/axonframework/messaging/deadletter/ThrowableCause.java#L139-L142