### PR TITLE
[#3166] Add `LegacyJpaEventStorageEngine`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -35,6 +35,7 @@ import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarke
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.AsyncEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.EmptyAppendTransaction;
 import org.axonframework.eventsourcing.eventstore.EventCriteria;
 import org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils;
 import org.axonframework.eventsourcing.eventstore.LegacyResources;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -115,7 +115,7 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                 String aggregateIdentifier = resolveAggregateIdentifier(taggedEvent.tags());
                 String aggregateType = resolveAggregateType(taggedEvent.tags());
                 if (aggregateIdentifier != null && aggregateType != null && !taggedEvent.tags().isEmpty()) {
-                    long nextSequence = aggregateSequencer.resolveBy(aggregateIdentifier).incrementAndGet();
+                    long nextSequence = aggregateSequencer.incrementAndGetSequenceOf(aggregateIdentifier);
                     builder.setAggregateIdentifier(aggregateIdentifier).setAggregateType(aggregateType)
                            .setAggregateSequenceNumber(nextSequence);
                 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -94,7 +94,7 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
         }
 
         if (events.isEmpty()) {
-            return CompletableFuture.completedFuture(new EmptyAppendTransaction(condition));
+            return CompletableFuture.completedFuture(EmptyAppendTransaction.INSTANCE);
         }
 
         AggregateBasedConsistencyMarker consistencyMarker = AggregateBasedConsistencyMarker.from(condition);

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -43,6 +43,7 @@ import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.eventsourcing.eventstore.Tag;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
+import org.axonframework.eventsourcing.eventstore.TooManyTagsOnEventMessageException;
 import org.axonframework.messaging.Context;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException.conflictingEventsDetected;
+import static org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils.*;
 
 /**
  * Event Storage Engine implementation that uses the aggregate-oriented APIs of Axon Server, allowing it to interact
@@ -85,28 +86,6 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                                               @Nonnull Converter payloadConverter) {
         this.connection = connection;
         this.payloadConverter = payloadConverter;
-    }
-
-    @Nullable
-    private static String resolveAggregateIdentifier(Set<Tag> tags) {
-        if (tags.isEmpty()) {
-            return null;
-        } else if (tags.size() > 1) {
-            throw new IllegalArgumentException("Condition must provide exactly one tag");
-        } else {
-            return tags.iterator().next().value();
-        }
-    }
-
-    @Nullable
-    private static String resolveAggregateType(Set<Tag> tags) {
-        if (tags.isEmpty()) {
-            return null;
-        } else if (tags.size() > 1) {
-            throw new IllegalArgumentException("Condition must provide exactly one tag");
-        } else {
-            return tags.iterator().next().key();
-        }
     }
 
     @Override
@@ -191,15 +170,6 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                                                AggregateBasedConsistencyMarker consistencyMarker) {
         return aggregateSequences.computeIfAbsent(aggregateIdentifier,
                                                   i -> new AtomicLong(consistencyMarker.positionOf(i)));
-    }
-
-    private void assertValidTags(List<TaggedEventMessage<?>> events) {
-        for (TaggedEventMessage<?> taggedEvent : events) {
-            if (taggedEvent.tags().size() > 1) {
-                throw new TooManyTagsOnEventMessageException(
-                        "An Event Storage engine in Aggregate mode does not support multiple tags per event", taggedEvent.event(), taggedEvent.tags());
-            }
-        }
     }
 
     private void buildMetaData(MetaData metaData, Map<String, MetaDataValue> metaDataMap) {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -48,6 +48,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Converter;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -118,7 +119,8 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                     builder.setAggregateIdentifier(aggregateIdentifier).setAggregateType(aggregateType)
                            .setAggregateSequenceNumber(nextSequence);
                 }
-                buildMetaData(event.getMetaData(), builder.getMetaDataMap());
+                var modifiableMetaDataMap = new HashMap<>(builder.getMetaDataMap());
+                buildMetaData(event.getMetaData(), modifiableMetaDataMap);
                 Event message = builder.build();
                 tx.appendEvent(message);
             });

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
@@ -89,13 +89,13 @@ class LegacyAxonServerEventStorageEngineTest extends
     }
 
     @Override
-    protected long globalSequenceOfEvent(long eventNumber) {
-        return eventNumber - 1;
+    protected long globalSequenceOfEvent(long position) {
+        return position - 1;
     }
 
     @Override
-    protected TrackingToken trackingTokenOnPosition(long eventNumber) {
-        return new GlobalSequenceTrackingToken(globalSequenceOfEvent(eventNumber));
+    protected TrackingToken trackingTokenAt(long position) {
+        return new GlobalSequenceTrackingToken(globalSequenceOfEvent(position));
     }
 
     @Override

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
@@ -20,9 +20,11 @@ import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
 import io.axoniq.axonserver.connector.impl.ServerAddress;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
+import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.serialization.Converter;
 import org.axonframework.test.server.AxonServerContainer;
 import org.junit.jupiter.api.*;
@@ -30,6 +32,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @Testcontainers
 class LegacyAxonServerEventStorageEngineTest extends
@@ -54,6 +59,15 @@ class LegacyAxonServerEventStorageEngineTest extends
     static void afterAll() {
         connection.disconnect();
         axonServerContainer.stop();
+    }
+
+    @Test
+    void sourcingFromNonGlobalSequenceTrackingTokenShouldThrowException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> testSubject.stream(StreamingCondition.startingFrom(new GapAwareTrackingToken(5,
+                                                                                                   Collections.emptySet())))
+        );
     }
 
     @Override

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngineTest.java
@@ -20,6 +20,8 @@ import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
 import io.axoniq.axonserver.connector.impl.ServerAddress;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.AsyncEventStorageEngine;
@@ -51,7 +53,8 @@ class LegacyAxonServerEventStorageEngineTest extends
     static void beforeAll() {
         axonServerContainer.start();
         connection = AxonServerConnectionFactory.forClient("Test")
-                                                .routingServers(new ServerAddress(axonServerContainer.getHost(), axonServerContainer.getGrpcPort()))
+                                                .routingServers(new ServerAddress(axonServerContainer.getHost(),
+                                                                                  axonServerContainer.getGrpcPort()))
                                                 .build()
                                                 .connect("default");
     }
@@ -105,8 +108,13 @@ class LegacyAxonServerEventStorageEngineTest extends
     }
 
     @Override
-    protected long sequenceOfEventNo(long eventNo) {
-        return eventNo - 1;
+    protected long globalSequenceOfEvent(long eventNumber) {
+        return eventNumber - 1;
+    }
+
+    @Override
+    protected TrackingToken trackingTokenOnPosition(long eventNumber) {
+        return new GlobalSequenceTrackingToken(globalSequenceOfEvent(eventNumber));
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AsyncEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AsyncEventStorageEngine.java
@@ -154,7 +154,9 @@ public interface AsyncEventStorageEngine extends DescribableComponent {
         /**
          * Commit any underlying transactions to make the appended events visible to consumers.
          *
-         * @return A {@code CompletableFuture} that completes with the new consistency marker for the transaction.
+         * @return A {@code CompletableFuture} that completes with the new consistency marker for the transaction. If
+         * the transaction is empty (without events to append) then returned consistency marker is always
+         * {@link ConsistencyMarker#ORIGIN}
          */
         CompletableFuture<ConsistencyMarker> commit();
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmptyAppendTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmptyAppendTransaction.java
@@ -21,20 +21,19 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Represents an empty append transaction. This transaction does nothing and always succeeds. It is used when there are
  * no events to persist.
- *
- * @param appendCondition will be returned as commit result
  */
-public record EmptyAppendTransaction(AppendCondition appendCondition)
-        implements AsyncEventStorageEngine.AppendTransaction {
+public record EmptyAppendTransaction() implements AsyncEventStorageEngine.AppendTransaction {
+
+    public static final AsyncEventStorageEngine.AppendTransaction INSTANCE = new EmptyAppendTransaction();
 
     /**
      * Commits the empty append transaction. Always completes successfully with the provided consistency marker.
      *
-     * @return a completed future with the consistency marker
+     * @return always a completed future with the consistency marker {@link ConsistencyMarker#ORIGIN}
      */
     @Override
     public CompletableFuture<ConsistencyMarker> commit() {
-        return CompletableFuture.completedFuture(AggregateBasedConsistencyMarker.from(appendCondition));
+        return CompletableFuture.completedFuture(ConsistencyMarker.ORIGIN);
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmptyAppendTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EmptyAppendTransaction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Represents an empty append transaction. This transaction does nothing and always succeeds. It is used when there are
+ * no events to persist.
+ *
+ * @param appendCondition will be returned as commit result
+ */
+public record EmptyAppendTransaction(AppendCondition appendCondition)
+        implements AsyncEventStorageEngine.AppendTransaction {
+
+    /**
+     * Commits the empty append transaction. Always completes successfully with the provided consistency marker.
+     *
+     * @return a completed future with the consistency marker
+     */
+    @Override
+    public CompletableFuture<ConsistencyMarker> commit() {
+        return CompletableFuture.completedFuture(AggregateBasedConsistencyMarker.from(appendCondition));
+    }
+
+    /**
+     * Rolls back the empty append transaction. This does nothing as the transaction has no effect.
+     */
+    @Override
+    public void rollback() {
+        // No action needed
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -187,34 +187,6 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         }
     }
 
-    /**
-     * Represents an empty append transaction. This transaction does nothing and always succeeds. It is used when there
-     * are no events to persist.
-     *
-     * @param appendCondition will be returned as commit result
-     */
-    public record EmptyAppendTransaction(AppendCondition appendCondition)
-            implements AsyncEventStorageEngine.AppendTransaction {
-
-        /**
-         * Commits the empty append transaction. Always completes successfully with the provided consistency marker.
-         *
-         * @return a completed future with the consistency marker
-         */
-        @Override
-        public CompletableFuture<ConsistencyMarker> commit() {
-            return CompletableFuture.completedFuture(AggregateBasedConsistencyMarker.from(appendCondition));
-        }
-
-        /**
-         * Rolls back the empty append transaction. This does nothing as the transaction has no effect.
-         */
-        @Override
-        public void rollback() {
-            // No action needed
-        }
-    }
-
     private LegacyAggregateBasedEventStorageEngineUtils() {
         // Utility class
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -21,13 +21,20 @@ import jakarta.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import static org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException.conflictingEventsDetected;
 
+/**
+ * // todo: describe
+ *
+ * @author Mateusz Nowak
+ * @author Allard Buijze
+ * @since 5.0.0
+ */
 public class LegacyAggregateBasedEventStorageEngineUtils {
 
     public static void assertValidTags(List<TaggedEventMessage<?>> events) {
@@ -112,6 +119,25 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         public AtomicLong resolveBy(String aggregateIdentifier) {
             return aggregateSequences.computeIfAbsent(aggregateIdentifier,
                                                       i -> new AtomicLong(consistencyMarker.positionOf(i)));
+        }
+    }
+
+    /**
+     * Transaction does nothing, always succeed. Useful if there is no events to be persisted.
+     *
+     * @param appendCondition will be returned as commit result
+     */
+    public record EmptyAppendTransaction(AppendCondition appendCondition)
+            implements AsyncEventStorageEngine.AppendTransaction {
+
+        @Override
+        public CompletableFuture<ConsistencyMarker> commit() {
+            return CompletableFuture.completedFuture(AggregateBasedConsistencyMarker.from(appendCondition));
+        }
+
+        @Override
+        public void rollback() {
+
         }
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -41,8 +41,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
      * Validates the tags associated with a list of event messages. Ensures that no event has more than one tag, as the
      * Event Storage engine in Aggregate mode only supports a single tag per event.
      *
-     * @param events the list of tagged event messages to validate
-     * @throws TooManyTagsOnEventMessageException if any event has more than one tag
+     * @param events The list of tagged event messages to validate.
+     * @throws TooManyTagsOnEventMessageException if any event has more than one tag.
      */
     public static void assertValidTags(List<TaggedEventMessage<?>> events) {
         for (TaggedEventMessage<?> taggedEvent : events) {
@@ -59,9 +59,9 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
      * Resolves the aggregate identifier from the provided set of tags. The set must contain exactly one tag, and its
      * value will be returned as the aggregate identifier.
      *
-     * @param tags the set of tags to resolve the aggregate identifier from
-     * @return the aggregate identifier, or {@code null} if the set is empty
-     * @throws IllegalArgumentException if the set contains more than one tag
+     * @param tags The set of tags to resolve the aggregate identifier from.
+     * @return The aggregate identifier, or {@code null} if the set is empty.
+     * @throws IllegalArgumentException if the set contains more than one tag.
      */
     @Nullable
     public static String resolveAggregateIdentifier(Set<Tag> tags) {
@@ -78,9 +78,9 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
      * Resolves the aggregate type from the provided set of tags. The set must contain exactly one tag, and its key will
      * be returned as the aggregate type.
      *
-     * @param tags the set of tags to resolve the aggregate type from
-     * @return the aggregate type, or {@code null} if the set is empty
-     * @throws IllegalArgumentException if the set contains more than one tag
+     * @param tags The set of tags to resolve the aggregate type from.
+     * @return The aggregate type, or {@code null} if the set is empty.
+     * @throws IllegalArgumentException if the set contains more than one tag.
      */
     @Nullable
     public static String resolveAggregateType(Set<Tag> tags) {
@@ -94,14 +94,14 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Translates a conflict exception into an {@link AppendEventsTransactionRejectedException} if the provided
-     * exception is identified as a conflict. If the exception is not a conflict, it recursively checks the cause of the
+     * Translates the given {@code Exception} into an {@link AppendEventsTransactionRejectedException} if it
+     * is identified as a conflict through the given {@code isConflictException} predicate. If the exception is not a conflict, it recursively checks the cause of the
      * exception.
      *
-     * @param consistencyMarker   the consistency marker used to identify conflicting events
-     * @param e                   the exception to translate
-     * @param isConflictException a predicate used to check if the exception is a conflict
-     * @return the translated exception
+     * @param consistencyMarker   The consistency marker used to identify conflicting events.
+     * @param e                   The exception to translate.
+     * @param isConflictException A predicate used to check if the exception is a conflict.
+     * @return The translated exception.
      */
     public static Throwable translateConflictException(
             ConsistencyMarker consistencyMarker,
@@ -136,8 +136,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         /**
          * Constructs a new {@code AggregateSequencer} with the specified aggregate sequences and consistency marker.
          *
-         * @param aggregateSequences a map of aggregate identifiers to atomic sequences
-         * @param consistencyMarker  the consistency marker for this sequencer
+         * @param aggregateSequences A map of aggregate identifiers to atomic sequences.
+         * @param consistencyMarker  The consistency marker for this sequencer.
          */
         private AggregateSequencer(Map<String, AtomicLong> aggregateSequences,
                                    AggregateBasedConsistencyMarker consistencyMarker) {
@@ -148,8 +148,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         /**
          * Creates a new {@code AggregateSequencer} with the provided consistency marker.
          *
-         * @param consistencyMarker the consistency marker for the new sequencer
-         * @return a new {@code AggregateSequencer}
+         * @param consistencyMarker The consistency marker for the new sequencer.
+         * @return A new {@code AggregateSequencer}.
          */
         public static AggregateSequencer with(AggregateBasedConsistencyMarker consistencyMarker) {
             return new AggregateSequencer(new HashMap<>(), consistencyMarker);
@@ -158,7 +158,7 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         /**
          * Advances the consistency marker by resolving and forwarding the state of aggregate sequences.
          *
-         * @return the new consistency marker after forwarding
+         * @return The new consistency marker after forwarding.
          */
         public AggregateBasedConsistencyMarker forwarded() {
             var newConsistencyMarker = consistencyMarker;
@@ -174,8 +174,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
          * Resolves the sequence for the given aggregate identifier. If the aggregate does not exist, it is initialized
          * with the consistency marker's position for that identifier.
          *
-         * @param aggregateIdentifier the identifier of the aggregate to resolve the sequence for
-         * @return the atomic long sequence for the aggregate
+         * @param aggregateIdentifier The identifier of the aggregate to resolve the sequence for.
+         * @return The atomic long sequence for the aggregate.
          */
         public AtomicLong resolveBy(String aggregateIdentifier) {
             return aggregateSequences.computeIfAbsent(aggregateIdentifier,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class LegacyAggregateBasedEventStorageEngineUtils {
+
+    public static void assertValidTags(List<TaggedEventMessage<?>> events) {
+        for (TaggedEventMessage<?> taggedEvent : events) {
+            if (taggedEvent.tags().size() > 1) {
+                throw new TooManyTagsOnEventMessageException(
+                        "An Event Storage engine in Aggregate mode does not support multiple tags per event",
+                        taggedEvent.event(),
+                        taggedEvent.tags());
+            }
+        }
+    }
+
+    @Nullable
+    public static String resolveAggregateIdentifier(Set<Tag> tags) {
+        if (tags.isEmpty()) {
+            return null;
+        } else if (tags.size() > 1) {
+            throw new IllegalArgumentException("Condition must provide exactly one tag");
+        } else {
+            return tags.iterator().next().value();
+        }
+    }
+
+    @Nullable
+    public static String resolveAggregateType(Set<Tag> tags) {
+        if (tags.isEmpty()) {
+            return null;
+        } else if (tags.size() > 1) {
+            throw new IllegalArgumentException("Condition must provide exactly one tag");
+        } else {
+            return tags.iterator().next().key();
+        }
+    }
+
+    public static final class AggregateSequencer {
+
+        private final Map<String, AtomicLong> aggregateSequences;
+        private AggregateBasedConsistencyMarker consistencyMarker;
+
+        AggregateSequencer(Map<String, AtomicLong> aggregateSequences,
+                           AggregateBasedConsistencyMarker consistencyMarker) {
+            this.aggregateSequences = aggregateSequences;
+            this.consistencyMarker = consistencyMarker;
+        }
+
+        public static AggregateSequencer with(AggregateBasedConsistencyMarker consistencyMarker) {
+            return new AggregateSequencer(new HashMap<>(), consistencyMarker);
+        }
+
+        public AggregateBasedConsistencyMarker forwarded() {
+            var newConsistencyMarker = consistencyMarker;
+            for (var aggSeq : aggregateSequences.entrySet()) {
+                newConsistencyMarker = newConsistencyMarker
+                        .forwarded(aggSeq.getKey(), aggSeq.getValue().get());
+            }
+            consistencyMarker = newConsistencyMarker;
+            return newConsistencyMarker;
+        }
+
+        public AtomicLong resolveBy(String aggregateIdentifier) {
+            return aggregateSequences.computeIfAbsent(aggregateIdentifier,
+                                                      i -> new AtomicLong(consistencyMarker.positionOf(i)));
+        }
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -211,9 +211,7 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         }
     }
 
-    public class MessageConverter {
-
-        private MessageConverter() {
-        }
+    private LegacyAggregateBasedEventStorageEngineUtils() {
+        // Utility class
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -94,9 +94,9 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Translates the given {@code Exception} into an {@link AppendEventsTransactionRejectedException} if it
-     * is identified as a conflict through the given {@code isConflictException} predicate. If the exception is not a conflict, it recursively checks the cause of the
-     * exception.
+     * Translates the given {@code Exception} into an {@link AppendEventsTransactionRejectedException} if it is
+     * identified as a conflict through the given {@code isConflictException} predicate. If the exception is not a
+     * conflict, it recursively checks the cause of the exception.
      *
      * @param consistencyMarker   The consistency marker used to identify conflicting events.
      * @param e                   The exception to translate.
@@ -156,9 +156,10 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         }
 
         /**
-         * Advances the consistency marker by resolving and forwarding the state of aggregate sequences.
+         * Forwarded the consistency marker by the state of aggregate sequences.
          *
-         * @return The new consistency marker after forwarding.
+         * @return The new consistency marker after forwarding
+         * @see AggregateBasedConsistencyMarker#forwarded(String, long)
          */
         public AggregateBasedConsistencyMarker forwarded() {
             var newConsistencyMarker = consistencyMarker;
@@ -171,15 +172,18 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         }
 
         /**
-         * Resolves the sequence for the given aggregate identifier. If the aggregate does not exist, it is initialized
-         * with the consistency marker's position for that identifier.
+         * Get and increment the sequence for the given aggregate identifier. If the aggregate does not exist, it is
+         * initialized with the consistency marker's position for that identifier.
          *
-         * @param aggregateIdentifier The identifier of the aggregate to resolve the sequence for.
-         * @return The atomic long sequence for the aggregate.
+         * @param aggregateIdentifier The identifier of the aggregate to get and increment the sequence for
+         * @return The atomic long sequence for the aggregate
          */
-        public AtomicLong resolveBy(String aggregateIdentifier) {
-            return aggregateSequences.computeIfAbsent(aggregateIdentifier,
-                                                      i -> new AtomicLong(consistencyMarker.positionOf(i)));
+        public long incrementAndGetSequenceOf(String aggregateIdentifier) {
+            var aggregateSequence = aggregateSequences.computeIfAbsent(
+                    aggregateIdentifier,
+                    i -> new AtomicLong(consistencyMarker.positionOf(i))
+            );
+            return aggregateSequence.incrementAndGet();
         }
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyAggregateBasedEventStorageEngineUtils.java
@@ -56,8 +56,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Resolves the aggregate identifier from the provided set of tags.
-     * The set must contain exactly one tag, and its value will be returned as the aggregate identifier.
+     * Resolves the aggregate identifier from the provided set of tags. The set must contain exactly one tag, and its
+     * value will be returned as the aggregate identifier.
      *
      * @param tags the set of tags to resolve the aggregate identifier from
      * @return the aggregate identifier, or {@code null} if the set is empty
@@ -75,8 +75,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Resolves the aggregate type from the provided set of tags.
-     * The set must contain exactly one tag, and its key will be returned as the aggregate type.
+     * Resolves the aggregate type from the provided set of tags. The set must contain exactly one tag, and its key will
+     * be returned as the aggregate type.
      *
      * @param tags the set of tags to resolve the aggregate type from
      * @return the aggregate type, or {@code null} if the set is empty
@@ -94,12 +94,12 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Translates a conflict exception into an {@link AppendEventsTransactionRejectedException}
-     * if the provided exception is identified as a conflict.
-     * If the exception is not a conflict, it recursively checks the cause of the exception.
+     * Translates a conflict exception into an {@link AppendEventsTransactionRejectedException} if the provided
+     * exception is identified as a conflict. If the exception is not a conflict, it recursively checks the cause of the
+     * exception.
      *
-     * @param consistencyMarker the consistency marker used to identify conflicting events
-     * @param e the exception to translate
+     * @param consistencyMarker   the consistency marker used to identify conflicting events
+     * @param e                   the exception to translate
      * @param isConflictException a predicate used to check if the exception is a conflict
      * @return the translated exception
      */
@@ -125,8 +125,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Helper class that tracks the sequence of events for different aggregates and
-     * manages the consistency marker for the aggregates.
+     * Helper class that tracks the sequence of events for different aggregates and manages the consistency marker for
+     * the aggregates.
      */
     public static final class AggregateSequencer {
 
@@ -184,8 +184,8 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
     }
 
     /**
-     * Represents an empty append transaction. This transaction does nothing and always succeeds.
-     * It is used when there are no events to persist.
+     * Represents an empty append transaction. This transaction does nothing and always succeeds. It is used when there
+     * are no events to persist.
      *
      * @param appendCondition will be returned as commit result
      */
@@ -208,6 +208,12 @@ public class LegacyAggregateBasedEventStorageEngineUtils {
         @Override
         public void rollback() {
             // No action needed
+        }
+    }
+
+    public class MessageConverter {
+
+        private MessageConverter() {
         }
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TooManyTagsOnEventMessageException.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TooManyTagsOnEventMessageException.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.axonframework.axonserver.connector.event;
+package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventsourcing.eventstore.Tag;
 
 import java.util.Set;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventsourcing.eventstore.jpa;
 
 import org.axonframework.common.DateTimeUtils;
@@ -11,6 +27,13 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+/**
+ * Contains operations that are used to interact with {@link GapAwareTrackingToken} used in Aggregate based JPA event
+ * store implementation.
+ *
+ * @author Mateusz Nowak
+ * @since 5.0.0
+ */
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
         Logger logger

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -50,7 +50,7 @@ record GapAwareTrackingTokenOperations(
         if (trackingToken instanceof GapAwareTrackingToken gapAwareTrackingToken) {
             return gapAwareTrackingToken;
         }
-        // todo: is it OK to get Gap aware tracking token from global one? or throw exception?
+        // todo: reject another types! adjust test suite
         return GapAwareTrackingToken.newInstance(trackingToken.position().orElse(lowestGlobalSequence),
                                                  Collections.emptySet());
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -9,11 +9,9 @@ import org.slf4j.Logger;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 
 record GapAwareTrackingTokenOperations(
-        long lowestGlobalSequence,
         int gapTimeout,
         Logger logger
 ) {
@@ -46,13 +44,14 @@ record GapAwareTrackingTokenOperations(
         return cleanedToken;
     }
 
-    GapAwareTrackingToken gapAwareTrackingTokenFrom(TrackingToken trackingToken) {
+    GapAwareTrackingToken assertGapAwareTrackingToken(TrackingToken trackingToken) {
         if (trackingToken instanceof GapAwareTrackingToken gapAwareTrackingToken) {
             return gapAwareTrackingToken;
+        } else {
+            throw new IllegalArgumentException(
+                    "Tracking Token is not of expected type. Must be GapAwareTrackingToken. Is: "
+                            + trackingToken.getClass().getName());
         }
-        // todo: reject another types! adjust test suite
-        return GapAwareTrackingToken.newInstance(trackingToken.position().orElse(lowestGlobalSequence),
-                                                 Collections.emptySet());
     }
 
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -103,7 +103,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
         this.legacyJpaOperations = new LegacyJpaEventStorageOperations(
                 transactionManager,
-                entityManagerProvider.getEntityManager(),
+                entityManagerProvider,
                 domainEventEntryEntityName(),
                 snapshotEventEntryEntityName()
         );

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     private List<Object[]> indexToTimestamp(GapAwareTrackingToken lastToken) {
-        return transactionManager.fetchInTransaction(() -> legacyJpaOperations.indexToTimestamp(lastToken));
+        return transactionManager.fetchInTransaction(() -> legacyJpaOperations.indexAndTimestampBetweenGaps(lastToken));
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -107,7 +107,7 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
                 domainEventEntryEntityName(),
                 snapshotEventEntryEntityName()
         );
-        this.tokenOperations = new GapAwareTrackingTokenOperations(lowestGlobalSequence, gapTimeout, logger);
+        this.tokenOperations = new GapAwareTrackingTokenOperations(gapTimeout, logger);
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -267,10 +267,10 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
                                   .orElse(null);
     }
 
-    private Optional<TrackingToken> gapAwareTrackingTokenOn(Long token) {
-        return token == null
+    private Optional<TrackingToken> gapAwareTrackingTokenOn(Long globalIndex) {
+        return globalIndex == null
                 ? Optional.empty()
-                : Optional.of(GapAwareTrackingToken.newInstance(token, Collections.emptySet()));
+                : Optional.of(GapAwareTrackingToken.newInstance(globalIndex, Collections.emptySet()));
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -57,7 +57,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterators;
 import java.util.concurrent.CompletableFuture;
@@ -215,7 +214,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         var isAggregateEvent =
                 aggregateIdentifier != null && aggregateType != null && !taggedEvent.tags().isEmpty();
         if (isAggregateEvent) {
-            var nextSequence = aggregateSequencer.resolveBy(aggregateIdentifier).incrementAndGet();
+            var nextSequence = aggregateSequencer.incrementAndGetSequenceOf(aggregateIdentifier);
             return new GenericDomainEventMessage<>(
                     aggregateType,
                     aggregateIdentifier,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -70,6 +70,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static java.util.Objects.*;
 import static org.axonframework.common.BuilderUtils.*;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils.*;
@@ -105,11 +106,12 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
             @Nonnull Serializer eventSerializer,
             @Nonnull UnaryOperator<Customization> configurationOverride
     ) {
-        this.entityManagerProvider = entityManagerProvider;
-        this.transactionManager = transactionManager;
-        this.eventSerializer = eventSerializer;
+        this.entityManagerProvider = requireNonNull(entityManagerProvider, "entityManagerProvider may not be null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager may not be null");
+        this.eventSerializer = requireNonNull(eventSerializer, "eventSerializer may not be null");
 
-        var customization = configurationOverride.apply(Customization.withDefaultValues());
+        var customization = requireNonNull(configurationOverride, "configurationOverride may not be null")
+                .apply(Customization.withDefaultValues());
 
         this.legacyJpaOperations = new LegacyJpaEventStorageOperations(transactionManager,
                                                                        entityManagerProvider.getEntityManager(),
@@ -499,7 +501,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
             @Override
             public boolean tryAdvance(Consumer<? super T> action) {
-                Objects.requireNonNull(action);
+                requireNonNull(action);
                 if (iterator == null || !iterator.hasNext()) {
                     if (lastBatchFound) {
                         return false;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -103,10 +103,10 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     private final GapAwareTrackingTokenOperations tokenOperations;
 
     public LegacyJpaEventStorageEngine(
-            @javax.annotation.Nonnull EntityManagerProvider entityManagerProvider,
-            @javax.annotation.Nonnull TransactionManager transactionManager,
-            @javax.annotation.Nonnull Serializer eventSerializer,
-            @javax.annotation.Nonnull UnaryOperator<Customization> configurationOverride
+            @Nonnull EntityManagerProvider entityManagerProvider,
+            @Nonnull TransactionManager transactionManager,
+            @Nonnull Serializer eventSerializer,
+            @Nonnull UnaryOperator<Customization> configurationOverride
     ) {
         this.entityManagerProvider = entityManagerProvider;
         this.transactionManager = transactionManager;
@@ -344,7 +344,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     }
 
     @Override
-    public void describeTo(@javax.annotation.Nonnull ComponentDescriptor descriptor) {
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
         descriptor.describeProperty("entityManagerProvider", entityManagerProvider);
         descriptor.describeProperty("transactionManager", transactionManager);
         descriptor.describeProperty("eventSerializer", eventSerializer);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -158,23 +158,28 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         var consistencyMarker = AggregateBasedConsistencyMarker.from(condition);
         var aggregateSequencer = AggregateSequencer.with(consistencyMarker);
 
-        var tx = transactionManager.startTransaction();
-        try {
-            entityManagerPersistEvents(aggregateSequencer, events);
-            if (explicitFlush) {
-                entityManagerProvider.getEntityManager().flush();
-            }
-        } catch (Exception e) {
-            tx.rollback();
-            return CompletableFuture.failedFuture(e);
-        }
+//        var tx = transactionManager.startTransaction();
+//        try {
+//            entityManagerPersistEvents(aggregateSequencer, events);
+//            if (explicitFlush) {
+//                entityManagerProvider.getEntityManager().flush();
+//            }
+//        } catch (Exception e) {
+//            tx.rollback();
+//            return CompletableFuture.failedFuture(e);
+//        }
 
         return CompletableFuture.completedFuture(new AppendTransaction() {
 
             @Override
             public CompletableFuture<ConsistencyMarker> commit() {
                 CompletableFuture<Void> txResult = new CompletableFuture<>();
+                var tx = transactionManager.startTransaction();
                 try {
+                    entityManagerPersistEvents(aggregateSequencer, events);
+                    if (explicitFlush) {
+                        entityManagerProvider.getEntityManager().flush();
+                    }
                     tx.commit();
                     txResult.complete(null);
                 } catch (Exception e) {
@@ -190,7 +195,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
             @Override
             public void rollback() {
-                tx.rollback();
+//                tx.rollback();
             }
         });
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -145,7 +145,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         }
 
         if (events.isEmpty()) {
-            return CompletableFuture.completedFuture(new EmptyAppendTransaction(condition));
+            return CompletableFuture.completedFuture(EmptyAppendTransaction.INSTANCE);
         }
 
         return CompletableFuture.completedFuture(new AppendTransaction() {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -155,6 +155,9 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
             return CompletableFuture.completedFuture(new EmptyAppendTransaction(condition));
         }
 
+        var consistencyMarker = AggregateBasedConsistencyMarker.from(condition);
+        var aggregateSequencer = AggregateSequencer.with(consistencyMarker);
+
         return CompletableFuture.completedFuture(new AppendTransaction() {
 
             private final AtomicBoolean finished = new AtomicBoolean(false);
@@ -165,8 +168,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                     return CompletableFuture.failedFuture(new IllegalStateException("Already committed or rolled back"));
                 }
 
-                var consistencyMarker = AggregateBasedConsistencyMarker.from(condition);
-                var aggregateSequencer = AggregateSequencer.with(consistencyMarker);
                 var tx = transactionManager.startTransaction();
 
                 CompletableFuture<Void> txResult = new CompletableFuture<>();

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -260,8 +260,10 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         var consistencyMarker = new AtomicReference<ConsistencyMarker>();
         return allCriteriaStream.map(e -> {
             var newMarker = consistencyMarker
-                    .accumulateAndGet(e.getResource(ConsistencyMarker.RESOURCE_KEY),
-                                      (m1, m2) -> m1 == null ? m2 : m1.upperBound(m2));
+                    .accumulateAndGet(
+                            e.getResource(ConsistencyMarker.RESOURCE_KEY),
+                            (m1, m2) -> m1 == null ? m2 : m1.upperBound(m2)
+                    );
             return e.withResource(ConsistencyMarker.RESOURCE_KEY, newMarker);
         });
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -160,12 +160,13 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
             @Override
             public CompletableFuture<ConsistencyMarker> commit() {
-                CompletableFuture<Void> txResult = new CompletableFuture<>();
                 if (txFinished.getAndSet(true)) {
                     return CompletableFuture.failedFuture(new IllegalStateException("Already committed or rolled back"));
                 }
+
                 var aggregateSequencer = AggregateSequencer.with(beforeCommitConsistencyMarker);
 
+                CompletableFuture<Void> txResult = new CompletableFuture<>();
                 var tx = transactionManager.startTransaction();
                 try {
                     entityManagerPersistEvents(aggregateSequencer, events);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -122,7 +122,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                                                        domainEventEntryEntityName(),
                                                                        SnapshotEventEntry.class.getSimpleName());
         this.tokenOperations = new GapAwareTrackingTokenOperations(
-                customization.lowestGlobalSequence(),
                 customization.tokenGapsHandling().timeout(),
                 logger
         );
@@ -301,7 +300,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
     @Override
     public MessageStream<EventMessage<?>> stream(@Nonnull StreamingCondition condition) {
-        var trackingToken = tokenOperations.gapAwareTrackingTokenFrom(condition.position());
+        var trackingToken = tokenOperations.assertGapAwareTrackingToken(condition.position());
         var events = batchingOperations.readEventData(trackingToken);
         var deserialized = upcastAndDeserializeTrackedEvents(events, eventSerializer, upcasterChain);
         return MessageStream.fromStream(

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -113,7 +113,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                 .apply(Customization.withDefaultValues());
 
         this.legacyJpaOperations = new LegacyJpaEventStorageOperations(transactionManager,
-                                                                       entityManagerProvider.getEntityManager(),
+                                                                       entityManagerProvider,
                                                                        DOMAIN_EVENT_ENTRY_ENTITY_NAME,
                                                                        "unused");
         this.tokenOperations = new GapAwareTrackingTokenOperations(

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -39,6 +39,7 @@ import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarke
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.AsyncEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.EmptyAppendTransaction;
 import org.axonframework.eventsourcing.eventstore.EventCriteria;
 import org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils;
 import org.axonframework.eventsourcing.eventstore.LegacyResources;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -155,6 +155,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
         }
+
         if (events.isEmpty()) {
             return CompletableFuture.completedFuture(new EmptyAppendTransaction(condition));
         }
@@ -367,19 +368,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         descriptor.describeProperty("legacyJpaOperations", legacyJpaOperations);
         descriptor.describeProperty("tokenOperations", tokenOperations);
         descriptor.describeProperty("batchingOperations", batchingOperations);
-    }
-
-    private record EmptyAppendTransaction(AppendCondition appendCondition) implements AppendTransaction {
-
-        @Override
-        public CompletableFuture<ConsistencyMarker> commit() {
-            return CompletableFuture.completedFuture(AggregateBasedConsistencyMarker.from(appendCondition));
-        }
-
-        @Override
-        public void rollback() {
-
-        }
     }
 
     private record BatchingEventStorageOperations(TransactionManager transactionManager,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -167,10 +167,9 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
                 var consistencyMarker = AggregateBasedConsistencyMarker.from(condition);
                 var aggregateSequencer = AggregateSequencer.with(consistencyMarker);
+                var tx = transactionManager.startTransaction();
 
                 CompletableFuture<Void> txResult = new CompletableFuture<>();
-
-                var tx = transactionManager.startTransaction();
                 try {
                     entityManagerPersistEvents(aggregateSequencer, events);
                     if (explicitFlush) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.eventsourcing.eventstore.Tag;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
+import org.axonframework.eventsourcing.eventstore.TooManyTagsOnEventMessageException;
 import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.messaging.ClassBasedMessageNameResolver;
 import org.axonframework.messaging.Context;
@@ -153,12 +154,13 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         return CompletableFuture.completedFuture(appendTransaction(condition, events));
     }
 
-    // todo: move it for some base class, copied from LegacyAxonServerEventStorageEngine
     private void assertValidTags(List<TaggedEventMessage<?>> events) {
         for (TaggedEventMessage<?> taggedEvent : events) {
             if (taggedEvent.tags().size() > 1) {
-                throw new IllegalArgumentException(
-                        "An Event Storage engine in Aggregate mode does not support multiple tags per event");
+                throw new TooManyTagsOnEventMessageException(
+                        "An Event Storage engine in Aggregate mode does not support multiple tags per event",
+                        taggedEvent.event(),
+                        taggedEvent.tags());
             }
         }
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -40,10 +40,8 @@ import org.axonframework.eventsourcing.eventstore.LegacyResources;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
-import org.axonframework.messaging.ClassBasedMessageNameResolver;
 import org.axonframework.messaging.Context;
 import org.axonframework.messaging.Message;
-import org.axonframework.messaging.MessageNameResolver;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcaster;
@@ -97,7 +95,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     private final PersistenceExceptionResolver persistenceExceptionResolver;
     private final boolean explicitFlush;
 
-    private final MessageNameResolver messageNameResolver; // todo: use while upcasting implementing MessageName
     private final LegacyJpaEventStorageOperations legacyJpaOperations;
     private final BatchingEventStorageOperations batchingOperations;
     private final GapAwareTrackingTokenOperations tokenOperations;
@@ -114,7 +111,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
         var customization = configurationOverride.apply(Customization.withDefaultValues());
         this.upcasterChain = customization.upcasterChain();
-        this.messageNameResolver = customization.messageNameResolver();
         this.explicitFlush = customization.explicitFlush();
 
         this.legacyJpaOperations = new LegacyJpaEventStorageOperations(transactionManager,
@@ -351,7 +347,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         descriptor.describeProperty("upcasterChain", upcasterChain);
         descriptor.describeProperty("explicitFlush", explicitFlush);
         descriptor.describeProperty("persistenceExceptionResolver", persistenceExceptionResolver);
-        descriptor.describeProperty("messageNameResolver", messageNameResolver);
         descriptor.describeProperty("legacyJpaOperations", legacyJpaOperations);
         descriptor.describeProperty("tokenOperations", tokenOperations);
         descriptor.describeProperty("batchingOperations", batchingOperations);
@@ -498,7 +493,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
             PersistenceExceptionResolver persistenceExceptionResolver,
             int batchSize,
             Predicate<List<? extends DomainEventData<?>>> finalAggregateBatchPredicate,
-            MessageNameResolver messageNameResolver,
             boolean explicitFlush,
             long lowestGlobalSequence,
             TokenGapsHandlingConfig tokenGapsHandling
@@ -511,7 +505,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         public Customization {
             assertNonNull(upcasterChain, "EventUpcaster may not be null");
             assertThat(batchSize, size -> size > 0, "The batchSize must be a positive number");
-            assertNonNull(messageNameResolver, "MessageNameResolver may not be null");
             assertThat(lowestGlobalSequence,
                        number -> number > 0,
                        "The lowestGlobalSequence must be a positive number");
@@ -542,7 +535,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                     null,
                     DEFAULT_BATCH_SIZE,
                     null,
-                    new ClassBasedMessageNameResolver(),
                     DEFAULT_EXPLICIT_FLUSH,
                     DEFAULT_LOWEST_GLOBAL_SEQUENCE,
                     TokenGapsHandlingConfig.withDefaultValues()
@@ -554,7 +546,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling
@@ -566,7 +557,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling
@@ -578,7 +568,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling
@@ -591,19 +580,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
-                                     explicitFlush,
-                                     lowestGlobalSequence,
-                                     tokenGapsHandling
-            );
-        }
-
-        public Customization messageNameResolver(MessageNameResolver messageNameResolver) {
-            return new Customization(upcasterChain,
-                                     persistenceExceptionResolver,
-                                     batchSize,
-                                     finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling
@@ -615,7 +591,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling
@@ -627,7 +602,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      configurationOverride.apply(tokenGapsHandling)
@@ -639,7 +613,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      persistenceExceptionResolver,
                                      batchSize,
                                      finalAggregateBatchPredicate,
-                                     messageNameResolver,
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      tokenGapsHandling

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -248,8 +248,10 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     private GenericEventMessage<?> convertToEventMessage(EventData<?> event) {
         var payload = event.getPayload();
         var revision = payload.getType().getRevision();
-        var name = QualifiedNameUtils.fromDottedName(payload.getType().getName(),
-                                                     revision == null ? "0.0.1" : revision);
+        Class<?> payloadClass = eventSerializer.classForType(payload.getType());
+        var name = revision == null
+                ? QualifiedNameUtils.fromClassName(payloadClass)
+                : QualifiedNameUtils.fromClassName(payloadClass, revision);
         var metadata = event.getMetaData();
         MetaData metaData = eventSerializer.convert(metadata.getData(), MetaData.class);
         return new GenericEventMessage<>(

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -241,8 +241,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     }
 
     // todo: move it for some base class, copied from LegacyAxonServerEventStorageEngine
-    // todo: how do I know (even if its only tag), that it's an aggregate id?
-
     @Nullable
     private static String resolveAggregateIdentifier(Set<Tag> tags) {
         if (tags.isEmpty()) {
@@ -253,8 +251,8 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
             return tags.iterator().next().value();
         }
     }
-    // todo: move it for some base class, copied from LegacyAxonServerEventStorageEngine
 
+    // todo: move it for some base class, copied from LegacyAxonServerEventStorageEngine
     @Nullable
     private static String resolveAggregateType(Set<Tag> tags) {
         if (tags.isEmpty()) {
@@ -440,7 +438,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
         /**
          * Build an exception message based on an EventMessage.
-         * todo: what to do!?!?!
          *
          * @param failedEvent the event to be used for the exception message
          * @return the created exception message
@@ -771,6 +768,19 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                      explicitFlush,
                                      lowestGlobalSequence,
                                      configurationOverride.apply(tokenGapsHandling)
+            );
+        }
+
+        public Customization explicitFlush(boolean explicitFlush) {
+            return new Customization(upcasterChain,
+                                     persistenceExceptionResolver,
+                                     snapshotFilter,
+                                     batchSize,
+                                     finalAggregateBatchPredicate,
+                                     messageNameResolver,
+                                     explicitFlush,
+                                     lowestGlobalSequence,
+                                     tokenGapsHandling
             );
         }
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -47,9 +47,8 @@ import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
 import org.axonframework.messaging.Context;
 import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.messaging.QualifiedName;
-import org.axonframework.messaging.QualifiedNameUtils;
 import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -220,7 +219,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                     aggregateIdentifier,
                     nextSequence,
                     event.getIdentifier(),
-                    event.name(),
+                    event.type(),
                     event.getPayload(),
                     event.getMetaData(),
                     event.getTimestamp()
@@ -248,15 +247,15 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
     private GenericEventMessage<?> convertToEventMessage(EventData<?> event) {
         var payload = event.getPayload();
         var revision = payload.getType().getRevision();
-        Class<?> payloadClass = eventSerializer.classForType(payload.getType());
-        var name = revision == null
-                ? QualifiedNameUtils.fromClassName(payloadClass)
-                : QualifiedNameUtils.fromClassName(payloadClass, revision);
+        var payloadClass = eventSerializer.classForType(payload.getType());
+        var messageType = revision == null
+                ? new MessageType(payloadClass)
+                : new MessageType(payloadClass, revision);
         var metadata = event.getMetaData();
         MetaData metaData = eventSerializer.convert(metadata.getData(), MetaData.class);
         return new GenericEventMessage<>(
                 event.getEventIdentifier(),
-                name,
+                messageType,
                 payload.getData(),
                 metaData,
                 event.getTimestamp()

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -33,6 +33,7 @@ import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
 import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.TrackedDomainEventData;
 import org.axonframework.eventhandling.TrackedEventData;
+import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
@@ -316,7 +317,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         );
     }
 
-    private EventMessage<?> convertToTrackedEventMessage(TrackedEventData<?> event) {
+    private TrackedEventMessage<?> convertToTrackedEventMessage(TrackedEventData<?> event) {
         var trackingToken = event.trackingToken();
         if (event instanceof TrackedDomainEventData<?> trackedDomainEventData) {
             var domainEventMessage = convertToDomainEventMessage(trackedDomainEventData);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -114,7 +114,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         this.legacyJpaOperations = new LegacyJpaEventStorageOperations(transactionManager,
                                                                        entityManagerProvider.getEntityManager(),
                                                                        DOMAIN_EVENT_ENTRY_ENTITY_NAME,
-                                                                       SnapshotEventEntry.class.getSimpleName());
+                                                                       "unused");
         this.tokenOperations = new GapAwareTrackingTokenOperations(
                 customization.tokenGapsHandling().timeout(),
                 logger
@@ -149,7 +149,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         return CompletableFuture.completedFuture(new AppendTransaction() {
 
             private final AtomicBoolean txFinished = new AtomicBoolean(false);
-            private final AggregateBasedConsistencyMarker beforeCommitConsistencyMarker = AggregateBasedConsistencyMarker.from(
+            private final AggregateBasedConsistencyMarker preCommitConsistencyMarker = AggregateBasedConsistencyMarker.from(
                     condition);
 
             @Override
@@ -158,7 +158,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                     return CompletableFuture.failedFuture(new IllegalStateException("Already committed or rolled back"));
                 }
 
-                var aggregateSequencer = AggregateSequencer.with(beforeCommitConsistencyMarker);
+                var aggregateSequencer = AggregateSequencer.with(preCommitConsistencyMarker);
 
                 CompletableFuture<Void> txResult = new CompletableFuture<>();
                 var tx = transactionManager.startTransaction();
@@ -182,7 +182,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                         && t instanceof Exception ex
                         && persistenceExceptionResolver.isDuplicateKeyViolation(ex);
                 return LegacyAggregateBasedEventStorageEngineUtils
-                        .translateConflictException(beforeCommitConsistencyMarker, e, isConflictException);
+                        .translateConflictException(preCommitConsistencyMarker, e, isConflictException);
             }
 
             @Override
@@ -619,7 +619,3 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         }
     }
 }
-
-
-
-

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -52,8 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -95,14 +93,11 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
 
     private final boolean explicitFlush;
 
-    // AsyncEventStorageEngine specific
     private final PersistenceExceptionMapper persistenceExceptionMapper;
     private final MessageNameResolver messageNameResolver; // todo: use while upcasting
     private final LegacyJpaEventStorageOperations legacyJpaOperations;
     private final BatchingEventStorageOperations batchingOperations;
     private final GapAwareTrackingTokenOperations tokenOperations;
-
-    private Executor writeExecutor; // todo: do we need that?
 
     public LegacyJpaEventStorageEngine(
             @javax.annotation.Nonnull EntityManagerProvider entityManagerProvider,
@@ -111,9 +106,6 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
             @javax.annotation.Nonnull Serializer snapshotSerializer,
             @javax.annotation.Nonnull UnaryOperator<Customization> configurationOverride
     ) {
-        this.writeExecutor = Executors.newFixedThreadPool(10); // todo: configurable, AxonThreadFactory etc.
-        // todo: is is useful? Maybe we'd like to utilize the same thread as invoker?
-
         this.entityManagerProvider = entityManagerProvider;
         this.transactionManager = transactionManager;
         this.eventSerializer = eventSerializer;
@@ -345,7 +337,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         var token = legacyJpaOperations.minGlobalIndex()
                                        .flatMap(this::gapAwareTrackingTokenOn)
                                        .orElse(null);
-        return CompletableFuture.completedFuture(token); // todo: supplyAsync?
+        return CompletableFuture.completedFuture(token);
     }
 
     private Optional<TrackingToken> gapAwareTrackingTokenOn(Long globalIndex) {
@@ -359,7 +351,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
         var headToken = legacyJpaOperations.maxGlobalIndex()
                                            .flatMap(this::gapAwareTrackingTokenOn)
                                            .orElse(null);
-        return CompletableFuture.completedFuture(headToken); // todo: supplyAsync?
+        return CompletableFuture.completedFuture(headToken);
     }
 
     @Override
@@ -369,7 +361,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                                        .or(() -> legacyJpaOperations.maxGlobalIndex()
                                                                     .flatMap(this::gapAwareTrackingTokenOn))
                                        .orElse(null);
-        return CompletableFuture.completedFuture(token); // todo: supplyAsync?
+        return CompletableFuture.completedFuture(token);
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
@@ -184,7 +184,7 @@ record LegacyJpaEventStorageOperations(
         var results = entityManager
                 .createQuery("SELECT MAX(e.globalIndex) FROM " + domainEventEntryEntityName() + " e", Long.class)
                 .getResultList();
-        return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+        return (results.isEmpty() || results.getFirst() == null) ? Optional.empty() : Optional.of(results.getFirst());
     }
 
     Optional<Long> globalIndexAt(Instant dateTime) {
@@ -195,14 +195,14 @@ record LegacyJpaEventStorageOperations(
                 )
                 .setParameter("dateTime", formatInstant(dateTime))
                 .getResultList();
-        return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+        return (results.isEmpty() || results.getFirst() == null) ? Optional.empty() : Optional.of(results.getFirst());
     }
 
     Optional<Long> minGlobalIndex() {
         var results = entityManager.createQuery(
                 "SELECT MIN(e.globalIndex) - 1 FROM " + domainEventEntryEntityName() + " e", Long.class
         ).getResultList();
-        return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+        return (results.isEmpty() || results.getFirst() == null) ? Optional.empty() : Optional.of(results.getFirst());
     }
 
     void deleteSnapshots(String aggregateIdentifier, long sequenceNumber) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
@@ -38,12 +38,8 @@ import javax.annotation.Nonnull;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 
 /**
- * Contains operations that are used to interact with the legacy JPA event storage database structure.
+ * Contains operations that are used to interact with the Aggregate based JPA event storage database structure.
  *
- * @param transactionManager
- * @param entityManager
- * @param domainEventEntryEntityName
- * @param snapshotEventEntryEntityName
  * @author Mateusz Nowak
  * @since 5.0.0
  */
@@ -54,14 +50,6 @@ record LegacyJpaEventStorageOperations(
         String snapshotEventEntryEntityName
 ) {
 
-    /**
-     * Returns a batch of event data as object entries in the event storage with a greater than the given
-     * {@code token}.
-     *
-     * @param token     Object describing the global index of the last processed event.
-     * @param batchSize Size of event list is decided by that.
-     * @return A batch of event messages as object stored since the given tracking token.
-     */
     List<Object[]> fetchEvents(GapAwareTrackingToken token, int batchSize) {
         TypedQuery<Object[]> query;
         if (token == null || token.getGaps().isEmpty()) {
@@ -178,7 +166,6 @@ record LegacyJpaEventStorageOperations(
                 .getResultList();
     }
 
-    //todo: check return type!
     @SuppressWarnings("unchecked")
     List<? extends DomainEventData<?>> readSnapshotData(String aggregateIdentifier) {
         return entityManager

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
@@ -153,7 +153,7 @@ record LegacyJpaEventStorageOperations(
         return result;
     }
 
-    List<Object[]> indexToTimestamp(GapAwareTrackingToken lastToken) {
+    List<Object[]> indexAndTimestampBetweenGaps(GapAwareTrackingToken token) {
         return entityManager
                 .createQuery(
                         "SELECT e.globalIndex, e.timeStamp FROM " + domainEventEntryEntityName() + " e "
@@ -161,8 +161,8 @@ record LegacyJpaEventStorageOperations(
                                 + "AND e.globalIndex <= :maxGlobalIndex",
                         Object[].class
                 )
-                .setParameter("firstGapOffset", lastToken.getGaps().first())
-                .setParameter("maxGlobalIndex", lastToken.getGaps().last() + 1L)
+                .setParameter("firstGapOffset", token.getGaps().first())
+                .setParameter("maxGlobalIndex", token.getGaps().last() + 1L)
                 .getResultList();
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventsourcing.eventstore.jpa;
 
 import jakarta.persistence.EntityManager;
@@ -111,8 +127,6 @@ record LegacyJpaEventStorageOperations(
                 .getResultList();
     }
 
-
-    // todo: check that return type changed!
     List<TrackedDomainEventData<?>> entriesToEvents(
             GapAwareTrackingToken previousToken,
             List<Object[]> entries,

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -193,6 +193,20 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
     }
 
     @Test
+    void appendEmptyEventsListShouldSucceed() {
+        // given
+        AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
+
+        // when
+        var commit = testSubject.appendEvents(appendCondition, Collections.emptyList())
+                                .thenCompose(AppendTransaction::commit);
+
+        // then
+        assertDoesNotThrow(commit::join);
+    }
+
+
+    @Test
     void sourcingEventsReturnsMatchingAggregateEvents() {
         AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
         AppendCondition appendCondition2 = AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -124,7 +124,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
                    .join();
 
         MessageStream<EventMessage<?>> result =
-                testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(-1)));
+                testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(0)));
 
         StepVerifier.create(result.asFlux())
                     .assertNext(entry -> assertTrackedEntry(entry, expectedEventOne.event(), 1))
@@ -429,7 +429,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
                                          taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())).join();
 
         assertDoesNotThrow(() -> tx.commit().get(1, TimeUnit.SECONDS));
-        var thrown = assertThrows(ExecutionException.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
+        var thrown = assertThrows(Exception.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
         assertInstanceOf(IllegalStateException.class, thrown.getCause());
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -389,10 +389,10 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
         var secondCommit = secondTx.thenCompose(AppendTransaction::commit);
 
         var result = CompletableFuture.allOf(firstCommit, secondCommit);
-        assertFalse(result.isDone());
-        assertFalse(result.isCompletedExceptionally());
         var thrown = assertThrows(Exception.class, result::join);
         assertInstanceOf(AppendEventsTransactionRejectedException.class, thrown.getCause());
+        assertTrue(firstCommit.isDone() || secondCommit.isDone());
+        assertTrue(firstCommit.isCompletedExceptionally() || secondCommit.isCompletedExceptionally());
     }
 
     private static <T> CompletableFuture<T> runAsync(Supplier<CompletableFuture<T>> task) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -23,10 +23,9 @@ import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AsyncEventStorageEngine.AppendTransaction;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageStream.Entry;
-import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.QualifiedName;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.opentest4j.TestAbortedException;
 import reactor.test.StepVerifier;
 
@@ -88,361 +87,395 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
 
     protected abstract TrackingToken trackingTokenOnPosition(long eventNumber);
 
-    @Test
-    void streamingFromStartReturnsSelectedMessages() {
-        TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
-        // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
-        ConsistencyMarker newMarker = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                                               expectedEventOne,
-                                                               expectedEventTwo).thenCompose(AppendTransaction::commit)
-                                                 .join();
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-2", emptySet()),
-                                 taggedEventMessage("event-3", emptySet())).thenCompose(AppendTransaction::commit)
-                   .join();
-        testSubject.appendEvents(new DefaultAppendCondition(newMarker, TEST_AGGREGATE_CRITERIA), expectedEventThree)
-                   .thenCompose(AppendTransaction::commit).join();
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-5", emptySet()),
-                                 taggedEventMessage("event-6", emptySet())).thenCompose(AppendTransaction::commit)
-                   .join();
+    @Nested
+    class AppendEvents {
 
-        MessageStream<EventMessage<?>> result =
-                testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(-1)));
+        @Test
+        void transactionRejectedWithConflictingEventsInStore() {
+            ConsistencyMarker consistencyMarker = testSubject.appendEvents(
+                                                                     AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                                                     taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()))
+                                                             .thenCompose(AppendTransaction::commit).join();
+            testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA)
+                                                    .withMarker(consistencyMarker),
+                                     taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()))
+                       .thenApply(AppendTransaction::commit).join();
 
-        StepVerifier.create(result.asFlux())
-                    .assertNext(entry -> assertTrackedEntry(entry, expectedEventOne.event(), 1))
-                    .assertNext(entry -> assertTrackedEntry(entry, expectedEventTwo.event(), 2))
-                    .expectNextCount(2)
-                    .assertNext(entry -> assertTrackedEntry(entry, expectedEventThree.event(), 5))
-                    .expectNextCount(2)
-                    .thenCancel()
-                    .verify();
-    }
-
-    @Test
-    void streamingFromSpecificPositionSkipsMessages() {
-        TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
-
-        // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
-        testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                 expectedEventOne,
-                                 expectedEventTwo,
-                                 taggedEventMessage("event-2", Set.of()),
-                                 taggedEventMessage("event-3", TEST_AGGREGATE_CRITERIA.tags()),
-                                 expectedEventThree,
-                                 taggedEventMessage("event-5", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-6", TEST_AGGREGATE_CRITERIA.tags())).thenCompose(
-                AppendTransaction::commit).join();
-
-        MessageStream<EventMessage<?>> result =
-                testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(2)));
-
-        StepVerifier.create(result.asFlux())
-                    // we've skipped the first two
-                    .expectNextCount(2).assertNext(entry -> assertTrackedEntry(entry, expectedEventThree.event(), 5))
-                    .expectNextCount(2).thenCancel().verify();
-    }
-
-    @Test
-    void streamingAfterLastPositionReturnsEmptyStream() {
-        EventCriteria expectedCriteria = TEST_AGGREGATE_CRITERIA;
-        TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
-        TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
-        // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
-        ConsistencyMarker marker1 = testSubject.appendEvents(AppendCondition.withCriteria(expectedCriteria),
-                                                             expectedEventOne,
-                                                             expectedEventTwo).thenCompose(AppendTransaction::commit)
-                                               .join();
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-2", Set.of()),
-                                 taggedEventMessage("event-3", Set.of())).thenCompose(
-                AppendTransaction::commit).join();
-        testSubject.appendEvents(new DefaultAppendCondition(marker1, expectedCriteria), expectedEventThree)
-                   .thenCompose(AppendTransaction::commit).join();
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-5", Set.of()),
-                                 taggedEventMessage("event-6", Set.of())).thenCompose(
-                AppendTransaction::commit).join();
-
-        MessageStream<EventMessage<?>> result = testSubject.stream(StreamingCondition.startingFrom(
-                trackingTokenOnPosition(10)).or(expectedCriteria));
-
-        try {
-            assertTrue(result.next().isEmpty());
-        } finally {
-            result.close();
-        }
-    }
-
-    @Test
-    void sourcingEventsReturnsMatchingAggregateEvent() {
-        AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
-        testSubject.appendEvents(appendCondition,
-                                 taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())
-                   )
-                   .thenCompose(AppendTransaction::commit).join();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
-                    .expectNextMatches(entryWithAggregateEvent("event-0", 0))
-                    .verifyComplete();
-    }
-
-    @Test
-    void sourcingEventsReturnsMatchingAggregateEvents() {
-        AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
-        AppendCondition appendCondition2 = AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA);
-        testSubject.appendEvents(appendCondition,
-                                 taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()))
-                   .thenCompose(AppendTransaction::commit).join();
-        testSubject.appendEvents(appendCondition2,
-                                 taggedEventMessage("event-4", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-6", OTHER_AGGREGATE_CRITERIA.tags()))
-                   .thenCompose(AppendTransaction::commit).join();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
-                    .expectNextMatches(entryWithAggregateEvent("event-0", 0))
-                    .expectNextMatches(entryWithAggregateEvent("event-1", 1))
-                    .expectNextMatches(entryWithAggregateEvent("event-2", 2))
-                    .verifyComplete();
-    }
-
-    @Test
-    void eventsWithoutTagsAreNotSourcedAsAggregatedEvents() {
-        testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                 taggedEventMessage("event-0", Set.of()),
-                                 taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-2", Set.of()),
-                                 taggedEventMessage("event-3", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-4", Set.of()))
-                   .thenCompose(AppendTransaction::commit).join();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
-                    .expectNextMatches(entryWithAggregateEvent("event-1", 0))
-                    .expectNextMatches(entryWithAggregateEvent("event-3", 1))
-                    .verifyComplete();
-    }
-
-    @Test
-    void eventsWithTagsNotMatchingCriteriaAreInsertedAtSequenceZero() {
-        testSubject.appendEvents(AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA),
-                                 taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-5", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-6", TEST_AGGREGATE_CRITERIA.tags()))
-                   .thenCompose(AppendTransaction::commit).join();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
-                    .expectNextMatches(entryWithAggregateEvent("event-4", 0))
-                    .expectNextMatches(entryWithAggregateEvent("event-5", 1))
-                    .expectNextMatches(entryWithAggregateEvent("event-6", 2))
-                    .verifyComplete();
-    }
-
-    @Test
-    void sourcingFromTwoAggregateStreamsReturnsACombinedStream() {
-        var marker = testSubject.appendEvents(AppendCondition.none(),
-                                              taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
-                                              taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
-                                .thenCompose(AppendTransaction::commit).join();
-
-        Set<String> actual = new HashSet<>();
-        AtomicReference<ConsistencyMarker> lastMarker = new AtomicReference<>();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA,
-                                                                              OTHER_AGGREGATE_CRITERIA)).asFlux())
-                    //there is no predefined order between aggregates. We just expect 6 entries.
-                    .thenConsumeWhile(e -> {
-                        lastMarker.set(e.getResource(ConsistencyMarker.RESOURCE_KEY));
-                        return actual.add(e.map(this::convertPayload).message().getPayload());
-                    })
-                    .verifyComplete();
-
-        assertEquals(Set.of("event-0", "event-1", "event-2", "event-3", "event-4", "event-5"), actual);
-        assertEquals(marker, lastMarker.get());
-    }
-
-    @Test
-    void sourcingWithStartAndEndReturnsEventsWithinBounds() {
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
-                   .thenCompose(AppendTransaction::commit).join();
-
-        List<String> actual = new ArrayList<>();
-
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(1, 1, TEST_AGGREGATE_CRITERIA)).asFlux())
-                    .thenConsumeWhile(e -> actual.add(e.map(this::convertPayload).message().getPayload()))
-                    .verifyComplete();
-
-        assertEquals(List.of("event-2"), actual);
-    }
-
-    @Test
-    void sourcingFromTwoAggregatesWithStartAndEndRespectsBounds() {
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
-                                 taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
-                   .thenCompose(AppendTransaction::commit).join();
-
-        Set<String> actual = new HashSet<>();
-        MessageStream<EventMessage<?>> source;
-        try {
-            source = testSubject.source(SourcingCondition.conditionFor(1, 2,
-                                                                       TEST_AGGREGATE_CRITERIA,
-                                                                       OTHER_AGGREGATE_CRITERIA));
-        } catch (IllegalArgumentException e) {
-            throw new TestAbortedException("Multi-aggregate streams not supported", e);
-        }
-        StepVerifier.create(source.asFlux())
-                    .thenConsumeWhile(e -> actual.add(e.map(this::convertPayload).message().getPayload()))
-                    .verifyComplete();
-        assertEquals(Set.of("event-2", "event-3", "event-4", "event-5"), actual);
-    }
-
-    @Test
-    void transactionRejectedWithConflictingEventsInStore() {
-        ConsistencyMarker consistencyMarker = testSubject.appendEvents(
-                                                                 AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                                                 taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()))
-                                                         .thenCompose(AppendTransaction::commit).join();
-        testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA).withMarker(consistencyMarker),
-                                 taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()))
-                   .thenApply(AppendTransaction::commit).join();
-
-        CompletableFuture<ConsistencyMarker> actual = testSubject.appendEvents(
-                AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA).withMarker(consistencyMarker),
-                taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags())/*,
+            CompletableFuture<ConsistencyMarker> actual = testSubject.appendEvents(
+                    AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA).withMarker(consistencyMarker),
+                    taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags())/*,
                 taggedEventMessage("event-3", TEST_AGGREGATE_CRITERIA.tags())*/
-        ).thenCompose(AppendTransaction::commit);
+            ).thenCompose(AppendTransaction::commit);
 
-        ExecutionException actualException = assertThrows(ExecutionException.class,
-                                                          () -> actual.get(1, TimeUnit.SECONDS));
-        assertInstanceOf(AppendEventsTransactionRejectedException.class, actualException.getCause());
-    }
-
-    @Test
-    void transactionRejectedWhenConcurrentlyCreatedTransactionIsCommittedFirst() {
-        var firstTx = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                               taggedEventMessage("event-10", TEST_AGGREGATE_CRITERIA.tags()));
-        var secondTx = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                                taggedEventMessage("event-11", TEST_AGGREGATE_CRITERIA.tags()));
-
-        CompletableFuture<ConsistencyMarker> firstCommit = firstTx.thenCompose(AppendTransaction::commit);
-        assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
-
-        CompletableFuture<ConsistencyMarker> secondCommit = secondTx.thenCompose(AppendTransaction::commit);
-        var actual = assertThrows(ExecutionException.class, () -> secondCommit.get(1, TimeUnit.SECONDS));
-        assertInstanceOf(AppendEventsTransactionRejectedException.class, actual.getCause());
-    }
-
-    @Test
-    void transactionRejectedWhenConcurrentlyCreatedTransactionIsCommittedFirstThreads() {
-        var executor = Executors.newVirtualThreadPerTaskExecutor(); // todo: move it to before/after each
-        var firstTx = CompletableFuture.supplyAsync(() -> testSubject.appendEvents(AppendCondition.withCriteria(
-                                                                                           TEST_AGGREGATE_CRITERIA),
-                                                                                   taggedEventMessage("event-10",
-                                                                                                      TEST_AGGREGATE_CRITERIA.tags()))
-                                                                     .join(), executor);
-        var secondTx = CompletableFuture.runAsync(() -> {
-        }, executor).thenCompose(r -> testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                                               taggedEventMessage("event-11",
-                                                                                  TEST_AGGREGATE_CRITERIA.tags())));
-
-        CompletableFuture<ConsistencyMarker> firstCommit = firstTx.thenCompose(AppendTransaction::commit);
-        assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
-
-        CompletableFuture<ConsistencyMarker> secondCommit = secondTx.thenCompose(AppendTransaction::commit);
-        var actual = assertThrows(ExecutionException.class, () -> secondCommit.get(1, TimeUnit.SECONDS));
-        assertInstanceOf(AppendEventsTransactionRejectedException.class, actual.getCause());
-        executor.close();
-    }
-
-    @Test
-    void concurrentTransactionsForNonOverlappingTagsBothCommit()
-            throws ExecutionException, InterruptedException, TimeoutException {
-
-        AppendTransaction firstTx =
-                testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                         taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()))
-                           .get(1, TimeUnit.SECONDS);
-        AppendTransaction secondTx =
-                testSubject.appendEvents(AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA),
-                                         taggedEventMessage("event-0", OTHER_AGGREGATE_CRITERIA.tags()))
-                           .get(1, TimeUnit.SECONDS);
-
-        CompletableFuture<ConsistencyMarker> firstCommit = firstTx.commit();
-        CompletableFuture<ConsistencyMarker> secondCommit = secondTx.commit();
-
-        assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
-        assertDoesNotThrow(() -> secondCommit.get(1, TimeUnit.SECONDS));
-
-        assertTrue(validConsistencyMarker(firstCommit.join(), TEST_AGGREGATE_ID, 0));
-        assertTrue(validConsistencyMarker(secondCommit.join(), OTHER_AGGREGATE_ID, 0));
-    }
-
-    @Test
-    void transactionCanBeCommitedOnlyOnce() {
-        var tx =
-                testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
-                                         taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())).join();
-
-        assertDoesNotThrow(() -> tx.commit().get(1, TimeUnit.SECONDS));
-        var thrown = assertThrows(ExecutionException.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
-        assertInstanceOf(IllegalStateException.class, thrown.getCause());
-    }
-
-    @Test
-    void emptyTransactionAlwaysCommitSuccessfully() {
-        var appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
-
-        var commit = testSubject.appendEvents(appendCondition, Collections.emptyList())
-                                .thenCompose(AppendTransaction::commit);
-
-        assertDoesNotThrow(commit::join);
-    }
-
-    @Test
-    void eventWithMultipleTagsIsReportedAsPartOfException() {
-        TaggedEventMessage<?> violatingEntry = taggedEventMessage("event2",
-                                                                  Set.of(new Tag("key1", "value1"),
-                                                                         new Tag("key2", "value2")));
-        CompletableFuture<AsyncEventStorageEngine.AppendTransaction> actual = testSubject.appendEvents(
-                AppendCondition.none(),
-                taggedEventMessage("event1", Set.of(new Tag("key1", "value1"))),
-                violatingEntry,
-                taggedEventMessage("event3", Set.of(new Tag("key1", "value1")))
-        );
-
-        assertTrue(actual.isDone());
-        assertTrue(actual.isCompletedExceptionally());
-
-        ExecutionException actualException = assertThrows(ExecutionException.class, actual::get);
-        if (actualException.getCause() instanceof TooManyTagsOnEventMessageException e) {
-            assertEquals(violatingEntry.tags(), e.tags());
-            assertEquals(violatingEntry.event(), e.eventMessage());
-        } else {
-            fail("Unexpected exception", actualException);
+            ExecutionException actualException = assertThrows(ExecutionException.class,
+                                                              () -> actual.get(1, TimeUnit.SECONDS));
+            assertInstanceOf(AppendEventsTransactionRejectedException.class, actualException.getCause());
         }
+
+        @Test
+        void transactionRejectedWhenConcurrentlyCreatedTransactionIsCommittedFirst() {
+            var firstTx = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                                   taggedEventMessage("event-10", TEST_AGGREGATE_CRITERIA.tags()));
+            var secondTx = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                                    taggedEventMessage("event-11", TEST_AGGREGATE_CRITERIA.tags()));
+
+            CompletableFuture<ConsistencyMarker> firstCommit = firstTx.thenCompose(AppendTransaction::commit);
+            assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
+
+            CompletableFuture<ConsistencyMarker> secondCommit = secondTx.thenCompose(AppendTransaction::commit);
+            var actual = assertThrows(ExecutionException.class, () -> secondCommit.get(1, TimeUnit.SECONDS));
+            assertInstanceOf(AppendEventsTransactionRejectedException.class, actual.getCause());
+        }
+
+        @Test
+        void transactionRejectedWhenConcurrentlyCreatedTransactionIsCommittedFirstThreads() {
+            var executor = Executors.newVirtualThreadPerTaskExecutor(); // todo: move it to before/after each
+            var firstTx = CompletableFuture.supplyAsync(() -> testSubject.appendEvents(AppendCondition.withCriteria(
+                                                                                               TEST_AGGREGATE_CRITERIA),
+                                                                                       taggedEventMessage("event-10",
+                                                                                                          TEST_AGGREGATE_CRITERIA.tags()))
+                                                                         .join(), executor);
+            var secondTx = CompletableFuture.runAsync(() -> {
+                                            }, executor)
+                                            .thenCompose(r -> testSubject.appendEvents(AppendCondition.withCriteria(
+                                                                                               TEST_AGGREGATE_CRITERIA),
+                                                                                       taggedEventMessage("event-11",
+                                                                                                          TEST_AGGREGATE_CRITERIA.tags())));
+
+            CompletableFuture<ConsistencyMarker> firstCommit = firstTx.thenCompose(AppendTransaction::commit);
+            assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
+
+            CompletableFuture<ConsistencyMarker> secondCommit = secondTx.thenCompose(AppendTransaction::commit);
+            var actual = assertThrows(ExecutionException.class, () -> secondCommit.get(1, TimeUnit.SECONDS));
+            assertInstanceOf(AppendEventsTransactionRejectedException.class, actual.getCause());
+            executor.close();
+        }
+
+        @Test
+        void concurrentTransactionsForNonOverlappingTagsBothCommit()
+                throws ExecutionException, InterruptedException, TimeoutException {
+
+            AppendTransaction firstTx =
+                    testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                             taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()))
+                               .get(1, TimeUnit.SECONDS);
+            AppendTransaction secondTx =
+                    testSubject.appendEvents(AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA),
+                                             taggedEventMessage("event-0", OTHER_AGGREGATE_CRITERIA.tags()))
+                               .get(1, TimeUnit.SECONDS);
+
+            CompletableFuture<ConsistencyMarker> firstCommit = firstTx.commit();
+            CompletableFuture<ConsistencyMarker> secondCommit = secondTx.commit();
+
+            assertDoesNotThrow(() -> firstCommit.get(1, TimeUnit.SECONDS));
+            assertDoesNotThrow(() -> secondCommit.get(1, TimeUnit.SECONDS));
+
+            assertTrue(validConsistencyMarker(firstCommit.join(), TEST_AGGREGATE_ID, 0));
+            assertTrue(validConsistencyMarker(secondCommit.join(), OTHER_AGGREGATE_ID, 0));
+        }
+
+        @Test
+        void alreadyCommitedTransactionCannotBeCommited() {
+            var tx =
+                    testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                             taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())).join();
+
+            assertDoesNotThrow(() -> tx.commit().get(1, TimeUnit.SECONDS));
+            assertThrows(Exception.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
+        }
+
+        @Test
+        void rolledbackTransactionCannotBeCommited() {
+            var tx =
+                    testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                             taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())).join();
+
+            assertDoesNotThrow(tx::rollback);
+            assertThrows(Exception.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
+        }
+
+        @Test
+        void emptyTransactionAlwaysCommitSuccessfully() {
+            var appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
+
+            var commit = testSubject.appendEvents(appendCondition, Collections.emptyList())
+                                    .thenCompose(AppendTransaction::commit);
+
+            assertDoesNotThrow(commit::join);
+        }
+
+        @Test
+        void eventWithMultipleTagsIsReportedAsPartOfException() {
+            TaggedEventMessage<?> violatingEntry = taggedEventMessage("event2",
+                                                                      Set.of(new Tag("key1", "value1"),
+                                                                             new Tag("key2", "value2")));
+            CompletableFuture<AsyncEventStorageEngine.AppendTransaction> actual = testSubject.appendEvents(
+                    AppendCondition.none(),
+                    taggedEventMessage("event1", Set.of(new Tag("key1", "value1"))),
+                    violatingEntry,
+                    taggedEventMessage("event3", Set.of(new Tag("key1", "value1")))
+            );
+
+            assertTrue(actual.isDone());
+            assertTrue(actual.isCompletedExceptionally());
+
+            ExecutionException actualException = assertThrows(ExecutionException.class, actual::get);
+            if (actualException.getCause() instanceof TooManyTagsOnEventMessageException e) {
+                assertEquals(violatingEntry.tags(), e.tags());
+                assertEquals(violatingEntry.event(), e.eventMessage());
+            } else {
+                fail("Unexpected exception", actualException);
+            }
+        }
+    }
+
+    @Nested
+    class Sourcing {
+
+        @Test
+        void sourcingEventsReturnsMatchingAggregateEvent() {
+            AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
+            testSubject.appendEvents(appendCondition,
+                                     taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())
+                       )
+                       .thenCompose(AppendTransaction::commit).join();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
+                        .expectNextMatches(entryWithAggregateEvent("event-0", 0))
+                        .verifyComplete();
+        }
+
+        @Test
+        void sourcingEventsReturnsMatchingAggregateEvents() {
+            AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
+            AppendCondition appendCondition2 = AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA);
+            testSubject.appendEvents(appendCondition,
+                                     taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()))
+                       .thenCompose(AppendTransaction::commit).join();
+            testSubject.appendEvents(appendCondition2,
+                                     taggedEventMessage("event-4", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-6", OTHER_AGGREGATE_CRITERIA.tags()))
+                       .thenCompose(AppendTransaction::commit).join();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
+                        .expectNextMatches(entryWithAggregateEvent("event-0", 0))
+                        .expectNextMatches(entryWithAggregateEvent("event-1", 1))
+                        .expectNextMatches(entryWithAggregateEvent("event-2", 2))
+                        .verifyComplete();
+        }
+
+        @Test
+        void eventsWithoutTagsAreNotSourcedAsAggregatedEvents() {
+            testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                     taggedEventMessage("event-0", Set.of()),
+                                     taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-2", Set.of()),
+                                     taggedEventMessage("event-3", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-4", Set.of()))
+                       .thenCompose(AppendTransaction::commit).join();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
+                        .expectNextMatches(entryWithAggregateEvent("event-1", 0))
+                        .expectNextMatches(entryWithAggregateEvent("event-3", 1))
+                        .verifyComplete();
+        }
+
+        @Test
+        void eventsWithTagsNotMatchingCriteriaAreInsertedAtSequenceZero() {
+            testSubject.appendEvents(AppendCondition.withCriteria(OTHER_AGGREGATE_CRITERIA),
+                                     taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-5", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-6", TEST_AGGREGATE_CRITERIA.tags()))
+                       .thenCompose(AppendTransaction::commit).join();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)).asFlux())
+                        .expectNextMatches(entryWithAggregateEvent("event-4", 0))
+                        .expectNextMatches(entryWithAggregateEvent("event-5", 1))
+                        .expectNextMatches(entryWithAggregateEvent("event-6", 2))
+                        .verifyComplete();
+        }
+
+        @Test
+        void sourcingFromTwoAggregateStreamsReturnsACombinedStream() {
+            var marker = testSubject.appendEvents(AppendCondition.none(),
+                                                  taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
+                                                  taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
+                                                  taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
+                                                  taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
+                                                  taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
+                                                  taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
+                                    .thenCompose(AppendTransaction::commit).join();
+
+            Set<String> actual = new HashSet<>();
+            AtomicReference<ConsistencyMarker> lastMarker = new AtomicReference<>();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA,
+                                                                                  OTHER_AGGREGATE_CRITERIA)).asFlux())
+                        //there is no predefined order between aggregates. We just expect 6 entries.
+                        .thenConsumeWhile(e -> {
+                            lastMarker.set(e.getResource(ConsistencyMarker.RESOURCE_KEY));
+                            return actual.add(e.map(this::convertPayload).message().getPayload());
+                        })
+                        .verifyComplete();
+
+            assertEquals(Set.of("event-0", "event-1", "event-2", "event-3", "event-4", "event-5"), actual);
+            assertEquals(marker, lastMarker.get());
+        }
+
+        @Test
+        void sourcingWithStartAndEndReturnsEventsWithinBounds() {
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
+                       .thenCompose(AppendTransaction::commit).join();
+
+            List<String> actual = new ArrayList<>();
+
+            StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(1, 1, TEST_AGGREGATE_CRITERIA))
+                                           .asFlux())
+                        .thenConsumeWhile(e -> actual.add(e.map(this::convertPayload).message().getPayload()))
+                        .verifyComplete();
+
+            assertEquals(List.of("event-2"), actual);
+        }
+
+        @Test
+        void sourcingFromTwoAggregatesWithStartAndEndRespectsBounds() {
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-1", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-2", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-3", OTHER_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-5", OTHER_AGGREGATE_CRITERIA.tags()))
+                       .thenCompose(AppendTransaction::commit).join();
+
+            Set<String> actual = new HashSet<>();
+            MessageStream<EventMessage<?>> source;
+            try {
+                source = testSubject.source(SourcingCondition.conditionFor(1, 2,
+                                                                           TEST_AGGREGATE_CRITERIA,
+                                                                           OTHER_AGGREGATE_CRITERIA));
+            } catch (IllegalArgumentException e) {
+                throw new TestAbortedException("Multi-aggregate streams not supported", e);
+            }
+            StepVerifier.create(source.asFlux())
+                        .thenConsumeWhile(e -> actual.add(e.map(this::convertPayload).message().getPayload()))
+                        .verifyComplete();
+            assertEquals(Set.of("event-2", "event-3", "event-4", "event-5"), actual);
+        }
+
+        private EventMessage<String> convertPayload(EventMessage<?> original) {
+            return AggregateBasedStorageEngineTestSuite.this.convertPayload(original);
+        }
+    }
+
+    @Nested
+    class Streaming {
+
+        @Test
+        void streamingFromStartReturnsSelectedMessages() {
+            TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
+            // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
+            ConsistencyMarker newMarker = testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                                                   expectedEventOne,
+                                                                   expectedEventTwo)
+                                                     .thenCompose(AppendTransaction::commit)
+                                                     .join();
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-2", emptySet()),
+                                     taggedEventMessage("event-3", emptySet())).thenCompose(AppendTransaction::commit)
+                       .join();
+            testSubject.appendEvents(new DefaultAppendCondition(newMarker, TEST_AGGREGATE_CRITERIA), expectedEventThree)
+                       .thenCompose(AppendTransaction::commit).join();
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-5", emptySet()),
+                                     taggedEventMessage("event-6", emptySet())).thenCompose(AppendTransaction::commit)
+                       .join();
+
+            MessageStream<EventMessage<?>> result =
+                    testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(0)));
+
+            StepVerifier.create(result.asFlux())
+                        .assertNext(entry -> assertTrackedEntry(entry, expectedEventOne.event(), 1))
+                        .assertNext(entry -> assertTrackedEntry(entry, expectedEventTwo.event(), 2))
+                        .expectNextCount(2)
+                        .assertNext(entry -> assertTrackedEntry(entry, expectedEventThree.event(), 5))
+                        .expectNextCount(2)
+                        .thenCancel()
+                        .verify();
+        }
+
+        @Test
+        void streamingFromSpecificPositionSkipsMessages() {
+            TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
+
+            // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
+            testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                     expectedEventOne,
+                                     expectedEventTwo,
+                                     taggedEventMessage("event-2", Set.of()),
+                                     taggedEventMessage("event-3", TEST_AGGREGATE_CRITERIA.tags()),
+                                     expectedEventThree,
+                                     taggedEventMessage("event-5", TEST_AGGREGATE_CRITERIA.tags()),
+                                     taggedEventMessage("event-6", TEST_AGGREGATE_CRITERIA.tags())).thenCompose(
+                    AppendTransaction::commit).join();
+
+            MessageStream<EventMessage<?>> result =
+                    testSubject.stream(StreamingCondition.startingFrom(trackingTokenOnPosition(2)));
+
+            StepVerifier.create(result.asFlux())
+                        // we've skipped the first two
+                        .expectNextCount(2).assertNext(entry -> assertTrackedEntry(entry,
+                                                                                   expectedEventThree.event(),
+                                                                                   5))
+                        .expectNextCount(2).thenCancel().verify();
+        }
+
+        @Test
+        void streamingAfterLastPositionReturnsEmptyStream() {
+            EventCriteria expectedCriteria = TEST_AGGREGATE_CRITERIA;
+            TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_CRITERIA.tags());
+            TaggedEventMessage<?> expectedEventThree = taggedEventMessage("event-4", TEST_AGGREGATE_CRITERIA.tags());
+            // Ensure there are "gaps" in the global stream based on events not matching the sourcing condition
+            ConsistencyMarker marker1 = testSubject.appendEvents(AppendCondition.withCriteria(expectedCriteria),
+                                                                 expectedEventOne,
+                                                                 expectedEventTwo)
+                                                   .thenCompose(AppendTransaction::commit)
+                                                   .join();
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-2", Set.of()),
+                                     taggedEventMessage("event-3", Set.of())).thenCompose(
+                    AppendTransaction::commit).join();
+            testSubject.appendEvents(new DefaultAppendCondition(marker1, expectedCriteria), expectedEventThree)
+                       .thenCompose(AppendTransaction::commit).join();
+            testSubject.appendEvents(AppendCondition.none(),
+                                     taggedEventMessage("event-5", Set.of()),
+                                     taggedEventMessage("event-6", Set.of())).thenCompose(
+                    AppendTransaction::commit).join();
+
+            MessageStream<EventMessage<?>> result = testSubject.stream(StreamingCondition.startingFrom(
+                    trackingTokenOnPosition(10)).or(expectedCriteria));
+
+            try {
+                assertTrue(result.next().isEmpty());
+            } finally {
+                result.close();
+            }
+        }
+
     }
 
     private void assertTrackedEntry(Entry<EventMessage<?>> actual, EventMessage<?> expected, long eventNumber) {
@@ -465,7 +498,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
 
     protected static TaggedEventMessage<?> taggedEventMessage(String payload, Set<Tag> tags) {
         return new GenericTaggedEventMessage<>(
-                new GenericEventMessage<>(new MessageType("event"), payload),
+                new GenericEventMessage<>(new QualifiedName("test", "event", "0.0.1"), payload),
                 tags
         );
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -459,13 +459,13 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
     }
 
     @Test
-    void emptyTransactionAlwaysCommitSuccessfully() {
+    void emptyTransactionAlwaysCommitSuccessfullyAndReturnsOriginConsistencyMarker() {
         var appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA);
-
         var commit = testSubject.appendEvents(appendCondition, Collections.emptyList())
                                 .thenCompose(AppendTransaction::commit);
 
-        assertDoesNotThrow(commit::join);
+        var afterCommitConsistencyMarker = assertDoesNotThrow(commit::join);
+        assertEquals(ConsistencyMarker.ORIGIN, afterCommitConsistencyMarker);
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -395,8 +395,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
         assertInstanceOf(AppendEventsTransactionRejectedException.class, thrown.getCause());
     }
 
-    <T> CompletableFuture<T> runAsync(Supplier<CompletableFuture<T>> task) {
-        return CompletableFuture.supplyAsync(() -> task.get().join(), executor);
+    private static <T> CompletableFuture<T> runAsync(Supplier<CompletableFuture<T>> task) {
+        return CompletableFuture.supplyAsync(task, executor).thenCompose(future -> future);
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -429,8 +429,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends AsyncEven
                                          taggedEventMessage("event-0", TEST_AGGREGATE_CRITERIA.tags())).join();
 
         assertDoesNotThrow(() -> tx.commit().get(1, TimeUnit.SECONDS));
-        var thrown = assertThrows(Exception.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
-        assertInstanceOf(IllegalStateException.class, thrown.getCause());
+        assertThrows(Exception.class, () -> tx.commit().get(1, TimeUnit.SECONDS));
     }
 
     @Test

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -241,27 +241,6 @@
             <artifactId>hibernate-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -34,7 +34,7 @@ import java.time.Instant;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = LegacyJpaEventStorageEngineTest.TestContext.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // todo: find better way to clear db between tests
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSuite<LegacyJpaEventStorageEngine> {
 
     public static final Serializer TEST_SERIALIZER = TestSerializer.JACKSON.getSerializer();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -23,12 +23,17 @@ import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
 import org.axonframework.eventsourcing.eventstore.StreamingCondition;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
 import org.axonframework.eventsourcing.eventstore.jpa.LegacyJpaEventStorageEngine;
+import org.axonframework.messaging.QualifiedNameUtils;
+import org.axonframework.serialization.LazyDeserializingObject;
+import org.axonframework.serialization.SerializedMessage;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.TestSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
@@ -47,6 +52,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 
@@ -85,7 +91,9 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
 
     @Override
     protected EventMessage<String> convertPayload(EventMessage<?> original) {
-        return original.withConvertedPayload(p -> TEST_SERIALIZER.convert(p, String.class));
+//        return original.withConvertedPayload(p -> TEST_SERIALIZER.convert(p, String.class));
+        return original.withConvertedPayload(p -> new String((byte[]) p, StandardCharsets.UTF_8).replaceAll("\"", ""));
+//        return original.withConvertedPayload(p -> TEST_SERIALIZER.convert(p, String.class).replaceAll("\"", ""));
     }
 
     @Test

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -71,7 +71,6 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
         return new LegacyJpaEventStorageEngine(entityManagerProvider,
                                                new SpringTransactionManager(platformTransactionManager),
                                                TEST_SERIALIZER,
-                                               TEST_SERIALIZER,
                                                config -> config
                                                        .explicitFlush(true)
                                                        .persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -11,13 +11,9 @@ import org.axonframework.eventhandling.GapAwareTrackingToken;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
-import org.axonframework.eventsourcing.eventstore.AppendCondition;
-import org.axonframework.eventsourcing.eventstore.AsyncEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.StreamingCondition;
-import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcSQLErrorCodesResolver;
 import org.axonframework.eventsourcing.eventstore.jpa.LegacyJpaEventStorageEngine;
-import org.axonframework.messaging.MessageStream;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.TestSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
@@ -36,12 +32,10 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
-import reactor.test.StepVerifier;
 
 import javax.sql.DataSource;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -91,9 +85,6 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
         );
     }
 
-    // todo: test batching
-    // todo: test token with gaps
-
     @Configuration
     public static class TestContext {
 
@@ -108,14 +99,6 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
                 return new SimpleEntityManagerProvider(entityManager);
             }
         }
-
-//        @Bean
-//        public DataSource dataSource() {
-//            DriverManagerDataSource driverManagerDataSource
-//                    = new DriverManagerDataSource("jdbc:tc:postgresql:17.2:///axon_test", "axon", "axon");
-//            driverManagerDataSource.setDriverClassName("org.postgresql.Driver");
-//            return Mockito.spy(driverManagerDataSource);
-//        }
 
         @Bean
         public DataSource dataSource() {
@@ -135,7 +118,6 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
             entityManagerFactoryBean.setPersistenceUnitName("integrationtest");
 
             HibernateJpaVendorAdapter jpaVendorAdapter = new HibernateJpaVendorAdapter();
-//            jpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.PostgreSQLDialect");
             jpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.HSQLDialect");
             jpaVendorAdapter.setGenerateDdl(true);
             jpaVendorAdapter.setShowSql(false);

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -73,7 +73,7 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
                                                TEST_SERIALIZER,
                                                TEST_SERIALIZER,
                                                config -> config
-                                                       .explicitFlush(true)
+                                                       .explicitFlush(false)
                                                        .persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -115,7 +115,7 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
         public DataSource dataSource() {
             var now = Instant.now();
             DriverManagerDataSource driverManagerDataSource
-                    = new DriverManagerDataSource("jdbc:hsqldb:file:./data/" + now + "_legacyjpatest",
+                    = new DriverManagerDataSource("jdbc:hsqldb:mem:legacyjpaeventstoreageenginetest",
                                                   "sa",
                                                   "password");
             driverManagerDataSource.setDriverClassName("org.hsqldb.jdbcDriver");

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -73,7 +73,7 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
                                                TEST_SERIALIZER,
                                                TEST_SERIALIZER,
                                                config -> config
-                                                       .explicitFlush(false)
+                                                       .explicitFlush(true)
                                                        .persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -34,7 +34,6 @@ import org.axonframework.serialization.TestSerializer;
 import org.axonframework.spring.messaging.unitofwork.SpringTransactionManager;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
-import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.*;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -71,9 +70,7 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
         return new LegacyJpaEventStorageEngine(entityManagerProvider,
                                                new SpringTransactionManager(platformTransactionManager),
                                                TEST_SERIALIZER,
-                                               config -> config
-                                                       .explicitFlush(true)
-                                                       .persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));
+                                               config -> config.persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));
     }
 
     @Override

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.integrationtests.eventsourcing.eventstore.jpa;
 
 import jakarta.persistence.EntityManager;
@@ -30,7 +46,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -53,14 +68,13 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
 
     @Override
     protected LegacyJpaEventStorageEngine buildStorageEngine() {
-//        var txDefinition = new DefaultTransactionDefinition();
-//        txDefinition.setPropagationBehavior(DefaultTransactionDefinition.PROPAGATION_REQUIRES_NEW);
         return new LegacyJpaEventStorageEngine(entityManagerProvider,
                                                new SpringTransactionManager(platformTransactionManager),
                                                TEST_SERIALIZER,
                                                TEST_SERIALIZER,
-                                               config -> config.persistenceExceptionResolver(new JdbcSQLErrorCodesResolver())
-                                                               .explicitFlush(false));
+                                               config -> config
+                                                       .explicitFlush(true)
+                                                       .persistenceExceptionResolver(new JdbcSQLErrorCodesResolver()));
     }
 
     @Override

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import javax.sql.DataSource;
 import java.time.Instant;
@@ -52,12 +53,14 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
 
     @Override
     protected LegacyJpaEventStorageEngine buildStorageEngine() {
+//        var txDefinition = new DefaultTransactionDefinition();
+//        txDefinition.setPropagationBehavior(DefaultTransactionDefinition.PROPAGATION_REQUIRES_NEW);
         return new LegacyJpaEventStorageEngine(entityManagerProvider,
                                                new SpringTransactionManager(platformTransactionManager),
                                                TEST_SERIALIZER,
                                                TEST_SERIALIZER,
                                                config -> config.persistenceExceptionResolver(new JdbcSQLErrorCodesResolver())
-                                                               .explicitFlush(true));
+                                                               .explicitFlush(false));
     }
 
     @Override
@@ -106,7 +109,7 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
                                                   "sa",
                                                   "password");
             driverManagerDataSource.setDriverClassName("org.hsqldb.jdbcDriver");
-            return Mockito.spy(driverManagerDataSource);
+            return driverManagerDataSource;
         }
 
         @Bean("entityManagerFactory")

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngineTest.java
@@ -76,13 +76,13 @@ class LegacyJpaEventStorageEngineTest extends AggregateBasedStorageEngineTestSui
     }
 
     @Override
-    protected long globalSequenceOfEvent(long eventNumber) {
-        return eventNumber;
+    protected long globalSequenceOfEvent(long position) {
+        return position;
     }
 
     @Override
-    protected TrackingToken trackingTokenOnPosition(long eventNumber) {
-        return GapAwareTrackingToken.newInstance(globalSequenceOfEvent(eventNumber), Collections.emptySet());
+    protected TrackingToken trackingTokenAt(long position) {
+        return GapAwareTrackingToken.newInstance(globalSequenceOfEvent(position), Collections.emptySet());
     }
 
     @Override


### PR DESCRIPTION
- Implemented JPA EventStore using the new API. 
- Adjusted test suite to work with different event sequencing and add more test cases.
- Extracted common parts (like LegacyJpaEventStorageOperations) from the old and new implementation of the Jpa Event Storage Engine in order to keep both implementations for now and better cohesion. 
- Fixed bug in LegacyAxonServerEventStorageEngine - handle Event metadata. 

Next PRs:
- I propose merging this PR in its current state, if it is good enough, and addressing the remaining work (e.g., changing the mechanism from serializer to converter, deciding how to handle metadata serialization, etc.) in subsequent PRs. This approach keeps the PR manageable in size and allows others to use the updated test suite and incorporate the bug fixes.

Note:
Do not focus on commit messages, i prefer to make small commits and use squash while merging.