### PR TITLE
Ignore aggregates that have been `AggregateLifecycle#markDeleted` when using the Create-if-missing policy.

### DIFF
--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.axonframework.test.aggregate;
 
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.eventsourcing.AggregateDeletedException;
 import org.axonframework.eventsourcing.EventSourcingHandler;
 import org.axonframework.modelling.command.AggregateCreationPolicy;
 import org.axonframework.modelling.command.AggregateIdentifier;
@@ -30,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
+import static org.axonframework.modelling.command.AggregateLifecycle.markDeleted;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -194,6 +196,14 @@ class FixtureTest_CreationPolicy {
                 .when(new AlwaysCreateWithoutResultCommand(AGGREGATE_ID, PUBLISH_EVENTS))
                 .expectEvents(new AlwaysCreatedEvent(AGGREGATE_ID))
                 .expectSuccessfulHandlerExecution();
+    }
+
+    @Test
+    void markedDeletedAggregateDoesNotAllowForCreateIfMissingButRethrowsAggregateDeletedException() {
+        fixture.given(new CreatedEvent(AGGREGATE_ID), new MarkedDeleted(AGGREGATE_ID))
+               .when(new CreateOrUpdateCommand(AGGREGATE_ID, PUBLISH_EVENTS))
+               .expectNoEvents()
+               .expectException(AggregateDeletedException.class);
     }
 
     private static class CreateCommand {
@@ -424,6 +434,19 @@ class FixtureTest_CreationPolicy {
         }
     }
 
+    private static class MarkedDeleted {
+
+        private final ComplexAggregateId id;
+
+        private MarkedDeleted(ComplexAggregateId id) {
+            this.id = id;
+        }
+
+        public ComplexAggregateId id() {
+            return id;
+        }
+    }
+
     @SuppressWarnings("unused")
     public static class TestAggregate {
 
@@ -497,6 +520,11 @@ class FixtureTest_CreationPolicy {
         @EventSourcingHandler
         public void on(AlwaysCreatedEvent event) {
             this.id = event.getId();
+        }
+
+        @EventSourcingHandler
+        public void on(MarkedDeleted event) {
+            markDeleted();
         }
     }
 


### PR DESCRIPTION
This pull request adjusts the `LockingRepository#doLoadOrCreate` by checking if it is handling with an exact match of the `AggregateNotFoundException`.
If we are not dealing with an exact match of the `AggregateNotFoundException` class, a `AggregateDeletedException` is being caught.

The `AggregateDeletedException` occurs whenever a subsequent command comes in for an aggregate that's been marked as deleted by the `AggregateLifecycle#markDeleted` operation.
If we react on this exception as if the aggregate does not exist, a `CREATE_IF_MISSING` command handling policy would, that moves through the `LockingRepository#doLoadOrCreate`, results in a subsequent failure as it thinks it can recreate the aggregate.
The subsequent failure would be a failure on inserting the event, as the `sequenceNumber` 1 is already in use.

Although ideally the `LockingRepository` would catch the `AggregateDeletedException` directly, it cannot as the `AggregateDeletedException` is an `axon-eventsourcing` concern.
Since the `LockingRepository` is an `axon-modelling` subject, it cannot access the `AggregateDeletedException` directly.
As such, I resorted to an exact-class match instead.

Furthermore, I added a test to validate that a create-if-missing operation on a marked deleted aggregate rethrows the `AggregateDeletedException`.

In doing so, this issue resolve #3323.