### PR TITLE
Introduce gRPC message limit warning and prevention

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -216,9 +212,15 @@ public class AxonServerConfiguration {
     private boolean suppressDownloadMessage = false;
 
     /**
-     * The gRPC max inbound message size. Defaults to {@code 0}, keeping the default value from the connector.
+     * The gRPC max inbound and outbound message size. Defaults to {@code 0}, keeping the default value (4,194,304 or 4MiB) from the connector.
+     * Upon messages exceeding this size, an exception is thrown to prevent unexpected disconnections.
      */
     private int maxMessageSize = 0;
+
+    /**
+     * The threshold (in percentage of 0-1) of the max message size at which a warning should be logged. Defaults to {@code 0.8}.
+     */
+    private double maxMessageSizeWarningThreshold = 0.8;
 
     /**
      * The timeout (in milliseconds) to wait for response on commit. Defaults to {@code 10_000} milliseconds.
@@ -918,6 +920,25 @@ public class AxonServerConfiguration {
      */
     public void setMaxMessageSize(int maxMessageSize) {
         this.maxMessageSize = maxMessageSize;
+    }
+
+    /**
+     * The threshold (in percentage of 0-1) of the max message size at which a warning should be logged. Defaults to {@code 0.8}.
+     *
+     * @return The threshold (in percentage of 0 to 1) of the max outbound message size at which a warning should be logged.
+     */
+    public double getMaxMessageSizeWarningThreshold() {
+        return maxMessageSizeWarningThreshold;
+    }
+
+    /**
+     * The threshold (in percentage of 0-1) of the max message size at which a warning should be logged. Defaults to {@code 0.8}.
+     *
+     * @param maxMessageSizeWarningThreshold The threshold (in percentage of 0 to 1) of the max outbound message size at
+     *                                       which a warning should be logged.
+     */
+    public void setMaxMessageSizeWarningThreshold(double maxMessageSizeWarningThreshold) {
+        this.maxMessageSizeWarningThreshold = maxMessageSizeWarningThreshold;
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -31,8 +31,6 @@ import org.axonframework.config.TagsConfiguration;
 import org.axonframework.lifecycle.Lifecycle;
 import org.axonframework.lifecycle.Phase;
 
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLException;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.net.ssl.SSLException;
 
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -54,7 +54,9 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @since 4.0
  */
 public class AxonServerConnectionManager implements Lifecycle, ConnectionManager {
+
     private static final int DEFAULT_GRPC_PORT = 8124;
+    private static final int DEFAULT_MAX_MESSAGE_SIZE = 4194304;
 
     private final Map<String, AxonServerConnection> connections = new ConcurrentHashMap<>();
     private final AxonServerConnectionFactory connectionFactory;
@@ -351,7 +353,9 @@ public class AxonServerConnectionManager implements Lifecycle, ConnectionManager
                 builder.maxInboundMessageSize(axonServerConfiguration.getMaxMessageSize());
             }
             builder.customize(managedChannelBuilder -> managedChannelBuilder.intercept(new GrpcMessageSizeInterceptor(
-                    axonServerConfiguration.getMaxMessageSize() > 0 ? axonServerConfiguration.getMaxMessageSize() : 4194304,
+                    axonServerConfiguration.getMaxMessageSize() > 0
+                            ? axonServerConfiguration.getMaxMessageSize()
+                            : DEFAULT_MAX_MESSAGE_SIZE,
                     axonServerConfiguration.getMaxMessageSizeWarningThreshold()
             )));
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeExceededException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeExceededException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.util;
+
+/**
+ * Exception thrown when a message exceeds the maximum allowed size. This means that the application has tried
+ * to send a message to Axon Server that is too large. This can be a command, query, response, or any other message.
+ *
+ * @author Mitchell Herrijgers
+ * @see GrpcMessageSizeInterceptor
+ * @since 4.11.0
+ */
+public class GrpcMessageSizeExceededException extends RuntimeException {
+
+    /**
+     * Creates a new exception that indicates the gRPC message size has been exceeded with the given message.
+     * @param message the message to include in the exception
+     */
+    public GrpcMessageSizeExceededException(String message) {
+        super(message);
+    }
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeInterceptor.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeInterceptor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.util;
+
+import com.google.protobuf.MessageLite;
+import io.grpc.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interceptor around a gRPC request that checks whether the message size is within the limits of the server.
+ * This is done for both outbound and inbound messages.
+ * <p>
+ * If an outbound message exceeds the maximum message size, a {@link GrpcMessageSizeExceededException} is thrown.
+ * Then, if the message's size exceeds the warning threshold, a warning is logged with a stack trace to debug the issue.
+ * <p>
+ * Inbound messages are only logged as warnings if they exceed the warning threshold.
+ * <p>
+ * When during initialization, the message size is greater than the default configuration of Axon Server,
+ * we inform the user that this can cause issues if they don't increase the maximum message size on the server.
+ * <p>
+ * The performance overhead of this interceptor is minimal, as it uses a simple check that GRPC does while sending the
+ * message anyway.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.11.0
+ */
+public class GrpcMessageSizeInterceptor implements ClientInterceptor {
+    private final Logger logger = LoggerFactory.getLogger(GrpcMessageSizeInterceptor.class);
+
+    private final int maxMessageSizeWarningPercentage;
+    private final int maxMessageSizeInBytes;
+    private final int maxMessageSizeWarningInBytes;
+
+    public GrpcMessageSizeInterceptor(
+            int maxMessageSizeInBytes,
+            double maxMessageSizeWarningPercentage
+    ) {
+        this.maxMessageSizeInBytes = maxMessageSizeInBytes;
+        this.maxMessageSizeWarningPercentage = (int) (maxMessageSizeWarningPercentage * 100);
+        this.maxMessageSizeWarningInBytes = (int) Math.ceil(maxMessageSizeInBytes * maxMessageSizeWarningPercentage);
+
+        if (maxMessageSizeInBytes > 4194304) {
+            logger.info("Your outgoing Axon Server messages will be limited to {} bytes, which is greater than the default maximum of 4194304 bytes.\n" +
+                            "Make sure the `axoniq.axonserver.max-message-size` property is set to at least {} to prevent issues such as connection instability.",
+                    maxMessageSizeInBytes, maxMessageSizeInBytes);
+        }
+    }
+
+
+    @Override
+    public <REQ, RESP> ClientCall<REQ, RESP> interceptCall(MethodDescriptor<REQ, RESP> methodDescriptor,
+                                                           CallOptions callOptions,
+                                                           Channel channel) {
+        ClientCall<REQ, RESP> call = channel.newCall(methodDescriptor, callOptions);
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<REQ, RESP>(call) {
+            @Override
+            public void sendMessage(REQ message) {
+
+                if (message instanceof MessageLite) {
+                    int messageLength = ((MessageLite) message).getSerializedSize();
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Sending outbound gRPC message {} with size {}", messageLength, message.getClass().getName());
+                    }
+                    if (messageLength > maxMessageSizeInBytes) {
+                        // It exceeds the (supposed) max message size of the server. Throw an exception to prevent disconnection.
+                        throw new GrpcMessageSizeExceededException(String.format("Message size for %s exceeds the maximum allowed size. \n"
+                                        + "Actual size: %d, Maximum size: %d",
+                                message.getClass().getName(),
+                                messageLength,
+                                maxMessageSizeWarningInBytes));
+                    }
+
+                    if (messageLength > maxMessageSizeWarningInBytes) {
+                        logger.warn("Outbound gRPC message of type {} exceeds {}% of the maximum allowed size. \n"
+                                        + "Increase the max-message-size on both your Axon Framework application and Axon Server to allow for larger messages. \n"
+                                        + "Actual size: {}, Maximum size: {}",
+                                message.getClass().getName(),
+                                maxMessageSizeWarningPercentage,
+                                messageLength,
+                                maxMessageSizeInBytes,
+                                new GrpcMessageSizeWarningThresholdReachedException());
+                    }
+                }
+                super.sendMessage(message);
+            }
+
+            @Override
+            public void start(Listener<RESP> responseListener, Metadata headers) {
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RESP>(
+                        responseListener
+                ) {
+                    @Override
+                    public void onMessage(RESP message) {
+                        if (message instanceof MessageLite) {
+                            int messageLength = ((MessageLite) message).getSerializedSize();
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Received inbound gRPC message {} with size {}", messageLength, message.getClass().getName());
+                            }
+
+                            if (messageLength > maxMessageSizeWarningInBytes) {
+                                logger.warn("Inbound gRPC message of type {} exceeds {}% of the maximum allowed size. \n"
+                                                + "Increase the max-message-size on both your Axon Framework application and Axon Server to allow for larger messages. \n"
+                                                + "Actual size: {}, Maximum size: {}",
+                                        message.getClass().getName(),
+                                        maxMessageSizeWarningPercentage,
+                                        messageLength,
+                                        maxMessageSizeInBytes,
+                                        new GrpcMessageSizeWarningThresholdReachedException());
+                            }
+                        }
+                        super.onMessage(message);
+                    }
+                }, headers);
+            }
+        };
+    }
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeWarningThresholdReachedException.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcMessageSizeWarningThresholdReachedException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.axonserver.connector.util;
+
+/**
+ * Exception created to log a warning when a message size exceeds a certain threshold.
+ * This means that the application has tried to send a message to Axon Server that is almost too large.
+ * This can be a command, query, response, or any other message.
+ * <p>
+ * This exception is never thrown, but only used to log a warning that includes the stack trace for better analysis.
+ *
+ * @author Mitchell Herrijgers
+ * @see GrpcMessageSizeInterceptor
+ * @since 4.11.0
+ */
+public class GrpcMessageSizeWarningThresholdReachedException extends RuntimeException {
+    /**
+     * Creates a new instance of the exception indicating that the message size has exceeded the threshold.
+     */
+    public GrpcMessageSizeWarningThresholdReachedException() {
+        super("Message size exceeds the warning threshold. This message will be accepted, but it is recommended to reduce the message size or increase the limits.");
+    }
+}


### PR DESCRIPTION
When Axon Server, or a client application, receives a message that is too large, its gRPC container (Netty) will automatically terminate the incoming connection without any clear error. This leads to confusion by the user, as it's often impossible to see the cause.

We can be clearer to the user in this regard. This change introduces the `GrpcMessageSizeInterceptor`, which rejects calls that are bigger than the configured max message size. This defaults to 4MiB, just like the inbound limit of Axon Server, but can be adjusted by the user. In addition, when 80% of the limit is reached, a warning with stack trace is logged to the user, so they can a) increase the limit on both sides or b) fix the problem in their application.

The latter warning also applies to inbound messages, to keep the limits consistent with one another. 

This method has been profiled on my local PC, and had no measurable overhead.

The same property is used for max size as we always did. It has no notion of being inbound or outbound, and I consider that these values should be the same. Sending a message larger than you can receive is counter-productive, as, for example, your event processor can not handle the message you just published in the stream and cause a disconnect.