### PR TITLE
Reset the `Coordinator's` processing gate if the `Coordinator` was aborted and rescheduled

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/Coordinator.java
@@ -1094,6 +1094,7 @@ class Coordinator {
                         } else {
                             logger.debug("Work packages have aborted successfully.");
                         }
+                        processingGate.set(false);
                         logger.debug("Scheduling new coordination task to run in {}ms", errorWaitBackOff);
                         // Construct a new CoordinationTask, thus abandoning the old task and it's progress entirely.
                         CoordinationTask task = new CoordinationTask();


### PR DESCRIPTION
The pooled event processor status is not reset to healthy when the connection to Axon Server was lost and recovered. 