### PR TITLE
Catch `IllegalJobStateChangeException` in `JobRunrDeadlineManager` when the failed change is from `DELETED` to `DELETED`

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/jobrunr/JobrunrDeadlineManagerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/deadline/jobrunr/JobrunrDeadlineManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.axonframework.deadline.DeadlineManagerSpanFactory;
 import org.axonframework.deadline.jobrunr.JobRunrDeadlineManager;
 import org.axonframework.integrationtests.deadline.AbstractDeadlineManagerTestSuite;
 import org.axonframework.messaging.ScopeAwareProvider;
+import org.axonframework.messaging.ScopeDescriptor;
+import org.axonframework.modelling.command.AggregateScopeDescriptor;
 import org.axonframework.serialization.TestSerializer;
 import org.jobrunr.configuration.JobRunr;
 import org.jobrunr.scheduling.JobScheduler;
@@ -39,6 +41,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -114,5 +117,16 @@ class JobrunrDeadlineManagerTest extends AbstractDeadlineManagerTestSuite {
     @Test
     @Disabled("Cancel all is not implemented for the non pro version.")
     public void deadlineCancelAllOnSagaIsCorrectlyTraced() {
+    }
+
+    @Test
+    void doNotThrowIllegalJobStateChangeExceptionForAnAlreadyDeletedJob() {
+        DeadlineManager testSubject = configuration.deadlineManager();
+
+        String deadlineName = "doubleDeleteDoesNotThrowException";
+        String scheduleId = testSubject.schedule(Duration.ofMinutes(15), deadlineName, null,
+                                                 new AggregateScopeDescriptor("aggregateType", "aggregateId"));
+        testSubject.cancelSchedule(deadlineName, scheduleId);
+        assertDoesNotThrow(() -> testSubject.cancelSchedule(deadlineName, scheduleId));
     }
 }


### PR DESCRIPTION
A user of ours had a scenario where a Saga's event handler invoked `JobRunrDeadlineManager#cancel`.
During that process, the connection to their Mongo store failed when updating the saga.

This predicament caused the JobRunr job to move to the `DELETED` state, while the saga would be retried by Axon Framework.
The retry caused the `JobRunrDeadlineManager#cancel` method to be invoked again for an already deleted JobRunr job.

JobRunr rightfully so throws a `IllegalJobStateChangeException` in such a scenario, as that's a faulty state change to make.
When JobRunr would participate in the Mongo transaction this could be resolved, of course.

However, since that's not the case at the moment, I have adjusted the `JobRunrDeadlineManager#cancel` to contain a try-catch when a `IllegalJobStateChangeException` is thrown.
If that exception points out that the state change from `DELETED` to `DELETED` was invoked, we ignore it instead of throwing the exception further up.