### PR TITLE
Fix for deadlock when many queries wait for responses

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -168,7 +168,7 @@ public class AxonServerConfiguration {
     private int queryThreads = 10;
 
     /**
-     * The number of threads handling query responses. Defaults to {@code 10} threads.
+     * The number of threads handling query responses. Defaults to {@code 5} threads.
      */
     private int queryResponseThreads = 5;
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -168,6 +168,11 @@ public class AxonServerConfiguration {
     private int queryThreads = 10;
 
     /**
+     * The number of threads handling query responses. Defaults to {@code 10} threads.
+     */
+    private int queryResponseThreads = 5;
+
+    /**
      * The interval (in ms.) application sends status updates on event processors to Axon Server. Defaults to
      * {@code 500} milliseconds.
      */
@@ -783,6 +788,24 @@ public class AxonServerConfiguration {
      */
     public void setQueryThreads(int queryThreads) {
         this.queryThreads = queryThreads;
+    }
+
+    /**
+     * The number of threads executing query responses. Defaults to {@code 5} threads.
+     *
+     * @return The number of threads executing query responses.
+     */
+    public int getQueryResponseThreads() {
+        return queryResponseThreads;
+    }
+
+    /**
+     * Sets the number of threads executing query responses. Defaults to {@code 5} threads.
+     *
+     * @param queryResponseThreads The number of threads executing query responses.
+     */
+    public void setQueryResponseThreads(int queryResponseThreads) {
+        this.queryResponseThreads = queryResponseThreads;
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -152,6 +152,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
     private final TargetContextResolver<? super QueryMessage<?, ?>> targetContextResolver;
     private final ShutdownLatch shutdownLatch = new ShutdownLatch();
     private final ExecutorService queryExecutor;
+    private final ExecutorService queryResponseExecutor;
     private final LocalSegmentAdapter localSegmentAdapter;
     private final String context;
     private final QueryBusSpanFactory spanFactory;
@@ -182,7 +183,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         dispatchInterceptors = new DispatchInterceptors<>();
 
         PriorityBlockingQueue<Runnable> queryProcessQueue = new PriorityBlockingQueue<>(QUERY_QUEUE_CAPACITY);
-        queryExecutor = builder.executorServiceBuilder.apply(configuration, queryProcessQueue);
+        queryExecutor = builder.queryExecutorServiceBuilder.apply(configuration, queryProcessQueue);
+        PriorityBlockingQueue<Runnable> queryResponseProcessQueue = new PriorityBlockingQueue<>(QUERY_QUEUE_CAPACITY);
+        queryResponseExecutor = builder.queryExecutorServiceBuilder.apply(configuration, queryResponseProcessQueue);
         localSegmentAdapter = new LocalSegmentAdapter();
         this.localSegmentShortCut = builder.localSegmentShortCut;
     }
@@ -194,21 +197,22 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
             StreamingQueryMessage<Q, R> queryWithContext = spanFactory.propagateContext(query);
             int priority = priorityCalculator.determinePriority(queryWithContext);
             AtomicReference<Scheduler> scheduler = new AtomicReference<>(PriorityTaskSchedulers.forPriority(
-                    queryExecutor,
+                    queryResponseExecutor,
                     priority,
                     TASK_SEQUENCE));
-            return Mono.fromSupplier(this::registerStreamingQueryActivity).flatMapMany(
-                    activity -> Mono.just(dispatchInterceptors.intercept(queryWithContext))
+            return Mono.fromSupplier(this::registerStreamingQueryActivity)
+                    .flatMapMany(activity ->
+                            Mono.just(dispatchInterceptors.intercept(queryWithContext))
                                     .flatMapMany(intercepted -> {
-                                                     if (shouldRunQueryLocally(intercepted.getQueryName())) {
-                                                         return localSegment.streamingQuery(intercepted);
-                                                     }
-                                                     return Mono.just(serializeStreaming(intercepted, priority))
-                                                                .flatMapMany(queryRequest -> new ResultStreamPublisher<>(
-                                                                        () -> sendRequest(intercepted, queryRequest)))
-                                                                .concatMap(queryResponse -> deserialize(intercepted,
-                                                                                                        queryResponse));
-                                                 }
+                                                if (shouldRunQueryLocally(intercepted.getQueryName())) {
+                                                    return localSegment.streamingQuery(intercepted);
+                                                }
+                                                return Mono.just(serializeStreaming(intercepted, priority))
+                                                        .flatMapMany(queryRequest -> new ResultStreamPublisher<>(
+                                                                () -> sendRequest(intercepted, queryRequest)))
+                                                        .concatMap(queryResponse -> deserialize(intercepted,
+                                                                queryResponse));
+                                            }
                                     )
                                     .publishOn(scheduler.get())
                                     .doOnError(span::recordException)
@@ -302,7 +306,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                                                                                    queryMessage.getResponseType(),
                                                                                    responseTaskSpan);
 
-                    result.onAvailable(() -> queryExecutor.execute(new PriorityRunnable(
+                    result.onAvailable(() -> queryResponseExecutor.execute(new PriorityRunnable(
                             responseProcessingTask,
                             priority,
                             TASK_SEQUENCE.incrementAndGet())));
@@ -598,7 +602,9 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         private QueryPriorityCalculator priorityCalculator = QueryPriorityCalculator.defaultQueryPriorityCalculator();
         private TargetContextResolver<? super QueryMessage<?, ?>> targetContextResolver =
                 q -> configuration.getContext();
-        private ExecutorServiceBuilder executorServiceBuilder =
+        private ExecutorServiceBuilder queryExecutorServiceBuilder =
+                ExecutorServiceBuilder.defaultQueryExecutorServiceBuilder();
+        private ExecutorServiceBuilder queryResponseExecutorServiceBuilder =
                 ExecutorServiceBuilder.defaultQueryExecutorServiceBuilder();
         private String defaultContext;
         private QueryBusSpanFactory spanFactory = DefaultQueryBusSpanFactory.builder()
@@ -731,13 +737,59 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
          * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
          *                               based on the {@link AxonServerConfiguration} and a {@link BlockingQueue}
          * @return the current Builder instance, for fluent interfacing
+         * @deprecated in favor of using the {@link #queryExecutorServiceBuilder(ExecutorServiceBuilder)} method
          */
+        @Deprecated
         @SuppressWarnings("unused")
         public Builder executorServiceBuilder(ExecutorServiceBuilder executorServiceBuilder) {
+            return queryExecutorServiceBuilder(executorServiceBuilder);
+        }
+
+        /**
+         * Sets the {@link ExecutorServiceBuilder} which builds an {@link ExecutorService} based on a given
+         * {@link AxonServerConfiguration} and {@link BlockingQueue} of {@link Runnable}. This ExecutorService is used
+         * to process incoming queries with. Defaults to a {@link ThreadPoolExecutor}, using the
+         * {@link AxonServerConfiguration#getQueryThreads()} for the pool size, a keep-alive-time of {@code 100ms}, the
+         * given BlockingQueue as the work queue and an {@link AxonThreadFactory}.
+         * <p/>
+         * Note that it is highly recommended to use the given BlockingQueue if you are to provide you own
+         * {@code executorServiceBuilder}, as it ensure the query's priority is taken into consideration. Defaults to
+         * {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
+         *
+         * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
+         *                               based on the {@link AxonServerConfiguration} and a {@link BlockingQueue}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        @SuppressWarnings("unused")
+        public Builder queryExecutorServiceBuilder(ExecutorServiceBuilder executorServiceBuilder) {
             assertNonNull(executorServiceBuilder, "ExecutorServiceBuilder may not be null");
-            this.executorServiceBuilder = executorServiceBuilder;
+            this.queryExecutorServiceBuilder = executorServiceBuilder;
             return this;
         }
+
+
+        /**
+         * Sets the {@link ExecutorServiceBuilder} which builds an {@link ExecutorService} based on a given
+         * {@link AxonServerConfiguration} and {@link BlockingQueue} of {@link Runnable}. This ExecutorService is used
+         * to process incoming query responses with. Defaults to a {@link ThreadPoolExecutor}, using the
+         * {@link AxonServerConfiguration#getQueryResponseThreads()} for the pool size, a keep-alive-time of
+         * {@code 100ms}, the given BlockingQueue as the work queue and an {@link AxonThreadFactory}.
+         * <p/>
+         * Note that it is highly recommended to use the given BlockingQueue if you are to provide you own
+         * {@code executorServiceBuilder}, as it ensure the query's priority is taken into consideration. Defaults to
+         * {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
+         *
+         * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
+         *                               based on the {@link AxonServerConfiguration} and a {@link BlockingQueue}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        @SuppressWarnings("unused")
+        public Builder queryResponseExecutorServiceBuilder(ExecutorServiceBuilder executorServiceBuilder) {
+            assertNonNull(executorServiceBuilder, "ExecutorServiceBuilder may not be null");
+            this.queryResponseExecutorServiceBuilder = executorServiceBuilder;
+            return this;
+        }
+
 
         /**
          * Sets the request stream factory that creates a request stream based on upstream. Defaults to

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -185,7 +185,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         PriorityBlockingQueue<Runnable> queryProcessQueue = new PriorityBlockingQueue<>(QUERY_QUEUE_CAPACITY);
         queryExecutor = builder.queryExecutorServiceBuilder.apply(configuration, queryProcessQueue);
         PriorityBlockingQueue<Runnable> queryResponseProcessQueue = new PriorityBlockingQueue<>(QUERY_QUEUE_CAPACITY);
-        queryResponseExecutor = builder.queryExecutorServiceBuilder.apply(configuration, queryResponseProcessQueue);
+        queryResponseExecutor = builder.queryResponseExecutorServiceBuilder.apply(configuration, queryResponseProcessQueue);
         localSegmentAdapter = new LocalSegmentAdapter();
         this.localSegmentShortCut = builder.localSegmentShortCut;
     }
@@ -605,7 +605,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
         private ExecutorServiceBuilder queryExecutorServiceBuilder =
                 ExecutorServiceBuilder.defaultQueryExecutorServiceBuilder();
         private ExecutorServiceBuilder queryResponseExecutorServiceBuilder =
-                ExecutorServiceBuilder.defaultQueryExecutorServiceBuilder();
+                ExecutorServiceBuilder.defaultQueryResponseExecutorServiceBuilder();
         private String defaultContext;
         private QueryBusSpanFactory spanFactory = DefaultQueryBusSpanFactory.builder()
                                                                             .spanFactory(NoOpSpanFactory.INSTANCE)
@@ -727,11 +727,11 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
          * Sets the {@link ExecutorServiceBuilder} which builds an {@link ExecutorService} based on a given
          * {@link AxonServerConfiguration} and {@link BlockingQueue} of {@link Runnable}. This ExecutorService is used
          * to process incoming queries with. Defaults to a {@link ThreadPoolExecutor}, using the
-         * {@link AxonServerConfiguration#getQueryThreads()} for the pool size, a keep-alive-time of {@code 100ms}, the
-         * given BlockingQueue as the work queue and an {@link AxonThreadFactory}.
+         * {@link AxonServerConfiguration#getQueryThreads()} for the pool size, the
+         * given BlockingQueue as the work queue, and an {@link AxonThreadFactory}.
          * <p/>
          * Note that it is highly recommended to use the given BlockingQueue if you are to provide you own
-         * {@code executorServiceBuilder}, as it ensure the query's priority is taken into consideration. Defaults to
+         * {@code executorServiceBuilder}, as it ensures the query's priority is taken into consideration. Defaults to
          * {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
          *
          * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
@@ -749,12 +749,12 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
          * Sets the {@link ExecutorServiceBuilder} which builds an {@link ExecutorService} based on a given
          * {@link AxonServerConfiguration} and {@link BlockingQueue} of {@link Runnable}. This ExecutorService is used
          * to process incoming queries with. Defaults to a {@link ThreadPoolExecutor}, using the
-         * {@link AxonServerConfiguration#getQueryThreads()} for the pool size, a keep-alive-time of {@code 100ms}, the
-         * given BlockingQueue as the work queue and an {@link AxonThreadFactory}.
+         * {@link AxonServerConfiguration#getQueryThreads()} for the pool size, the
+         * given BlockingQueue as the work queue, and an {@link AxonThreadFactory}.
          * <p/>
          * Note that it is highly recommended to use the given BlockingQueue if you are to provide you own
-         * {@code executorServiceBuilder}, as it ensure the query's priority is taken into consideration. Defaults to
-         * {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
+         * {@code executorServiceBuilder}, as it ensures the query's priority is taken into consideration. Defaults to
+         * {@link ExecutorServiceBuilder#defaultQueryResponseExecutorServiceBuilder()}.
          *
          * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}
          *                               based on the {@link AxonServerConfiguration} and a {@link BlockingQueue}
@@ -772,11 +772,11 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
          * Sets the {@link ExecutorServiceBuilder} which builds an {@link ExecutorService} based on a given
          * {@link AxonServerConfiguration} and {@link BlockingQueue} of {@link Runnable}. This ExecutorService is used
          * to process incoming query responses with. Defaults to a {@link ThreadPoolExecutor}, using the
-         * {@link AxonServerConfiguration#getQueryResponseThreads()} for the pool size, a keep-alive-time of
-         * {@code 100ms}, the given BlockingQueue as the work queue and an {@link AxonThreadFactory}.
+         * {@link AxonServerConfiguration#getQueryResponseThreads()} for the pool size, the given BlockingQueue as the
+         * work queue, and an {@link AxonThreadFactory}.
          * <p/>
          * Note that it is highly recommended to use the given BlockingQueue if you are to provide you own
-         * {@code executorServiceBuilder}, as it ensure the query's priority is taken into consideration. Defaults to
+         * {@code executorServiceBuilder}, as it ensures the query's priority is taken into consideration. Defaults to
          * {@link ExecutorServiceBuilder#defaultQueryExecutorServiceBuilder()}.
          *
          * @param executorServiceBuilder an {@link ExecutorServiceBuilder} used to build an {@link ExecutorService}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExecutorServiceBuilder.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExecutorServiceBuilder.java
@@ -39,13 +39,10 @@ import java.util.function.BiFunction;
 public interface ExecutorServiceBuilder extends
         BiFunction<AxonServerConfiguration, BlockingQueue<Runnable>, ExecutorService> {
 
-    long THREAD_KEEP_ALIVE_TIME = 100L;
-
     /**
      * Create a default ExecutorServiceBuilder used to create a {@link ThreadPoolExecutor} for processing incoming
-     * commands. Uses the {@link AxonServerConfiguration#getCommandThreads()} as the core and maximum pool size, a
-     * keep-alive time of {@code 100ms}, the given {@link BlockingQueue} as the {@code workQueue} and an {@link
-     * AxonThreadFactory}.
+     * commands. Uses the {@link AxonServerConfiguration#getCommandThreads()} as the core and maximum pool size,
+     * the given {@link BlockingQueue} as the {@code workQueue} and an {@link AxonThreadFactory}.
      *
      * @return a default ExecutorServiceBuilder to create an executor for processing commands
      */
@@ -53,7 +50,7 @@ public interface ExecutorServiceBuilder extends
         return (configuration, commandProcessQueue) -> new ThreadPoolExecutor(
                 configuration.getCommandThreads(),
                 configuration.getCommandThreads(),
-                THREAD_KEEP_ALIVE_TIME,
+                0L,
                 TimeUnit.MILLISECONDS,
                 commandProcessQueue,
                 new AxonThreadFactory("CommandProcessor")
@@ -62,9 +59,8 @@ public interface ExecutorServiceBuilder extends
 
     /**
      * Create a default ExecutorServiceBuilder used to create a {@link ThreadPoolExecutor} for processing incoming
-     * queries. Uses the {@link AxonServerConfiguration#getQueryThreads()} as the core and maximum pool size, a
-     * keep-alive time of {@code 100ms}, the given {@link BlockingQueue} as the {@code workQueue} and an {@link
-     * AxonThreadFactory}.
+     * queries. Uses the {@link AxonServerConfiguration#getQueryThreads()} as the core and maximum pool size,
+     * the given {@link BlockingQueue} as the {@code workQueue} and an {@link AxonThreadFactory}.
      *
      * @return a default ExecutorServiceBuilder to create an executor for processing queries
      */
@@ -72,7 +68,7 @@ public interface ExecutorServiceBuilder extends
         return (configuration, queryProcessQueue) -> new ThreadPoolExecutor(
                 configuration.getQueryThreads(),
                 configuration.getQueryThreads(),
-                THREAD_KEEP_ALIVE_TIME,
+                0L,
                 TimeUnit.MILLISECONDS,
                 queryProcessQueue,
                 new AxonThreadFactory("QueryProcessor")
@@ -83,9 +79,8 @@ public interface ExecutorServiceBuilder extends
     /**
      * Create a default ExecutorServiceBuilder used to create a {@link ThreadPoolExecutor} for processing incoming
      * query responses.
-     * Uses the {@link AxonServerConfiguration#getQueryResponseThreads()} as the core and maximum pool size, a
-     * keep-alive time of {@code 100ms}, the given {@link BlockingQueue} as the {@code workQueue} and an {@link
-     * AxonThreadFactory}.
+     * Uses the {@link AxonServerConfiguration#getQueryResponseThreads()} as the core and maximum pool size,
+     * the given {@link BlockingQueue} as the {@code workQueue} and an {@link AxonThreadFactory}.
      *
      * @return a default ExecutorServiceBuilder to create an executor for processing incoming query responses
      */
@@ -93,7 +88,7 @@ public interface ExecutorServiceBuilder extends
         return (configuration, queryResponseProcessQueue) -> new ThreadPoolExecutor(
                 configuration.getQueryResponseThreads(),
                 configuration.getQueryResponseThreads(),
-                THREAD_KEEP_ALIVE_TIME,
+                0L,
                 TimeUnit.MILLISECONDS,
                 queryResponseProcessQueue,
                 new AxonThreadFactory("QueryResponse")

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExecutorServiceBuilder.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExecutorServiceBuilder.java
@@ -78,4 +78,25 @@ public interface ExecutorServiceBuilder extends
                 new AxonThreadFactory("QueryProcessor")
         );
     }
+
+
+    /**
+     * Create a default ExecutorServiceBuilder used to create a {@link ThreadPoolExecutor} for processing incoming
+     * query responses.
+     * Uses the {@link AxonServerConfiguration#getQueryResponseThreads()} as the core and maximum pool size, a
+     * keep-alive time of {@code 100ms}, the given {@link BlockingQueue} as the {@code workQueue} and an {@link
+     * AxonThreadFactory}.
+     *
+     * @return a default ExecutorServiceBuilder to create an executor for processing incoming query responses
+     */
+    static ExecutorServiceBuilder defaultQueryResponseExecutorServiceBuilder() {
+        return (configuration, queryResponseProcessQueue) -> new ThreadPoolExecutor(
+                configuration.getQueryResponseThreads(),
+                configuration.getQueryResponseThreads(),
+                THREAD_KEEP_ALIVE_TIME,
+                TimeUnit.MILLISECONDS,
+                queryResponseProcessQueue,
+                new AxonThreadFactory("QueryResponse")
+        );
+    }
 }

--- a/docs/old-reference-guide/modules/queries/pages/query-dispatchers.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/query-dispatchers.adoc
@@ -47,15 +47,12 @@ If we want to query our view model, the `List&lt;String&gt;`, we would do someth
 // <1>
 GenericQueryMessage<String, List<String>> query =
         new GenericQueryMessage<>("criteria", ResponseTypes.multipleInstancesOf(String.class));
-// <2> send a query message and print query response
+// <2>
 queryBus.query(query).thenAccept(System.out::println);
 
 ----
 
-<1> It is also possible to state the query name when we are building the query message,
-
-by default this is the fully qualified class name of the query payload.
-
+<1> It is also possible to state the query name when we are building the query message, by default this is the fully qualified class name of the query payload.
 <2> The response of sending a query is a Java `CompletableFuture`,
 
 which depending on the type of the query bus may be resolved immediately.

--- a/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
@@ -144,7 +144,8 @@ You can take different routes to remedy this:
 
 === Remote query handler
 
-Before Axon Framework 4.10.4, a thread deadlock could occur in the same manner,
+When calling a remote query handler from your query handler before Axon Framework 4.10.4,
+a thread deadlock could occur in the same manner,
 as processing the response of a query also required a thread.
 This was resolved in Axon Framework 4.10.4 by using a different thread pool to process the response of a query.
 

--- a/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
@@ -102,6 +102,58 @@ public class SubQueryHandler extends QueryHandler {
 
 In the example above, the handler method of `SubQueryHandler` will be invoked for queries for `QueryB` and result `MyResult` the handler methods of `QueryHandler` are invoked for queries for `QueryA` and `QueryC` and result `MyResult`.
 
+== Query handler chaining
+
+When you need information from another query to complete your query,
+you might call the `QueryGateway` or `QueryBus` from your query handler.
+This needs to be done with caution, as we create a dependency between two query handlers.
+
+[[chaining-local]]
+=== Local query handler
+
+When the secondary query handler is located in the same application,
+you can still use
+the `QueryGateway` or `QueryBus` to retrieve the information you need and keep the two components decoupled.
+This gives you the freedom to move the other query handler to a different application in the future.
+
+
+[WARNING]
+.Projection dependency
+====
+When a query handler depends on another query in the same application, this can indicate a design issue.
+Each projection processes events at their own pace, so two projections might not have the data in sync.
+This can lead to unexpected behavior.
+
+The proper solution is to create independent projections that contain all the data needed
+to function correctly.
+By duplicating data to the event processor locally,
+you are guaranteed to have up-to-date data when handling a query, as well as the flexibility to change it.
+====
+
+When using a distributed query bus, such as the `AxonServerQueryBus`, this secondary query will use a second thread to process in. If both queries block the thread, this could potentially lead to a deadlock.
+
+Example: You have configured the `AxonServerQueryBus` to have 1 thread, and you have query A and B in the same application.
+Query A calls query B. Because query A is waiting on a response of query B, and query B is waiting for a thread to free up, this has now caused a deadlock.
+
+You can take different routes to remedy this:
+
+1. Not chaining queries in this way, and instead duplicating the data locally based on the events.
+2. Returning a `CompletableFuture` from your query handlers, and using `thenCompose` to chain the queries. This will free up the thread to process other queries.
+3. Using the `localSegmentShortcut` configuration in the `AxonServerQueryBus` to prevent the second query from being sent over the network, and thus process it in the same thread.
+4. Configure your distributed query bus to have more threads available. This will reduce the chance of a deadlock, but it will not prevent it.
+
+=== Remote query handler
+
+Before Axon Framework 4.10.4, a thread deadlock could occur in the same manner,
+as processing the response of a query also required a thread.
+This was resolved in Axon Framework 4.10.4 by using a different thread pool to process the response of a query.
+
+If you use an older version of Axon Framework,
+you can still use the `QueryGateway` to retrieve the information you need,
+taking the same measures outlined in the previous section for the xref:#chaining-local[local query handlers].
+
+
+
 == Query handler return values
 
 Axon allows a multitude of return types for a query handler method, as defined <<writing-query-handler,earlier>> on this page. You should think of single objects and collections of objects, taking into account wildcards or generics too. Below we share a list of all the options which are supported and tested in the framework.

--- a/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/query-handlers.adoc
@@ -144,10 +144,10 @@ You can take different routes to remedy this:
 
 === Remote query handler
 
-When calling a remote query handler from your query handler before Axon Framework 4.10.4,
+When calling a remote query handler from your query handler before Axon Framework 4.11,
 a thread deadlock could occur in the same manner,
 as processing the response of a query also required a thread.
-This was resolved in Axon Framework 4.10.4 by using a different thread pool to process the response of a query.
+This was resolved in Axon Framework 4.11 by using a different thread pool to process the response of a query.
 
 If you use an older version of Axon Framework,
 you can still use the `QueryGateway` to retrieve the information you need,

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -133,6 +133,12 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.integrationtests.queryhandling;
 
 import io.grpc.ManagedChannelBuilder;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
@@ -1,0 +1,141 @@
+package org.axonframework.integrationtests.queryhandling;
+
+import io.grpc.ManagedChannelBuilder;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.command.AxonServerCommandBus;
+import org.axonframework.axonserver.connector.query.AxonServerQueryBus;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.queryhandling.GenericQueryMessage;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryResponseMessage;
+import org.axonframework.queryhandling.SimpleQueryBus;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.axonframework.test.server.AxonServerContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+public class QueryThreadingIntegrationTest {
+
+    private static final String HOSTNAME = "localhost";
+    private static AtomicBoolean secondaryQueryBlock = new AtomicBoolean(true);
+
+    @Container
+    private static final AxonServerContainer axonServer =
+            new AxonServerContainer()
+                    .withAxonServerName("axonserver")
+                    .withAxonServerHostname(HOSTNAME)
+                    .withDevMode(true)
+                    .withEnv("AXONIQ_AXONSERVER_INSTRUCTION-CACHE-TIMEOUT", "1000")
+                    .withImagePullPolicy(PullPolicy.ageBased(Duration.ofDays(1)))
+                    .withNetworkAliases("axonserver");
+
+    private AxonServerConnectionManager connectionManager;
+    private AxonServerCommandBus commandBus;
+    private AxonServerQueryBus queryBus;
+
+    @BeforeEach
+    void setUp() {
+        Serializer serializer = JacksonSerializer.defaultSerializer();
+
+        String server = axonServer.getHost() + ":" + axonServer.getGrpcPort();
+        AxonServerConfiguration configuration = AxonServerConfiguration.builder()
+                .componentName("threadingTest")
+                .servers(server)
+                .build();
+        configuration.setCommandThreads(5);
+        configuration.setQueryThreads(5);
+        configuration.setQueryResponseThreads(5);
+        connectionManager = AxonServerConnectionManager.builder()
+                .axonServerConfiguration(configuration)
+                .channelCustomizer(ManagedChannelBuilder::directExecutor)
+                .build();
+        connectionManager.start();
+
+
+        QueryBus localQueryBus = SimpleQueryBus.builder().build();
+        queryBus = AxonServerQueryBus.builder()
+                .axonServerConnectionManager(connectionManager)
+                .configuration(configuration)
+                .localSegment(localQueryBus)
+                .updateEmitter(localQueryBus.queryUpdateEmitter())
+                .messageSerializer(serializer)
+                .genericSerializer(serializer)
+                .build();
+        queryBus.start();
+
+        queryBus.subscribe("query-b", String.class, query -> {
+            while (secondaryQueryBlock.get()) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return "b";
+        });
+
+        queryBus.subscribe("query-a", String.class, query -> {
+            QueryResponseMessage<String> b = queryBus.query(new GenericQueryMessage<>("start", "query-b", ResponseTypes.instanceOf(String.class))).get();
+            return "a" + b.getPayload();
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        commandBus.shutdownDispatching();
+        queryBus.shutdownDispatching();
+
+        commandBus.disconnect();
+        queryBus.disconnect();
+
+        connectionManager.shutdown();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void canStillHandleQueryResponsesWhileManyQueriesHandling() throws InterruptedException {
+
+        CompletableFuture<QueryResponseMessage<String>> query1 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+        CompletableFuture<QueryResponseMessage<String>> query2 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+        CompletableFuture<QueryResponseMessage<String>> query3 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+        CompletableFuture<QueryResponseMessage<String>> query4 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+        CompletableFuture<QueryResponseMessage<String>> query5 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+        CompletableFuture<QueryResponseMessage<String>> query6 = queryBus.query(new GenericQueryMessage<>("start", "query-a", ResponseTypes.instanceOf(String.class)));
+
+        Thread.sleep(500);
+        // We should still have the queries not done, it's waiting on the secondary one.
+        assertFalse(query1.isDone());
+        assertFalse(query2.isDone());
+        assertFalse(query3.isDone());
+        assertFalse(query4.isDone());
+        assertFalse(query5.isDone());
+        assertFalse(query6.isDone());
+
+        secondaryQueryBlock.set(false);
+
+        await().untilAsserted(() -> {
+            assertTrue(query1.isDone());
+            assertTrue(query2.isDone());
+            assertTrue(query3.isDone());
+            assertTrue(query4.isDone());
+            assertTrue(query5.isDone());
+            assertTrue(query6.isDone());
+        });
+    }
+
+}


### PR DESCRIPTION
Splits the thead pool of the AxonServerQueryBus in two, one responsible for handling queries, and the other for handling incoming query responses. By having these two separate, the situation that the pool becomes full while waiting for query responses will no longer lead to a deadlock.