### PR TITLE
Added asciidoctor rendering configuration

### DIFF
--- a/docs/.asciidoctorconfig
+++ b/docs/.asciidoctorconfig
@@ -1,0 +1,3 @@
+:linkcss:
+:stylesdir: https://docs.axoniq.io/_/css/
+:stylesheet: site.css


### PR DESCRIPTION
Added an .asciidoctorconfig file which tells the IDE to render the preview of asciidoc using the stylesheets from the documentation platform.
This only works for adoc files that have an antora configuration file in one of the parent directories.