### PR TITLE
[#3171] Ensure `AggregateAnnotationCommandHandler` default `CreationPolicyAggregateFactory` can kick in

### DIFF
--- a/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/AggregateConfigurer.java
@@ -254,7 +254,7 @@ public class AggregateConfigurer<A> implements AggregateConfiguration<A> {
                 });
         creationPolicyAggregateFactory = new Component<>(
                 () -> parent, name("creationPolicyAggregateFactory"),
-                c -> new NoArgumentConstructorCreationPolicyAggregateFactory<>(aggregateType()));
+                c -> null);
         commandHandler = new Component<>(
                 () -> parent, name("aggregateCommandHandler"),
                 c -> AggregateAnnotationCommandHandler.<A>builder()

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -380,7 +380,6 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
         public Builder<T> creationPolicyAggregateFactory(
                 CreationPolicyAggregateFactory<T> creationPolicyAggregateFactory
         ) {
-            assertNonNull(creationPolicyAggregateFactory, "CreationPolicyAggregateFactory may not be null");
             this.creationPolicyAggregateFactory = creationPolicyAggregateFactory;
             return this;
         }


### PR DESCRIPTION
This pull request ensures that the `AggregateAnnotationCommandHandler` is in charge of constructing the default `CreationPolicyAggregateFactory` instead of the `AggregateConfigurer`.
In doing so, we ascertain that the entire type set, which is important for polymorphic aggregates, play a role when constructing `CreationPolicyAggregateFactory` instances.

I do admit that I do not fully fancy the current solution. In an ideal world, we would have a `Supplier`/`Function` returning the `CreationPolicyAggregateFactory` per type in a polymorphic aggregate.
However, the given parameters may widely differ per `CreationPolicyAggregateFactory`, hence it is tough to decide if the aggregate type is enough or whether more fields are required.
Furthermore, I have yet to find a user that customized the `CreationPolicyAggregateFactory` in combination with a polymorphic aggregate.

As such, I am taking the stance that simply removing the default `NoArgumentConstructorCreationPolicyAggregateFactory` from the `AggregateConfigurer`, in combination with allowing a `null` `CreationPolicyAggregateFactory` on the builder of the `AggregateAnnotationCommandHandler`, is sufficient a solution for now.

Note that this change should've been a part of pull request #3173. 
I, however, only tested through the `AggregateTestFixture`, which does not cover the `AggregateConfigurer`. 
Hence why this follow-up PR exists.