### PR TITLE
[#3179] fix: do not shutdown Axon before incoming requests processed during graceful shutdown

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.web.context.WebServerGracefulShutdownLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Role;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InfraConfiguration.java
@@ -41,7 +41,6 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.context.WebServerGracefulShutdownLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Role;

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAxonConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.spring.config;
 
+import jakarta.annotation.Nonnull;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.spring.event.AxonStartedEvent;
@@ -99,15 +100,24 @@ public class SpringAxonConfiguration
 
     @Override
     public void stop() {
-        try {
-            contextClosedLatch.await(30, TimeUnit.SECONDS); // Wait for graceful shutdown completion / different thread?
-        } catch (InterruptedException ignored) {
-        } finally {
-            Configuration c = this.configuration.get();
-            if (isRunning.compareAndSet(true, false) && c != null) {
-                c.shutdown();
+        throw new UnsupportedOperationException("Stop must not be invoked directly");
+    }
+
+    @Override
+    public void stop(@Nonnull Runnable callback) {
+        new Thread(() -> {
+            try {
+                contextClosedLatch.await(30, TimeUnit.SECONDS); // todo: configure time?
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            } finally {
+                Configuration c = this.configuration.get();
+                if (isRunning.compareAndSet(true, false) && c != null) {
+                    c.shutdown();
+                    callback.run();
+                }
             }
-        }
+        }).start();
     }
 
     @Override
@@ -126,7 +136,7 @@ public class SpringAxonConfiguration
     }
 
     @Override
-    public void onApplicationEvent(ContextClosedEvent event) {
-        contextClosedLatch.countDown(); // Signal that the web server is fully stopped
+    public void onApplicationEvent(@Nonnull ContextClosedEvent event) {
+        contextClosedLatch.countDown();
     }
 }


### PR DESCRIPTION
WORK IN PROGRESS
Fix for: https://github.com/AxonFramework/AxonFramework/issues/3179

PR in order to gather your opinions about the usage of  `ContextClosedEvent`. 
The event happens after all requests were processed by web server. 

It fixes the problem with already shut down bus during graceful shutdown, but I'm not sure if we can do something better than listening for the event. 

I'm not sure if it'd be possible to write automated test for that - I will investigate that on Monday. 
For now, I reproduced the problem and check the solution on real app. 


-----
Problem reproduced:
https://github.com/MateuszNaKodach/bike-rental-quick-start/tree/investigation/graceful-shutdown
Run Rental and Payment services and just execute:
```
curl -X GET http://localhost:8080/dummy &
curl -X POST http://localhost:8080/actuator/shutdown
```