### PR TITLE
SagaTestFixture extend APIs for publishing historic events with metadata

### DIFF
--- a/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/saga/FixtureConfiguration.java
@@ -35,6 +35,7 @@ import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.utils.CallbackBehavior;
 
 import java.time.Instant;
+import java.util.Map;
 
 
 /**
@@ -300,6 +301,17 @@ public interface FixtureConfiguration {
      * @return an object that allows chaining of more given state
      */
     ContinuedGivenState givenAPublished(Object event);
+
+
+    /**
+     * Indicates that the given {@code event} with given {@code metaData} has been published in the past.
+     * This event is sent to the associated sagas.
+     *
+     * @param event The event to publish
+     * @param metaData The meta data to attach to the event
+     * @return an object that allows chaining of more given state
+     */
+    ContinuedGivenState givenAPublished(Object event, Map<String, ?> metaData);
 
     /**
      * Indicates that no relevant activity has occurred in the past.

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -300,6 +300,13 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     @Override
+    public ContinuedGivenState givenAPublished(Object event, Map<String, ?> metaData) {
+        EventMessage<?> msg = GenericEventMessage.asEventMessage(event).andMetaData(metaData);
+        handleInSaga(timeCorrectedEventMessage(msg));
+        return this;
+    }
+
+    @Override
     public ContinuedGivenState givenCurrentTime(Instant currentTime) {
         eventScheduler.initializeAt(currentTime);
         deadlineManager.initializeAt(currentTime);

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -99,6 +99,21 @@ class AnnotatedSagaTest {
     }
 
     @Test
+    void fixtureApi_AggregatePublishedHistoricEventWithMetaData() {
+        String extraIdentifier = UUID.randomUUID().toString();
+        Map<String, String> metaData = new HashMap<>();
+        metaData.put("extraIdentifier", extraIdentifier);
+
+        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
+        fixture.givenAPublished(new TriggerSagaStartEvent("id"), metaData)
+               .whenPublishingA(new TriggerSagaStartEvent("id"))
+               .expectActiveSagas(1)
+               .expectNoScheduledDeadlines()
+               .expectAssociationWith("identifier", "id")
+               .expectAssociationWith("extraIdentifier", extraIdentifier);
+    }
+
+    @Test
     void fixtureApi_NonTransientResourceInjected() {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         fixture.registerResource(new NonTransientResource());


### PR DESCRIPTION
This change allows the usage of metadata in the saga test fixture when using the givenAPublished GivenState. To do this currently, there is only the workaround to do sth. like:
```
fixture.givenAggregate("id")
.published()
.andThenAPublished(orderCreatedEvent, MetaData.emptyInstance())
```
fixes #3197