### PR TITLE
Cleanup of persistent stream processing logic

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamConnection.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,6 @@ public class PersistentStreamConnection {
     private static final int MAX_RETRY_INTERVAL_SECONDS = 60;
     private static final int MIN_RETRY_INTERVAL_SECONDS = 1;
     private final Logger logger = LoggerFactory.getLogger(PersistentStreamConnection.class);
-
-    private static final int MAX_MESSAGES_PER_RUN = 10_000;
 
     private final String streamId;
     private final Configuration configuration;
@@ -166,11 +164,7 @@ public class PersistentStreamConnection {
     }
 
     private void segmentClosed(PersistentStreamSegment persistentStreamSegment) {
-        SegmentConnection segmentConnection = segments.remove(persistentStreamSegment.segment());
-        if (segmentConnection != null) {
-            segmentConnection.close();
-        }
-
+        segments.remove(persistentStreamSegment.segment());
         logger.info("Segment closed: {}", persistentStreamSegment);
     }
 
@@ -210,7 +204,6 @@ public class PersistentStreamConnection {
 
         private final AtomicBoolean processGate = new AtomicBoolean();
         private final AtomicBoolean doneConfirmed = new AtomicBoolean();
-        private final AtomicBoolean closed = new AtomicBoolean();
         private final PersistentStreamSegment persistentStreamSegment;
         private final GrpcMetaDataAwareSerializer serializer;
         private final AtomicReference<SegmentState> currentState = new AtomicReference<>(new ProcessingState());
@@ -260,45 +253,37 @@ public class PersistentStreamConnection {
 
                 if (logger.isTraceEnabled()) {
                     logger.trace("{}[{}] readMessagesFromSegment - closed: {}",
-                                 streamId, persistentStreamSegment.segment(), persistentStreamSegment.isClosed());
+                            streamId, persistentStreamSegment.segment(), persistentStreamSegment.isClosed());
                 }
 
                 try {
-                    int remaining = Math.max(MAX_MESSAGES_PER_RUN, batchSize);
-                    while (remaining > 0 && !closed.get()) {
+                    if (!persistentStreamSegment.isClosed()) {
                         List<PersistentStreamEvent> batch = readBatch(persistentStreamSegment);
-                        if (batch.isEmpty()) {
-                            break;
-                        }
-
-                        try {
-                            processBatch(batch);
-                            remaining -= batch.size();
-                        } catch (Exception ex) {
-                            logger.warn("{}: Exception while processing events for segment {}, retrying after {} second",
+                        if (!batch.isEmpty()) {
+                            try {
+                                processBatch(batch);
+                            } catch (Exception ex) {
+                                logger.warn("{}: Exception while processing events for segment {}, retrying after {} second",
                                         streamId, persistentStreamSegment.segment(), MIN_RETRY_INTERVAL_SECONDS, ex);
 
-                            currentState.set(new RetryState(batch));
-                            remaining = 0;
+                                currentState.set(new RetryState(batch));
+                            }
                         }
                     }
 
                     acknowledgeDoneWhenClosed(persistentStreamSegment);
                 } catch (StreamClosedException e) {
                     logger.debug("{}: Stream closed for segment {}", streamId, persistentStreamSegment.segment());
-                    close();
-                    // stop loop
                 } catch (Exception e) {
                     if (e instanceof InterruptedException) {
                         Thread.currentThread().interrupt();
                     }
                     persistentStreamSegment.error(e.getMessage());
                     logger.warn("{}: Exception while processing events for segment {}",
-                                streamId, persistentStreamSegment.segment(), e);
-                    close();
+                            streamId, persistentStreamSegment.segment(), e);
                 } finally {
                     processGate.set(false);
-                    if (!closed.get() && persistentStreamSegment.peek() != null) {
+                    if (!persistentStreamSegment.isClosed() && persistentStreamSegment.peek() != null) {
                         scheduler.submit(SegmentConnection.this::readMessagesFromSegment);
                     }
                 }
@@ -315,7 +300,7 @@ public class PersistentStreamConnection {
                 }
                 batch.add(event);
                 // allow next event to arrive within a small amount of time
-                while (batch.size() < batchSize && !closed.get()
+                while (batch.size() < batchSize && !persistentStreamSegment.isClosed()
                         && (event = persistentStreamSegment.nextIfAvailable(1, TimeUnit.MILLISECONDS)) != null) {
                     batch.add(event);
                 }
@@ -323,7 +308,7 @@ public class PersistentStreamConnection {
             }
 
             private void acknowledgeDoneWhenClosed(PersistentStreamSegment persistentStreamSegment) {
-                if (closed.get() && doneConfirmed.compareAndSet(false, true)) {
+                if (persistentStreamSegment.isClosed() && doneConfirmed.compareAndSet(false, true)) {
                     persistentStreamSegment.acknowledge(PENDING_WORK_DONE_MARKER);
                 }
             }
@@ -331,14 +316,14 @@ public class PersistentStreamConnection {
 
         private void processBatch(List<PersistentStreamEvent> batch) {
             List<TrackedEventMessage<?>> eventMessages = upcastAndDeserialize(batch);
-            if (!closed.get()) {
+            if (!persistentStreamSegment.isClosed()) {
                 long token = batch.get(batch.size() - 1).getEvent().getToken();
                 consumer.get().accept(eventMessages);
                 if (logger.isTraceEnabled()) {
                     logger.trace("{}/{} processed {} entries",
-                                 streamId,
-                                 persistentStreamSegment.segment(),
-                                 eventMessages.size());
+                            streamId,
+                            persistentStreamSegment.segment(),
+                            eventMessages.size());
                 }
                 persistentStreamSegment.acknowledge(token);
             }
@@ -376,10 +361,6 @@ public class PersistentStreamConnection {
             }
             return ReplayToken.createReplayToken(new GlobalSequenceTrackingToken(event.getEvent().getToken() + 1),
                                                  new GlobalSequenceTrackingToken(event.getEvent().getToken()));
-        }
-
-        public void close() {
-            closed.set(true);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2024. Axon Framework
+  ~ Copyright (c) 2010-2025. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <!-- Axon Server -->
-        <axonserver-connector-java.version>2024.1.1</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2024.2.2</axonserver-connector-java.version>
         <!-- Caching -->
         <ehcache.version>2.10.9.2</ehcache.version>
         <ehcache3.version>3.10.8</ehcache3.version>


### PR DESCRIPTION
Persistent streams were sometimes slow in closing their connections, to the point that most of the time they were simply aborted.

This change removes the 10k iterations logic and simply processes a batch at a time.