### PR TITLE
Fix failing Spring Boot tests due to 4.11.x merge.

### DIFF
--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithEventSerializerPropertiesTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -55,7 +56,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @ContextConfiguration(classes = AxonAutoConfigurationWithEventSerializerPropertiesTest.TestContext.class)
 @EnableAutoConfiguration(exclude = {
         JmxAutoConfiguration.class,
-        WebClientAutoConfiguration.class
+        WebClientAutoConfiguration.class,
+        HttpMessageConvertersAutoConfiguration.class,
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/CBORMapperAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/CBORMapperAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -45,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         WebClientAutoConfiguration.class,
         DataSourceAutoConfiguration.class,
         JacksonAutoConfiguration.class,
+        HttpMessageConvertersAutoConfiguration.class,
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/ObjectMapperAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
@@ -43,7 +44,8 @@ import static org.junit.jupiter.api.Assertions.*;
         JmxAutoConfiguration.class,
         WebClientAutoConfiguration.class,
         DataSourceAutoConfiguration.class,
-        JacksonAutoConfiguration.class
+        JacksonAutoConfiguration.class,
+        HttpMessageConvertersAutoConfiguration.class,
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @TestPropertySource("classpath:application.serializertest.properties")

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleConfigTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleConfigTest.java
@@ -18,9 +18,9 @@ package org.axonframework.springboot.integration;
 
 import org.axonframework.config.EventProcessingModule;
 import org.axonframework.config.ProcessingGroup;
-import org.axonframework.eventhandling.annotation.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventProcessor;
+import org.axonframework.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.interceptors.CorrelationDataInterceptor;
 import org.axonframework.messaging.interceptors.LoggingInterceptor;
@@ -49,6 +49,8 @@ class EventProcessingModuleConfigTest {
     @BeforeEach
     void setUp() {
         testApplicationContext = new ApplicationContextRunner().withPropertyValues("axon.axonserver.enabled:false")
+                                                               // Exclude the timeout module, which adds an interceptor
+                                                               .withPropertyValues("axon.timeout.enabled:false")
                                                                .withUserConfiguration(TestContext.class);
     }
 


### PR DESCRIPTION
First, the HttpMessageConvertersAutoConfiguration autoconfiguration class requires a singular ObjectMapper bean because it imports JacksonHttpMessageConvertersConfiguration. It breaks, as there *are* two ObjectMapper implementations in the bean registry. As such, I have excluded this for a few tests.

Second and last, the assertion for the number of interceptors in the EventProcessingModuleConfigTest was wrong, as there is an additional interceptor added by the AxonTimeoutConfigurerModule introduced in 4.11. I have disabled the module adding this interceptor through a property.