### PR TITLE
ci: GitHub Actions (AF4) - timeout for builds and one in-progress run per pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,14 +1,19 @@
-name: Axon Framework
+name: Axon Framework (Pull Request)
 
 on:
   pull_request:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Currently
The Pull Request GitHub Actions workflow takes about 15 minutes.
- If you push another commit during an ongoing build, you end up with two builds running simultaneously, even though you only care about the latest result.
- Sometimes the tests can stuck and remain in progress till someone cancel them (a lot of lost resources and money for eg. more than hour)

## Change
- When you push another commit during a build, the ongoing build will be canceled, and only the latest commit will be processed.
- When the build takes more than 20 minutes, then will be cancelled.

## Benefits
- Saves time and resources.
- Reduces unnecessary and too long builds, optimizing costs.