### PR TITLE
[#3085] QualifiedName: remove static factory method from `GenericEventMessage`

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,9 @@ import org.axonframework.axonserver.connector.event.axon.AxonServerEventStoreFac
 import org.axonframework.axonserver.connector.event.axon.EventProcessorInfoConfiguration;
 import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
 import org.axonframework.axonserver.connector.utils.TestSerializer;
-import org.axonframework.commandhandling.CommandBus;
-import org.axonframework.common.ReflectionUtils;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.junit.jupiter.api.*;
 
@@ -66,7 +64,7 @@ class ServerConnectorConfigurerModuleTest {
                 testSubject.getComponent(TargetContextResolver.class);
         assertNotNull(resultTargetContextResolver);
         // The default TargetContextResolver is a no-op which returns null
-        assertNull(resultTargetContextResolver.resolveContext(GenericEventMessage.asEventMessage("some-event")));
+        assertNull(resultTargetContextResolver.resolveContext(EventTestUtils.asEventMessage("some-event")));
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DefaultEventBusSpanFactory;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
@@ -124,9 +124,9 @@ class AxonServerEventStoreTest {
     @Test
     void publishAndConsumeEvents() throws Exception {
         UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
-        EventMessage<?>[] eventMessages = {GenericEventMessage.asEventMessage("Test1"),
-                GenericEventMessage.asEventMessage("Test2"),
-                GenericEventMessage.asEventMessage("Test3")};
+        EventMessage<?>[] eventMessages = {EventTestUtils.asEventMessage("Test1"),
+                EventTestUtils.asEventMessage("Test2"),
+                EventTestUtils.asEventMessage("Test3")};
         testSubject.publish(eventMessages);
         Arrays.stream(eventMessages).forEach(e -> testSpanFactory.verifySpanCompleted("EventBus.publishEvent", e));
         testSpanFactory.verifyNotStarted("EventBus.commitEvents");
@@ -150,9 +150,9 @@ class AxonServerEventStoreTest {
         boolean noLiveUpdates = false;
 
         UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
-        testSubject.publish(GenericEventMessage.asEventMessage("Test1"),
-                            GenericEventMessage.asEventMessage("Test2"),
-                            GenericEventMessage.asEventMessage("Test3"));
+        testSubject.publish(EventTestUtils.asEventMessage("Test1"),
+                            EventTestUtils.asEventMessage("Test2"),
+                            EventTestUtils.asEventMessage("Test3"));
         uow.commit();
 
         //noinspection ConstantConditions

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.EventProcessorSpanFactory;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.eventhandling.MultiEventHandlerInvoker;
@@ -113,8 +114,8 @@ class EventProcessingModuleTest {
                                               .storageEngine(new InMemoryEventStorageEngine())
                                               .build());
 
-        eventStoreOne.publish(GenericEventMessage.asEventMessage("test1"));
-        eventStoreTwo.publish(GenericEventMessage.asEventMessage("test2"));
+        eventStoreOne.publish(EventTestUtils.asEventMessage("test1"));
+        eventStoreTwo.publish(EventTestUtils.asEventMessage("test2"));
     }
 
     @Test

--- a/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/SagaConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.config;
 
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
@@ -124,7 +124,7 @@ class SagaConfigurerTest {
                                                        .buildConfiguration();
         configuration.start();
         TestEvent testEvent = new TestEvent();
-        eventStore.publish(GenericEventMessage.asEventMessage(testEvent));
+        eventStore.publish(EventTestUtils.asEventMessage(testEvent));
         Set<String> sagas = sagaStore.findSagas(TestSaga.class, new AssociationValue("id", testEvent.id.toString()));
         assertEquals(1, sagas.size());
         assertEquals(1, TestSaga.counter.get());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.messaging.QualifiedName;
 import org.junit.jupiter.api.*;
@@ -44,9 +44,9 @@ class FilteringEventStorageEngineTest {
 
     @Test
     void eventsFromArrayMatchingAreForwarded() {
-        EventMessage<String> event1 = GenericEventMessage.asEventMessage("accept");
-        EventMessage<String> event2 = GenericEventMessage.asEventMessage("fail");
-        EventMessage<String> event3 = GenericEventMessage.asEventMessage("accept");
+        EventMessage<String> event1 = EventTestUtils.asEventMessage("accept");
+        EventMessage<String> event2 = EventTestUtils.asEventMessage("fail");
+        EventMessage<String> event3 = EventTestUtils.asEventMessage("accept");
 
         testSubject.appendEvents(event1, event2, event3);
 
@@ -55,9 +55,9 @@ class FilteringEventStorageEngineTest {
 
     @Test
     void eventsFromListMatchingAreForwarded() {
-        EventMessage<String> event1 = GenericEventMessage.asEventMessage("accept");
-        EventMessage<String> event2 = GenericEventMessage.asEventMessage("fail");
-        EventMessage<String> event3 = GenericEventMessage.asEventMessage("accept");
+        EventMessage<String> event1 = EventTestUtils.asEventMessage("accept");
+        EventMessage<String> event2 = EventTestUtils.asEventMessage("fail");
+        EventMessage<String> event3 = EventTestUtils.asEventMessage("accept");
 
         testSubject.appendEvents(asList(event1, event2, event3));
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictResolutionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/conflictresolution/ConflictResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.eventsourcing.conflictresolution;
 
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -60,7 +60,7 @@ class ConflictResolutionTest {
     @Test
     void resolve() {
         ConflictResolution.initialize(conflictResolver);
-        assertFalse(subject.matches(GenericEventMessage.asEventMessage("testEvent"), null));
+        assertFalse(subject.matches(EventTestUtils.asEventMessage("testEvent"), null));
         assertTrue(subject.matches(commandMessage, null));
         assertSame(conflictResolver, ConflictResolution.getConflictResolver());
         assertSame(conflictResolver, subject.resolveParameterValue(commandMessage, null));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GenericTaggedEventMessageTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GenericTaggedEventMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
 
@@ -34,8 +34,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericTaggedEventMessageTest {
 
     private static final MetaData TEST_META_DATA = MetaData.with("key", "value");
-    private static final EventMessage<String> TEST_EVENT = GenericEventMessage.<String>asEventMessage("event")
-                                                                              .withMetaData(TEST_META_DATA);
+    private static final EventMessage<String> TEST_EVENT = EventTestUtils.<String>asEventMessage("event")
+                                                                         .withMetaData(TEST_META_DATA);
     private static final Tag TEST_TAG = new Tag("key", "value");
     private static final Set<Tag> TEST_TAGS = Set.of(TEST_TAG);
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -71,7 +71,7 @@ class SequenceEventStorageEngineTest {
 
     @Test
     void publishEventsSendsToActiveStorageOnly() {
-        List<EventMessage<Object>> events = singletonList(GenericEventMessage.asEventMessage("test"));
+        List<EventMessage<Object>> events = singletonList(EventTestUtils.asEventMessage("test"));
         testSubject.appendEvents(events);
 
         verify(historicStorage, never()).appendEvents(anyList());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.StubProcessingContext;
@@ -512,6 +512,6 @@ public abstract class SimpleEventStoreTestSuite<ESE extends AsyncEventStorageEng
 
     // TODO - Discuss: Perfect candidate to move to a commons test utils module?
     protected static EventMessage<?> eventMessage(int seq) {
-        return GenericEventMessage.asEventMessage("Event[" + seq + "]");
+        return EventTestUtils.asEventMessage("Event[" + seq + "]");
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.eventsourcing.eventstore.inmemory;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngineTest;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class InMemoryEventStorageEngineTest extends EventStorageEngineTest {
 
-    private static final EventMessage<Object> TEST_EVENT = GenericEventMessage.asEventMessage("test");
+    private static final EventMessage<Object> TEST_EVENT = EventTestUtils.asEventMessage("test");
 
     private InMemoryEventStorageEngine testSubject;
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/cache/CachingIntegrationTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.axonframework.config.Configuration;
 import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.config.SagaConfigurer;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.StreamingEventProcessor;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
@@ -435,7 +435,7 @@ public abstract class CachingIntegrationTestSuite {
     private void publish(Object... events) {
         List<EventMessage<?>> eventMessages = new ArrayList<>();
         for (Object event : events) {
-            eventMessages.add(GenericEventMessage.asEventMessage(event));
+            eventMessages.add(EventTestUtils.asEventMessage(event));
         }
         config.eventBus().publish(eventMessages);
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.axonframework.integrationtests.eventhandling;
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.MultiSourceTrackingToken;
@@ -72,7 +72,7 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void simplePublishAndConsume() throws InterruptedException {
-        EventMessage<?> publishedEvent = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> publishedEvent = EventTestUtils.asEventMessage("Event1");
 
         eventStoreA.publish(publishedEvent);
 
@@ -127,7 +127,7 @@ class MultiStreamableMessageSourceTest {
     @SuppressWarnings("resource")
     @Test
     void peekingLastMessageKeepsItAvailable() throws InterruptedException {
-        EventMessage<?> publishedEvent1 = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> publishedEvent1 = EventTestUtils.asEventMessage("Event1");
 
 
         eventStoreA.publish(publishedEvent1);
@@ -146,7 +146,7 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void openStreamWithNullTokenReturnsFirstEvent() throws InterruptedException {
-        EventMessage<Object> message = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<Object> message = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(message);
 
         BlockingStream<TrackedEventMessage<?>> actual = testSubject.openStream(null);
@@ -176,7 +176,7 @@ class MultiStreamableMessageSourceTest {
         BlockingStream<TrackedEventMessage<?>> singleEventStream =
                 testSubject.openStream(testSubject.createTokenAt(Instant.now()));
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event1");
         eventStoreB.publish(pubToStreamB);
 
         long beforePollTime = System.currentTimeMillis();
@@ -190,12 +190,12 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void multiPublishAndConsume() throws InterruptedException {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
 
         Thread.sleep(20);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
 
         BlockingStream<TrackedEventMessage<?>> singleEventStream =
@@ -213,7 +213,7 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void peek() throws InterruptedException {
-        EventMessage<?> publishedEvent = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> publishedEvent = EventTestUtils.asEventMessage("Event1");
 
         eventStoreA.publish(publishedEvent);
 
@@ -231,12 +231,12 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void peekWithMultipleStreams() throws InterruptedException {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
 
         Thread.sleep(20);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
 
         BlockingStream<TrackedEventMessage<?>> singleEventStream =
@@ -278,10 +278,10 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void createTailToken() {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
 
         MultiSourceTrackingToken tailToken = testSubject.createTailToken();
@@ -296,10 +296,10 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void createHeadToken() {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
         eventStoreB.publish(pubToStreamB);
 
@@ -315,13 +315,13 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void createTokenAt() throws InterruptedException {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
         eventStoreA.publish(pubToStreamA);
 
         Thread.sleep(20);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
 
         // Token should track events in eventStoreB and skip those in eventStoreA
@@ -336,13 +336,13 @@ class MultiStreamableMessageSourceTest {
 
     @Test
     void createTokenSince() throws InterruptedException {
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
         eventStoreA.publish(pubToStreamA);
 
         Thread.sleep(20);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event2");
         eventStoreB.publish(pubToStreamB);
 
         // Token should track events in eventStoreB and skip those in eventStoreA
@@ -373,17 +373,17 @@ class MultiStreamableMessageSourceTest {
                                             .trackedEventComparator(eventStoreAPriority)
                                             .build();
 
-        EventMessage<?> pubToStreamA = GenericEventMessage.asEventMessage("Event1");
+        EventMessage<?> pubToStreamA = EventTestUtils.asEventMessage("Event1");
         eventStoreA.publish(pubToStreamA);
         eventStoreA.publish(pubToStreamA);
         eventStoreA.publish(pubToStreamA);
 
-        EventMessage<?> pubToStreamC = GenericEventMessage.asEventMessage("Event2");
+        EventMessage<?> pubToStreamC = EventTestUtils.asEventMessage("Event2");
         eventStoreC.publish(pubToStreamC);
 
         Thread.sleep(5);
 
-        EventMessage<?> pubToStreamB = GenericEventMessage.asEventMessage("Event3");
+        EventMessage<?> pubToStreamB = EventTestUtils.asEventMessage("Event3");
         eventStoreB.publish(pubToStreamB);
 
         BlockingStream<TrackedEventMessage<?>> singleEventStream =
@@ -400,7 +400,7 @@ class MultiStreamableMessageSourceTest {
     @Test
     void skipMessagesWithPayloadTypeOfInvokesAllConfiguredStreams() {
         TrackedEventMessage<String> testEvent = new GenericTrackedEventMessage<>(
-                new GlobalSequenceTrackingToken(1), GenericEventMessage.asEventMessage("some-payload")
+                new GlobalSequenceTrackingToken(1), EventTestUtils.asEventMessage("some-payload")
         );
 
         StreamableMessageSource<TrackedEventMessage<?>> sourceOne = mock(StreamableMessageSource.class);

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.integrationtests.queryhandling;
 
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -197,7 +197,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         // Sets given UnitOfWork as the current, active, started UnitOfWork
         DefaultUnitOfWork<?> unitOfWork =
-                new DefaultUnitOfWork<>(GenericEventMessage.<String>asEventMessage("some-event-payload"));
+                new DefaultUnitOfWork<>(EventTestUtils.<String>asEventMessage("some-event-payload"));
         unitOfWork.start();
 
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
@@ -294,7 +294,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         // Sets given UnitOfWork as the current, active, started UnitOfWork
         DefaultUnitOfWork<?> unitOfWork =
-                new DefaultUnitOfWork<>(GenericEventMessage.<String>asEventMessage("some-event-payload"));
+                new DefaultUnitOfWork<>(EventTestUtils.<String>asEventMessage("some-event-payload"));
         unitOfWork.start();
 
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(
@@ -356,7 +356,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         // Sets given UnitOfWork as the current, active, started UnitOfWork
         DefaultUnitOfWork<?> unitOfWork =
-                new DefaultUnitOfWork<>(GenericEventMessage.<String>asEventMessage("some-event-payload"));
+                new DefaultUnitOfWork<>(EventTestUtils.<String>asEventMessage("some-event-payload"));
         unitOfWork.start();
 
         SubscriptionQueryMessage<String, List<String>, String> queryMessage = new GenericSubscriptionQueryMessage<>(

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.QualifiedName;
-import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.serialization.CachingSupplier;
 
 import java.io.Serial;
@@ -55,33 +54,6 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
      */
     @Deprecated // TODO #3083 - Configure application wide Clock
     public static Clock clock = Clock.systemUTC();
-
-    /**
-     * Returns the given event as an EventMessage. If {@code event} already implements EventMessage, it is returned
-     * as-is. If it is a Message, a new EventMessage will be created using the payload and meta data of the given
-     * message. Otherwise, the given {@code event} is wrapped into a GenericEventMessage as its payload.
-     *
-     * @param event the event to wrap as EventMessage
-     * @param <P>   The generic type of the expected payload of the resulting object
-     * @return an EventMessage containing given {@code event} as payload, or {@code event} if it already implements
-     * EventMessage.
-     * @deprecated In favor of using the constructor, as we intend to enforce thinking about the
-     * {@link QualifiedName name}.
-     */
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public static <P> EventMessage<P> asEventMessage(@Nonnull Object event) {
-        if (event instanceof EventMessage) {
-            return (EventMessage<P>) event;
-        } else if (event instanceof Message) {
-            Message<P> message = (Message<P>) event;
-            return new GenericEventMessage<>(message, clock.instant());
-        }
-        return new GenericEventMessage<>(
-                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
-                clock.instant()
-        );
-    }
 
     /**
      * Constructs a {@link GenericEventMessage} for the given {@code name} and {@code payload}.

--- a/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ class AbstractEventBusTest {
         when(mockMonitor.onMessageIngested(any())).thenReturn(mockMonitorCallback);
         testSubject = spy(StubPublishingEventBus.builder().messageMonitor(mockMonitor).build());
 
-        testSubject.publish(GenericEventMessage.asEventMessage("test1"), GenericEventMessage.asEventMessage("test2"));
+        testSubject.publish(EventTestUtils.asEventMessage("test1"), EventTestUtils.asEventMessage("test2"));
 
         verify(mockMonitor, times(2)).onMessageIngested(any());
         verify(mockMonitorCallback, never()).reportSuccess();

--- a/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/messaging/src/test/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ConcludesBatchParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.*;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.utils.EventTestUtils.createEvents;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
@@ -19,7 +19,6 @@ package org.axonframework.eventhandling;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
-import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.QualifiedNameUtils;
 
 public abstract class EventTestUtils {
@@ -37,10 +36,7 @@ public abstract class EventTestUtils {
      * @param <P>   The generic type of the expected payload of the resulting object
      * @return an EventMessage containing given {@code event} as payload, or {@code event} if it already implements
      * EventMessage.
-     * @deprecated In favor of using the constructor, as we intend to enforce thinking about the
-     * {@link QualifiedName name}.
      */
-    @Deprecated
     @SuppressWarnings("unchecked")
     public static <P> EventMessage<P> asEventMessage(@Nonnull Object event) {
         if (event instanceof EventMessage) {

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.QualifiedNameUtils;
+
+public abstract class EventTestUtils {
+
+    private EventTestUtils() {
+        // Utility class
+    }
+
+    /**
+     * Returns the given event as an EventMessage. If {@code event} already implements EventMessage, it is returned
+     * as-is. If it is a Message, a new EventMessage will be created using the payload and meta data of the given
+     * message. Otherwise, the given {@code event} is wrapped into a GenericEventMessage as its payload.
+     *
+     * @param event the event to wrap as EventMessage
+     * @param <P>   The generic type of the expected payload of the resulting object
+     * @return an EventMessage containing given {@code event} as payload, or {@code event} if it already implements
+     * EventMessage.
+     * @deprecated In favor of using the constructor, as we intend to enforce thinking about the
+     * {@link QualifiedName name}.
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public static <P> EventMessage<P> asEventMessage(@Nonnull Object event) {
+        if (event instanceof EventMessage) {
+            return (EventMessage<P>) event;
+        } else if (event instanceof Message) {
+            Message<P> message = (Message<P>) event;
+            return new GenericEventMessage<>(message, GenericEventMessage.clock.instant());
+        }
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                GenericEventMessage.clock.instant()
+        );
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,9 +119,9 @@ class GenericEventMessageTest {
 
     @Test
     void testToString() {
-        String actual = GenericEventMessage.asEventMessage("MyPayload").andMetaData(MetaData.with("key", "value")
-                                                                                            .and("key2", 13))
-                                           .toString();
+        String actual = EventTestUtils.asEventMessage("MyPayload").andMetaData(MetaData.with("key", "value")
+                                                                                       .and("key2", 13))
+                                      .toString();
         assertTrue(actual.startsWith("GenericEventMessage{payload={MyPayload}, metadata={"), "Wrong output: " + actual);
         assertTrue(actual.contains("'key'->'value'"), "Wrong output: " + actual);
         assertTrue(actual.contains("'key2'->'13'"), "Wrong output: " + actual);

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiEventHandlerInvokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,11 @@ class MultiEventHandlerInvokerTest {
 
     @BeforeEach
     void setUp() {
-        testEventMessage = GenericEventMessage.asEventMessage("some-event");
+        testEventMessage = EventTestUtils.asEventMessage("some-event");
         TrackingToken testToken = ReplayToken.createReplayToken(
                 new GlobalSequenceTrackingToken(10), new GlobalSequenceTrackingToken(0)
         );
-        replayMessage = new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("replay-event"));
+        replayMessage = new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("replay-event"));
         testSegment = new Segment(1, 1);
 
         when(mockedEventHandlerInvokerOne.canHandle(any(), eq(testSegment))).thenReturn(true);

--- a/messaging/src/test/java/org/axonframework/eventhandling/TimestampParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/TimestampParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ class TimestampParameterResolverFactoryTest {
         ParameterResolver<Instant> resolver =
                 testSubject.createInstance(instantMethod, instantMethod.getParameters(), 0);
 
-        final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> message = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(message, null));
         assertEquals(message.getTimestamp(), resolver.resolveParameterValue(message, null));
     }
@@ -93,7 +93,7 @@ class TimestampParameterResolverFactoryTest {
         ParameterResolver<Instant> resolver =
                 testSubject.createInstance(temporalMethod, temporalMethod.getParameters(), 0);
 
-        final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> message = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(message, null));
         assertEquals(message.getTimestamp(), resolver.resolveParameterValue(message, null));
     }
@@ -115,7 +115,7 @@ class TimestampParameterResolverFactoryTest {
     void resolvesToDateTimeWhenAnnotatedWithMetaAnnotation() {
         Parameter[] parameters = metaAnnotatedMethod.getParameters();
         ParameterResolver<?> resolver = testSubject.createInstance(metaAnnotatedMethod, parameters, 0);
-        final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> message = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(message, null), "Resolver should be a match for message " + message);
         assertEquals(message.getTimestamp(), resolver.resolveParameterValue(message, null));
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package org.axonframework.eventhandling.async;
 
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.Message;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -30,9 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Allard Buijze

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteredEventProcessingTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.deadletter.DeadLetter;
 import org.axonframework.messaging.deadletter.Decisions;
@@ -48,7 +48,7 @@ class DeadLetteredEventProcessingTaskTest {
 
     @SuppressWarnings("rawtypes") // The DeadLetter mocks don't like the generic, at all...
     private static final EventMessage TEST_EVENT =
-            GenericEventMessage.asEventMessage("Then this happened..." + UUID.randomUUID());
+            EventTestUtils.asEventMessage("Then this happened..." + UUID.randomUUID());
     private static final EnqueueDecision<EventMessage<?>> TEST_DECISION = Decisions.ignore();
 
     private EventMessageHandler eventHandlerOne;

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.PropagatingErrorHandler;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.async.SequencingPolicy;
@@ -429,7 +429,7 @@ class DeadLetteringEventHandlerInvokerTest {
     @Test
     void processAnyLettersReturnsTrueWhenFirstInvocationReturnsTrue() {
         DeadLetter<EventMessage<?>> testDeadLetter =
-                new GenericDeadLetter<>("expectedIdentifier", GenericEventMessage.asEventMessage("payload"));
+                new GenericDeadLetter<>("expectedIdentifier", EventTestUtils.asEventMessage("payload"));
 
         when(queue.process(any(), any())).thenReturn(true)
                                          .thenReturn(false);
@@ -483,7 +483,7 @@ class DeadLetteringEventHandlerInvokerTest {
     @Test
     void processLettersMatchingSequenceReturnsTrueWhenFirstInvocationReturnsTrue() {
         DeadLetter<EventMessage<?>> testDeadLetter =
-                new GenericDeadLetter<>("expectedIdentifier", GenericEventMessage.asEventMessage("payload"));
+                new GenericDeadLetter<>("expectedIdentifier", EventTestUtils.asEventMessage("payload"));
 
         AtomicBoolean filterInvoked = new AtomicBoolean();
         Predicate<DeadLetter<? extends EventMessage<?>>> testFilter = letter -> {

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import static org.awaitility.Awaitility.await;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.utils.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import javax.sql.DataSource;
 
 import static org.axonframework.common.jdbc.JdbcUtils.closeQuietly;
 import static org.axonframework.common.jdbc.JdbcUtils.executeUpdate;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GapAwareTrackingToken;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
@@ -59,7 +60,7 @@ class EventMessageDeadLetterJpaConverterTest {
 
     @Test
     void canConvertGenericEventMessageAndBackCorrectly() {
-        testConversion(GenericEventMessage.asEventMessage(event).andMetaData(metaData));
+        testConversion(EventTestUtils.asEventMessage(event).andMetaData(metaData));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/CoordinatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling.pooled;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.common.transaction.NoTransactionManager;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.ReplayToken;
@@ -138,9 +138,9 @@ class CoordinatorTest {
     void ifCoordinationTaskSchedulesEventsWithTheSameTokenTogether() throws InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(0);
         TrackedEventMessage testEventOne =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("this-event"));
         TrackedEventMessage testEventTwo =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("that-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("that-event"));
         List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
         testEvents.add(testEventOne);
         testEvents.add(testEventTwo);

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.eventhandling.DefaultEventProcessorSpanFactory;
 import org.axonframework.eventhandling.EventHandlerInvoker;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.PropagatingErrorHandler;
@@ -417,7 +418,7 @@ class PooledStreamingEventProcessorTest {
         when(stubEventHandler.canHandle(any(), any())).thenReturn(false);
         when(stubEventHandler.canHandleType(Integer.class)).thenReturn(false);
 
-        EventMessage<Integer> eventToIgnoreOne = GenericEventMessage.asEventMessage(1337);
+        EventMessage<Integer> eventToIgnoreOne = EventTestUtils.asEventMessage(1337);
         stubMessageSource.publishMessage(eventToIgnoreOne);
 
         testSubject.start();
@@ -458,16 +459,16 @@ class PooledStreamingEventProcessorTest {
         when(stubEventHandler.canHandleType(Integer.class)).thenReturn(false);
         when(stubEventHandler.canHandleType(String.class)).thenReturn(true);
 
-        EventMessage<Integer> eventToIgnoreOne = GenericEventMessage.asEventMessage(1337);
-        EventMessage<Integer> eventToIgnoreTwo = GenericEventMessage.asEventMessage(42);
-        EventMessage<Integer> eventToIgnoreThree = GenericEventMessage.asEventMessage(9001);
+        EventMessage<Integer> eventToIgnoreOne = EventTestUtils.asEventMessage(1337);
+        EventMessage<Integer> eventToIgnoreTwo = EventTestUtils.asEventMessage(42);
+        EventMessage<Integer> eventToIgnoreThree = EventTestUtils.asEventMessage(9001);
         List<Integer> eventsToIgnore = new ArrayList<>();
         eventsToIgnore.add(eventToIgnoreOne.getPayload());
         eventsToIgnore.add(eventToIgnoreTwo.getPayload());
         eventsToIgnore.add(eventToIgnoreThree.getPayload());
 
-        EventMessage<String> eventToHandleOne = GenericEventMessage.asEventMessage("some-text");
-        EventMessage<String> eventToHandleTwo = GenericEventMessage.asEventMessage("some-other-text");
+        EventMessage<String> eventToHandleOne = EventTestUtils.asEventMessage("some-text");
+        EventMessage<String> eventToHandleTwo = EventTestUtils.asEventMessage("some-other-text");
         List<String> eventsToHandle = new ArrayList<>();
         eventsToHandle.add(eventToHandleOne.getPayload());
         eventsToHandle.add(eventToHandleTwo.getPayload());
@@ -1265,12 +1266,12 @@ class PooledStreamingEventProcessorTest {
             unitOfWork.onCleanup(uow -> countDownLatch.countDown());
             return interceptorChain.proceedSync();
         }));
-        stubMessageSource.publishMessage(GenericEventMessage.asEventMessage(0));
-        stubMessageSource.publishMessage(GenericEventMessage.asEventMessage(1));
+        stubMessageSource.publishMessage(EventTestUtils.asEventMessage(0));
+        stubMessageSource.publishMessage(EventTestUtils.asEventMessage(1));
 
         testSubject.start();
 
-        stubMessageSource.publishMessage(GenericEventMessage.asEventMessage(2));
+        stubMessageSource.publishMessage(EventTestUtils.asEventMessage(2));
 
         assertTrue(countDownLatch.await(5, TimeUnit.SECONDS), "Expected Unit of Work to have reached clean up phase");
         TrackingToken trackingToken = tokenStore.fetchToken(testSubject.getName(), 0);

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/WorkPackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.eventhandling.pooled;
 
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.ReplayToken;
@@ -121,7 +121,7 @@ class WorkPackageTest {
     @Test
     void scheduleEventDoesNotScheduleIfTheLastDeliveredTokenCoversTheEventsToken() {
         TrackedEventMessage<String> testEvent = new GenericTrackedEventMessage<>(
-                new GlobalSequenceTrackingToken(1L), GenericEventMessage.asEventMessage("some-event")
+                new GlobalSequenceTrackingToken(1L), EventTestUtils.asEventMessage("some-event")
         );
 
         WorkPackage testSubjectWithCustomInitialToken =
@@ -137,7 +137,7 @@ class WorkPackageTest {
     void scheduleEventUpdatesLastDeliveredToken() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
 
         testSubject.scheduleEvent(testEvent);
 
@@ -148,7 +148,7 @@ class WorkPackageTest {
     void scheduleEventFailsOnEventValidator() throws ExecutionException, InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("some-event"));
         eventFilterPredicate = event -> {
             if (event.equals(testEvent)) {
                 throw new IllegalStateException("Some exception");
@@ -172,7 +172,7 @@ class WorkPackageTest {
     void scheduleEventFailsOnBatchProcessor() throws ExecutionException, InterruptedException {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEvent =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("some-event"));
         batchProcessorPredicate = event -> {
             if (event.stream().anyMatch(e -> ((TrackedEventMessage<?>) e).trackingToken().equals(testToken))) {
                 throw new IllegalStateException("Some exception");
@@ -200,7 +200,7 @@ class WorkPackageTest {
     void scheduleEventRunsSuccessfully() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
 
         testSubject.scheduleEvent(expectedEvent);
 
@@ -228,7 +228,7 @@ class WorkPackageTest {
         testSubject = testSubjectBuilder.build();
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
 
         testSubject.scheduleEvent(expectedEvent);
 
@@ -249,7 +249,7 @@ class WorkPackageTest {
         testSubject = testSubjectBuilder.build();
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
 
         testSubject.scheduleEvent(expectedEvent);
 
@@ -272,7 +272,7 @@ class WorkPackageTest {
 
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
         testSubjectWithShortThreshold.scheduleEvent(expectedEvent);
 
         // Should have handled one event, so a subsequent run of WorkPackage#processEvents will extend the claim.
@@ -311,7 +311,7 @@ class WorkPackageTest {
 
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("some-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("some-event"));
         testSubjectWithShortThreshold.scheduleEvent(expectedEvent);
 
         List<EventMessage<?>> validatedEvents = eventFilter.getValidatedEvents();
@@ -402,10 +402,10 @@ class WorkPackageTest {
     void scheduleEventsThrowsIllegalArgumentExceptionForNoneMatchingTokens() {
         TrackingToken testTokenOne = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEventOne =
-                new GenericTrackedEventMessage<>(testTokenOne, GenericEventMessage.asEventMessage("this-event"));
+                new GenericTrackedEventMessage<>(testTokenOne, EventTestUtils.asEventMessage("this-event"));
         TrackingToken testTokenTwo = new GlobalSequenceTrackingToken(2L);
         TrackedEventMessage<String> testEventTwo =
-                new GenericTrackedEventMessage<>(testTokenTwo, GenericEventMessage.asEventMessage("that-event"));
+                new GenericTrackedEventMessage<>(testTokenTwo, EventTestUtils.asEventMessage("that-event"));
         List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
         testEvents.add(testEventOne);
         testEvents.add(testEventTwo);
@@ -420,9 +420,9 @@ class WorkPackageTest {
     void scheduleEventsDoesNotScheduleIfTheLastDeliveredTokensCoversTheEventsToken() {
         TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> testEventOne =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("this-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("this-event"));
         TrackedEventMessage<String> testEventTwo =
-                new GenericTrackedEventMessage<>(testToken, GenericEventMessage.asEventMessage("that-event"));
+                new GenericTrackedEventMessage<>(testToken, EventTestUtils.asEventMessage("that-event"));
         List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
         testEvents.add(testEventOne);
         testEvents.add(testEventTwo);
@@ -441,9 +441,9 @@ class WorkPackageTest {
     void scheduleEventsReturnsTrueIfOnlyOneEventIsAcceptedByTheEventValidator() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> filteredEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("this-event"));
         TrackedEventMessage<String> expectedEvent =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("that-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("that-event"));
         List<TrackedEventMessage<?>> testEvents = new ArrayList<>();
         testEvents.add(filteredEvent);
         testEvents.add(expectedEvent);
@@ -476,9 +476,9 @@ class WorkPackageTest {
     void scheduleEventsHandlesAllEventsInOneTransactionWhenAllEventsCanBeHandled() {
         TrackingToken expectedToken = new GlobalSequenceTrackingToken(1L);
         TrackedEventMessage<String> expectedEventOne =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("this-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("this-event"));
         TrackedEventMessage<String> expectedEventTwo =
-                new GenericTrackedEventMessage<>(expectedToken, GenericEventMessage.asEventMessage("that-event"));
+                new GenericTrackedEventMessage<>(expectedToken, EventTestUtils.asEventMessage("that-event"));
         List<TrackedEventMessage<?>> expectedEvents = new ArrayList<>();
         expectedEvents.add(expectedEventOne);
         expectedEvents.add(expectedEventTwo);

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReplayAwareMessageHandlerWrapperTest {

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapperWithDisallowReplayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayContextParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayContextParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReplayContextParameterResolverFactoryTest {

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/ReplayParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ReplayParameterResolverFactoryTest {

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.eventhandling.scheduling.quartz;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
@@ -48,8 +48,8 @@ class DirectEventJobDataBinderTest {
 
     DirectEventJobDataBinderTest() {
         this.testMetaData = MetaData.with("some-key", "some-value");
-        this.testEventMessage = GenericEventMessage.<String>asEventMessage(TEST_EVENT_PAYLOAD)
-                .withMetaData(testMetaData);
+        this.testEventMessage = EventTestUtils.<String>asEventMessage(TEST_EVENT_PAYLOAD)
+                                              .withMetaData(testMetaData);
     }
 
     static Stream<Arguments> serializerImplementationAndAssertionSpecifics() {

--- a/messaging/src/test/java/org/axonframework/messaging/HeadersTests.java
+++ b/messaging/src/test/java/org/axonframework/messaging/HeadersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.messaging.Headers.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AggregateTypeParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.axonframework.messaging.annotation;
 
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.QualifiedName;
 import org.junit.jupiter.api.*;
 
@@ -74,7 +74,7 @@ class AggregateTypeParameterResolverFactoryTest {
     void ignoredForNonDomainEventMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(aggregateTypeMethod, aggregateTypeMethod.getParameters(), 0);
-        EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        EventMessage<Object> eventMessage = EventTestUtils.asEventMessage("test");
         assertFalse(resolver.matches(eventMessage, null));
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.messaging.QualifiedNameUtils.fromClassName;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/MessageIdentifierParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/MessageIdentifierParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.messaging.annotation;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.QualifiedName;
 import org.junit.jupiter.api.*;
 
@@ -63,7 +63,7 @@ class MessageIdentifierParameterResolverFactoryTest {
     void resolvesToMessageIdentifierWhenAnnotatedForEventMessage() {
         ParameterResolver<String> resolver =
                 testSubject.createInstance(messageIdentifierMethod, messageIdentifierMethod.getParameters(), 0);
-        final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> eventMessage = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(eventMessage, null));
         assertEquals(eventMessage.getIdentifier(), resolver.resolveParameterValue(eventMessage, null));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/MultiParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/MultiParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.messaging.annotation;
 
 import org.axonframework.common.Priority;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.junit.jupiter.api.*;
@@ -86,7 +86,7 @@ class MultiParameterResolverFactoryTest {
     @Test
     void firstMatchingResolverMayReturnValue() throws Exception {
         Method equals = getClass().getMethod("equals", Object.class);
-        final EventMessage<Object> message = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> message = EventTestUtils.asEventMessage("test");
         when(mockFactory1.createInstance(ArgumentMatchers.any(Executable.class),
                                          ArgumentMatchers.any(),
                                          ArgumentMatchers.anyInt()))

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/SimpleResourceParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.annotation;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.junit.jupiter.api.*;
 
@@ -70,7 +70,7 @@ class SimpleResourceParameterResolverFactoryTest {
     void resolvesToResourceWhenMessageHandlingMethodHasResourceParameter() {
         ParameterResolver resolver =
                 testSubject.createInstance(messageHandlingMethodWithResourceParameter, messageHandlingMethodWithResourceParameter.getParameters(), 1);
-        final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> eventMessage = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(eventMessage, null));
         assertEquals(TEST_RESOURCE, resolver.resolveParameterValue(eventMessage, null));
     }
@@ -80,7 +80,7 @@ class SimpleResourceParameterResolverFactoryTest {
     void resolvesToResourceWhenMessageHandlingMethodHasAnotherResourceParameter() {
         ParameterResolver resolver =
                 testSubject.createInstance(messageHandlingMethodWithResource2Parameter, messageHandlingMethodWithResource2Parameter.getParameters(), 1);
-        final EventMessage<Object> eventMessage = GenericEventMessage.asEventMessage("test");
+        final EventMessage<Object> eventMessage = EventTestUtils.asEventMessage("test");
         assertTrue(resolver.matches(eventMessage, null));
         assertEquals(TEST_RESOURCE2, resolver.resolveParameterValue(eventMessage, null));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/DeadLetterParameterResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.messaging.deadletter;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.annotation.ParameterResolver;
@@ -89,7 +89,7 @@ class DeadLetterParameterResolverFactoryTest {
     void resolverMatchesForAnyMessageType() {
         CommandMessage<Object> testCommand =
                 new GenericCommandMessage<>(new QualifiedName("test", "command", "0.0.1"), "some-command");
-        EventMessage<Object> testEvent = GenericEventMessage.asEventMessage("some-command");
+        EventMessage<Object> testEvent = EventTestUtils.asEventMessage("some-command");
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new QualifiedName("test", "query", "0.0.1"), "some-query", instanceOf(String.class)
         );
@@ -104,7 +104,7 @@ class DeadLetterParameterResolverFactoryTest {
 
     @Test
     void resolvesDeadLetterFromUnitOfWorkResources() {
-        EventMessage<String> testMessage = GenericEventMessage.asEventMessage("some-event");
+        EventMessage<String> testMessage = EventTestUtils.asEventMessage("some-event");
         DeadLetter<EventMessage<String>> expected = new GenericDeadLetter<>(
                 "sequenceId", testMessage, new RuntimeException("some-cause")
         );
@@ -120,7 +120,7 @@ class DeadLetterParameterResolverFactoryTest {
 
     @Test
     void resolvesNullWhenNoUnitOfWorkIsActive() {
-        Message<Object> testMessage = GenericEventMessage.asEventMessage("some-event");
+        Message<Object> testMessage = EventTestUtils.asEventMessage("some-event");
 
         ParameterResolver<DeadLetter<?>> resolver =
                 testSubject.createInstance(deadLetterMethod, deadLetterMethod.getParameters(), 0);
@@ -130,7 +130,7 @@ class DeadLetterParameterResolverFactoryTest {
 
     @Test
     void resolvesNullWhenNoDeadLetterIsPresentInTheUnitOfWorkResources() {
-        EventMessage<String> testMessage = GenericEventMessage.asEventMessage("some-event");
+        EventMessage<String> testMessage = EventTestUtils.asEventMessage("some-event");
         DefaultUnitOfWork.startAndGet(testMessage);
 
         ParameterResolver<DeadLetter<?>> resolver =

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/DoNotEnqueueTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/DoNotEnqueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.deadletter;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.junit.jupiter.api.*;
 
@@ -41,7 +41,7 @@ class DoNotEnqueueTest {
     void setUp() {
         GenericDeadLetter.clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
 
-        testLetter = new GenericDeadLetter<>("seqId", GenericEventMessage.asEventMessage("payload"));
+        testLetter = new GenericDeadLetter<>("seqId", EventTestUtils.asEventMessage("payload"));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/GenericDeadLetterTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/GenericDeadLetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.deadletter;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
 
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericDeadLetterTest {
 
     private static final String SEQUENCE_IDENTIFIER = "sesequenceIdentifier";
-    private static final EventMessage<String> MESSAGE = GenericEventMessage.asEventMessage("payload");
+    private static final EventMessage<String> MESSAGE = EventTestUtils.asEventMessage("payload");
 
     @Test
     void constructorForIdentifierAndMessageSetsGivenIdentifierAndMessage() {

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/IgnoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/IgnoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.deadletter;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.junit.jupiter.api.*;
 
@@ -41,7 +41,7 @@ class IgnoreTest {
     void setUp() {
         GenericDeadLetter.clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
 
-        testLetter = new GenericDeadLetter<>("seqId", GenericEventMessage.asEventMessage("payload"));
+        testLetter = new GenericDeadLetter<>("seqId", EventTestUtils.asEventMessage("payload"));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueueTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.deadletter;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -26,9 +26,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -917,7 +915,7 @@ public abstract class SequencedDeadLetterQueueTest<M extends Message<?>> {
      * @return A unique {@link EventMessage} to serves as the {@link DeadLetter#message()} contents.
      */
     protected static EventMessage<String> generateEvent() {
-        return GenericEventMessage.asEventMessage("Then this happened..." + UUID.randomUUID());
+        return EventTestUtils.asEventMessage("Then this happened..." + UUID.randomUUID());
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/ShouldEnqueueTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/ShouldEnqueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging.deadletter;
 
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -42,7 +42,7 @@ class ShouldEnqueueTest {
     void setUp() {
         GenericDeadLetter.clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
 
-        testLetter = new GenericDeadLetter<>("seqId", GenericEventMessage.asEventMessage("payload"));
+        testLetter = new GenericDeadLetter<>("seqId", EventTestUtils.asEventMessage("payload"));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/ExceptionHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/ExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/messaging/src/test/java/org/axonframework/tracing/attributes/MessageIdSpanAttributesProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/attributes/MessageIdSpanAttributesProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.tracing.attributes;
 
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.tracing.SpanAttributesProvider;
 import org.junit.jupiter.api.*;
@@ -31,7 +31,7 @@ class MessageIdSpanAttributesProviderTest {
 
     @Test
     void extractsMessageIdentifier() {
-        Message<?> event = GenericEventMessage.asEventMessage("Some event");
+        Message<?> event = EventTestUtils.asEventMessage("Some event");
         Map<String, String> map = provider.provideForMessage(event);
         assertEquals(1, map.size());
         assertEquals(event.getIdentifier(), map.get("axon_message_id"));

--- a/messaging/src/test/java/org/axonframework/tracing/attributes/MessageNameSpanAttributesProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/tracing/attributes/MessageNameSpanAttributesProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.tracing.attributes;
 
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.queryhandling.GenericQueryMessage;
@@ -36,7 +36,7 @@ class MessageNameSpanAttributesProviderTest {
 
     @Test
     void extractsNothingForEvent() {
-        EventMessage<Object> event = GenericEventMessage.asEventMessage("Some event");
+        EventMessage<Object> event = EventTestUtils.asEventMessage("Some event");
         Map<String, String> map = provider.provideForMessage(event);
         assertEquals(0, map.size());
     }

--- a/messaging/src/test/java/org/axonframework/utils/InMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/utils/InMemoryStreamableEventSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.utils;
 
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -49,7 +49,7 @@ public class InMemoryStreamableEventSource implements StreamableMessageSource<Tr
     /**
      * An {@link EventMessage} representing a failed event.
      */
-    public static final EventMessage<String> FAIL_EVENT = GenericEventMessage.asEventMessage(FAIL_PAYLOAD);
+    public static final EventMessage<String> FAIL_EVENT = EventTestUtils.asEventMessage(FAIL_PAYLOAD);
 
     private List<TrackedEventMessage<?>> messages = new CopyOnWriteArrayList<>();
     private final boolean streamCallbackSupported;

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/CapacityMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -32,7 +34,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CapacityMonitorTest {
@@ -134,5 +135,9 @@ class CapacityMonitorTest {
         assertTrue(capacityGauges.stream()
                                  .anyMatch(gauge -> Objects
                                          .equals(gauge.getId().getTag("myMetaData"), "myMetadataValue2")));
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
@@ -36,7 +37,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import javax.annotation.Nonnull;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class GlobalMetricRegistryTest {
@@ -182,5 +182,9 @@ class GlobalMetricRegistryTest {
         MessageMonitor<? extends Message<?>> actual = subject.registerComponentWithDefaultTags(String.class, "test");
 
         assertSame(NoOpMessageMonitor.instance(), actual);
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageCountingMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -31,7 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -222,5 +223,9 @@ class MessageCountingMonitorTest {
                                   .filter(counter -> Objects
                                           .equals(counter.getId().getTag("payloadType"), "myMetadataValue2"))
                                   .allMatch(counter -> counter.count() == 1));
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/MessageTimerMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -37,7 +39,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -280,5 +281,9 @@ class MessageTimerMonitorTest {
     void buildWithNullTimerCustomizationThrowsAxonConfigurationException() {
         MessageTimerMonitor.Builder testSubject = MessageTimerMonitor.builder();
         assertThrows(AxonConfigurationException.class, () -> testSubject.timerCustomization(null));
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics/src/test/java/org/axonframework/metrics/CapacityMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/CapacityMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ package org.axonframework.metrics;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -27,7 +29,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("unchecked")
@@ -70,5 +71,9 @@ class CapacityMonitorTest {
         Map<String, Metric> metricSet = testSubject.getMetrics();
         Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get("capacity");
         assertEquals(0, capacityGauge.getValue(), 0);
+    }
+
+    private static EventMessage<Object> asEventMessage(String payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics/src/test/java/org/axonframework/metrics/GlobalMetricRegistryTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/GlobalMetricRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.codahale.metrics.ConsoleReporter;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.*;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class GlobalMetricRegistryTest {
@@ -89,5 +89,9 @@ class GlobalMetricRegistryTest {
         MessageMonitor<? extends Message<?>> actual = subject.registerComponent(String.class, "test");
 
         assertSame(NoOpMessageMonitor.instance(), actual);
+    }
+
+    private static EventMessage<Object> asEventMessage(String payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/metrics/src/test/java/org/axonframework/metrics/MessageCountingMonitorTest.java
+++ b/metrics/src/test/java/org/axonframework/metrics/MessageCountingMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,15 @@ package org.axonframework.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Metric;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MessageCountingMonitorTest {
@@ -55,5 +56,9 @@ class MessageCountingMonitorTest {
         assertEquals(1, successCounter.getCount());
         assertEquals(1, failureCounter.getCount());
         assertEquals(1, ignoredCounter.getCount());
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/command/EntityEventForwardingModelInspectorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/EntityEventForwardingModelInspectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.axonframework.modelling.command;
 
-import org.axonframework.modelling.command.inspection.AggregateModel;
 import org.axonframework.eventhandling.EventHandler;
-import org.junit.jupiter.api.Test;
+import org.axonframework.modelling.command.inspection.AggregateModel;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory.inspectAggregate;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EntityEventForwardingModelInspectorTest {
 

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -125,8 +125,8 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
         int expectedNumberOfAggregateEventHandlerInvocations = 2;
         int expectedNumberOfMemberEventHandlerInvocations = 1;
 
-        EventMessage<AggregateCreatedEvent> testAggregateEvent = GenericEventMessage.asEventMessage(AGGREGATE_EVENT);
-        EventMessage<MemberEvent> testMemberEvent = GenericEventMessage.asEventMessage(new MemberEvent());
+        EventMessage<AggregateCreatedEvent> testAggregateEvent = EventTestUtils.asEventMessage(AGGREGATE_EVENT);
+        EventMessage<MemberEvent> testMemberEvent = EventTestUtils.asEventMessage(new MemberEvent());
         LeafAggregate testModel = new LeafAggregate();
 
         AggregateModel<LeafAggregate> testSubject =
@@ -143,8 +143,8 @@ class AnnotatedRootMessageHandlingMemberAggregateMetaModelFactoryTest {
         int expectedNumberOfAggregateEventHandlerInvocations = 2;
         int expectedNumberOfMemberEventHandlerInvocations = 1;
 
-        EventMessage<AggregateCreatedEvent> testAggregateEvent = GenericEventMessage.asEventMessage(AGGREGATE_EVENT);
-        EventMessage<MemberEvent> testMemberEvent = GenericEventMessage.asEventMessage(new MemberEvent());
+        EventMessage<AggregateCreatedEvent> testAggregateEvent = EventTestUtils.asEventMessage(AGGREGATE_EVENT);
+        EventMessage<MemberEvent> testMemberEvent = EventTestUtils.asEventMessage(new MemberEvent());
         LeafAggregate testModel = new LeafAggregate();
 
         //noinspection unchecked

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.axonframework.modelling.saga.metamodel.AnnotationSagaMetaModelFactory
 import org.axonframework.modelling.saga.metamodel.SagaModel;
 import org.junit.jupiter.api.*;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/modelling/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AnnotationSagaMetaModelFactoryTest {

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.modelling.saga.repository;
 
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.eventhandling.EventHandler;
-import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.EventTestUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
@@ -164,7 +164,7 @@ class AnnotatedSagaRepositoryTest {
                                                                                   .build();
         Saga<TestSaga> saga =
                 sagaRepository.createInstance(IdentifierFactory.getInstance().generateIdentifier(), TestSaga::new);
-        saga.handleSync(GenericEventMessage.asEventMessage(new Object()));
+        saga.handleSync(EventTestUtils.asEventMessage(new Object()));
 
         assertEquals(1, CountingInterceptors.counter.get());
     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
 import org.axonframework.eventsourcing.AggregateFactory;
@@ -39,6 +41,7 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.messaging.ClassBasedMessageNameResolver;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.annotation.FixedValueParameterResolver;
 import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
 import org.axonframework.messaging.annotation.ParameterResolver;
@@ -73,7 +76,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singleton;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -210,6 +212,10 @@ class AxonAutoConfigurationTest {
                     assertTrue(startupFailure.getMessage().contains("gatewayTwo"),
                                "Expected mention of 'gatewayTwo' in: " + startupFailure.getMessage());
                 });
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 
     @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithHibernateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.eventhandling.EventBus;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
@@ -108,7 +107,7 @@ class AxonAutoConfigurationWithHibernateTest {
 
         Assertions.assertEquals(serializer, engine.getSnapshotSerializer());
 
-        engine.appendEvents(GenericEventMessage.asEventMessage("hello"));
+        engine.appendEvents(EventTestUtils.asEventMessage("hello"));
         List<? extends TrackedEventMessage<?>> events = engine.readEvents(null, false).collect(Collectors.toList());
         assertEquals(1, events.size());
 

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/SagaCustomizeIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.EventProcessingModule;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.modelling.saga.SagaEventHandler;
@@ -53,7 +56,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -107,6 +109,10 @@ class SagaCustomizeIntegrationTest {
                         eventBus.publish(asEventMessage(event));
                     }
                 });
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 
     @AutoConfigureBefore(AxonAutoConfiguration.class)

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,16 @@ import org.axonframework.config.EventProcessingModule;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventProcessor;
 import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.ResetHandler;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventProcessor;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventhandling.tokenstore.TokenStore;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
@@ -74,7 +77,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.awaitility.Awaitility.await;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -215,6 +217,10 @@ public class TrackingEventProcessorIntegrationTest {
                         eventBus.publish(asEventMessage(event));
                     }
                 });
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 
     @Configuration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.axonframework.config.EventProcessingModule;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.annotation.MetaDataValue;
@@ -58,7 +57,7 @@ class EventProcessingModuleWithInterceptorsTest {
             EventBus eventBus = context.getBean(EventBus.class);
             TestContext.MyEventHandler myEventHandler = context.getBean(TestContext.MyEventHandler.class);
 
-            eventBus.publish(GenericEventMessage.asEventMessage("myEvent"));
+            eventBus.publish(EventTestUtils.asEventMessage("myEvent"));
 
             assertEquals("myMetaDataValue", myEventHandler.getMetaDataValue());
         });

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
@@ -20,8 +20,11 @@ import org.axonframework.config.EventProcessingModule;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.InterceptorChain;
 import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.messaging.annotation.MetaDataValue;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.junit.jupiter.api.*;
@@ -51,13 +54,20 @@ class EventProcessingModuleWithInterceptorsTest {
                                                                .withUserConfiguration(TestContext.class);
     }
 
+    private static <P> EventMessage<P> asEventMessage(P event) {
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                () -> GenericEventMessage.clock.instant()
+        );
+    }
+
     @Test
     void interceptorRegistration() {
         testApplicationContext.run(context -> {
             EventBus eventBus = context.getBean(EventBus.class);
             TestContext.MyEventHandler myEventHandler = context.getBean(TestContext.MyEventHandler.class);
 
-            eventBus.publish(EventTestUtils.asEventMessage("myEvent"));
+            eventBus.publish(asEventMessage("myEvent"));
 
             assertEquals("myMetaDataValue", myEventHandler.getMetaDataValue());
         });

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/SpringBeanResolverFactoryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/SpringBeanResolverFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,32 +18,40 @@ package org.axonframework.springboot.integration;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
-import org.axonframework.eventhandling.*;
+import org.axonframework.eventhandling.AnnotationEventHandlerAdapter;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream.Entry;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.spring.config.annotation.SpringBeanDependencyResolverFactory;
 import org.axonframework.spring.config.annotation.SpringBeanParameterResolverFactory;
 import org.axonframework.test.FixtureExecutionException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the functionality of Spring dependency resolution at the application context level. This covers both
@@ -242,6 +250,10 @@ class SpringBeanResolverFactoryTest {
             assertFalse(context.getBean("duplicateResourceWithPrimary2", DuplicateResourceWithPrimary.class)
                                .isPrimary());
         });
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 
     public interface DuplicateResourceWithPrimary {

--- a/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.axonframework.integrationtests.deadline;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.common.AxonNonTransientException;
 import org.axonframework.config.Configuration;
@@ -35,7 +33,11 @@ import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
-import org.axonframework.messaging.*;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.correlation.MessageOriginProvider;
 import org.axonframework.messaging.correlation.SimpleCorrelationDataProvider;
@@ -70,7 +72,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import javax.sql.DataSource;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/ApplicationContextEventPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.spring.messaging;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.PayloadApplicationEvent;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
         return new ApplyMore() {
             @Override
             public ApplyMore andThenApply(Supplier<?> payloadOrMessageSupplier) {
-                appliedMessages.add(GenericEventMessage.asEventMessage(payloadOrMessageSupplier.get()));
+                appliedMessages.add(EventTestUtils.asEventMessage(payloadOrMessageSupplier.get()));
                 return this;
             }
 

--- a/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
+++ b/test/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.axonframework.test.eventscheduler;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 
@@ -86,7 +85,7 @@ public class StubEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Instant triggerDateTime, Object event) {
-        EventMessage eventMessage = GenericEventMessage.asEventMessage(event);
+        EventMessage eventMessage = EventTestUtils.asEventMessage(event);
         StubScheduleToken token = new StubScheduleToken(triggerDateTime, eventMessage, counter.getAndIncrement());
         scheduledEvents.add(token);
         return token;
@@ -94,7 +93,7 @@ public class StubEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        EventMessage eventMessage = GenericEventMessage.asEventMessage(event);
+        EventMessage eventMessage = EventTestUtils.asEventMessage(event);
         Instant scheduleTime = currentDateTime.plus(triggerDuration);
         StubScheduleToken token = new StubScheduleToken(scheduleTime, eventMessage, counter.getAndIncrement());
         scheduledEvents.add(token);

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -38,6 +38,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.messaging.annotation.ClasspathHandlerDefinition;
@@ -297,11 +298,18 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
         return this;
     }
 
-    @Override
-    public ContinuedGivenState givenAPublished(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
-        handleInSaga(timeCorrectedEventMessage(msg));
-        return this;
+    @SuppressWarnings("unchecked")
+    private static <P> EventMessage<P> asEventMessage(Object event) {
+        if (event instanceof EventMessage) {
+            return (EventMessage<P>) event;
+        } else if (event instanceof Message) {
+            Message<P> message = (Message<P>) event;
+            return new GenericEventMessage<>(message, () -> GenericEventMessage.clock.instant());
+        }
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                () -> GenericEventMessage.clock.instant()
+        );
     }
 
     @Override
@@ -342,9 +350,8 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     @Override
-    public ContinuedGivenState andThenAPublished(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
-
+    public ContinuedGivenState givenAPublished(Object event, Map<String, ?> metaData) {
+        EventMessage<?> msg = asEventMessage(event).andMetaData(metaData);
         handleInSaga(timeCorrectedEventMessage(msg));
         return this;
     }
@@ -363,8 +370,16 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     @Override
+    public ContinuedGivenState andThenAPublished(Object event, Map<String, ?> metaData) {
+        EventMessage<?> msg = asEventMessage(event).andMetaData(metaData);
+
+        handleInSaga(timeCorrectedEventMessage(msg));
+        return this;
+    }
+
+    @Override
     public FixtureExecutionResult whenPublishingA(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
+        EventMessage<?> msg = asEventMessage(event).andMetaData(metaData);
 
         fixtureExecutionResult.startRecording();
         handleInSaga(timeCorrectedEventMessage(msg));
@@ -372,7 +387,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     private EventMessage<Object> timeCorrectedEventMessage(Object event) {
-        EventMessage<?> msg = EventTestUtils.asEventMessage(event);
+        EventMessage<?> msg = asEventMessage(event);
         return new GenericEventMessage<>(
                 msg.getIdentifier(), msg.name(), msg.getPayload(), msg.getMetaData(), currentTime()
         );
@@ -495,7 +510,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
         @Override
         public FixtureExecutionResult publishes(Object event, Map<String, ?> metaData) {
-            EventMessage<?> eventMessage = EventTestUtils.asEventMessage(event).andMetaData(metaData);
+            EventMessage<?> eventMessage = asEventMessage(event).andMetaData(metaData);
             publish(eventMessage);
 
             return fixtureExecutionResult;
@@ -503,7 +518,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
         private void publish(Object... events) {
             for (Object event : events) {
-                EventMessage<?> eventMessage = EventTestUtils.asEventMessage(event);
+                EventMessage<?> eventMessage = asEventMessage(event);
                 handleInSaga(new GenericDomainEventMessage<>(aggregateType,
                                                              aggregateIdentifier,
                                                              sequenceNumber++,

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -299,7 +299,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
     @Override
     public ContinuedGivenState givenAPublished(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = GenericEventMessage.asEventMessage(event).andMetaData(metaData);
+        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
         handleInSaga(timeCorrectedEventMessage(msg));
         return this;
     }
@@ -343,7 +343,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
     @Override
     public ContinuedGivenState andThenAPublished(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = GenericEventMessage.asEventMessage(event).andMetaData(metaData);
+        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
 
         handleInSaga(timeCorrectedEventMessage(msg));
         return this;
@@ -364,7 +364,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
     @Override
     public FixtureExecutionResult whenPublishingA(Object event, Map<String, ?> metaData) {
-        EventMessage<?> msg = GenericEventMessage.asEventMessage(event).andMetaData(metaData);
+        EventMessage<?> msg = EventTestUtils.asEventMessage(event).andMetaData(metaData);
 
         fixtureExecutionResult.startRecording();
         handleInSaga(timeCorrectedEventMessage(msg));
@@ -372,7 +372,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     private EventMessage<Object> timeCorrectedEventMessage(Object event) {
-        EventMessage<?> msg = GenericEventMessage.asEventMessage(event);
+        EventMessage<?> msg = EventTestUtils.asEventMessage(event);
         return new GenericEventMessage<>(
                 msg.getIdentifier(), msg.name(), msg.getPayload(), msg.getMetaData(), currentTime()
         );
@@ -495,7 +495,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
         @Override
         public FixtureExecutionResult publishes(Object event, Map<String, ?> metaData) {
-            EventMessage<?> eventMessage = GenericEventMessage.asEventMessage(event).andMetaData(metaData);
+            EventMessage<?> eventMessage = EventTestUtils.asEventMessage(event).andMetaData(metaData);
             publish(eventMessage);
 
             return fixtureExecutionResult;
@@ -503,7 +503,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
 
         private void publish(Object... events) {
             for (Object event : events) {
-                EventMessage<?> eventMessage = GenericEventMessage.asEventMessage(event);
+                EventMessage<?> eventMessage = EventTestUtils.asEventMessage(event);
                 handleInSaga(new GenericDomainEventMessage<>(aggregateType,
                                                              aggregateIdentifier,
                                                              sequenceNumber++,

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,18 @@ package org.axonframework.test.aggregate;
 import org.axonframework.deadline.DeadlineMessage;
 import org.axonframework.deadline.GenericDeadlineMessage;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.deadline.ScheduledDeadlineInfo;
 import org.axonframework.test.deadline.StubDeadlineManager;
 import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.matchers.MatchAllFieldFilter;
-import org.hamcrest.*;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.mockito.*;
@@ -39,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.*;
-import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
@@ -378,5 +381,9 @@ class ResultValidatorImplTest {
             assertThat(e.getMessage(), containsString("<EXPECTED DESCRIPTION TEXT>"));
             assertThat(e.getMessage(), containsString("<MISMATCH TEXT>"));
         }
+    }
+
+    private static EventMessage<Object> asEventMessage(Object payload) {
+        return new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload);
     }
 }

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class AnnotatedSagaTest {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         FixtureExecutionResult validator = fixture
                 .givenAggregate(aggregate1).published(
-                        GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
+                        EventTestUtils.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
                         new TriggerExistingSagaEvent(aggregate1))
                 .andThenAggregate(aggregate2).published(new TriggerSagaStartEvent(aggregate2))
                 .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));
@@ -349,7 +349,7 @@ class AnnotatedSagaTest {
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         FixtureExecutionResult validator = fixture
                 .givenAggregate(aggregate1).published(
-                        GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
+                        EventTestUtils.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
                         new TriggerExistingSagaEvent(aggregate1),
                         new TriggerAssociationResolverSagaEvent(aggregate1))
                 .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));

--- a/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -16,9 +16,12 @@
 
 package org.axonframework.test.saga;
 
+import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.matchers.Matchers;
 import org.axonframework.test.utils.CallbackBehavior;
@@ -44,34 +47,11 @@ import static org.mockito.Mockito.*;
  */
 class AnnotatedSagaTest {
 
-    @Test
-    void fixtureApi_WhenEventOccurs() {
-        String aggregate1 = UUID.randomUUID().toString();
-        String aggregate2 = UUID.randomUUID().toString();
-        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
-        FixtureExecutionResult validator = fixture
-                .givenAggregate(aggregate1).published(
-                        EventTestUtils.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
-                        new TriggerExistingSagaEvent(aggregate1))
-                .andThenAggregate(aggregate2).published(new TriggerSagaStartEvent(aggregate2))
-                .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));
-
-        validator.expectActiveSagas(1);
-        validator.expectAssociationWith("identifier", aggregate2);
-        validator.expectNoAssociationWith("identifier", aggregate1);
-        validator.expectScheduledEventOfType(Duration.ofMinutes(10), TimerTriggeredEvent.class);
-        validator.expectScheduledEventMatching(Duration.ofMinutes(10), messageWithPayload(CoreMatchers.any(
-                TimerTriggeredEvent.class)));
-        validator.expectScheduledEvent(Duration.ofMinutes(10), new TimerTriggeredEvent(aggregate1));
-        validator.expectScheduledEventOfType(fixture.currentTime().plusSeconds(600), TimerTriggeredEvent.class);
-        validator.expectScheduledEventMatching(fixture.currentTime().plusSeconds(600),
-                                               messageWithPayload(CoreMatchers.any(TimerTriggeredEvent.class)));
-        validator.expectScheduledEvent(fixture.currentTime().plusSeconds(600),
-                                       new TimerTriggeredEvent(aggregate1));
-        validator.expectDispatchedCommands();
-        validator.expectNoDispatchedCommands();
-        validator.expectPublishedEventsMatching(noEvents());
-        validator.expectNoScheduledDeadlines();
+    private static <P> EventMessage<P> asEventMessage(P event) {
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                () -> GenericEventMessage.clock.instant()
+        );
     }
 
     @Test
@@ -344,12 +324,42 @@ class AnnotatedSagaTest {
     }
 
     @Test
+    void fixtureApi_WhenEventOccurs() {
+        String aggregate1 = UUID.randomUUID().toString();
+        String aggregate2 = UUID.randomUUID().toString();
+        SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
+        FixtureExecutionResult validator = fixture
+                .givenAggregate(aggregate1).published(
+                        asEventMessage(new TriggerSagaStartEvent(aggregate1)),
+                        new TriggerExistingSagaEvent(aggregate1))
+                .andThenAggregate(aggregate2).published(new TriggerSagaStartEvent(aggregate2))
+                .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));
+
+        validator.expectActiveSagas(1);
+        validator.expectAssociationWith("identifier", aggregate2);
+        validator.expectNoAssociationWith("identifier", aggregate1);
+        validator.expectScheduledEventOfType(Duration.ofMinutes(10), TimerTriggeredEvent.class);
+        validator.expectScheduledEventMatching(Duration.ofMinutes(10), messageWithPayload(CoreMatchers.any(
+                TimerTriggeredEvent.class)));
+        validator.expectScheduledEvent(Duration.ofMinutes(10), new TimerTriggeredEvent(aggregate1));
+        validator.expectScheduledEventOfType(fixture.currentTime().plusSeconds(600), TimerTriggeredEvent.class);
+        validator.expectScheduledEventMatching(fixture.currentTime().plusSeconds(600),
+                                               messageWithPayload(CoreMatchers.any(TimerTriggeredEvent.class)));
+        validator.expectScheduledEvent(fixture.currentTime().plusSeconds(600),
+                                       new TimerTriggeredEvent(aggregate1));
+        validator.expectDispatchedCommands();
+        validator.expectNoDispatchedCommands();
+        validator.expectPublishedEventsMatching(noEvents());
+        validator.expectNoScheduledDeadlines();
+    }
+
+    @Test
     void fixtureApi_DomainEventMessageIsAssignableFromMessage() {
         String aggregate1 = UUID.randomUUID().toString();
         SagaTestFixture<StubSaga> fixture = new SagaTestFixture<>(StubSaga.class);
         FixtureExecutionResult validator = fixture
                 .givenAggregate(aggregate1).published(
-                        EventTestUtils.asEventMessage(new TriggerSagaStartEvent(aggregate1)),
+                        asEventMessage(new TriggerSagaStartEvent(aggregate1)),
                         new TriggerExistingSagaEvent(aggregate1),
                         new TriggerAssociationResolverSagaEvent(aggregate1))
                 .whenAggregate(aggregate1).publishes(new TriggerSagaEndEvent(aggregate1));

--- a/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,13 @@
 package org.axonframework.test.saga;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.test.AxonAssertionError;
 import org.axonframework.test.aggregate.MyOtherEvent;
 import org.axonframework.test.matchers.AllFieldsFilter;
 import org.axonframework.test.matchers.Matchers;
 import org.junit.jupiter.api.*;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EventValidatorTest {
 
@@ -42,7 +41,7 @@ class EventValidatorTest {
 
     @Test
     void assertPublishedEventsWithNoEventsMatcherThrowsAssertionErrorIfEventWasPublished() {
-        testSubject.handleSync(GenericEventMessage.asEventMessage(new MyOtherEvent()));
+        testSubject.handleSync(EventTestUtils.asEventMessage(new MyOtherEvent()));
 
         assertThrows(AxonAssertionError.class, () -> testSubject.assertPublishedEventsMatching(Matchers.noEvents()));
     }
@@ -54,14 +53,14 @@ class EventValidatorTest {
 
     @Test
     void assertPublishedEventsThrowsAssertionErrorIfEventWasPublished() {
-        testSubject.handleSync(GenericEventMessage.asEventMessage(new MyOtherEvent()));
+        testSubject.handleSync(EventTestUtils.asEventMessage(new MyOtherEvent()));
 
         assertThrows(AxonAssertionError.class, testSubject::assertPublishedEvents);
     }
 
     @Test
     void assertPublishedEventsForEventMessages() {
-        EventMessage<MyOtherEvent> testEventMessage = GenericEventMessage.asEventMessage(new MyOtherEvent());
+        EventMessage<MyOtherEvent> testEventMessage = EventTestUtils.asEventMessage(new MyOtherEvent());
         testSubject.handleSync(testEventMessage);
 
         testSubject.assertPublishedEvents(testEventMessage);

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,16 @@
 
 package org.axonframework.test.saga;
 
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
-import org.axonframework.messaging.annotation.*;
+import org.axonframework.messaging.annotation.HandlerDefinition;
+import org.axonframework.messaging.annotation.HandlerEnhancerDefinition;
+import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
-import javax.annotation.Nonnull;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -33,10 +34,11 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 
 import static org.axonframework.test.matchers.Matchers.listWithAnyOf;
 import static org.axonframework.test.matchers.Matchers.predicate;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test class is intended to test whether the registration of a
@@ -75,8 +77,8 @@ public class FixtureTest_RegisteringMethodEnhancements {
     void testRegisterParameterResolverFactoryStillCallsMetadataValue() {
         testSubject.registerParameterResolverFactory(new TestParameterResolverFactory(new AtomicBoolean(false)))
                    .givenAggregate(TEST_AGGREGATE_IDENTIFIER)
-                   .published(GenericEventMessage.asEventMessage(new TriggerSagaStartEvent(TEST_AGGREGATE_IDENTIFIER))
-                                                 .withMetaData(
+                   .published(EventTestUtils.asEventMessage(new TriggerSagaStartEvent(TEST_AGGREGATE_IDENTIFIER))
+                                            .withMetaData(
                                                          Collections.singletonMap("extraIdentifier",
                                                                                   "myExtraIdentifier")))
                    .whenPublishingA(new ParameterResolvedEvent(TEST_AGGREGATE_IDENTIFIER))

--- a/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/MetadataContextGetterTest.java
+++ b/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/MetadataContextGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.axonframework.tracing.opentelemetry;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
@@ -29,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MetadataContextGetterTest {
 
-    private final EventMessage<Object> message = GenericEventMessage
+    private final EventMessage<Object> message = EventTestUtils
             .asEventMessage("MyEvent")
             .andMetaData(Collections.singletonMap("myKeyOne", "myValueTwo"))
             .andMetaData(Collections.singletonMap("MyKeyTwo", 2));

--- a/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/MetadataContextGetterTest.java
+++ b/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/MetadataContextGetterTest.java
@@ -17,6 +17,9 @@
 package org.axonframework.tracing.opentelemetry;
 
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
@@ -28,8 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MetadataContextGetterTest {
 
-    private final EventMessage<Object> message = EventTestUtils
-            .asEventMessage("MyEvent")
+    private final EventMessage<String> message = asEventMessage("MyEvent")
             .andMetaData(Collections.singletonMap("myKeyOne", "myValueTwo"))
             .andMetaData(Collections.singletonMap("MyKeyTwo", 2));
 
@@ -50,5 +52,12 @@ class MetadataContextGetterTest {
     @Test
     void shouldGetNullFromNullMessage() {
         assertNull(MetadataContextGetter.INSTANCE.get(null, "myKeyOne"));
+    }
+
+    private static <P> EventMessage<P> asEventMessage(P event) {
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                () -> GenericEventMessage.clock.instant()
+        );
     }
 }

--- a/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
+++ b/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
@@ -28,7 +28,10 @@ import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.tracing.SpanAttributesProvider;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -89,12 +92,11 @@ class OpenTelemetrySpanFactoryTest {
         GlobalOpenTelemetry.set(otelMock);
     }
 
-    @Test
-    void propagatesContextInjectsMetadata() {
-        EventMessage<Object> originalMessage = EventTestUtils.asEventMessage("MyEvent");
-        EventMessage<Object> modifiedMessage = factory.propagateContext(originalMessage);
-
-        assertNotNull(modifiedMessage.getMetaData().get("traceparent"));
+    private static <P> EventMessage<P> asEventMessage(P event) {
+        return new GenericEventMessage<>(
+                new GenericMessage<>(QualifiedNameUtils.fromClassName(event.getClass()), (P) event),
+                () -> GenericEventMessage.clock.instant()
+        );
     }
 
     @Test
@@ -206,9 +208,12 @@ class OpenTelemetrySpanFactoryTest {
         verify(spanBuilder).setAttribute("myKey", "myValue");
     }
 
-    private Message<?> generateMessageWithTraceId(String traceId) {
-        return EventTestUtils.asEventMessage("MyEvent")
-                             .andMetaData(Collections.singletonMap("traceparent", traceId));
+    @Test
+    void propagatesContextInjectsMetadata() {
+        EventMessage<Object> originalMessage = asEventMessage("MyEvent");
+        EventMessage<Object> modifiedMessage = factory.propagateContext(originalMessage);
+
+        assertNotNull(modifiedMessage.getMetaData().get("traceparent"));
     }
 
     @Test
@@ -233,5 +238,9 @@ class OpenTelemetrySpanFactoryTest {
     void builderRejectsNullTextMapSetter() {
         OpenTelemetrySpanFactory.Builder builder = OpenTelemetrySpanFactory.builder();
         assertThrows(AxonConfigurationException.class, () -> builder.textMapSetter(null));
+    }
+
+    private Message<?> generateMessageWithTraceId(String traceId) {
+        return asEventMessage("MyEvent").andMetaData(Collections.singletonMap("traceparent", traceId));
     }
 }

--- a/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
+++ b/tracing-opentelemetry/src/test/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.tracing.SpanAttributesProvider;
 import org.junit.jupiter.api.*;
@@ -92,7 +91,7 @@ class OpenTelemetrySpanFactoryTest {
 
     @Test
     void propagatesContextInjectsMetadata() {
-        EventMessage<Object> originalMessage = GenericEventMessage.asEventMessage("MyEvent");
+        EventMessage<Object> originalMessage = EventTestUtils.asEventMessage("MyEvent");
         EventMessage<Object> modifiedMessage = factory.propagateContext(originalMessage);
 
         assertNotNull(modifiedMessage.getMetaData().get("traceparent"));
@@ -208,8 +207,8 @@ class OpenTelemetrySpanFactoryTest {
     }
 
     private Message<?> generateMessageWithTraceId(String traceId) {
-        return GenericEventMessage.asEventMessage("MyEvent")
-                                  .andMetaData(Collections.singletonMap("traceparent", traceId));
+        return EventTestUtils.asEventMessage("MyEvent")
+                             .andMetaData(Collections.singletonMap("traceparent", traceId));
     }
 
     @Test


### PR DESCRIPTION
Continuation of changes from this PR:
https://github.com/AxonFramework/AxonFramework/pull/3214