### PR TITLE
Set Consistency Marker on `AppendCondition` from `EventStoreTransaction#source` calls

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AsyncEventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AsyncEventSourcingRepository.java
@@ -17,12 +17,12 @@
 package org.axonframework.eventsourcing;
 
 import jakarta.annotation.Nonnull;
-import org.axonframework.messaging.Context.ResourceKey;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventsourcing.eventstore.AsyncEventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
+import org.axonframework.messaging.Context.ResourceKey;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.AsyncRepository;
 import org.axonframework.modelling.repository.ManagedEntity;
@@ -67,7 +67,7 @@ public class AsyncEventSourcingRepository<ID, M> implements AsyncRepository.Life
      *                          {@link org.axonframework.eventsourcing.eventstore.EventCriteria} used to load a matching
      *                          event stream.
      * @param eventStateApplier The function to apply event state changes to the loaded entities.
-     * @param context           The (bounded) context this {@link AsyncEventSourcingRepository} provides access to
+     * @param context           The (bounded) context this {@code AsyncEventSourcingRepository} provides access to
      *                          models for.
      */
     public AsyncEventSourcingRepository(AsyncEventStore eventStore,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AsyncEventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AsyncEventSourcingRepository.java
@@ -105,10 +105,7 @@ public class AsyncEventSourcingRepository<ID, M> implements AsyncRepository.Life
         return managedEntities.computeIfAbsent(
                 identifier,
                 id -> eventStore.transaction(processingContext, context)
-                                .source(
-                                        SourcingCondition.conditionFor(start, end, criteriaResolver.resolve(id)),
-                                        processingContext
-                                )
+                                .source(SourcingCondition.conditionFor(start, end, criteriaResolver.resolve(id)))
                                 .reduce(new EventSourcedEntity<>(identifier, (M) null), (entity, entry) -> {
                                     entity.applyStateChange(entry.message(), eventStateApplier);
                                     return entity;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnyEvent.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnyEvent.java
@@ -28,8 +28,8 @@ import java.util.Set;
  * Use this instance when all events are of interest during
  * {@link StreamableEventSource#open(String, org.axonframework.eventsourcing.eventstore.StreamingCondition) streaming}
  * or when there are no consistency boundaries to validate during
- * {@link EventStoreTransaction#appendEvent(EventMessage) appending}. Note that {@code EventCriteria} criteria does not
- * make sense for {@link EventStoreTransaction#source(SourcingCondition, ProcessingContext) sourcing}, as it is
+ * {@link EventStoreTransaction#appendEvent(EventMessage) appending}. Note that {@code AnyEvent} criteria does not
+ * make sense for {@link EventStoreTransaction#source(SourcingCondition) sourcing}, as it is
  * <b>not</b> recommended to source the entire event store.
  *
  * @author Steven van Beelen
@@ -59,5 +59,10 @@ final class AnyEvent implements EventCriteria {
     @Override
     public boolean matchingTags(@Nonnull Set<Tag> tags) {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        return "AnyEvent";
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnyEvent.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.axonframework.eventsourcing.eventstore;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.Set;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultAppendCondition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultAppendCondition.java
@@ -53,6 +53,9 @@ record DefaultAppendCondition(
 
     @Override
     public AppendCondition withMarker(ConsistencyMarker consistencyMarker) {
+        if (this.consistencyMarker.equals(consistencyMarker)) {
+            return this;
+        }
         return new DefaultAppendCondition(consistencyMarker, criteria);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -17,8 +17,8 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import jakarta.annotation.Nonnull;
-import org.axonframework.messaging.Context.ResourceKey;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Context.ResourceKey;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
@@ -19,7 +19,6 @@ package org.axonframework.eventsourcing.eventstore;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.MessageStream;
-import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.function.Consumer;
 
@@ -27,8 +26,8 @@ import java.util.function.Consumer;
  * Interface describing the actions that can be taken on a transaction to source a model from the
  * {@link AsyncEventStore} based on the resulting {@link MessageStream}.
  * <p>
- * Note that this transaction includes operations for {@link #source(SourcingCondition, ProcessingContext) sourcing} the
- * model as well as {@link #appendEvent(EventMessage) appending events}.
+ * Note that this transaction includes operations for {@link #source(SourcingCondition)} the model as well as
+ * {@link #appendEvent(EventMessage) appending events}.
  *
  * @author Allard Buijze
  * @author Steven van Beelen
@@ -39,23 +38,13 @@ public interface EventStoreTransaction {
     /**
      * Sources a {@link MessageStream} of type {@link EventMessage} based on the given {@code condition} that can be
      * used to rehydrate a model.
-     * <p>
-     * The given {@code context} is used to perform tasks at the right
-     * {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.Phase phases} and register resources throughout
-     * its lifecycle. All {@code condition} instances provided to source as part of the given {@code context} should be
-     * used to derive the {@link AppendCondition} typically used by the {@link #appendEvent(EventMessage)} method's
-     * implementation.
      *
      * @param condition The {@link SourcingCondition} used to retrieve the {@link MessageStream} containing the sequence
      *                  of events that can rehydrate a model.
-     * @param context   The {@link ProcessingContext} used to perform tasks at the right
-     *                  {@link org.axonframework.messaging.unitofwork.ProcessingLifecycle.Phase phases} and register
-     *                  resources throughout its lifecycle.
      * @return The {@link MessageStream} of type {@link EventMessage} containing to the event sequence complying to the
      * given {@code condition}.
      */
-    MessageStream<? extends EventMessage<?>> source(@Nonnull SourcingCondition condition,
-                                                    @Nonnull ProcessingContext context);
+    MessageStream<? extends EventMessage<?>> source(@Nonnull SourcingCondition condition);
 
     /**
      * Appends an {@code eventMessage} to be appended to an {@link AsyncEventStore} in this transaction with the given
@@ -82,9 +71,8 @@ public interface EventStoreTransaction {
      * <p>
      * Will return {@link ConsistencyMarker#ORIGIN} if nothing has been appended yet.
      *
-     * @param context The {@link ProcessingContext} for which to retrieve the last appended event for
      * @return The position in the event store of the last {@link #appendEvent(EventMessage) appended} event by this
      * transaction.
      */
-    ConsistencyMarker appendPosition(@Nonnull ProcessingContext context);
+    ConsistencyMarker appendPosition();
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexConsistencyMarker.java
@@ -63,4 +63,25 @@ public class GlobalIndexConsistencyMarker extends AbstractConsistencyMarker<Glob
     protected ConsistencyMarker doUpperBound(GlobalIndexConsistencyMarker other) {
         return other.position > this.position ? other : this;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GlobalIndexConsistencyMarker that = (GlobalIndexConsistencyMarker) o;
+        return position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(position);
+    }
+
+    @Override
+    public String toString() {
+        return "GlobalIndexConsistencyMarker{" +
+                "position=" + position +
+                '}';
+    }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AsyncEventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AsyncEventSourcingRepositoryTest.java
@@ -72,7 +72,7 @@ class AsyncEventSourcingRepositoryTest {
         ProcessingContext processingContext = new StubProcessingContext();
         doReturn(MessageStream.fromStream(Stream.of(domainEvent(0), domainEvent(1))))
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
 
@@ -81,7 +81,7 @@ class AsyncEventSourcingRepositoryTest {
         verify(eventStore, times(2)).transaction(processingContext, TEST_CONTEXT);
         verify(eventStoreTransaction).onAppend(any());
         verify(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         assertEquals("null-0-1", result.resultNow().entity());
     }
@@ -116,7 +116,7 @@ class AsyncEventSourcingRepositoryTest {
         ProcessingContext processingContext2 = new StubProcessingContext();
         doReturn(MessageStream.fromStream(Stream.of(domainEvent(0), domainEvent(1))))
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         ManagedEntity<String, String> result = testSubject.load("test", processingContext).get();
 
@@ -131,7 +131,7 @@ class AsyncEventSourcingRepositoryTest {
         ProcessingContext processingContext2 = new StubProcessingContext();
         doReturn(MessageStream.fromStream(Stream.of(domainEvent(0), domainEvent(1))))
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         ManagedEntity<String, String> result = testSubject.load("test", processingContext).get();
 
@@ -161,7 +161,7 @@ class AsyncEventSourcingRepositoryTest {
         ProcessingContext processingContext = new StubProcessingContext();
         doReturn(MessageStream.fromStream(Stream.of(domainEvent(0), domainEvent(1))))
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
 
@@ -170,7 +170,7 @@ class AsyncEventSourcingRepositoryTest {
         verify(eventStore, times(2)).transaction(processingContext, TEST_CONTEXT);
         verify(eventStoreTransaction).onAppend(any());
         verify(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
         //noinspection unchecked
         ArgumentCaptor<Consumer<EventMessage<?>>> callback = ArgumentCaptor.forClass(Consumer.class);
         verify(eventStoreTransaction).onAppend(callback.capture());
@@ -185,7 +185,7 @@ class AsyncEventSourcingRepositoryTest {
         ProcessingContext processingContext = new StubProcessingContext();
         doReturn(MessageStream.fromStream(Stream.of(domainEvent(0), domainEvent(1))))
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         CompletableFuture<ManagedEntity<String, String>> result =
                 testSubject.loadOrCreate("test", processingContext, () -> fail("This should not have been invoked"));
@@ -198,7 +198,7 @@ class AsyncEventSourcingRepositoryTest {
         StubProcessingContext processingContext = new StubProcessingContext();
         doReturn(MessageStream.empty())
                 .when(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         CompletableFuture<ManagedEntity<String, String>> loaded =
                 testSubject.loadOrCreate("test", processingContext, () -> "created");
@@ -208,7 +208,7 @@ class AsyncEventSourcingRepositoryTest {
         verify(eventStore, times(2)).transaction(processingContext, TEST_CONTEXT);
         verify(eventStoreTransaction).onAppend(any());
         verify(eventStoreTransaction)
-                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate), eq(processingContext));
+                .source(argThat(AsyncEventSourcingRepositoryTest::conditionPredicate));
 
         assertEquals("created", loaded.resultNow().entity());
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AsyncEventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AsyncEventSourcingRepositoryTest.java
@@ -24,7 +24,6 @@ import org.axonframework.eventsourcing.eventstore.AsyncEventStore;
 import org.axonframework.eventsourcing.eventstore.EventCriteria;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
-import org.axonframework.eventsourcing.eventstore.Tag;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.unitofwork.ProcessingContext;

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AsyncEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AsyncEventStoreTest.java
@@ -56,7 +56,7 @@ class AsyncEventStoreTest {
         appendedEventsReference = new AtomicReference<>();
         appendedEventsReference.set(new ArrayList<>());
 
-        testSubject = new DefaultEventStore(processingContextReference, contextReference, appendedEventsReference);
+        testSubject = new StubEventStore(processingContextReference, contextReference, appendedEventsReference);
     }
 
     @Test
@@ -77,15 +77,15 @@ class AsyncEventStoreTest {
         assertTrue(testAppendedEvents.contains(testEventTwo));
     }
 
-    static class DefaultEventStore implements AsyncEventStore {
+    static class StubEventStore implements AsyncEventStore {
 
         private final AtomicReference<ProcessingContext> processingContext;
         private final AtomicReference<String> context;
         private final AtomicReference<List<EventMessage<?>>> appendedEvents;
 
-        public DefaultEventStore(AtomicReference<ProcessingContext> processingContext,
-                                 AtomicReference<String> context,
-                                 AtomicReference<List<EventMessage<?>>> appendedEvents) {
+        public StubEventStore(AtomicReference<ProcessingContext> processingContext,
+                              AtomicReference<String> context,
+                              AtomicReference<List<EventMessage<?>>> appendedEvents) {
             this.processingContext = processingContext;
             this.context = context;
             this.appendedEvents = appendedEvents;
@@ -120,8 +120,7 @@ class AsyncEventStoreTest {
         }
 
         @Override
-        public MessageStream<EventMessage<?>> source(@NotNull SourcingCondition condition,
-                                                     @NotNull ProcessingContext context) {
+        public MessageStream<EventMessage<?>> source(@NotNull SourcingCondition condition) {
             throw new UnsupportedOperationException("We don't need this method to test the defaulted methods.");
         }
 
@@ -136,7 +135,7 @@ class AsyncEventStoreTest {
         }
 
         @Override
-        public ConsistencyMarker appendPosition(@NotNull ProcessingContext context) {
+        public ConsistencyMarker appendPosition() {
             throw new UnsupportedOperationException("We don't need this method to test the defaulted methods.");
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -77,7 +77,7 @@ class DefaultEventStoreTransactionTest {
             var uow = new AsyncUnitOfWork();
             uow.runOnPreInvocation(context -> {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                   beforeCommitEvents.set(transaction.source(sourcingCondition, context));
+                   beforeCommitEvents.set(transaction.source(sourcingCondition));
                })
                .runOnPostInvocation(context -> {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
@@ -89,9 +89,9 @@ class DefaultEventStoreTransactionTest {
                // Hence, we retrieve the sourced set after that.
                .runOnAfterCommit(context -> {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                   afterCommitEvents.set(transaction.source(sourcingCondition, context));
+                   afterCommitEvents.set(transaction.source(sourcingCondition));
 
-                   consistencyMarker.set(transaction.appendPosition(context));
+                   consistencyMarker.set(transaction.appendPosition());
                });
             awaitCompletion(uow.execute());
 
@@ -123,11 +123,11 @@ class DefaultEventStoreTransactionTest {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
                    transaction.appendEvent(event1);
                    transaction.appendEvent(event2);
-                   beforeCommitEvents.set(transaction.source(sourcingCondition, context));
+                   beforeCommitEvents.set(transaction.source(sourcingCondition));
                })
                .runOnAfterCommit(context -> {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                   afterCommitEvents.set(transaction.source(sourcingCondition, context));
+                   afterCommitEvents.set(transaction.source(sourcingCondition));
                });
             awaitCompletion(uow.execute());
 
@@ -202,7 +202,7 @@ class DefaultEventStoreTransactionTest {
             var uow = new AsyncUnitOfWork();
             uow.runOnAfterCommit(context -> {
                 EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                result.set(transaction.appendPosition(context));
+                result.set(transaction.appendPosition());
             });
             awaitCompletion(uow.execute());
 
@@ -223,7 +223,7 @@ class DefaultEventStoreTransactionTest {
                 transaction.appendEvent(eventMessage(3));
             }).runOnAfterCommit(context -> {
                 EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                result.set(transaction.appendPosition(context));
+                result.set(transaction.appendPosition());
             });
             awaitCompletion(uow.execute());
 
@@ -263,7 +263,7 @@ class DefaultEventStoreTransactionTest {
             var eventsAfterRollback = new AtomicReference<MessageStream<? extends EventMessage<?>>>();
             verificationUow.runOnPreInvocation(context -> {
                 EventStoreTransaction transaction = defaultEventStoreTransactionFor(context);
-                eventsAfterRollback.set(transaction.source(sourcingCondition, context));
+                eventsAfterRollback.set(transaction.source(sourcingCondition));
             });
             awaitCompletion(verificationUow.execute());
 
@@ -315,7 +315,7 @@ class DefaultEventStoreTransactionTest {
     private static <R> R awaitException(CompletableFuture<R> completion) {
         await().atMost(Duration.ofMillis(500)).pollDelay(Duration.ofMillis(25)).untilAsserted(() -> assertTrue(
                 completion.isCompletedExceptionally(),
-                () -> "Expected exception but none occurred"));
+                "Expected exception but none occurred"));
         return completion.join();
     }
 


### PR DESCRIPTION
This PR introduces the implementation and tests for the AsyncEventSourcingRepository to ensure that events are appended using a correct AppendCondition.
It's constructed using the `SourcingConditions` from each of the `source` calls on that repository in the same `ProcessingContext`, combined with the consistency marker resulting from the sourced stream.

The `ProcessingContext` parameter has been removed from the methods on an `EventStoreTransaction`, as the context is already provided on retrieval of that transaction. 
The transaction itself is already aware of the `ProcessingContext` it operates under.