### PR TITLE
Fix infinite event source call and missing ConsistencyMarker

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
@@ -74,4 +74,15 @@ public interface ConsistencyMarker {
      * @return a ConsistencyMarker that represents the upper bound of two other markers
      */
     ConsistencyMarker upperBound(ConsistencyMarker other);
+
+    /**
+     * Adds the given {@code consistencyMarker} to the given {@code context} using the {@link #RESOURCE_KEY}.
+     *
+     * @param context           The {@link Context} to add the given {@code token} to.
+     * @param consistencyMarker The {@code consistencyMarker} to add to the given {@code context} using the
+     *                          {@link #RESOURCE_KEY}.
+     */
+    static Context addToContext(Context context, ConsistencyMarker consistencyMarker) {
+        return context.withResource(RESOURCE_KEY, consistencyMarker);
+    }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/AsyncInMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/AsyncInMemoryEventStorageEngine.java
@@ -277,6 +277,7 @@ public class AsyncInMemoryEventStorageEngine implements AsyncEventStorageEngine 
                     Context context = Context.empty();
                     context = TrackingToken.addToContext(context, new GlobalSequenceTrackingToken(currentPosition));
                     context = Tag.addToContext(context, nextEvent.tags());
+                    context = ConsistencyMarker.addToContext(context, new GlobalIndexConsistencyMarker(end));
                     return Optional.of(new SimpleEntry<>(nextEvent.event(), context));
                 }
                 currentPosition = position.get();
@@ -287,7 +288,7 @@ public class AsyncInMemoryEventStorageEngine implements AsyncEventStorageEngine 
         @Override
         public void onAvailable(@Nonnull Runnable callback) {
             this.callback.set(callback);
-            if (eventStorage.containsKey(position.get())) {
+            if (eventStorage.isEmpty() || eventStorage.containsKey(position.get())) {
                 callback.run();
             }
         }


### PR DESCRIPTION
The AsyncInMemoryEventStorageEngine does not call the availability callback when starting a sourcing stream and the store is empty. This causes the stream to hang indefinitely when using normal `MessageStream` methods like `reduce` (which the `EventSourcingAsyncRepository` does).

To fix this, we now call the availability callback immediately when the store is empty. For flux this worked, because it called `hasNextAvailable`.

Additionally, the `Context` of the `EventMessage`s were missing the `ConsistencyMarker`, which caused always cause the marker to be origin, and any event to be appended a conflict when used in conjunction with the `EventSourcingAsyncRepository`.