### PR TITLE
Fluent interface composition proposal for command handling components

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/AnnotationBasedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/AnnotationBasedCommandHandlingComponent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+
+import java.util.Set;
+
+public class AnnotationBasedCommandHandlingComponent<T> implements CommandHandlingComponent {
+
+    private AnnotationBasedCommandHandlingComponent(T instance) {
+        // Inspect methods
+    }
+
+    public static <T> AnnotationBasedCommandHandlingComponent<T> forInstance(T instance) {
+        return new AnnotationBasedCommandHandlingComponent<>(instance);
+    }
+
+    @Override
+    public Set<QualifiedName> supportedCommands() {
+        return Set.of();
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                   @Nonnull ProcessingContext context) {
+        return MessageStream.empty();
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * @author Allard Buijze
  * @since 0.5
  */
-public interface CommandBus extends CommandHandlerRegistry, DescribableComponent {
+public interface CommandBus extends CommandHandlerRegistry<CommandBus>, DescribableComponent {
 
     /**
      * Dispatch the given {@code command} to the {@link CommandHandler command handler}
@@ -71,7 +71,11 @@ public interface CommandBus extends CommandHandlerRegistry, DescribableComponent
      * @param handlingComponent The command handling component instance to subscribe with this bus.
      * @return This registry for fluent interfacing.
      */
-    default CommandHandlerRegistry subscribe(@Nonnull CommandHandlingComponent handlingComponent) {
+    default CommandBus subscribe(@Nonnull CommandHandlingComponent handlingComponent) {
         return subscribe(handlingComponent.supportedCommands(), handlingComponent);
+    }
+
+    default CommandBus self() {
+        return this;
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandHandlerRegistry.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandHandlerRegistry.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-public interface CommandHandlerRegistry {
+public interface CommandHandlerRegistry<SELF extends CommandHandlerRegistry<SELF>> {
 
     /**
      * Subscribe the given {@code handler} for {@link CommandMessage commands} of the given {@code names}.
@@ -45,10 +45,10 @@ public interface CommandHandlerRegistry {
      * @param commandHandler The handler instance that handles {@link CommandMessage commands} for the given names.
      * @return This registry for fluent interfacing.
      */
-    default CommandHandlerRegistry subscribe(@Nonnull Set<QualifiedName> names,
+    default SELF subscribe(@Nonnull Set<QualifiedName> names,
                                              @Nonnull CommandHandler commandHandler) {
         names.forEach(name -> subscribe(name, commandHandler));
-        return this;
+        return self();
     }
 
     /**
@@ -62,6 +62,8 @@ public interface CommandHandlerRegistry {
      * @param commandHandler The handler instance that handles {@link CommandMessage commands} for the given name.
      * @return This registry for fluent interfacing.
      */
-    CommandHandlerRegistry subscribe(@Nonnull QualifiedName name,
-                                     @Nonnull CommandHandler commandHandler);
+    SELF subscribe(@Nonnull QualifiedName name,
+                   @Nonnull CommandHandler commandHandler);
+
+    SELF self();
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/DefaultCommandHandlingComponent.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class DefaultCommandHandlingComponent implements
+        CommandHandlingComponent,
+        HierarchicalCommandHandlerRegistry<DefaultCommandHandlingComponent>,
+        DescribableComponent {
+
+    private final String name;
+    private final Map<QualifiedName, CommandHandler> commandHandlers = new HashMap<>();
+    private final Set<CommandHandlingComponent> subComponents = new HashSet<>();
+
+    public static DefaultCommandHandlingComponent forComponent(String name) {
+        return new DefaultCommandHandlingComponent(name);
+    }
+
+    private DefaultCommandHandlingComponent(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public DefaultCommandHandlingComponent subscribe(@Nonnull QualifiedName name,
+                                                     @Nonnull CommandHandler commandHandler) {
+        if (commandHandlers.containsKey(name)) {
+            // TODO: Duplicate handler resolver?
+            throw new IllegalArgumentException("CommandHandlerRegistry already contains a handler for " + name);
+        }
+        commandHandlers.put(name, commandHandler);
+        return this;
+    }
+
+    @Override
+    public DefaultCommandHandlingComponent subscribeChildHandlingComponent(
+            @Nonnull CommandHandlingComponent commandHandlingComponent) {
+        subComponents.add(commandHandlingComponent);
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                   @Nonnull ProcessingContext context) {
+        QualifiedName name = command.type().qualifiedName();
+        Optional<CommandHandlingComponent> optionalSubHandler = subComponents
+                .stream()
+                .filter(subComponent ->
+                                subComponent.supportedCommands().contains(name)
+                )
+                .findFirst();
+
+        if (optionalSubHandler.isPresent()) {
+            return optionalSubHandler.get().handle(command, context);
+        }
+
+
+        if (commandHandlers.containsKey(name)) {
+            return commandHandlers.get(name).handle(command, context);
+        }
+        return MessageStream.failed(new NoHandlerForCommandException(
+                "No handler was subscribed for command with qualified name[%s] on component [%s]".formatted(
+                        name.fullName(),
+                        this.getClass().getName()))
+        );
+    }
+
+    @Override
+    public DefaultCommandHandlingComponent self() {
+        return this;
+    }
+
+    @Override
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
+        descriptor.describeProperty("name", name);
+        descriptor.describeProperty("commandHandlers", commandHandlers);
+        subComponents.forEach(descriptor::describeWrapperOf);
+    }
+
+    @Override
+    public Set<QualifiedName> supportedCommands() {
+        var combinedNames = new HashSet<>(commandHandlers.keySet());
+        subComponents.forEach(subComponent -> combinedNames.addAll(subComponent.supportedCommands()));
+        return combinedNames;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/commandhandling/HierarchicalCommandHandlerRegistry.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/HierarchicalCommandHandlerRegistry.java
@@ -16,27 +16,26 @@
 
 package org.axonframework.commandhandling;
 
+import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.QualifiedName;
 
 import java.util.Set;
 
 /**
- * Interface describing a group of {@code CommandHandlers} belonging to a single component.
- * <p>
- * As such, it allows registration of {@code CommandHandlers} through the {@code CommandHandlerRegistry}. Besides
- * handling and registration, it specifies which {@link #supportedCommands() commands} it supports.
+ * Interface describing a registry of {@link CommandHandler command handlers}.
  *
  * @author Allard Buijze
- * @author Rene de Waele
+ * @author Gerard Klijs
+ * @author Milan Savic
+ * @author Mitchell Herrijgers
+ * @author Sara Pellegrini
  * @author Steven van Beelen
- * @since 3.0.0
+ * @since 5.0.0
  */
-public interface CommandHandlingComponent extends CommandHandler {
+public interface HierarchicalCommandHandlerRegistry<SELF extends HierarchicalCommandHandlerRegistry<SELF>>
+        extends CommandHandlerRegistry<SELF> {
 
-    /**
-     * All supported {@link CommandMessage commands}, referenced through a {@link QualifiedName}.
-     *
-     * @return All supported {@link CommandMessage commands}, referenced through a {@link QualifiedName}.
-     */
-    Set<QualifiedName> supportedCommands();
+    SELF subscribeChildHandlingComponent(@Nonnull CommandHandlingComponent commandHandlingComponent);
+
+    SELF self();
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandHandlingComponent.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-public class SimpleCommandHandlingComponent implements CommandHandlingComponent {
+public class SimpleCommandHandlingComponent implements CommandHandlingComponent, CommandHandlerRegistry<SimpleCommandHandlingComponent> {
 
     private final ConcurrentHashMap<QualifiedName, CommandHandler> commandHandlers;
 
@@ -55,17 +55,20 @@ public class SimpleCommandHandlingComponent implements CommandHandlingComponent 
         return handler.handle(command, context);
     }
 
-    @Override
     public SimpleCommandHandlingComponent subscribe(@Nonnull Set<QualifiedName> names,
                                                     @Nonnull CommandHandler handler) {
         names.forEach(name -> commandHandlers.put(name, Objects.requireNonNull(handler, "TODO")));
         return this;
     }
 
-    @Override
     public SimpleCommandHandlingComponent subscribe(@Nonnull QualifiedName name,
                                                     @Nonnull CommandHandler messageHandler) {
         return subscribe(Set.of(name), messageHandler);
+    }
+
+    @Override
+    public SimpleCommandHandlingComponent self() {
+        return this;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/commandhandling/annotation/AnnotationCommandHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/annotation/AnnotationCommandHandlerAdapter.java
@@ -110,14 +110,6 @@ public class AnnotationCommandHandlerAdapter<T> implements CommandHandlingCompon
         this.messageTypeResolver = requireNonNull(messageTypeResolver, "The MessageTypeResolver may not be null");
     }
 
-    @Override
-    public AnnotationCommandHandlerAdapter<T> subscribe(@Nonnull QualifiedName name,
-                                                        @Nonnull org.axonframework.commandhandling.CommandHandler commandHandler) {
-        throw new UnsupportedOperationException(
-                "This Command Handling Component does not support direct command handler registration."
-        );
-    }
-
     @Nonnull
     @Override
     public MessageStream<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,

--- a/messaging/src/main/java/org/axonframework/messaging/annotation2/AnnotatedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation2/AnnotatedCommandHandlingComponent.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation2;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.CommandHandlingComponent;
+import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.NoHandlerForCommandException;
+import org.axonframework.common.ReflectionUtils;
+import org.axonframework.common.annotation.AnnotationUtils;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComponent {
+
+    public static final Class<org.axonframework.commandhandling.annotation.CommandHandler> ANNOTATION_CLASS =
+            org.axonframework.commandhandling.annotation.CommandHandler.class;
+    private final T instance;
+    private final Map<QualifiedName, CommandHandler> commandHandlers = new HashMap<>();
+
+    public AnnotatedCommandHandlingComponent(T instance) {
+        this.instance = instance;
+        inspectComponent(instance);
+    }
+
+    private void inspectComponent(T instance) {
+        ReflectionUtils.methodsOf(instance.getClass())
+                       .forEach(this::registerPotentialCommandHandler);
+    }
+
+    private void registerPotentialCommandHandler(Method method) {
+        AnnotationUtils.findAnnotationAttributes(method, ANNOTATION_CLASS)
+                       .ifPresent(attributes -> {
+                           String commandName = requireNonNull(attributes.get("commandName").toString());
+                           QualifiedName qualifiedName = new QualifiedName(commandName);
+                           commandHandlers.put(qualifiedName, new MethodCommandHandler(instance, method));
+                       });
+    }
+
+    @Override
+    public Set<QualifiedName> supportedCommands() {
+        return commandHandlers.keySet();
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                   @Nonnull ProcessingContext context) {
+        var handler = commandHandlers.get(command.type().qualifiedName());
+        if (handler == null) {
+            return MessageStream.failed(new NoHandlerForCommandException(
+                    "No handler was subscribed for command with qualified name[%s] on component [%s]".formatted(
+                            command.type().qualifiedName().fullName(),
+                            instance.getClass().getName()))
+            );
+        }
+        return handler.handle(command, context);
+    }
+
+    static class MethodCommandHandler implements CommandHandler {
+
+        private final Object target;
+        private final Method method;
+
+        public MethodCommandHandler(Object target, Method method) {
+            this.target = target;
+            this.method = method;
+        }
+
+        @Override
+        public MessageStream<? extends CommandResultMessage<?>> handle(CommandMessage<?> commandMessage,
+                                                                       ProcessingContext processingContext) {
+            try {
+                Object result = method.invoke(target, commandMessage);
+                if (result instanceof MessageStream<?> resultStream) {
+                    return resultStream.mapMessage(r -> {
+                        if (r instanceof CommandResultMessage<?> cr) {
+                            return cr;
+                        }
+                        throw new IllegalArgumentException("Expected CommandResultMessage but got: " + r);
+                    });
+                }
+                return (MessageStream<? extends CommandResultMessage<?>>) result;
+            } catch (Exception e) {
+                return MessageStream.failed(e);
+            }
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/configuration/CommandModelComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/configuration/CommandModelComponent.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.configuration;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.CommandHandlerRegistry;
 import org.axonframework.commandhandling.CommandHandlingComponent;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
@@ -38,7 +39,8 @@ import java.util.Set;
  * @author Steven van Beelen
  * @since 5.0.0
  */
-public class CommandModelComponent implements CommandHandlingComponent, EventHandlingComponent {
+public class CommandModelComponent
+        implements CommandHandlingComponent, EventHandlingComponent, CommandHandlerRegistry<CommandModelComponent> {
 
     private final SimpleCommandHandlingComponent commandComponent;
     private final SimpleEventHandlingComponent eventComponent;
@@ -48,9 +50,13 @@ public class CommandModelComponent implements CommandHandlingComponent, EventHan
         this.eventComponent = new SimpleEventHandlingComponent();
     }
 
-    @Override
     public CommandModelComponent subscribe(@Nonnull QualifiedName name, @Nonnull CommandHandler commandHandler) {
         commandComponent.subscribe(name, commandHandler);
+        return this;
+    }
+
+    @Override
+    public CommandModelComponent self() {
         return this;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/configuration/MessageHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/configuration/MessageHandlingComponent.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.configuration;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.commandhandling.CommandHandlerRegistry;
 import org.axonframework.commandhandling.CommandHandlingComponent;
 import org.axonframework.common.CollectionUtils;
 import org.axonframework.eventhandling.EventHandler;
@@ -45,7 +46,8 @@ import java.util.Set;
  * @since 5.0.0
  */
 public interface MessageHandlingComponent
-        extends CommandHandlingComponent, EventHandlingComponent, QueryHandlingComponent, MessageHandler {
+        extends CommandHandlingComponent, CommandHandlerRegistry<MessageHandlingComponent>,
+        EventHandlingComponent, QueryHandlingComponent, MessageHandler {
 
     /**
      * Subscribe the given {@code handler} for {@link org.axonframework.messaging.Message messages} of the given
@@ -147,5 +149,10 @@ public interface MessageHandlingComponent
                                                                               supportedEvents(),
                                                                               HashSet::new);
         return CollectionUtils.merge(supportedCommandsAndEvents, supportedQueries(), HashSet::new);
+    }
+
+    @Override
+    default MessageHandlingComponent self() {
+        return this;
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/CommandHandlingComponentBuilderTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/CommandHandlingComponentBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.QualifiedName;
+import org.axonframework.messaging.annotation2.AnnotatedCommandHandlingComponent;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class CommandHandlingComponentBuilderTest {
+
+    @Test
+    void name() {
+        AtomicBoolean command1Handled = new AtomicBoolean(false);
+        AtomicBoolean command2HandledParent = new AtomicBoolean(false);
+        AtomicBoolean command2HandledChild = new AtomicBoolean(false);
+        AtomicBoolean command3Handled = new AtomicBoolean(false);
+
+        CommandHandlingComponent handlingComponent = DefaultCommandHandlingComponent
+                .forComponent("MySuperComponent")
+                // Method one, factory of CommandHandlingComponent
+                .subscribeChildHandlingComponent(
+                        // Third-level layer
+                        AnnotationBasedCommandHandlingComponentFactory
+                                .createHandlingComponent("MyAnnotatedCommandHandler", new MyAnnotatedCommandHandler())
+                )
+                // Method two, direct implementation of CommandHandlingComponent
+                .subscribeChildHandlingComponent(new AnnotatedCommandHandlingComponent<>(new MyAnnotatedCommandHandler()))
+                .subscribe(
+                        new QualifiedName("Command1"),
+                        (command, context) -> {
+                            command1Handled.set(true);
+                            return MessageStream.empty();
+                        }
+                )
+                // Second layer
+                .subscribeChildHandlingComponent(
+                        DefaultCommandHandlingComponent
+                                .forComponent("MySubComponent")
+                                .subscribe(
+                                        new QualifiedName("Command2"),
+                                        (command, context) -> {
+                                            command2HandledChild.set(true);
+                                            return MessageStream.empty();
+                                        }
+                                )
+                                .subscribe(
+                                        new QualifiedName("Command3"),
+                                        (command, context) -> {
+                                            command3Handled.set(true);
+                                            return MessageStream.empty();
+                                        }
+                                )
+                );
+
+        handlingComponent.handle(new GenericCommandMessage<>(new MessageType("Command1"), ""), ProcessingContext.NONE);
+        assertTrue(command1Handled.get());
+        assertFalse(command2HandledParent.get());
+        assertFalse(command2HandledChild.get());
+        assertFalse(command3Handled.get());
+
+        command1Handled.set(false);
+
+        handlingComponent.handle(new GenericCommandMessage<>(new MessageType("Command2"), ""), ProcessingContext.NONE);
+        assertFalse(command1Handled.get());
+        assertFalse(command2HandledParent.get());
+        assertTrue(command2HandledChild.get());
+        assertFalse(command3Handled.get());
+
+    }
+
+
+    class MyAnnotatedCommandHandler {
+
+        @org.axonframework.commandhandling.annotation.CommandHandler(commandName = "MyCommand")
+        public void handle(String command) {
+            // Bla
+        }
+    }
+
+
+    class AnnotationBasedCommandHandlingComponentFactory {
+        static <T> CommandHandlingComponent createHandlingComponent(String name, T instance) {
+            // Inspect
+            DefaultCommandHandlingComponent component = DefaultCommandHandlingComponent.forComponent(name);
+            // For every found handler, register. Might even use nesting here.
+            return component;
+        }
+    }
+
+}


### PR DESCRIPTION
Proposal for Slack discussion on how to proceed with definition of capabilities of components.

The existential question; is every `MessageHandlingComponent` a `MessageHandlerRegistry`? If so, it would expose the subscribe function on all handling components, even if they don't support it.

Just splitting interfaces would mean us losing the fluent interfacing in Java. This has been worked around by using Generics. 