### PR TITLE
[#3067] Introduce `MessageStream` `Single` and `Empty` interfaces

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -180,7 +180,7 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                 .criteria()
                 .stream()
                 .map(criteria -> this.eventsForCriteria(condition, criteria))
-                .reduce(MessageStream.empty(), MessageStream::concatWith);
+                .reduce(MessageStream.emptyOfType(), MessageStream::concatWith);
 
         AtomicReference<ConsistencyMarker> consistencyMarker = new AtomicReference<>();
         return resultingStream.map(e -> {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/LegacyAxonServerEventStorageEngine.java
@@ -180,7 +180,7 @@ public class LegacyAxonServerEventStorageEngine implements AsyncEventStorageEngi
                 .criteria()
                 .stream()
                 .map(criteria -> this.eventsForCriteria(condition, criteria))
-                .reduce(MessageStream.emptyOfType(), MessageStream::concatWith);
+                .reduce(MessageStream.empty().cast(), MessageStream::concatWith);
 
         AtomicReference<ConsistencyMarker> consistencyMarker = new AtomicReference<>();
         return resultingStream.map(e -> {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -70,11 +70,11 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static java.util.Objects.*;
-import static org.axonframework.common.BuilderUtils.*;
+import static java.util.Objects.requireNonNull;
+import static org.axonframework.common.BuilderUtils.assertPositive;
+import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils.*;
-import static org.axonframework.eventsourcing.eventstore.LegacyAggregateBasedEventStorageEngineUtils.resolveAggregateIdentifier;
 
 
 /**
@@ -270,7 +270,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                 .criteria()
                 .stream()
                 .map(criteria -> this.eventsForCriteria(condition, criteria))
-                .reduce(MessageStream.emptyOfType(), MessageStream::concatWith);
+                .reduce(MessageStream.empty().cast(), MessageStream::concatWith);
 
         var consistencyMarker = new AtomicReference<ConsistencyMarker>();
         return allCriteriaStream.map(e -> {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -270,7 +270,7 @@ public class LegacyJpaEventStorageEngine implements AsyncEventStorageEngine {
                 .criteria()
                 .stream()
                 .map(criteria -> this.eventsForCriteria(condition, criteria))
-                .reduce(MessageStream.empty(), MessageStream::concatWith);
+                .reduce(MessageStream.emptyOfType(), MessageStream::concatWith);
 
         var consistencyMarker = new AtomicReference<ConsistencyMarker>();
         return allCriteriaStream.map(e -> {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -96,7 +96,7 @@ class DefaultEventStoreTransactionTest {
             awaitCompletion(uow.execute());
 
             // then
-            assertNull(beforeCommitEvents.get().firstAsCompletableFuture().join());
+            assertNull(beforeCommitEvents.get().first().asCompletableFuture().join());
             StepVerifier.create(afterCommitEvents.get().asFlux())
                         .assertNext(entry -> assertTagsPositionAndEvent(entry, eventCriteria, 0, event1))
                         .assertNext(entry -> assertTagsPositionAndEvent(entry, eventCriteria, 1, event2))

--- a/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ public class SimpleCommandBus implements CommandBus {
         AsyncUnitOfWork unitOfWork = new AsyncUnitOfWork(command.getIdentifier(), worker);
         processingLifecycleHandlerRegistrars.forEach(it -> it.registerHandlers(unitOfWork));
 
-        var result = unitOfWork.executeWithResult(c -> handler.handle(command, c).firstAsCompletableFuture());
+        var result = unitOfWork.executeWithResult(c -> handler.handle(command, c).first().asCompletableFuture());
         if (logger.isDebugEnabled()) {
             result = result.whenComplete((r, e) -> {
                 if (e == null) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/retry/RetryingCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import org.axonframework.messaging.MessageStream.Entry;
 import org.axonframework.messaging.retry.RetryScheduler;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static org.axonframework.common.FutureUtils.unwrap;
 
@@ -71,7 +71,7 @@ public class RetryingCommandBus implements CommandBus {
                                                        ProcessingContext processingContext,
                                                        Throwable e) {
         return retryScheduler.scheduleRetry(command, processingContext, e, this::redispatch)
-                             .firstAsCompletableFuture()
+                             .first().asCompletableFuture()
                              .thenApply(Entry::message);
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -172,7 +172,8 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
                      .ifPresent(messageHandlingMember -> messageHandlingMember.handle(resetMessage,
                                                                                       processingContext,
                                                                                       annotatedEventListener)
-                                                                              .firstAsCompletableFuture()
+                                                                              .first()
+                                                                              .asCompletableFuture()
                                                                               .join());
         } catch (Exception e) {
             throw new ResetNotSupportedException("An Error occurred while notifying handlers of the reset", e);

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -110,8 +110,14 @@ class CompletionCallbackMessageStream<M extends Message<?>> extends DelegatingMe
                        });
     }
 
-    static class Single<M extends Message<?>> extends CompletionCallbackMessageStream<M> implements
-            MessageStream.Single<M> {
+    /**
+     * A {@link CompletionCallbackMessageStream} implementation completing on only the first
+     * {@link org.axonframework.messaging.MessageStream.Entry} of this stream.
+     *
+     * @param <M> The type of {@link Message} contained in the {@link Entry} of this stream.
+     */
+    static class Single<M extends Message<?>> extends CompletionCallbackMessageStream<M>
+            implements MessageStream.Single<M> {
 
         /**
          * Construct a {@link MessageStream stream} invoking the given {@code completeHandler} when the given
@@ -126,8 +132,14 @@ class CompletionCallbackMessageStream<M extends Message<?>> extends DelegatingMe
         }
     }
 
-    static class Empty<M extends Message<?>> extends CompletionCallbackMessageStream<M> implements
-            MessageStream.Empty<M> {
+    /**
+     * A {@link CompletionCallbackMessageStream} implementation completing on no
+     * {@link org.axonframework.messaging.MessageStream.Entry} of this stream.
+     *
+     * @param <M> The type of {@link Message} for the empty {@link Entry} of this stream.
+     */
+    static class Empty<M extends Message<?>> extends CompletionCallbackMessageStream<M>
+            implements MessageStream.Empty<M> {
 
         /**
          * Construct a {@link MessageStream stream} invoking the given {@code completeHandler} when the given

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,16 +56,6 @@ class CompletionCallbackMessageStream<M extends Message<?>> extends DelegatingMe
     }
 
     @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
-        return delegate.firstAsCompletableFuture()
-                       .whenComplete((result, exception) -> {
-                           if (exception == null) {
-                               completeHandler.run();
-                           }
-                       });
-    }
-
-    @Override
     public Flux<Entry<M>> asFlux() {
         return delegate.asFlux()
                        .doOnComplete(completeHandler);
@@ -103,7 +93,7 @@ class CompletionCallbackMessageStream<M extends Message<?>> extends DelegatingMe
     @Override
     public boolean hasNextAvailable() {
         boolean b = delegate.hasNextAvailable();
-        if (!b) {
+        if (!b && delegate().isCompleted()) {
             invokeOnCompleted();
         }
         return b;
@@ -118,5 +108,37 @@ class CompletionCallbackMessageStream<M extends Message<?>> extends DelegatingMe
                                completeHandler.run();
                            }
                        });
+    }
+
+    static class Single<M extends Message<?>> extends CompletionCallbackMessageStream<M> implements
+            MessageStream.Single<M> {
+
+        /**
+         * Construct a {@link MessageStream stream} invoking the given {@code completeHandler} when the given
+         * {@code delegate} completes.
+         *
+         * @param delegate        The {@link MessageStream stream} that once completed results in the invocation of the
+         *                        given {@code completeHandler}.
+         * @param completeHandler The {@link Runnable} to invoke when the given {@code delegate} completes.
+         */
+        Single(@Nonnull MessageStream.Single<M> delegate, @Nonnull Runnable completeHandler) {
+            super(delegate, completeHandler);
+        }
+    }
+
+    static class Empty<M extends Message<?>> extends CompletionCallbackMessageStream<M> implements
+            MessageStream.Empty<M> {
+
+        /**
+         * Construct a {@link MessageStream stream} invoking the given {@code completeHandler} when the given
+         * {@code delegate} completes.
+         *
+         * @param delegate        The {@link MessageStream stream} that once completed results in the invocation of the
+         *                        given {@code completeHandler}.
+         * @param completeHandler The {@link Runnable} to invoke when the given {@code delegate} completes.
+         */
+        Empty(@Nonnull MessageStream.Empty<M> delegate, @Nonnull Runnable completeHandler) {
+            super(delegate, completeHandler);
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,15 +51,6 @@ class ConcatenatingMessageStream<M extends Message<?>> implements MessageStream<
                                @Nonnull MessageStream<M> second) {
         this.first = first;
         this.second = second;
-    }
-
-    @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
-        return first.firstAsCompletableFuture()
-                    .thenCompose(message -> message == null
-                            ? second.firstAsCompletableFuture()
-                            : CompletableFuture.completedFuture(message)
-                    );
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -142,15 +142,39 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
         return delegate.thenCompose(delegateStream -> delegateStream.reduce(identity, accumulator));
     }
 
+    /**
+     * An implementation of the {@link DelayedMessageStream} that expects a message stream with only a
+     * {@link org.axonframework.messaging.MessageStream.Single entry}.
+     *
+     * @param <M> The type of {@link Message} contained in the {@link Entry} of this stream.
+     */
     static class Single<M extends Message<?>> extends DelayedMessageStream<M> implements MessageStream.Single<M> {
 
+        /**
+         * Construct a {@code DelayedMessageStream.Single} for the given {@code delegate}.
+         *
+         * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream.Single stream} to
+         *                 delegate to when it becomes available.
+         */
         Single(@Nonnull CompletableFuture<MessageStream.Single<M>> delegate) {
             super(delegate);
         }
     }
 
+    /**
+     * An implementation of the {@link DelayedMessageStream} that expects a message stream
+     * {@link org.axonframework.messaging.MessageStream.Empty without} any entry.
+     *
+     * @param <M> The type of {@link Message} for the empty {@link Entry} of this stream.
+     */
     static class Empty<M extends Message<?>> extends DelayedMessageStream<M> implements MessageStream.Empty<M> {
 
+        /**
+         * Construct a {@code DelayedMessageStream.Empty} for the given {@code delegate}.
+         *
+         * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream.Empty stream} to
+         *                 delegate to when it becomes available.
+         */
         Empty(@Nonnull CompletableFuture<MessageStream.Empty<M>> delegate) {
             super(delegate);
         }

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -58,7 +58,7 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
             @Nonnull CompletableFuture<MessageStream<M>> delegate) {
         CompletableFuture<MessageStream<M>> safeDelegate = delegate
                 .exceptionallyCompose(CompletableFuture::failedFuture)
-                .thenApply(ms -> Objects.requireNonNullElse(ms, EmptyMessageStream.instance()));
+                .thenApply(ms -> Objects.requireNonNullElse(ms, MessageStream.emptyOfType()));
         if (safeDelegate.isDone()) {
             try {
                 return delegate.get();

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -22,7 +22,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 
@@ -36,17 +38,18 @@ import java.util.function.BiFunction;
  */
 public class DelayedMessageStream<M extends Message<?>> implements MessageStream<M> {
 
-    private final CompletableFuture<MessageStream<M>> delegate;
+    private final CompletableFuture<? extends MessageStream<M>> delegate;
 
-    private DelayedMessageStream(@Nonnull CompletableFuture<MessageStream<M>> delegate) {
+    private DelayedMessageStream(@Nonnull CompletableFuture<? extends MessageStream<M>> delegate) {
         this.delegate = delegate;
     }
+
     /**
      * Creates a {@link MessageStream stream} that delays actions to its {@code delegate} when it becomes available.
      * <p>
      * If the given {@code delegate} has already {@link CompletableFuture#isDone() completed}, it returns the
-     * {@code MessageStream} immediately from it. Otherwise, it returns a DelayedMessageStream instance wrapping
-     * the given {@code delegate}.
+     * {@code MessageStream} immediately from it. Otherwise, it returns a DelayedMessageStream instance wrapping the
+     * given {@code delegate}.
      *
      * @param delegate A {@link CompletableFuture} providing access to the {@link MessageStream stream} to delegate to
      *                 when it becomes available.
@@ -55,14 +58,15 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
      * available.
      */
     public static <M extends Message<?>> MessageStream<M> create(
-            @Nonnull CompletableFuture<MessageStream<M>> delegate) {
+            @Nonnull CompletableFuture<? extends MessageStream<M>> delegate) {
         CompletableFuture<MessageStream<M>> safeDelegate = delegate
                 .exceptionallyCompose(CompletableFuture::failedFuture)
-                .thenApply(ms -> Objects.requireNonNullElse(ms, MessageStream.emptyOfType()));
+                .thenApply(ms -> Objects.requireNonNullElse(ms, MessageStream.empty().cast()));
         if (safeDelegate.isDone()) {
             try {
                 return delegate.get();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 return new DelayedMessageStream<>(safeDelegate);
             } catch (ExecutionException e) {
                 return MessageStream.failed(e.getCause());
@@ -72,18 +76,13 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
     }
 
     @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
-        return delegate.thenCompose(MessageStream::firstAsCompletableFuture);
-    }
-
-    @Override
     public Flux<Entry<M>> asFlux() {
         return Mono.fromFuture(delegate).flatMapMany(MessageStream::asFlux);
     }
 
     @Override
     public Optional<Entry<M>> next() {
-        if (delegate.isDone()) {
+        if (delegate.isDone() && !delegate.isCompletedExceptionally()) {
             return delegate.getNow(null).next();
         }
         return Optional.empty();
@@ -103,10 +102,15 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
     @Override
     public Optional<Throwable> error() {
         if (delegate.isDone()) {
-            if (delegate.isCompletedExceptionally()) {
+            if (delegate.isCompletedExceptionally() && !delegate.isCancelled()) {
+                // unfortunately, CompletableFuture's don't treat cancellations the same way as other exceptions
                 return Optional.of(delegate.exceptionNow());
             } else {
-                return delegate.getNow(null).error();
+                try {
+                    return delegate.getNow(null).error();
+                } catch (CancellationException | CompletionException e) {
+                    return Optional.of(e);
+                }
             }
         }
         return Optional.empty();
@@ -114,25 +118,41 @@ public class DelayedMessageStream<M extends Message<?>> implements MessageStream
 
     @Override
     public boolean isCompleted() {
-        return delegate.isDone() && delegate.getNow(null).isCompleted();
+        return delegate.isDone() && (delegate.isCompletedExceptionally() || delegate.getNow(null).isCompleted());
     }
 
     @Override
     public boolean hasNextAvailable() {
-        return delegate.isDone() && (delegate.isCompletedExceptionally() || delegate.getNow(null).hasNextAvailable());
+        return delegate.isDone() && !delegate.isCompletedExceptionally() && delegate.getNow(null).hasNextAvailable();
     }
 
     @Override
     public void close() {
-        if (!delegate.isDone()) {
-            delegate.cancel(false);
+        if (delegate.isDone()) {
+            if (!delegate.isCompletedExceptionally()) {
+                delegate.getNow(null).close();
+            }
         } else {
-            delegate.getNow(null).close();
+            delegate.cancel(false);
         }
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@Nonnull R identity, @Nonnull BiFunction<R, Entry<M>, R> accumulator) {
         return delegate.thenCompose(delegateStream -> delegateStream.reduce(identity, accumulator));
+    }
+
+    static class Single<M extends Message<?>> extends DelayedMessageStream<M> implements MessageStream.Single<M> {
+
+        Single(@Nonnull CompletableFuture<MessageStream.Single<M>> delegate) {
+            super(delegate);
+        }
+    }
+
+    static class Empty<M extends Message<?>> extends DelayedMessageStream<M> implements MessageStream.Empty<M> {
+
+        Empty(@Nonnull CompletableFuture<MessageStream.Empty<M>> delegate) {
+            super(delegate);
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -23,7 +23,6 @@ import reactor.core.publisher.Flux;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -33,12 +32,12 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class EmptyMessageStream implements MessageStream.Empty {
+class EmptyMessageStream implements MessageStream.Empty<Message<Void>> {
 
     private static final EmptyMessageStream INSTANCE = new EmptyMessageStream();
 
     private EmptyMessageStream() {
-        // No-arg constructor to enforce use of INSTANCE constant.
+        // Private no-arg constructor to enforce use of INSTANCE constant.
     }
 
     /**
@@ -46,12 +45,12 @@ class EmptyMessageStream implements MessageStream.Empty {
      *
      * @return The singular instance of the {@code EmptyMessageStream} to be used throughout.
      */
-    public static EmptyMessageStream instance() {
+    public static Empty<Message<Void>> instance() {
         return INSTANCE;
     }
 
     @Override
-    public CompletableFuture<Entry<Message<Void>>> firstAsCompletableFuture() {
+    public CompletableFuture<Entry<Message<Void>>> asCompletableFuture() {
         return FutureUtils.emptyCompletedFuture();
     }
 
@@ -91,41 +90,22 @@ class EmptyMessageStream implements MessageStream.Empty {
     }
 
     @Override
-    public <RM extends Message<?>> MessageStream<RM> map(@Nonnull Function<Entry<Message<Void>>, Entry<RM>> mapper) {
-        //noinspection unchecked
-        return (MessageStream<RM>) this;
-    }
-
-    @Override
-    public <R> CompletableFuture<R> reduce(@Nonnull R identity,
-                                           @Nonnull BiFunction<R, Entry<Message<Void>>, R> accumulator) {
+    public <R> CompletableFuture<R> reduce(@Nonnull R identity, @Nonnull BiFunction<R, Entry<Message<Void>>, R> accumulator) {
         return CompletableFuture.completedFuture(identity);
     }
 
     @Override
-    public MessageStream<Message<Void>> onNext(@Nonnull Consumer<Entry<Message<Void>>> onNext) {
+    public MessageStream<Message<Void>> onErrorContinue(@Nonnull Function<Throwable, MessageStream<Message<Void>>> onError) {
         return this;
     }
 
     @Override
-    public MessageStream<Message<Void>> onErrorContinue(
-            @Nonnull Function<Throwable, MessageStream<Message<Void>>> onError
-    ) {
-        return this;
-    }
-
-    @Override
-    public MessageStream<Message<Void>> whenComplete(@Nonnull Runnable completeHandler) {
+    public Empty<Message<Void>> whenComplete(@Nonnull Runnable completeHandler) {
         try {
             completeHandler.run();
             return this;
         } catch (Exception e) {
             return MessageStream.failed(e);
         }
-    }
-
-    @Override
-    public MessageStream<Message<Void>> concatWith(@Nonnull MessageStream<Message<Void>> other) {
-        return other;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -29,15 +29,13 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream stream} implementation that contains no {@link Entry entries} at all.
  *
- * @param <M> The type of {@link Message} contained in the {@link Entry entries} of this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
+class EmptyMessageStream implements MessageStream.Empty {
 
-    @SuppressWarnings("rawtypes")
-    private static final EmptyMessageStream INSTANCE = new EmptyMessageStream<>();
+    private static final EmptyMessageStream INSTANCE = new EmptyMessageStream();
 
     private EmptyMessageStream() {
         // No-arg constructor to enforce use of INSTANCE constant.
@@ -46,26 +44,24 @@ class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
     /**
      * Return a singular instance of the {@code EmptyMessageStream} to be used throughout.
      *
-     * @param <M> The type of {@link Message} contained in the {@link Entry entries} of this stream.
      * @return The singular instance of the {@code EmptyMessageStream} to be used throughout.
      */
-    public static <M extends Message<?>> EmptyMessageStream<M> instance() {
-        //noinspection unchecked
+    public static EmptyMessageStream instance() {
         return INSTANCE;
     }
 
     @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
+    public CompletableFuture<Entry<Message<Void>>> firstAsCompletableFuture() {
         return FutureUtils.emptyCompletedFuture();
     }
 
     @Override
-    public Flux<Entry<M>> asFlux() {
+    public Flux<Entry<Message<Void>>> asFlux() {
         return Flux.empty();
     }
 
     @Override
-    public Optional<Entry<M>> next() {
+    public Optional<Entry<Message<Void>>> next() {
         return Optional.empty();
     }
 
@@ -95,29 +91,31 @@ class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public <RM extends Message<?>> MessageStream<RM> map(@Nonnull Function<Entry<M>, Entry<RM>> mapper) {
+    public <RM extends Message<?>> MessageStream<RM> map(@Nonnull Function<Entry<Message<Void>>, Entry<RM>> mapper) {
         //noinspection unchecked
         return (MessageStream<RM>) this;
     }
 
     @Override
     public <R> CompletableFuture<R> reduce(@Nonnull R identity,
-                                           @Nonnull BiFunction<R, Entry<M>, R> accumulator) {
+                                           @Nonnull BiFunction<R, Entry<Message<Void>>, R> accumulator) {
         return CompletableFuture.completedFuture(identity);
     }
 
     @Override
-    public MessageStream<M> onNext(@Nonnull Consumer<Entry<M>> onNext) {
+    public MessageStream<Message<Void>> onNext(@Nonnull Consumer<Entry<Message<Void>>> onNext) {
         return this;
     }
 
     @Override
-    public MessageStream<M> onErrorContinue(@Nonnull Function<Throwable, MessageStream<M>> onError) {
+    public MessageStream<Message<Void>> onErrorContinue(
+            @Nonnull Function<Throwable, MessageStream<Message<Void>>> onError
+    ) {
         return this;
     }
 
     @Override
-    public MessageStream<M> whenComplete(@Nonnull Runnable completeHandler) {
+    public MessageStream<Message<Void>> whenComplete(@Nonnull Runnable completeHandler) {
         try {
             completeHandler.run();
             return this;
@@ -127,7 +125,7 @@ class EmptyMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public MessageStream<M> concatWith(@Nonnull MessageStream<M> other) {
+    public MessageStream<Message<Void>> concatWith(@Nonnull MessageStream<Message<Void>> other) {
         return other;
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 /**
  * A {@link MessageStream} implementation that completes exceptionally through the given {@code error}.
  *
- * @param <M> The type of {@link Message} contained in the {@link Entry entries} of this stream.
+ * @param <M> The type of {@link Message} for the empty {@link Entry} of this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
+class FailedMessageStream<M extends Message<?>> implements MessageStream.Empty<M> {
 
     private final Throwable error;
 
@@ -46,7 +46,7 @@ class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
+    public CompletableFuture<Entry<M>> asCompletableFuture() {
         return CompletableFuture.failedFuture(error);
     }
 
@@ -86,7 +86,7 @@ class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public <RM extends Message<?>> MessageStream<RM> map(@Nonnull Function<Entry<M>, Entry<RM>> mapper) {
+    public <RM extends Message<?>> Empty<RM> map(@Nonnull Function<Entry<M>, Entry<RM>> mapper) {
         //noinspection unchecked
         return (FailedMessageStream<RM>) this;
     }
@@ -98,7 +98,7 @@ class FailedMessageStream<M extends Message<?>> implements MessageStream<M> {
     }
 
     @Override
-    public MessageStream<M> whenComplete(@Nonnull Runnable completeHandler) {
+    public Empty<M> whenComplete(@Nonnull Runnable completeHandler) {
         return this;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,11 +57,6 @@ class FluxMessageStream<M extends Message<?>> implements MessageStream<M> {
      */
     FluxMessageStream(@Nonnull Flux<Entry<M>> source) {
         this.source = source;
-    }
-
-    @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
-        return source.singleOrEmpty().toFuture();
     }
 
     @Override
@@ -169,8 +164,4 @@ class FluxMessageStream<M extends Message<?>> implements MessageStream<M> {
         return new FluxMessageStream<>(source.onErrorResume(exception -> onError.apply(exception).asFlux()));
     }
 
-    @Override
-    public MessageStream<M> whenComplete(@Nonnull Runnable completeHandler) {
-        return new FluxMessageStream<>(source.doOnComplete(completeHandler));
-    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/IteratorMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/IteratorMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
-import org.axonframework.common.FutureUtils;
 
 import java.util.Iterator;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A {@link MessageStream} implementation using an {@link Iterator} as the source for {@link Entry entries}.
@@ -42,13 +40,6 @@ class IteratorMessageStream<M extends Message<?>> implements MessageStream<M> {
      */
     IteratorMessageStream(@Nonnull Iterator<? extends Entry<M>> source) {
         this.source = source;
-    }
-
-    @Override
-    public CompletableFuture<Entry<M>> firstAsCompletableFuture() {
-        return source.hasNext()
-                ? CompletableFuture.completedFuture(source.next())
-                : FutureUtils.emptyCompletedFuture();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
@@ -56,8 +56,8 @@ class MappedMessageStream<DM extends Message<?>, RM extends Message<?>> extends 
     }
 
     /**
-     * Extension of the MappedMessageStream that maps the entry in a single-value stream. This allows the wrapped stream
-     * to also implement {@link MessageStream.Single}.
+     * Extension of the {@code MappedMessageStream} that maps the entry in a single-value stream. This allows the
+     * wrapped stream to also implement {@link MessageStream.Single}.
      *
      * @param <DM> The type of {@link Message} contained in the {@link Entry entries} of this stream.
      * @param <RM> The type of {@link Message} contained in the {@link Entry} as a result of mapping.
@@ -66,12 +66,12 @@ class MappedMessageStream<DM extends Message<?>, RM extends Message<?>> extends 
             MessageStream.Single<RM> {
 
         /**
-         * Construct a {@link MessageStream stream} mapping the {@link Entry entries} of the given
-         * {@code delegate MessageStream} to entries containing {@link Message Messages} of type {@code RM}.
+         * Construct a {@link MessageStream stream} mapping only the first {@link Entry} of the given
+         * {@code delegate MessageStream} to an entry containing a {@link Message} of type {@code RM}.
          *
-         * @param delegate The {@link MessageStream stream} who's {@link Entry entries} are mapped with the given
-         *                 {@code mapper}.
-         * @param mapper   The {@link Function} mapping {@link Entry entries}.
+         * @param delegate The {@link MessageStream stream} from which only the first {@link Entry} is mapped with the
+         *                 given {@code mapper}.
+         * @param mapper   The {@link Function} mapping the first {@link Entry} from the given {@code delegate}.
          */
         Single(@Nonnull MessageStream.Single<DM> delegate, @Nonnull Function<Entry<DM>, Entry<RM>> mapper) {
             super(delegate, mapper);

--- a/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MappedMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,5 +55,26 @@ class MappedMessageStream<DM extends Message<?>, RM extends Message<?>> extends 
         return delegate.next().map(mapper);
     }
 
+    /**
+     * Extension of the MappedMessageStream that maps the entry in a single-value stream. This allows the wrapped stream
+     * to also implement {@link MessageStream.Single}.
+     *
+     * @param <DM> The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @param <RM> The type of {@link Message} contained in the {@link Entry} as a result of mapping.
+     */
+    static class Single<DM extends Message<?>, RM extends Message<?>> extends MappedMessageStream<DM, RM> implements
+            MessageStream.Single<RM> {
 
+        /**
+         * Construct a {@link MessageStream stream} mapping the {@link Entry entries} of the given
+         * {@code delegate MessageStream} to entries containing {@link Message Messages} of type {@code RM}.
+         *
+         * @param delegate The {@link MessageStream stream} who's {@link Entry entries} are mapped with the given
+         *                 {@code mapper}.
+         * @param mapper   The {@link Function} mapping {@link Entry entries}.
+         */
+        Single(@Nonnull MessageStream.Single<DM> delegate, @Nonnull Function<Entry<DM>, Entry<RM>> mapper) {
+            super(delegate, mapper);
+        }
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -533,10 +533,17 @@ public interface MessageStream<M extends Message<?>> {
             return map(e -> e.map(mapper));
         }
 
+        /**
+         * Creates a Mono that emits the element emitted by this stream and completes the same way (normally or with
+         * error) as this stream.
+         *
+         * @return a Mono that emits the same elements and completes the way this stream does.
+         */
         default Mono<Entry<M>> asMono() {
             return asFlux().singleOrEmpty();
         }
 
+        @Override
         default <R extends Message<?>> Single<R> cast() {
             //noinspection unchecked
             return (Single<R>) this;

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -260,7 +260,8 @@ public interface MessageStream<M extends Message<?>> {
 
     /**
      * Create a stream that carries no {@link Entry} and is considered to be successfully completed. The type of an
-     * empty stream is forced to a {@link Message} containing a {@link Void}.
+     * empty stream is forced to a {@link Message} containing a {@link Void}. To declare empty streams of another type,
+     * call {@link #cast()} on the returned Empty stream.
      * <p>
      * Any attempt to convert this stream to a component that requires an entry to be returned (such as
      * {@link CompletableFuture}), will have it return {@code null}.
@@ -335,6 +336,10 @@ public interface MessageStream<M extends Message<?>> {
     /**
      * Closes this stream, freeing any possible resources occupied by the underlying stream. After invocation, some
      * {@link Entry entries} may still be available for reading.
+     * <p>
+     * Implementations must always release resources when a stream is completed, either with an error or normally.
+     * Therefore, it is only required to {@code close()} a Stream if the consumer decides to not read until the end.
+     *
      */
     void close();
 

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStreamUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public abstract class MessageStreamUtils {
      * @return A {@code CompletableFuture} that completes with the first {@link MessageStream.Entry entry} from the
      * stream.
      */
-    public static <M extends Message<?>> CompletableFuture<MessageStream.Entry<M>> firstAsCompletableFuture(
+    public static <M extends Message<?>> CompletableFuture<MessageStream.Entry<M>> asCompletableFuture(
             @Nonnull MessageStream<M> source
     ) {
         FirstResult<M> firstResult = new FirstResult<>(source);

--- a/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnErrorContinueMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,4 +103,5 @@ class OnErrorContinueMessageStream<M extends Message<?>> implements MessageStrea
     public void close() {
         resolveCurrentDelegate().close();
     }
+
 }

--- a/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
@@ -57,15 +57,21 @@ class OnNextMessageStream<M extends Message<?>> extends DelegatingMessageStream<
         return next;
     }
 
+    /**
+     * An implementation of the {@link OnNextMessageStream} that expects a message stream with only a
+     * {@link org.axonframework.messaging.MessageStream.Single entry}.
+     *
+     * @param <M> The type of {@link Message} contained in the {@link Entry} of this stream.
+     */
     static class Single<M extends Message<?>> extends OnNextMessageStream<M> implements MessageStream.Single<M> {
 
         /**
-         * Construct an {@link MessageStream stream} that invokes the given {@code onNext} {@link Consumer} each time a
-         * new {@link Entry entry} is consumed by the given {@code delegate}.
+         * Construct an {@link MessageStream stream} that invokes the given {@code onNext} {@link Consumer} once, for
+         * when the first new {@link Entry entry} is consumed by the given {@code delegate}.
          *
-         * @param delegate The delegate {@link MessageStream stream} from which each consumed {@link Entry entry} is
+         * @param delegate The delegate {@link MessageStream stream} from which the first consumed {@link Entry} is
          *                 given to the {@code onNext} {@link Consumer}.
-         * @param onNext   The {@link Consumer} to handle each consumed {@link Entry entry} from the given
+         * @param onNext   The {@link Consumer} to handle the singular consumed {@link Entry} from the given
          *                 {@code delegate}.
          */
         Single(@Nonnull MessageStream.Single<M> delegate, @Nonnull Consumer<Entry<M>> onNext) {

--- a/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/OnNextMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,7 @@ class OnNextMessageStream<M extends Message<?>> extends DelegatingMessageStream<
      * @param onNext   The {@link Consumer} to handle each consumed {@link Entry entry} from the given
      *                 {@code delegate}.
      */
-    OnNextMessageStream(@Nonnull MessageStream<M> delegate,
-                        @Nonnull Consumer<Entry<M>> onNext) {
+    OnNextMessageStream(@Nonnull MessageStream<M> delegate, @Nonnull Consumer<Entry<M>> onNext) {
         super(delegate);
         this.delegate = delegate;
         this.onNext = onNext;
@@ -56,5 +55,21 @@ class OnNextMessageStream<M extends Message<?>> extends DelegatingMessageStream<
         Optional<Entry<M>> next = delegate.next();
         next.ifPresent(onNext);
         return next;
+    }
+
+    static class Single<M extends Message<?>> extends OnNextMessageStream<M> implements MessageStream.Single<M> {
+
+        /**
+         * Construct an {@link MessageStream stream} that invokes the given {@code onNext} {@link Consumer} each time a
+         * new {@link Entry entry} is consumed by the given {@code delegate}.
+         *
+         * @param delegate The delegate {@link MessageStream stream} from which each consumed {@link Entry entry} is
+         *                 given to the {@code onNext} {@link Consumer}.
+         * @param onNext   The {@link Consumer} to handle each consumed {@link Entry entry} from the given
+         *                 {@code delegate}.
+         */
+        Single(@Nonnull MessageStream.Single<M> delegate, @Nonnull Consumer<Entry<M>> onNext) {
+            super(delegate, onNext);
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
  * A {@link MessageStream} implementation using a single {@link Entry entry} or {@link CompletableFuture} completing to
  * an entry as the source.
  *
- * @param <M> The type of {@link Message} contained in the {@link Entry entries} of this stream.
+ * @param <M> The type of {@link Message} contained in the singular {@link Entry} of this stream.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 5.0.0

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.function.Function;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-class SingleValueMessageStream<M extends Message<?>> implements MessageStream<M> {
+class SingleValueMessageStream<M extends Message<?>> implements MessageStream.Single<M> {
 
     private final CompletableFuture<Entry<M>> source;
     private final AtomicBoolean read = new AtomicBoolean(false);

--- a/messaging/src/main/java/org/axonframework/messaging/TruncateFirstMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/TruncateFirstMessageStream.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+import jakarta.annotation.Nonnull;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class TruncateFirstMessageStream<M extends Message<?>> extends DelegatingMessageStream<M, M> implements MessageStream.Single<M> {
+
+    private final AtomicBoolean consumed = new AtomicBoolean(false);
+
+    /**
+     * Constructs the DelegatingMessageStream with given {@code delegate} to receive calls.
+     *
+     * @param delegate The instance to delegate calls to.
+     */
+    public TruncateFirstMessageStream(@Nonnull MessageStream<M> delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public Optional<Entry<M>> next() {
+        Optional<Entry<M>> next = delegate().next();
+        if (next.isPresent() && consumed.compareAndSet(false, true)) {
+            close();
+            return next;
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean hasNextAvailable() {
+        return !consumed.get() && super.hasNextAvailable();
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return consumed.get() || super.isCompleted();
+    }
+
+    @Override
+    public Optional<Throwable> error() {
+        return consumed.get() ? Optional.empty() : super.error();
+    }
+
+    @Override
+    public void onAvailable(@Nonnull Runnable callback) {
+        super.onAvailable(() -> {
+            if (!consumed.get()) {
+                callback.run();
+            }
+        });
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MethodInvokingMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MethodInvokingMessageHandlingMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public class MethodInvokingMessageHandlingMember<T> implements MessageHandlingMe
     @Override
     public Object handleSync(@Nonnull Message<?> message, T target) throws Exception {
         try {
-            return handle(message, ProcessingContext.NONE, target).firstAsCompletableFuture().get()
+            return handle(message, ProcessingContext.NONE, target).first().asCompletableFuture().get()
                                                                   .message().getPayload();
         } catch (ExecutionException e) {
             if (e.getCause() instanceof Exception ex) {

--- a/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
@@ -168,7 +168,7 @@ class InterceptingCommandBusTest {
                      "Expected command interceptors to be invoked in registered order");
 
         assertEquals(Map.of("handler1", "value-1", "handler2", "value-0"),
-                     result.firstAsCompletableFuture().get().message().getMetaData(),
+                     result.first().asCompletableFuture().get().message().getMetaData(),
                      "Expected result interceptors to be invoked in reverse order");
     }
 
@@ -183,8 +183,8 @@ class InterceptingCommandBusTest {
 
         ProcessingContext context = mock(ProcessingContext.class);
         var result = actualHandler.handle(testCommand, context);
-        assertTrue(result.firstAsCompletableFuture().isCompletedExceptionally());
-        assertInstanceOf(MockException.class, result.firstAsCompletableFuture().exceptionNow());
+        assertTrue(result.first().asCompletableFuture().isCompletedExceptionally());
+        assertInstanceOf(MockException.class, result.first().asCompletableFuture().exceptionNow());
 
         verify(handlerInterceptor1).interceptOnHandle(any(), eq(context), any());
         verify(handlerInterceptor2).interceptOnHandle(any(), eq(context), any());
@@ -209,7 +209,7 @@ class InterceptingCommandBusTest {
         ProcessingContext processingContext = mock(ProcessingContext.class);
         var result = actualHandler.handle(testCommand, processingContext);
 
-        assertTrue(result.firstAsCompletableFuture().isDone());
+        assertTrue(result.first().asCompletableFuture().isDone());
         verify(handlerInterceptor1).interceptOnHandle(any(), any(), any());
         verify(handlerInterceptor2, times(2)).interceptOnHandle(any(), any(), any());
         assertEquals(2, handledMessages.size());
@@ -219,7 +219,7 @@ class InterceptingCommandBusTest {
         assertEquals(Map.of("handler1", "value-0", "handler2", "value-1"),
                      handledMessages.get(1).getMetaData());
         assertEquals(Map.of("handler1", "value-1", "handler2", "value-0"),
-                     result.firstAsCompletableFuture().join().message().getMetaData());
+                     result.first().asCompletableFuture().join().message().getMetaData());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.messaging;
 
+import org.junit.jupiter.api.*;
+
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -33,6 +35,18 @@ class CompletionCallbackMessageStreamTest extends MessageStreamTest<Message<Stri
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
         return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(messages), NO_OP_COMPLETION_CALLBACK);
+    }
+
+    @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("CompletionCallbackMessageStream does not support explicit single-item streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("CompletionCallbackMessageStream does not support explicit zero-item streams");
+        return null;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.messaging;
 
+import org.junit.jupiter.api.*;
+
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -30,14 +32,26 @@ class ConcatenatingMessageStreamTest extends MessageStreamTest<Message<String>> 
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
         if (messages.isEmpty()) {
-            return new ConcatenatingMessageStream<>(MessageStream.emptyOfType(), MessageStream.emptyOfType());
+            return new ConcatenatingMessageStream<>(MessageStream.empty().cast(), MessageStream.empty().cast());
         } else if (messages.size() == 1) {
-            return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()), MessageStream.emptyOfType());
+            return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()), MessageStream.empty().cast());
         }
         return new ConcatenatingMessageStream<>(
                 MessageStream.just(messages.getFirst()),
                 MessageStream.fromIterable(messages.subList(1, messages.size()))
         );
+    }
+
+    @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("ConcatenatingMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("ConcatenatingMessageStream doesn't support explicitly empty streams");
+        return null;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
@@ -30,10 +30,9 @@ class ConcatenatingMessageStreamTest extends MessageStreamTest<Message<String>> 
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
         if (messages.isEmpty()) {
-            return new ConcatenatingMessageStream<>(MessageStream.empty(), MessageStream.empty());
+            return new ConcatenatingMessageStream<>(MessageStream.emptyOfType(), MessageStream.emptyOfType());
         } else if (messages.size() == 1) {
-            return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()),
-                                                    MessageStream.empty());
+            return new ConcatenatingMessageStream<>(MessageStream.just(messages.getFirst()), MessageStream.emptyOfType());
         }
         return new ConcatenatingMessageStream<>(
                 MessageStream.just(messages.getFirst()),

--- a/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
@@ -17,8 +17,7 @@
 package org.axonframework.messaging;
 
 import org.axonframework.messaging.MessageStream.Entry;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -37,6 +36,17 @@ class EmptyMessageStreamTest extends MessageStreamTest<Message<Void>> {
     @Override
     MessageStream<Message<Void>> completedTestSubject(List<Message<Void>> messages) {
         Assumptions.assumeTrue(messages.isEmpty(), "EmptyMessageStream doesn't support content");
+        return MessageStream.empty();
+    }
+
+    @Override
+    MessageStream.Single<Message<Void>> completedSingleStreamTestSubject(Message<Void> message) {
+        Assumptions.abort("EmptyMessageStream doesn't support content");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<Void>> completedEmptyStreamTestSubject() {
         return MessageStream.empty();
     }
 
@@ -62,7 +72,8 @@ class EmptyMessageStreamTest extends MessageStreamTest<Message<Void>> {
                                                                           invoked.set(true);
                                                                           return MessageStream.empty();
                                                                       })
-                                                                      .firstAsCompletableFuture();
+                                                                      .first()
+                                                                      .asCompletableFuture();
         assertTrue(result.isDone());
         assertNull(result.join());
         assertFalse(invoked.get());
@@ -76,7 +87,8 @@ class EmptyMessageStreamTest extends MessageStreamTest<Message<Void>> {
                                                         .whenComplete(() -> {
                                                             throw expected;
                                                         })
-                                                        .firstAsCompletableFuture()
+                                                        .first()
+                                                        .asCompletableFuture()
                                                         .thenApply(Entry::message);
 
         assertTrue(result.isCompletedExceptionally());

--- a/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,12 +57,12 @@ class EmptyMessageStreamTest extends MessageStreamTest<Message<Void>> {
     void doesNothingOnErrorContinue() {
         AtomicBoolean invoked = new AtomicBoolean(false);
 
-        CompletableFuture<Entry<Message<?>>> result = MessageStream.empty()
-                                                                   .onErrorContinue(e -> {
-                                                                       invoked.set(true);
-                                                                       return MessageStream.empty();
-                                                                   })
-                                                                   .firstAsCompletableFuture();
+        CompletableFuture<Entry<Message<Void>>> result = MessageStream.empty()
+                                                                      .onErrorContinue(e -> {
+                                                                          invoked.set(true);
+                                                                          return MessageStream.empty();
+                                                                      })
+                                                                      .firstAsCompletableFuture();
         assertTrue(result.isDone());
         assertNull(result.join());
         assertFalse(invoked.get());

--- a/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging;
 
-import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 
@@ -30,6 +30,18 @@ class FailedMessageStreamTest extends MessageStreamTest<Message<Void>> {
 
     @Override
     MessageStream<Message<Void>> completedTestSubject(List<Message<Void>> messages) {
+        Assumptions.abort("FailedMessageStream doesn't support successful streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Single<Message<Void>> completedSingleStreamTestSubject(Message<Void> message) {
+        Assumptions.abort("FailedMessageStream doesn't support successful streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<Void>> completedEmptyStreamTestSubject() {
         Assumptions.abort("FailedMessageStream doesn't support successful streams");
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
@@ -59,14 +59,13 @@ class FluxMessageStreamTest extends MessageStreamTest<Message<String>> {
         return MessageStream.fromFlux(Flux.fromIterable(messages).concatWith(
                 Flux.create(emitter -> completionMarker.whenComplete(
                         (v, e) -> {
-                            if (e
-                                    != null) {
-                                emitter.error(
-                                        e);
+                            if (e != null) {
+                                emitter.error(e);
                             } else {
                                 emitter.complete();
                             }
-                        }))));
+                        })))
+        );
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -40,10 +41,32 @@ class FluxMessageStreamTest extends MessageStreamTest<Message<String>> {
     }
 
     @Override
-    protected MessageStream<Message<String>> uncompletedTestSubject(List<Message<String>> messages) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages).concatWith(Flux.create(emitter -> {
-            // does nothing to keep it lingering
-        })));
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("FluxMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("FluxMessageStream doesn't support explicitly empty streams");
+        return null;
+    }
+
+
+    @Override
+    protected MessageStream<Message<String>> uncompletedTestSubject(List<Message<String>> messages,
+                                                                    CompletableFuture<Void> completionMarker) {
+        return MessageStream.fromFlux(Flux.fromIterable(messages).concatWith(
+                Flux.create(emitter -> completionMarker.whenComplete(
+                        (v, e) -> {
+                            if (e
+                                    != null) {
+                                emitter.error(
+                                        e);
+                            } else {
+                                emitter.complete();
+                            }
+                        }))));
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/IteratorMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/IteratorMessageStreamTest.java
@@ -35,6 +35,18 @@ class IteratorMessageStreamTest extends MessageStreamTest<Message<String>> {
     }
 
     @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("IteratorMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("IteratorMessageStream doesn't support explicitly empty streams");
+        return null;
+    }
+
+    @Override
     MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages,
                                                       Exception failure) {
         Assumptions.abort("IterableMessageStream doesn't support failures");

--- a/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging;
 
 import org.axonframework.messaging.MessageStream.Entry;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -34,7 +35,21 @@ class MappedMessageStreamTest extends MessageStreamTest<Message<String>> {
 
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
+        if (messages.size() == 1) {
+            return new MappedMessageStream.Single<>(MessageStream.just(messages.getFirst()), NO_OP_MAPPER);
+        }
         return new MappedMessageStream<>(MessageStream.fromIterable(messages), NO_OP_MAPPER);
+    }
+
+    @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        return new MappedMessageStream.Single<>(MessageStream.just(message), NO_OP_MAPPER);
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("MappedMessageStream does not support empty streams");
+        return null;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
@@ -52,8 +52,24 @@ public abstract class MessageStreamTest<M extends Message<?>> {
      */
     abstract MessageStream<M> completedTestSubject(List<M> messages);
 
+    /**
+     * Construct a test subject with a {@link MessageStream.Single single} entry using the given {@code message} as the
+     * source.
+     * <p>
+     * It is the task of the implementer of this method to map th {@code messages} to an {@link Entry} for the
+     * {@link MessageStream.Single stream} under test.
+     *
+     * @param message The {@link Message} of type {@code M} acting as the source for the
+     *                {@link MessageStream.Single single-entry-stream} under construction.
+     * @return A {@link MessageStream.Single single-entry-stream} to use for testing.
+     */
     abstract MessageStream.Single<M> completedSingleStreamTestSubject(M message);
 
+    /**
+     * Construct an {@link MessageStream.Empty empty} test subject.
+     *
+     * @return An {@link MessageStream.Empty empty stream} to use for testing.
+     */
     abstract MessageStream.Empty<M> completedEmptyStreamTestSubject();
 
     /**
@@ -69,9 +85,11 @@ public abstract class MessageStreamTest<M extends Message<?>> {
      */
     protected MessageStream<M> uncompletedTestSubject(List<M> messages, CompletableFuture<Void> completionMarker) {
         return completedTestSubject(messages)
-                .concatWith(DelayedMessageStream.create(completionMarker.thenApply(e -> MessageStream.empty())
-                                                                        .exceptionally(MessageStream::failed))
-                                                .cast());
+                .concatWith(
+                        DelayedMessageStream.create(completionMarker.thenApply(e -> MessageStream.empty())
+                                                                    .exceptionally(MessageStream::failed))
+                                            .cast()
+                );
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test suite used to validate implementations of the {@link MessageStream}.
@@ -51,9 +52,13 @@ public abstract class MessageStreamTest<M extends Message<?>> {
      */
     abstract MessageStream<M> completedTestSubject(List<M> messages);
 
+    abstract MessageStream.Single<M> completedSingleStreamTestSubject(M message);
+
+    abstract MessageStream.Empty<M> completedEmptyStreamTestSubject();
+
     /**
-     * Construct a test subject using the given {@code messages} as the source. The resulting stream should not report
-     * as completed if given messages are consumed.
+     * Construct a test subject using the given {@code messages} as the source. The resulting stream must not report as
+     * completed if given messages are consumed until the given {@code completionMarker} completes.
      * <p>
      * It is the task of the implementer of this method to map the {@code messages} to {@link Entry entries} for the
      * {@link MessageStream stream} under test.
@@ -62,8 +67,11 @@ public abstract class MessageStreamTest<M extends Message<?>> {
      *                 {@link MessageStream stream} under construction.
      * @return A {@link MessageStream stream} to use for testing.
      */
-    protected MessageStream<M> uncompletedTestSubject(List<M> messages) {
-        return completedTestSubject(messages).concatWith(MessageStream.fromFuture(new CompletableFuture<>()));
+    protected MessageStream<M> uncompletedTestSubject(List<M> messages, CompletableFuture<Void> completionMarker) {
+        return completedTestSubject(messages)
+                .concatWith(DelayedMessageStream.create(completionMarker.thenApply(e -> MessageStream.empty())
+                                                                        .exceptionally(MessageStream::failed))
+                                                .cast());
     }
 
     /**
@@ -123,8 +131,17 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
-    void shouldNotInvokeOnAvailableCallbackWhenNotCompleted() {
-        MessageStream<M> testSubject = uncompletedTestSubject(List.of());
+    void shouldReturnEmptyNextAndNoAvailableMessagesOnError() {
+        MessageStream<M> testSubject = failingTestSubject(List.of(), new RuntimeException("Oops"));
+
+        assertFalse(testSubject.hasNextAvailable());
+        assertFalse(testSubject.next().isPresent());
+        assertTrue(testSubject.isCompleted());
+    }
+
+    @Test
+    void shouldNotInvokeOnAvailableCallbackUntilCompleted() {
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(), new CompletableFuture<>());
 
         AtomicBoolean invoked = new AtomicBoolean(false);
         testSubject.onAvailable(() -> invoked.set(true));
@@ -133,8 +150,90 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
+    void shouldInvokeCompletionCallbackWhenNextIsRequestedAfterCompletion() {
+        CompletableFuture<Void> completionMarker = new CompletableFuture<>();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(), completionMarker)
+                .whenComplete(() -> invoked.set(true));
+
+
+        while (testSubject.next().isPresent()) {
+            assertFalse(invoked.get());
+        }
+
+        completionMarker.complete(null);
+
+        assertFalse(testSubject.next().isPresent());
+        assertTrue(invoked.get());
+    }
+
+    @Test
+    void shouldInvokeCompletionCallbackWhenOnAvailableIsRequestedAfterCompletion() {
+        CompletableFuture<Void> completionMarker = new CompletableFuture<>();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(), completionMarker)
+                .whenComplete(() -> invoked.set(true));
+
+        while (testSubject.hasNextAvailable()) {
+            assertFalse(invoked.get());
+            testSubject.next();
+        }
+
+        completionMarker.complete(null);
+        // streams _may_ notify their listeners at this point
+
+        assertFalse(testSubject.hasNextAvailable());
+
+        assertTrue(invoked.get());
+    }
+
+    @Test
+    void shouldInvokeCompletionCallbackOnceAllMessagesHaveBeenConsumed() {
+        CompletableFuture<Void> completionMarker = new CompletableFuture<>();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage()), completionMarker)
+                .whenComplete(() -> invoked.set(true));
+
+        completionMarker.complete(null);
+        // streams _must not_ have notified their listeners at this point
+        assertFalse(invoked.get());
+
+        testSubject.next();
+        // consuming the last message must not trigger the completion callback. The next interaction with the stream will.
+
+        assertFalse(invoked.get());
+
+        assertFalse(testSubject.hasNextAvailable());
+        assertTrue(invoked.get());
+    }
+
+    @Test
+    void shouldInvokeCompletionCallbackImmediatelyOnCompletedEmptyStream() {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        completedEmptyStreamTestSubject().whenComplete(() -> invoked.set(true));
+
+        assertTrue(invoked.get());
+    }
+
+    @Test
+    void shouldInvokeCompletionCallbackWhenStreamCompletesEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+
+        CompletableFuture<Void> completionMarker = new CompletableFuture<>();
+        uncompletedTestSubject(List.of(), completionMarker).whenComplete(() -> invoked.set(true));
+
+        assertFalse(invoked.get());
+        completionMarker.complete(null);
+        assertTrue(invoked.get());
+    }
+
+    @Test
     void shouldNotInvokeOnAvailableCallbackWhenNotCompletedAndAvailableMessageIsConsumed() {
-        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage()));
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage()),
+                                                              new CompletableFuture<>());
 
         assertTrue(testSubject.next().isPresent());
         assertFalse(testSubject.next().isPresent());
@@ -147,7 +246,8 @@ public abstract class MessageStreamTest<M extends Message<?>> {
 
     @Test
     void shouldNotInvokeOnAvailableCallbackWhenNotCompletedAndAvailableMessagesAreConsumed() {
-        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage(), createRandomMessage()));
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage(), createRandomMessage()),
+                                                              new CompletableFuture<>());
 
         assertTrue(testSubject.next().isPresent());
         assertTrue(testSubject.next().isPresent());
@@ -161,7 +261,8 @@ public abstract class MessageStreamTest<M extends Message<?>> {
 
     @Test
     void shouldInvokeOnAvailableCallbackWhenNotCompletedAndNotAllAvailableMessagesAreConsumed() {
-        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage(), createRandomMessage()));
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(createRandomMessage(), createRandomMessage()),
+                                                              new CompletableFuture<>());
 
         assertTrue(testSubject.next().isPresent());
 
@@ -175,7 +276,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     void shouldEmitOriginalExceptionAsFailure() {
         MessageStream<M> testSubject = failingTestSubject(List.of(), new MockException());
 
-        CompletableFuture<Entry<M>> actual = testSubject.firstAsCompletableFuture();
+        CompletableFuture<Entry<M>> actual = testSubject.first().asCompletableFuture();
 
         assertTrue(actual.isCompletedExceptionally());
         assertInstanceOf(MockException.class, actual.exceptionNow());
@@ -185,7 +286,16 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     void shouldCompleteWithNullOnEmptyList() {
         MessageStream<M> testSubject = completedTestSubject(Collections.emptyList());
 
-        CompletableFuture<Entry<M>> actual = testSubject.firstAsCompletableFuture();
+        CompletableFuture<Entry<M>> actual = testSubject.first().asCompletableFuture();
+
+        assertNull(actual.resultNow());
+    }
+
+    @Test
+    void shouldCompleteWithNullOnEmptyStream() {
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject();
+
+        CompletableFuture<Entry<M>> actual = testSubject.first().asCompletableFuture();
 
         assertNull(actual.resultNow());
     }
@@ -198,7 +308,22 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = completedTestSubject(List.of(in));
 
         var actual = testSubject.map(entry -> entry.map(input -> out))
-                                .firstAsCompletableFuture()
+                                .first().asCompletableFuture()
+                                .join()
+                                .message();
+
+        assertSame(out, actual);
+    }
+
+    @Test
+    void shouldMapSingleEntry_asCompletableFuture_ExplicitlyDeclaredSingle() {
+        M in = createRandomMessage();
+        M out = createRandomMessage();
+
+        MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
+
+        var actual = testSubject.map(entry -> entry.map(input -> out))
+                                .first().asCompletableFuture()
                                 .join()
                                 .message();
 
@@ -213,7 +338,22 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = completedTestSubject(List.of(in));
 
         var actual = testSubject.mapMessage(input -> out)
-                                .firstAsCompletableFuture()
+                                .first().asCompletableFuture()
+                                .join()
+                                .message();
+
+        assertSame(out, actual);
+    }
+
+    @Test
+    void shouldMapSingleMessage_asCompletableFuture_ExplicitlyDeclaredSingle() {
+        M in = createRandomMessage();
+        M out = createRandomMessage();
+
+        MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
+
+        var actual = testSubject.mapMessage(input -> out)
+                                .first().asCompletableFuture()
                                 .join()
                                 .message();
 
@@ -233,6 +373,18 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
+    void shouldMapSingleEntry_asMono() {
+        M in = createRandomMessage();
+        M out = createRandomMessage();
+
+        MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
+
+        StepVerifier.create(testSubject.map(entry -> entry.map(input -> out)).asMono())
+                    .expectNextMatches(entry -> entry.message().equals(out))
+                    .verifyComplete();
+    }
+
+    @Test
     void shouldMapSingleMessage_asFlux() {
         M in = createRandomMessage();
         M out = createRandomMessage();
@@ -240,6 +392,18 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = completedTestSubject(List.of(in));
 
         StepVerifier.create(testSubject.mapMessage(input -> out).asFlux())
+                    .expectNextMatches(entry -> entry.message().equals(out))
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldMapSingleMessage_asMono() {
+        M in = createRandomMessage();
+        M out = createRandomMessage();
+
+        MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
+
+        StepVerifier.create(testSubject.mapMessage(input -> out).asMono())
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .verifyComplete();
     }
@@ -314,7 +478,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                     return entry;
                 });
 
-        Entry<M> actual = testSubject.firstAsCompletableFuture().join();
+        Entry<M> actual = testSubject.first().asCompletableFuture().join();
 
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
         assertNull(actual, "Expected null value from empty stream");
@@ -330,7 +494,23 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                     return message;
                 });
 
-        Entry<M> actual = testSubject.firstAsCompletableFuture().join();
+        Entry<M> actual = testSubject.first().asCompletableFuture().join();
+
+        assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
+        assertNull(actual, "Expected null value from empty stream");
+    }
+
+    @Test
+    void shouldNotCallMapperForEmptyStream_asCompletableFuture_ExplicitlyDeclaredEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject()
+                .map(entry -> {
+                    invoked.set(true);
+                    return entry;
+                });
+
+        Entry<M> actual = testSubject.first().asCompletableFuture().join();
 
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
         assertNull(actual, "Expected null value from empty stream");
@@ -352,6 +532,36 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
+    void shouldNotCallMapperForEmptyStream_asFlux_ExplicitlyDeclaredEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject()
+                .map(entry -> {
+                    invoked.set(true);
+                    return entry;
+                });
+
+        StepVerifier.create(testSubject.asFlux())
+                    .verifyComplete();
+        assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
+    }
+
+    @Test
+    void shouldNotCallMapperForEmptyStream_asMono_ExplicitlyDeclaredEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject()
+                .map(entry -> {
+                    invoked.set(true);
+                    return entry;
+                });
+
+        StepVerifier.create(testSubject.asMono())
+                    .verifyComplete();
+        assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
+    }
+
+    @Test
     void shouldNotCallMessageMapperForEmptyStream_asFlux() {
         AtomicBoolean invoked = new AtomicBoolean();
 
@@ -367,6 +577,36 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
+    void shouldNotCallMessageMapperForEmptyStream_asFlux_ExplicitlyDeclaredEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject()
+                .mapMessage(message -> {
+                    invoked.set(true);
+                    return message;
+                });
+
+        StepVerifier.create(testSubject.asFlux())
+                    .verifyComplete();
+        assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
+    }
+
+    @Test
+    void shouldNotCallMessageMapperForEmptyStream_asMono_ExplicitlyDeclaredEmpty() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Empty<M> testSubject = completedEmptyStreamTestSubject()
+                .mapMessage(message -> {
+                    invoked.set(true);
+                    return message;
+                });
+
+        StepVerifier.create(testSubject.asMono())
+                    .verifyComplete();
+        assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
+    }
+
+    @Test
     void shouldNotCallMapperForFailedStream() {
         AtomicBoolean invoked = new AtomicBoolean();
 
@@ -376,7 +616,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                     return entry;
                 });
 
-        assertTrue(testSubject.firstAsCompletableFuture().isCompletedExceptionally());
+        assertTrue(testSubject.first().asCompletableFuture().isCompletedExceptionally());
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
 
@@ -390,7 +630,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                     return message;
                 });
 
-        assertTrue(testSubject.firstAsCompletableFuture().isCompletedExceptionally());
+        assertTrue(testSubject.first().asCompletableFuture().isCompletedExceptionally());
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
 
@@ -479,7 +719,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = completedTestSubject(List.of(expected));
 
         CompletableFuture<Entry<M>> result = testSubject.onNext(entry -> invoked.set(true))
-                                                        .firstAsCompletableFuture();
+                                                        .first().asCompletableFuture();
         assertTrue(result.isDone());
         assertEquals(expected, result.join().message());
         assertTrue(invoked.get());
@@ -512,7 +752,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                                assertEquals(expectedError, FutureUtils.unwrap(error));
                                return onErrorStream;
                            })
-                           .firstAsCompletableFuture();
+                           .first().asCompletableFuture();
 
         assertTrue(result.isDone());
         assertEquals(expected, result.join().message());
@@ -545,7 +785,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> firstStream = completedTestSubject(List.of(expected));
 
         CompletableFuture<Entry<M>> result = firstStream.concatWith(secondStream)
-                                                        .firstAsCompletableFuture();
+                                                        .first().asCompletableFuture();
         assertTrue(result.isDone());
         assertEquals(expected, result.join().message());
     }
@@ -558,7 +798,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> firstStream = completedTestSubject(List.of());
 
         CompletableFuture<Entry<M>> result = firstStream.concatWith(secondStream)
-                                                        .firstAsCompletableFuture();
+                                                        .first().asCompletableFuture();
         assertTrue(result.isDone());
         assertEquals(expected, result.join().message());
     }
@@ -584,7 +824,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = completedTestSubject(List.of());
 
         testSubject.whenComplete(() -> invoked.set(true))
-                   .firstAsCompletableFuture()
+                   .first().asCompletableFuture()
                    .join();
 
         assertTrue(invoked.get());
@@ -598,7 +838,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         MessageStream<M> testSubject = failingTestSubject(List.of(), expected);
 
         CompletableFuture<Entry<M>> result = testSubject.whenComplete(() -> invoked.set(true))
-                                                        .firstAsCompletableFuture();
+                                                        .first().asCompletableFuture();
         assertTrue(result.isCompletedExceptionally());
         assertEquals(expected, result.exceptionNow());
         assertFalse(invoked.get());
@@ -617,6 +857,19 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
+    void shouldInvokeCompletionCallback_asMono() {
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(createRandomMessage());
+
+        StepVerifier.create(testSubject.whenComplete(() -> invoked.set(true))
+                                       .asMono())
+                    .expectNextCount(1)
+                    .verifyComplete();
+        assertTrue(invoked.get());
+    }
+
+    @Test
     void shouldNotInvokeCompletionCallbackForFailedStream_asFlux() {
         AtomicBoolean invoked = new AtomicBoolean();
 
@@ -630,18 +883,17 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     }
 
     @Test
-    void shouldResultInFailedStreamWhenCompletionCallbackThrowsAnException_asCompletableFuture() {
-        RuntimeException expected = new RuntimeException("oops");
+    void shouldNotInvokeCompletionCallbackForFailedStream_asMono() {
+        AtomicBoolean invoked = new AtomicBoolean();
 
-        MessageStream<M> testSubject = completedTestSubject(List.of(createRandomMessage()));
+        RuntimeException oops = new RuntimeException("oops");
+        MessageStream<M> testSubject = failingTestSubject(List.of(), oops);
+        Assumptions.assumeTrue(testSubject instanceof MessageStream.Single<M>);
 
-        CompletableFuture<Entry<M>> result = testSubject.whenComplete(() -> {
-                                                            throw expected;
-                                                        })
-                                                        .firstAsCompletableFuture();
-
-        assertTrue(result.isCompletedExceptionally());
-        assertEquals(expected, result.exceptionNow());
+        StepVerifier.create(((MessageStream.Single<M>) testSubject).whenComplete(() -> invoked.set(true))
+                                                                   .asMono())
+                    .verifyErrorMatches(e -> e == oops);
+        assertFalse(invoked.get());
     }
 
     @Test
@@ -663,7 +915,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     void shouldInvokeCallbackOnceAdditionalMessagesBecomeAvailable() {
         AtomicBoolean invoked = new AtomicBoolean();
 
-        MessageStream<M> testSubject = uncompletedTestSubject(List.of());
+        MessageStream<M> testSubject = uncompletedTestSubject(List.of(), new CompletableFuture<>());
         testSubject.onAvailable(() -> invoked.set(true));
 
         assertFalse(invoked.get());
@@ -671,4 +923,35 @@ public abstract class MessageStreamTest<M extends Message<?>> {
         assertTrue(invoked.get());
     }
 
+    @Test
+    void shouldCallCloseWhenConsumingOnlyTheFirstMessage() {
+        //noinspection unchecked
+        MessageStream<M> mock = mock();
+        MessageStream<M> testSubject = completedTestSubject(List.of(createRandomMessage(),
+                                                                    createRandomMessage())).concatWith(mock);
+        MessageStream.Single<M> first = testSubject.first();
+        assertTrue(first.next().isPresent());
+        assertFalse(first.hasNextAvailable());
+        assertFalse(first.error().isPresent());
+        assertFalse(first.next().isPresent());
+        assertFalse(first.hasNextAvailable());
+        assertFalse(first.next().isPresent());
+        assertTrue(first.isCompleted());
+
+        verify(mock).close();
+    }
+
+    @Test
+    void shouldCallCloseWhenConsumingFirstAsCompletableFuture() {
+        //noinspection unchecked
+        MessageStream<M> mock = mock();
+        MessageStream<M> testSubject = completedTestSubject(List.of(createRandomMessage(),
+                                                                    createRandomMessage()))
+                .concatWith(mock);
+        CompletableFuture<Entry<M>> first = testSubject.first().asCompletableFuture();
+        assertTrue(first.isDone());
+        assertNotNull(first.getNow(null));
+
+        verify(mock).close();
+    }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
@@ -29,7 +29,8 @@ class OnErrorContinueMessageStreamTest extends MessageStreamTest<Message<String>
 
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
-        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages), error -> MessageStream.empty());
+        return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages),
+                                                  error -> MessageStream.emptyOfType());
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.messaging;
 
+import org.junit.jupiter.api.*;
+
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -30,7 +32,19 @@ class OnErrorContinueMessageStreamTest extends MessageStreamTest<Message<String>
     @Override
     MessageStream<Message<String>> completedTestSubject(List<Message<String>> messages) {
         return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages),
-                                                  error -> MessageStream.emptyOfType());
+                                                  error -> MessageStream.empty().cast());
+    }
+
+    @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("OnErrorContinueMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("OnErrorContinueMessageStream doesn't support explicitly empty streams");
+        return null;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -62,8 +62,8 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message<String>> {
     @Test
     void onNextNotInvokedOnEmptyStream() {
         //noinspection unchecked
-        Consumer<Entry<Message<?>>> handler = mock();
-        MessageStream<Message<?>> testSubject = MessageStream.empty().onNext(handler);
+        Consumer<Entry<Message<Void>>> handler = mock();
+        MessageStream<Message<Void>> testSubject = MessageStream.empty().onNext(handler);
 
         testSubject.firstAsCompletableFuture().isDone();
         verify(handler, never()).accept(any());

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -46,6 +46,17 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message<String>> {
     }
 
     @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        return new OnNextMessageStream.Single<>(MessageStream.just(message), NO_OP_ON_NEXT);
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("OnNextMessageStream does not support empty streams");
+        return null;
+    }
+
+    @Override
     MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages,
                                                       Exception failure) {
         return new OnNextMessageStream<>(MessageStream.fromIterable(messages)
@@ -65,7 +76,7 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message<String>> {
         Consumer<Entry<Message<Void>>> handler = mock();
         MessageStream<Message<Void>> testSubject = MessageStream.empty().onNext(handler);
 
-        testSubject.firstAsCompletableFuture().isDone();
+        testSubject.first().asCompletableFuture().isDone();
         verify(handler, never()).accept(any());
     }
 
@@ -77,7 +88,8 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message<String>> {
 
         CompletableFuture<Message<String>> actual = MessageStream.fromIterable(messages)
                                                                  .onNext(seen::add)
-                                                                 .firstAsCompletableFuture()
+                                                                 .first()
+                                                                 .asCompletableFuture()
                                                                  .thenApply(Entry::message);
 
         assertTrue(actual.isDone());

--- a/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class validating the {@link SingleValueMessageStream} through the {@link MessageStreamTest} suite.
@@ -37,6 +40,17 @@ class SingleValueMessageStreamTest extends MessageStreamTest<Message<String>> {
     }
 
     @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        return MessageStream.just(message);
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("DelayedMessageStream does not support empty streams");
+        return null;
+    }
+
+    @Override
     MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages,
                                                       Exception failure) {
         Assumptions.assumeTrue(messages.isEmpty(),
@@ -48,5 +62,45 @@ class SingleValueMessageStreamTest extends MessageStreamTest<Message<String>> {
     Message<String> createRandomMessage() {
         return new GenericMessage<>(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
+    }
+
+    @Test
+    void shouldReturnNextItemOnceWhenFutureCompletes() {
+        CompletableFuture<MessageStream.Entry<Message<?>>> future = new CompletableFuture<>();
+        SingleValueMessageStream<Message<?>> testSubject = new SingleValueMessageStream<>(future);
+
+        assertFalse(testSubject.hasNextAvailable());
+        assertFalse(testSubject.next().isPresent());
+
+        future.complete(new SimpleEntry<>(createRandomMessage()));
+
+        assertTrue(testSubject.hasNextAvailable());
+        assertTrue(testSubject.next().isPresent());
+        assertFalse(testSubject.hasNextAvailable());
+        assertFalse(testSubject.next().isPresent());
+    }
+
+    @Test
+    void shouldInvokeOnAvailableWhenFutureCompletes() {
+        CompletableFuture<MessageStream.Entry<Message<?>>> future = new CompletableFuture<>();
+        SingleValueMessageStream<Message<?>> testSubject = new SingleValueMessageStream<>(future);
+
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        testSubject.onAvailable(() -> invoked.set(true));
+
+        assertFalse(invoked.get());
+        future.complete(new SimpleEntry<>(createRandomMessage()));
+
+        assertTrue(invoked.get());
+    }
+
+    @Test
+    void closeCancelsTheCompletableFuture() {
+        CompletableFuture<MessageStream.Entry<Message<?>>> future = new CompletableFuture<>();
+        SingleValueMessageStream<Message<?>> testSubject = new SingleValueMessageStream<>(future);
+
+        testSubject.close();
+
+        assertTrue(future.isCancelled());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
@@ -36,6 +36,18 @@ class StreamMessageStreamTest extends MessageStreamTest<Message<String>> {
     }
 
     @Override
+    MessageStream.Single<Message<String>> completedSingleStreamTestSubject(Message<String> message) {
+        Assumptions.abort("StreamMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    MessageStream.Empty<Message<String>> completedEmptyStreamTestSubject() {
+        Assumptions.abort("StreamMessageStream doesn't support explicitly empty streams");
+        return null;
+    }
+
+    @Override
     MessageStream<Message<String>> failingTestSubject(List<Message<String>> messages,
                                                       Exception failure) {
         Assumptions.abort("StreamMessageStream doesn't support failures");

--- a/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
@@ -82,7 +82,7 @@ class AsyncRetrySchedulerTest {
         Message<Object> testMessage = new GenericMessage<>(TEST_TYPE, "stub");
         policyOutcome.set(RetryPolicy.Outcome.rescheduleIn(1, TimeUnit.SECONDS));
         RetryScheduler.Dispatcher<Message<Object>, Message<?>> dispatcher = mock();
-        when(dispatcher.dispatch(any(), any())).thenReturn(MessageStream.empty());
+        when(dispatcher.dispatch(any(), any())).thenReturn(MessageStream.emptyOfType());
 
         MessageStream<Message<?>> actual =
                 testSubject.scheduleRetry(testMessage, null, new MockException("Simulating exception"), dispatcher);
@@ -110,7 +110,7 @@ class AsyncRetrySchedulerTest {
         RetryScheduler.Dispatcher<Message<Object>, Message<?>> dispatcher = mock();
         when(dispatcher.dispatch(any(), any()))
                 .thenReturn(MessageStream.failed(new MockException("Repeated failure")))
-                .thenReturn(MessageStream.empty());
+                .thenReturn(MessageStream.emptyOfType());
 
         MessageStream<Message<?>> actual =
                 testSubject.scheduleRetry(testMessage, null, new MockException("Simulating exception"), dispatcher);

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/SpringBeanResolverFactoryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/SpringBeanResolverFactoryTest.java
@@ -20,10 +20,10 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.eventhandling.AnnotationEventHandlerAdapter;
 import org.axonframework.eventhandling.EventBus;
-import org.axonframework.eventhandling.annotation.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.SimpleEventBus;
+import org.axonframework.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream.Entry;
@@ -122,7 +122,8 @@ class SpringBeanResolverFactoryTest {
             CompletableFuture<Message<Void>> result =
                     new AnnotationEventHandlerAdapter(bean, parameterResolver, messageTypeResolver)
                             .handle(EVENT_MESSAGE, processingContext)
-                            .firstAsCompletableFuture()
+                            .first()
+                            .asCompletableFuture()
                             .thenApply(Entry::message);
             assertTrue(result.isCompletedExceptionally());
             assertThrows(FixtureExecutionException.class, () -> {
@@ -158,7 +159,8 @@ class SpringBeanResolverFactoryTest {
             CompletableFuture<Message<Void>> result =
                     new AnnotationEventHandlerAdapter(bean, parameterResolver, messageTypeResolver)
                             .handle(EVENT_MESSAGE, processingContext)
-                            .firstAsCompletableFuture()
+                            .first()
+                            .asCompletableFuture()
                             .thenApply(Entry::message);
             assertTrue(result.isCompletedExceptionally());
             assertThrows(FixtureExecutionException.class, () -> {
@@ -222,7 +224,8 @@ class SpringBeanResolverFactoryTest {
 
             // Spring dependency resolution will resolve at time of execution
             CompletableFuture<Message<Void>> result = adapter.handle(EVENT_MESSAGE, processingContext)
-                                                             .firstAsCompletableFuture()
+                                                             .first()
+                                                             .asCompletableFuture()
                                                              .thenApply(Entry::message);
             assertTrue(result.isCompletedExceptionally());
             assertThrows(NoUniqueBeanDefinitionException.class, () -> {


### PR DESCRIPTION
To enforce stronger typing on the `MessageStream`, it is beneficial if there is a known empty and single implementation of the `MessageStream`. 
To that end, this PR adds the `MessageStream.Empty` and `MessageStream.Single` interfaces.

Furthermore, the `EmptyMessageStream` now implements `MessageStream.Empty`, whereas the `SingleValueMessageStream` implements `MessageStream.Single`.
This thus also adjusts the `MessageStream#empty` and `MessageStream#just`/`MessageStream#fromFuture` methods to align with this change.

Additionally, I have added `MessageStream#emptyOfType`. This was necessary to keep allowing concatination of a `MessageStream` instance with an empty `MessageStream` while preserving the generic type.
This PR thus also adjusts usages of `MessageStream#empty` to `MessageStream#emptyOfType` when applicable to keep things working.
If you know a better name for this new method, I am all ears; I don't necessarily like the current choice.

Note that this PR can be regarded as a part of issue #3067, since it will allow a clearer definition of the `CommandHandler` and `EventHandler` interface that are introduced in #3247.