### PR TITLE
Have `DefaultEventGateway` provide a collection of events to the `EventBus` instead of looping over the events

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/AbstractEventGateway.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/AbstractEventGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.Registration;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import static java.util.Arrays.asList;
@@ -63,6 +65,19 @@ public abstract class AbstractEventGateway {
      */
     protected void publish(@Nonnull Object event) {
         this.eventBus.publish(processInterceptors(asEventMessage(event)));
+    }
+
+    /**
+     * Publishes (dispatches) the given {@link List} of {@code events}.
+     *
+     * @param events The {@link List} of events to publish.
+     */
+    protected void publishAll(@Nonnull List<?> events) {
+        List<EventMessage<?>> interceptedEvents = events.stream()
+                                                        .map(GenericEventMessage::asEventMessage)
+                                                        .map(this::processInterceptors)
+                                                        .collect(Collectors.toList());
+        this.eventBus.publish(interceptedEvents);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/DefaultEventGateway.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/DefaultEventGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class DefaultEventGateway extends AbstractEventGateway implements EventGa
 
     @Override
     public void publish(@Nonnull List<?> events) {
-        events.forEach(this::publish);
+        this.publishAll(events);
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,56 +18,83 @@ package org.axonframework.eventhandling.gateway;
 
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MessageDispatchInterceptor;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
 
-import static org.mockito.ArgumentMatchers.isA;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
+ * This class validating the {@link DefaultEventGateway}.
+ *
  * @author Bert Laverman
  */
 class DefaultEventGatewayTest {
 
     private DefaultEventGateway testSubject;
     private EventBus mockEventBus;
-    private MessageDispatchInterceptor mockEventMessageTransformer;
+    private MessageDispatchInterceptor<EventMessage<?>> mockEventMessageTransformer;
 
-    @SuppressWarnings("unchecked")
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mockEventBus = mock(EventBus.class);
+        //noinspection unchecked
         mockEventMessageTransformer = mock(MessageDispatchInterceptor.class);
 
         when(mockEventMessageTransformer.handle(isA(EventMessage.class)))
                 .thenAnswer(invocation -> invocation.getArguments()[0]);
+        //noinspection unchecked
         testSubject = DefaultEventGateway.builder()
-                .eventBus(mockEventBus)
-                .dispatchInterceptors(mockEventMessageTransformer)
-                .build();
+                                         .eventBus(mockEventBus)
+                                         .dispatchInterceptors(mockEventMessageTransformer)
+                                         .build();
     }
 
-    @SuppressWarnings({"unchecked", "serial"})
     @Test
-    void publish() {
-        testSubject.publish("Event1");
-        verify(mockEventBus).publish(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event1")));
-        verify(mockEventMessageTransformer).handle(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event1")));
+    void publishSingleEvent() {
+        // Given
+        //noinspection unchecked
+        ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
 
+        // When
+        testSubject.publish("Event1");
+
+        // Then
+        verify(mockEventBus).publish(eventCaptor.capture());
+        EventMessage<?> result = eventCaptor.getValue();
+        assertEquals("Event1", result.getPayload());
+
+        verify(mockEventMessageTransformer).handle(eventCaptor.capture());
+        EventMessage<?> interceptedResult = eventCaptor.getValue();
+        assertEquals("Event1", interceptedResult.getPayload());
+    }
+
+    @Test
+    void publishMultipleEvents() {
+        //Given
+        //noinspection unchecked
+        ArgumentCaptor<List<EventMessage<?>>> eventsCaptor = ArgumentCaptor.forClass(List.class);
+        //noinspection unchecked
+        ArgumentCaptor<EventMessage<?>> interceptedCaptor = ArgumentCaptor.forClass(EventMessage.class);
+
+        //When
         testSubject.publish("Event2", "Event3");
 
-        verify(mockEventBus).publish(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event2")));
-        verify(mockEventMessageTransformer).handle(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event2")));
-        verify(mockEventBus).publish(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event3")));
-        verify(mockEventMessageTransformer).handle(
-                argThat((GenericEventMessage msg) -> msg.getPayload().equals("Event3")));
-    }
+        //Then
+        verify(mockEventBus).publish(eventsCaptor.capture());
+        List<EventMessage<?>> result = eventsCaptor.getValue();
+        assertEquals(2, result.size());
+        assertEquals("Event2", result.get(0).getPayload());
+        assertEquals("Event3", result.get(1).getPayload());
 
+        verify(mockEventMessageTransformer, times(2)).handle(interceptedCaptor.capture());
+        List<EventMessage<?>> interceptedResult = interceptedCaptor.getAllValues();
+        assertEquals(2, interceptedResult.size());
+        assertEquals("Event2", interceptedResult.get(0).getPayload());
+        assertEquals("Event3", interceptedResult.get(1).getPayload());
+    }
 }


### PR DESCRIPTION
This pull request makes a slight change in the `DefaultEventGateway`.
Before this PR, the `DefaultEventGateway` did a foreach over the given collection of `events`.
Hence, the `EventBus#publish` method was invoked multiple times. 

In doing so, the behavior of the `EventGateway` differs depending on whether a `UnitOfWork` is present or not.
With an active `UnitOfWork`, Axon Framework would batch the events in a single commit, as expected from the API.
But if there's no active `UnitOfWork`, each event would be published separately; regardless of whether the `EventGateway` was invoked with a single event or a set of events.

I think this behavior is off, hence this PR ensures the given collections is provided as a collection to the `EventBus`.