### PR TITLE
ci: GitHub Actions - one in-progress run per pull request

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,9 +1,13 @@
-name: Axon Framework
+name: Axon Framework (Pull Request)
 
 on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Currently
The Pull Request GitHub Actions workflow takes about 15 minutes.
If you push another commit during an ongoing build, you end up with two builds running simultaneously, even though you only care about the latest result.

## Change
When you push another commit during a build, the ongoing build will be canceled, and only the latest commit will be processed.

## Benefits
- Saves time and resources.
- Reduces unnecessary builds, optimizing costs.