### PR TITLE
[#3085] QualifiedName: use `MessageNameResolver` for `AnnotationCommandHandlerAdapter`

### DIFF
--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.axonframework.eventsourcing.eventstore.jpa.JpaEventStorageEngine;
 import org.axonframework.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.messaging.ClassBasedMessageNameResolver;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageNameResolver;
 import org.axonframework.messaging.ScopeAwareProvider;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
@@ -174,6 +175,7 @@ public class DefaultConfigurer implements Configurer {
     private final Component<EventUpcasterChain> upcasterChain = new Component<>(
             config, "eventUpcasterChain", this::defaultUpcasterChain
     );
+    private final MessageNameResolver messageNameResolver = new ClassBasedMessageNameResolver();
 
     private final Component<Function<Class<?>, HandlerDefinition>> handlerDefinition = new Component<>(
             config, "handlerDefinition",
@@ -354,7 +356,7 @@ public class DefaultConfigurer implements Configurer {
      */
     protected CommandGateway defaultCommandGateway(Configuration config) {
         return defaultComponent(CommandGateway.class, config)
-                .orElseGet(() -> new DefaultCommandGateway(config.commandBus(), new ClassBasedMessageNameResolver()));
+                .orElseGet(() -> new DefaultCommandGateway(config.commandBus(), messageNameResolver));
     }
 
     /**
@@ -845,7 +847,8 @@ public class DefaultConfigurer implements Configurer {
                         (config, commandHandler) -> new AnnotationCommandHandlerAdapter<>(
                                 commandHandler,
                                 config.parameterResolverFactory(),
-                                config.handlerDefinition(commandHandler.getClass())
+                                config.handlerDefinition(commandHandler.getClass()),
+                                messageNameResolver
                         ).subscribe(config.commandBus())
                 )
         ));

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,11 @@ package org.axonframework.commandhandling.gateway;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.messaging.*;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageNameResolver;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.retry.RetryScheduler;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
@@ -88,8 +92,6 @@ public class DefaultCommandGateway implements CommandGateway {
                           )
         );
     }
-
-    // todo: QualifiedName - leave it here or create some CommandMessageFactory?
 
     /**
      * Returns the given command as a {@link CommandMessage}. If {@code command} already implements

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.axonframework.eventsourcing.GenericAggregateFactory;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
+import org.axonframework.messaging.ClassBasedMessageNameResolver;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDispatchInterceptor;
@@ -215,7 +216,10 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         registerAggregateCommandHandlers();
         explicitCommandHandlersSet = true;
         AnnotationCommandHandlerAdapter<?> adapter = new AnnotationCommandHandlerAdapter<>(
-                annotatedCommandHandler, getParameterResolverFactory(), getHandlerDefinition()
+                annotatedCommandHandler,
+                getParameterResolverFactory(),
+                getHandlerDefinition(),
+                new ClassBasedMessageNameResolver()
         );
         adapter.subscribe(commandBus);
         return this;


### PR DESCRIPTION
Continuation of changes from this PR:
https://github.com/AxonFramework/AxonFramework/pull/3214