### PR TITLE
Remove initializer from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ Furthermore, below are several other helpful resources:
 * The [quickstart page](https://docs.axoniq.io/reference-guide/getting-started/quick-start) of the documentation provides a simplified entry point into the framework with the [quickstart project](https://download.axoniq.io/quickstart/AxonQuickStart.zip).
 * We have our very own [academy](https://academy.axoniq.io/)! 
   The introductory courses are free, followed by more in-depth (paid) courses.
-* When ready, you can quickly and easily start your very own Axon Framework based application at https://start.axoniq.io/. 
-  Note that this solution is only feasible if you want to stick to the Spring ecosphere.
 * The [reference guide](https://docs.axoniq.io) explains all of the components maintained within Axon Framework's products.
 * If the guide doesn't help, our [forum](https://discuss.axoniq.io/) provides a place to ask questions you have during development.
 * The [hotel demo](https://github.com/AxonIQ/hotel-demo) shows a fleshed-out example of using Axon Framework.


### PR DESCRIPTION
My eye just fell on the README.md, still containing start.axoniq.io as a link.  As we don't have that anymore, let's remove it.