### PR TITLE
[#3283] fix: Auto-register `MessageHandlerInterceptors` with Spring Boot fails for interceptors which depends on Axon components

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
@@ -39,14 +39,14 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Interceptor autoconfiguration class for Axon Framework application. Discovers {@link MessageHandlerInterceptor}s and {@link MessageDispatchInterceptor}
- * and registers them with the respective buses and gateways.
+ * Interceptor autoconfiguration class for Axon Framework application. Discovers {@link MessageHandlerInterceptor}s and
+ * {@link MessageDispatchInterceptor} and registers them with the respective buses and gateways.
  * <p>
- * Note:
- * This class use a hack approach! Because some gateways/buses need an axonConfiguration to initialize, the usual way of
- * registering interceptors in the ConfigurerModule.onInitialize method does not work for the EventGateway.
- * This is due to a circular reference caused e.g. by JpaJavaxEventStoreAutoConfiguration.
- * So we register them by injecting gateway/bus components in to the InitializingBean function and register the interceptors there.
+ * Note: This class use a hack approach! Because some gateways/buses (or custom interceptors provided by the framework
+ * user) need an axonConfiguration to initialize, the usual way of registering interceptors in the
+ * ConfigurerModule.onInitialize method does not work for them. This is due to a circular reference caused e.g. by
+ * JpaJavaxEventStoreAutoConfiguration. So we register them by injecting gateway/bus components in to the
+ * InitializingBean function and register the interceptors there.
  *
  * @author Christian Thiel
  * @since 4.11.0

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
@@ -15,12 +15,16 @@
  */
 package org.axonframework.springboot.autoconfig;
 
+import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.config.ConfigurerModule;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.spring.config.SpringConfigurer;
 import org.springframework.beans.factory.InitializingBean;
@@ -36,6 +40,12 @@ import java.util.Optional;
 /**
  * Interceptor autoconfiguration class for Axon Framework application. Discovers {@link MessageHandlerInterceptor}s and {@link MessageDispatchInterceptor}
  * and registers them with the respective buses and gateways.
+ * <p>
+ * Note:
+ * This class use a hack approach! Because some gateways/buses need an axonConfiguration to initialize, the usual way of
+ * registering interceptors in the ConfigurerModule.onInitialize method does not work for the EventGateway.
+ * This is due to a circular reference caused e.g. by JpaJavaxEventStoreAutoConfiguration.
+ * So we register them by injecting gateway/bus components in to the InitializingBean function and register the interceptors there.
  *
  * @author Christian Thiel
  * @since 4.11.0
@@ -53,67 +63,55 @@ public class InterceptorAutoConfiguration {
 
     @Bean
     @ConditionalOnBean(MessageDispatchInterceptor.class)
-    public ConfigurerModule commandDispatchInterceptorConfigurer(Optional<List<MessageDispatchInterceptor<? super CommandMessage<?>>>> interceptors) {
-        return configurer ->
-                configurer.onInitialize(configuration ->
-                        interceptors.ifPresent(it ->
-                                it.forEach(configuration.commandGateway()::registerDispatchInterceptor)
-                        )
-                );
-    }
-
-    //
-    // This is a hack! Because some eventGateways need an axonConfiguration to initialize, the usual way of
-    // registering interceptors in the ConfigurerModule.onInitialize method does not work for the EventGateway.
-    // This is due to a circular reference caused e.g. by JpaJavaxEventStoreAutoConfiguration.
-    //
-    @Bean
-    @ConditionalOnBean(MessageDispatchInterceptor.class)
-    public InitializingBean eventDispatchInterceptorConfigurer(EventGateway eventGateway, Optional<List<MessageDispatchInterceptor<? super EventMessage<?>>>> interceptors) {
-        return () ->
-                interceptors.ifPresent(it ->
-                        it.forEach(eventGateway::registerDispatchInterceptor)
-                );
+    public InitializingBean commandDispatchInterceptorConfigurer(
+            CommandGateway commandGateway,
+            Optional<List<MessageDispatchInterceptor<? super CommandMessage<?>>>> interceptors
+    ) {
+        return () -> interceptors.ifPresent(it -> it.forEach(commandGateway::registerDispatchInterceptor));
     }
 
     @Bean
     @ConditionalOnBean(MessageDispatchInterceptor.class)
-    public ConfigurerModule queryDispatchInterceptorConfigurer(Optional<List<MessageDispatchInterceptor<? super QueryMessage<?, ?>>>> interceptors) {
-        return configurer ->
-                configurer.onInitialize(configuration ->
-                        interceptors.ifPresent(it ->
-                                it.forEach(configuration.queryGateway()::registerDispatchInterceptor)
-                        )
-                );
+    public InitializingBean eventDispatchInterceptorConfigurer(
+            EventGateway eventGateway,
+            Optional<List<MessageDispatchInterceptor<? super EventMessage<?>>>> interceptors
+    ) {
+        return () -> interceptors.ifPresent(it -> it.forEach(eventGateway::registerDispatchInterceptor));
+    }
+
+    @Bean
+    @ConditionalOnBean(MessageDispatchInterceptor.class)
+    public InitializingBean queryDispatchInterceptorConfigurer(
+            QueryGateway queryGateway,
+            Optional<List<MessageDispatchInterceptor<? super QueryMessage<?, ?>>>> interceptors
+    ) {
+        return () -> interceptors.ifPresent(it -> it.forEach(queryGateway::registerDispatchInterceptor));
     }
 
     @Bean
     @ConditionalOnBean(MessageHandlerInterceptor.class)
-    public ConfigurerModule commandHandlerInterceptorConfigurer(Optional<List<MessageHandlerInterceptor<? super CommandMessage<?>>>> interceptors) {
-        return configurer ->
-                configurer.onInitialize(configuration ->
-                        interceptors.ifPresent(it ->
-                                it.forEach(configuration.commandBus()::registerHandlerInterceptor)
-                        )
-                );
+    public InitializingBean commandHandlerInterceptorConfigurer(
+            CommandBus commandBus,
+            Optional<List<MessageHandlerInterceptor<? super CommandMessage<?>>>> interceptors
+    ) {
+        return () -> interceptors.ifPresent(it -> it.forEach(commandBus::registerHandlerInterceptor));
     }
 
     @Bean
-    public ConfigurerModule messageHandlerInterceptorConfigurer(Optional<List<MessageHandlerInterceptor<? super EventMessage<?>>>> interceptors) {
+    @ConditionalOnBean(MessageHandlerInterceptor.class)
+    public InitializingBean queryHandlerInterceptorConfigurer(
+            QueryBus queryBus,
+            Optional<List<MessageHandlerInterceptor<? super QueryMessage<?, ?>>>> interceptors) {
+        return () -> interceptors.ifPresent(it -> it.forEach(queryBus::registerHandlerInterceptor));
+    }
+
+    @Bean
+    public ConfigurerModule messageHandlerInterceptorConfigurer(
+            Optional<List<MessageHandlerInterceptor<? super EventMessage<?>>>> interceptors
+    ) {
         return configurer -> interceptors
                 .ifPresent(it -> it
                         .forEach(i -> configurer.eventProcessing().registerDefaultHandlerInterceptor((c, n) -> i)
-                        )
-                );
-    }
-
-    @Bean
-    @ConditionalOnBean(MessageHandlerInterceptor.class)
-    public ConfigurerModule queryHandlerInterceptorConfigurer(Optional<List<MessageHandlerInterceptor<? super QueryMessage<?, ?>>>> interceptors) {
-        return configurer ->
-                configurer.onInitialize(configuration ->
-                        interceptors.ifPresent(it ->
-                                it.forEach(configuration.queryBus()::registerHandlerInterceptor)
                         )
                 );
     }

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/InterceptorAutoConfiguration.java
@@ -19,6 +19,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.config.ConfigurerModule;
+import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.messaging.MessageDispatchInterceptor;
@@ -106,13 +107,11 @@ public class InterceptorAutoConfiguration {
     }
 
     @Bean
-    public ConfigurerModule messageHandlerInterceptorConfigurer(
+    public InitializingBean messageHandlerInterceptorConfigurer(
+            EventProcessingConfigurer eventProcessingConfigurer,
             Optional<List<MessageHandlerInterceptor<? super EventMessage<?>>>> interceptors
     ) {
-        return configurer -> interceptors
-                .ifPresent(it -> it
-                        .forEach(i -> configurer.eventProcessing().registerDefaultHandlerInterceptor((c, n) -> i)
-                        )
-                );
+        return () -> interceptors
+                .ifPresent(it -> it.forEach(i -> eventProcessingConfigurer.registerDefaultHandlerInterceptor((c, n) -> i)));
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InterceptorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InterceptorConfigurationTest.java
@@ -283,45 +283,57 @@ class InterceptorConfigurationTest {
         @Order(0)
         public MyCommandHandlerInterceptor mySecondCommandHandlerInterceptor(
                 @Qualifier("commandHandlerInterceptorInvocations") CountDownLatch commandHandlerInterceptorInvocations,
-                @Qualifier("commandHandlingInterceptingOutcome") Queue<String> commandHandlingInterceptingOutcome) {
-            return new MyCommandHandlerInterceptor("Order-0", commandHandlerInterceptorInvocations, commandHandlingInterceptingOutcome);
+                @Qualifier("commandHandlingInterceptingOutcome") Queue<String> commandHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyCommandHandlerInterceptor("Order-0", commandHandlerInterceptorInvocations, commandHandlingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyCommandHandlerInterceptor myThirdCommandHandlerInterceptor(
                 @Qualifier("commandHandlerInterceptorInvocations") CountDownLatch commandHandlerInterceptorInvocations,
-                @Qualifier("commandHandlingInterceptingOutcome") Queue<String> commandHandlingInterceptingOutcome) {
-            return new MyCommandHandlerInterceptor("Unordered", commandHandlerInterceptorInvocations, commandHandlingInterceptingOutcome);
+                @Qualifier("commandHandlingInterceptingOutcome") Queue<String> commandHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyCommandHandlerInterceptor("Unordered", commandHandlerInterceptorInvocations, commandHandlingInterceptingOutcome, configuration);
         }
 
         @Bean
         @Order(0)
         public MyQueryHandlerInterceptor mySecondQueryHandlerInterceptor(
                 @Qualifier("queryHandlerInterceptorInvocations") CountDownLatch queryHandlerInterceptorInvocations,
-                @Qualifier("queryHandlingInterceptingOutcome") Queue<String> queryHandlingInterceptingOutcome) {
-            return new MyQueryHandlerInterceptor("Order-0", queryHandlerInterceptorInvocations, queryHandlingInterceptingOutcome);
+                @Qualifier("queryHandlingInterceptingOutcome") Queue<String> queryHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyQueryHandlerInterceptor("Order-0", queryHandlerInterceptorInvocations, queryHandlingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyQueryHandlerInterceptor myThirdQueryHandlerInterceptor(
                 @Qualifier("queryHandlerInterceptorInvocations") CountDownLatch queryHandlerInterceptorInvocations,
-                @Qualifier("queryHandlingInterceptingOutcome") Queue<String> queryHandlingInterceptingOutcome) {
-            return new MyQueryHandlerInterceptor("Unordered", queryHandlerInterceptorInvocations, queryHandlingInterceptingOutcome);
+                @Qualifier("queryHandlingInterceptingOutcome") Queue<String> queryHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyQueryHandlerInterceptor("Unordered", queryHandlerInterceptorInvocations, queryHandlingInterceptingOutcome, configuration);
         }
 
         @Bean
         @Order(0)
         public MyEventHandlerInterceptor mySecondEventHandlerInterceptor(
                 @Qualifier("eventHandlerInterceptorInvocations") CountDownLatch eventHandlerInterceptorInvocations,
-                @Qualifier("eventHandlingInterceptingOutcome") Queue<String> eventHandlingInterceptingOutcome) {
-            return new MyEventHandlerInterceptor("Order-0", eventHandlerInterceptorInvocations, eventHandlingInterceptingOutcome);
+                @Qualifier("eventHandlingInterceptingOutcome") Queue<String> eventHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyEventHandlerInterceptor("Order-0", eventHandlerInterceptorInvocations, eventHandlingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyEventHandlerInterceptor myThirdEventHandlerInterceptor(
                 @Qualifier("eventHandlerInterceptorInvocations") CountDownLatch eventHandlerInterceptorInvocations,
-                @Qualifier("eventHandlingInterceptingOutcome") Queue<String> eventHandlingInterceptingOutcome) {
-            return new MyEventHandlerInterceptor("Unordered", eventHandlerInterceptorInvocations, eventHandlingInterceptingOutcome);
+                @Qualifier("eventHandlingInterceptingOutcome") Queue<String> eventHandlingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyEventHandlerInterceptor("Unordered", eventHandlerInterceptorInvocations, eventHandlingInterceptingOutcome, configuration);
         }
 
 
@@ -348,45 +360,57 @@ class InterceptorConfigurationTest {
         @Order(0)
         public MyCommandDispatchInterceptor mySecondCommandDispatchInterceptor(
                 @Qualifier("commandDispatchInterceptorInvocations") CountDownLatch commandDispatchInterceptorInvocations,
-                @Qualifier("commandDispatchingInterceptingOutcome") Queue<String> commandDispatchingInterceptingOutcome) {
-            return new MyCommandDispatchInterceptor("Order-0", commandDispatchInterceptorInvocations, commandDispatchingInterceptingOutcome);
+                @Qualifier("commandDispatchingInterceptingOutcome") Queue<String> commandDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyCommandDispatchInterceptor("Order-0", commandDispatchInterceptorInvocations, commandDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyCommandDispatchInterceptor myThirdCommandDispatchInterceptor(
                 @Qualifier("commandDispatchInterceptorInvocations") CountDownLatch commandDispatchInterceptorInvocations,
-                @Qualifier("commandDispatchingInterceptingOutcome") Queue<String> commandDispatchingInterceptingOutcome) {
-            return new MyCommandDispatchInterceptor("Unordered", commandDispatchInterceptorInvocations, commandDispatchingInterceptingOutcome);
+                @Qualifier("commandDispatchingInterceptingOutcome") Queue<String> commandDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyCommandDispatchInterceptor("Unordered", commandDispatchInterceptorInvocations, commandDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
         @Order(0)
         public MyQueryDispatchInterceptor mySecondQueryDispatchInterceptor(
                 @Qualifier("queryDispatchInterceptorInvocations") CountDownLatch queryDispatchInterceptorInvocations,
-                @Qualifier("queryDispatchingInterceptingOutcome") Queue<String> queryDispatchingInterceptingOutcome) {
-            return new MyQueryDispatchInterceptor("Order-0", queryDispatchInterceptorInvocations, queryDispatchingInterceptingOutcome);
+                @Qualifier("queryDispatchingInterceptingOutcome") Queue<String> queryDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyQueryDispatchInterceptor("Order-0", queryDispatchInterceptorInvocations, queryDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyQueryDispatchInterceptor myThirdQueryDispatchInterceptor(
                 @Qualifier("queryDispatchInterceptorInvocations") CountDownLatch queryDispatchInterceptorInvocations,
-                @Qualifier("queryDispatchingInterceptingOutcome") Queue<String> queryDispatchingInterceptingOutcome) {
-            return new MyQueryDispatchInterceptor("Unordered", queryDispatchInterceptorInvocations, queryDispatchingInterceptingOutcome);
+                @Qualifier("queryDispatchingInterceptingOutcome") Queue<String> queryDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyQueryDispatchInterceptor("Unordered", queryDispatchInterceptorInvocations, queryDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
         @Order(0)
         public MyEventDispatchInterceptor mySecondEventDispatchInterceptor(
                 @Qualifier("eventDispatchInterceptorInvocations") CountDownLatch eventDispatchInterceptorInvocations,
-                @Qualifier("eventDispatchingInterceptingOutcome") Queue<String> eventDispatchingInterceptingOutcome) {
-            return new MyEventDispatchInterceptor("Order-0", eventDispatchInterceptorInvocations, eventDispatchingInterceptingOutcome);
+                @Qualifier("eventDispatchingInterceptingOutcome") Queue<String> eventDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyEventDispatchInterceptor("Order-0", eventDispatchInterceptorInvocations, eventDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
         public MyEventDispatchInterceptor myThirdEventDispatchInterceptor(
                 @Qualifier("eventDispatchInterceptorInvocations") CountDownLatch eventDispatchInterceptorInvocations,
-                @Qualifier("eventDispatchingInterceptingOutcome") Queue<String> eventDispatchingInterceptingOutcome) {
-            return new MyEventDispatchInterceptor("Unordered", eventDispatchInterceptorInvocations, eventDispatchingInterceptingOutcome);
+                @Qualifier("eventDispatchingInterceptingOutcome") Queue<String> eventDispatchingInterceptingOutcome,
+                Configuration configuration
+        ) {
+            return new MyEventDispatchInterceptor("Unordered", eventDispatchInterceptorInvocations, eventDispatchingInterceptingOutcome, configuration);
         }
 
         @Bean
@@ -405,38 +429,38 @@ class InterceptorConfigurationTest {
         }
 
         public static class MyCommandHandlerInterceptor extends MyHandlerInterceptor<CommandMessage<?>> {
-            public MyCommandHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyCommandHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
         public static class MyQueryHandlerInterceptor extends MyHandlerInterceptor<QueryMessage<?, ?>> {
-            public MyQueryHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyQueryHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
         public static class MyEventHandlerInterceptor extends MyHandlerInterceptor<EventMessage<?>> {
-            public MyEventHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyEventHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
         public static class MyCommandDispatchInterceptor extends MyDispatchInterceptor<CommandMessage<?>> {
-            public MyCommandDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyCommandDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
         public static class MyQueryDispatchInterceptor extends MyDispatchInterceptor<QueryMessage<?, ?>> {
-            public MyQueryDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyQueryDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
         public static class MyEventDispatchInterceptor extends MyDispatchInterceptor<EventMessage<?>> {
-            public MyEventDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
-                super(name, invocation, handlingOutcome);
+            public MyEventDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome, Configuration configuration) {
+                super(name, invocation, handlingOutcome, configuration);
             }
         }
 
@@ -445,16 +469,24 @@ class InterceptorConfigurationTest {
             private final String name;
             private final CountDownLatch invocation;
             private final Queue<String> handlingOutcome;
+            private final Configuration axonConfiguration;
 
-            public MyHandlerInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
+            public MyHandlerInterceptor(
+                    String name,
+                    CountDownLatch invocation,
+                    Queue<String> handlingOutcome,
+                    Configuration axonConfiguration
+            ) {
                 this.name = name;
                 this.invocation = invocation;
                 this.handlingOutcome = handlingOutcome;
+                this.axonConfiguration = axonConfiguration;
             }
 
             @Override
             public Object handle(UnitOfWork<? extends T> unitOfWork, InterceptorChain interceptorChain) throws Exception {
                 invocation.countDown();
+                axonConfiguration.tags();
                 handlingOutcome.add(name + ": " + unitOfWork.getMessage());
                 return interceptorChain.proceed();
             }
@@ -465,16 +497,24 @@ class InterceptorConfigurationTest {
             private final String name;
             private final CountDownLatch invocation;
             private final Queue<String> handlingOutcome;
+            private final Configuration axonConfiguration;
 
-            public MyDispatchInterceptor(String name, CountDownLatch invocation, Queue<String> handlingOutcome) {
+            public MyDispatchInterceptor(
+                    String name,
+                    CountDownLatch invocation,
+                    Queue<String> handlingOutcome,
+                    Configuration axonConfiguration
+            ) {
                 this.name = name;
                 this.invocation = invocation;
                 this.handlingOutcome = handlingOutcome;
+                this.axonConfiguration = axonConfiguration;
             }
 
             @NotNull
             @Override
             public BiFunction<Integer, T, T> handle(@NotNull List<? extends T> messages) {
+                axonConfiguration.tags();
                 return (index, message) -> {
                     invocation.countDown();
                     handlingOutcome.add(name + ": " + message);
@@ -595,6 +635,7 @@ class InterceptorConfigurationTest {
             }
         }
     }
+
     static class SlimMessageInterceptorContext {
 
         @Bean


### PR DESCRIPTION
closes #3283 
