### PR TITLE
ci: GitHub Actions (AF5) - rerun flaky tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -38,12 +39,12 @@ jobs:
       - name: Regular Build
         if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true -Dsurefire.rerunFailingTestsCount=5 clean verify
 
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Dcoverage clean verify
+          ./mvnw -B -U -Dstyle.color=always -Dcoverage -Dsurefire.rerunFailingTestsCount=5 clean verify
 
       - name: Sonar Analysis
         if: matrix.sonar-enabled

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Test and Build on JDK ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -37,12 +38,12 @@ jobs:
       - name: Regular Build
         if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true -Dsurefire.rerunFailingTestsCount=5 clean verify
 
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Dcoverage clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh -Dcoverage -Dsurefire.rerunFailingTestsCount=5 clean verify
 
       - name: Sonar Analysis
         if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Currently
The build contains some flaky tests:
- To ensure our changes work, we need to repeat the workflow multiple times. This wastes developers' time, as well as resources and money on GitHub Actions.
- We might encounter flaky test failures and assume "everything is OK," but some other tests may fail afterward. As a result, we may unknowingly merge something problematic.

## Change
- When a test fails, it will be retried up to 5 times.
Then this test will be counted as a flaky test. The build will be successful, but in the end of the summary of all tests run, the number of flaky tests will be output on the screen.

### Example result:

```
[INFO] Results:
[INFO] 
[WARNING] Flakes: 
[WARNING] org.axonframework.axonserver.connector.query.AxonServerQueryBusTest.queryReportsCorrectException
[ERROR]   Run 1: AxonServerQueryBusTest.queryReportsCorrectException:333 No span matching name QueryBus.queryDistributed, but got the following recorded spans: TestSpan{type=DISPATCH, name='QueryBus.queryDistributed', message=GenericQueryMessage{payload={Hello, World}, metadata={}, messageIdentifier='a7f4be5b-59b9-4ad7-a733-d00209339b6a', queryName='java.lang.String', expectedResponseType='InstanceResponseType{class java.lang.String}'}, started=true, ended=false, exception=null, attributes={}}
TestSpan{type=INTERNAL, name='QueryBus.processQueryResponse', message=GenericQueryMessage{payload={Hello, World}, metadata={}, messageIdentifier='a7f4be5b-59b9-4ad7-a733-d00209339b6a', queryName='java.lang.String', expectedResponseType='InstanceResponseType{class java.lang.String}'}, started=true, ended=false, exception=null, attributes={}} ==> expected: <true> but was: <false>
[INFO]   Run 2: PASS
[INFO] 
[INFO] 
[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 1, Flakes: 1
```

## Benefits
- Saves developers' time and resources.
- Reduces repeated builds, optimizing costs.
- More ✅ than ❌ :) 