### PR TITLE
[#3171] Support `@CreationPolicy` annotated interface methods __again__

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,12 +204,14 @@ public class AggregateAnnotationCommandHandler<T> implements CommandMessageHandl
                 switch (policy.orElse(NEVER)) {
                     case ALWAYS:
                         messageHandler = new AlwaysCreateAggregateCommandHandler(
-                                handler, factoryPerType.get(handler.declaringClass())
+                                handler, Optional.ofNullable(factoryPerType.get(handler.declaringClass()))
+                                                 .orElse(factoryPerType.get(aggregateModel.entityClass()))
                         );
                         break;
                     case CREATE_IF_MISSING:
                         messageHandler = new AggregateCreateOrUpdateCommandHandler(
-                                handler, factoryPerType.get(handler.declaringClass())
+                                handler, Optional.ofNullable(factoryPerType.get(handler.declaringClass()))
+                                                 .orElse(factoryPerType.get(aggregateModel.entityClass()))
                         );
                         break;
                     case NEVER:

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AvroSerializerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AvroSerializerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,15 @@ import org.apache.avro.message.SchemaStore;
 import org.axonframework.spring.serialization.avro.AvroSchemaPackages;
 import org.axonframework.spring.serialization.avro.ClasspathAvroSchemaLoader;
 import org.axonframework.spring.serialization.avro.SpecificRecordBaseClasspathAvroSchemaLoader;
-import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.io.ResourceLoader;
@@ -51,6 +53,7 @@ public class AvroSerializerAutoConfiguration {
 
     /**
      * Constructs a simple default in-memory schema store filled with schemas.
+     *
      * @param schemas Avro schemas to put into the store.
      * @return schema store instance.
      */
@@ -63,8 +66,8 @@ public class AvroSerializerAutoConfiguration {
     }
 
     /**
-     * Scans classpath for schemas,
-     * configured using {@link org.axonframework.spring.serialization.avro.AvroSchemaScan} annotations.
+     * Scans classpath for schemas, configured using {@link org.axonframework.spring.serialization.avro.AvroSchemaScan}
+     * annotations.
      *
      * @param beanFactory  spring bean factory.
      * @param schemaLoader list of schema loaders.
@@ -72,7 +75,8 @@ public class AvroSerializerAutoConfiguration {
      */
     @Bean
     @Conditional({AvroConfiguredCondition.class})
-    public Set<Schema> collectAvroSchemasFromClassPath(BeanFactory beanFactory, List<ClasspathAvroSchemaLoader> schemaLoader) {
+    public Set<Schema> collectAvroSchemasFromClassPath(BeanFactory beanFactory,
+                                                       List<ClasspathAvroSchemaLoader> schemaLoader) {
         final List<String> packagesCandidates = AvroSchemaPackages.get(beanFactory).getPackages();
         final List<String> packagesToScan = new ArrayList<>();
         if (packagesCandidates.isEmpty() && AutoConfigurationPackages.has(beanFactory)) {
@@ -89,6 +93,7 @@ public class AvroSerializerAutoConfiguration {
 
     /**
      * Constructs default schema loader from Avro-Java-Maven-Generated classes.
+     *
      * @param resourceLoader resource loader.
      * @return ClasspathAvroSchemaLoader instance.
      */
@@ -135,7 +140,7 @@ public class AvroSerializerAutoConfiguration {
 
         @ConditionalOnMissingBean(SchemaStore.class)
         @SuppressWarnings("unused")
-        static class SchemaStoreIsMissingCondition{
+        static class SchemaStoreIsMissingCondition {
 
         }
     }

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CreationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -425,7 +425,7 @@ class FixtureTest_CreationPolicy {
     }
 
     @SuppressWarnings("unused")
-    public static class TestAggregate {
+    public static class TestAggregate implements TestAggregateInterface {
 
         @AggregateIdentifier
         private ComplexAggregateId id;
@@ -443,16 +443,14 @@ class FixtureTest_CreationPolicy {
             apply(new CreatedEvent(command.getId()));
         }
 
-        @CommandHandler
-        @CreationPolicy(AggregateCreationPolicy.CREATE_IF_MISSING)
+        @Override
         public void handle(CreateOrUpdateCommand command) {
             if (command.shouldPublishEvent()) {
                 apply(new CreatedOrUpdatedEvent(command.getId()));
             }
         }
 
-        @CommandHandler
-        @CreationPolicy(AggregateCreationPolicy.ALWAYS)
+        @Override
         public void handle(AlwaysCreateWithoutResultCommand command) {
             if (command.shouldPublishEvent()) {
                 apply(new AlwaysCreatedEvent(command.getId()));
@@ -498,6 +496,17 @@ class FixtureTest_CreationPolicy {
         public void on(AlwaysCreatedEvent event) {
             this.id = event.getId();
         }
+    }
+
+    public interface TestAggregateInterface {
+
+        @CommandHandler
+        @CreationPolicy(AggregateCreationPolicy.CREATE_IF_MISSING)
+        void handle(CreateOrUpdateCommand command);
+
+        @CommandHandler
+        @CreationPolicy(AggregateCreationPolicy.ALWAYS)
+        void handle(AlwaysCreateWithoutResultCommand command);
     }
 
     public static class TestAggregateWithPrivateNoArgConstructor {


### PR DESCRIPTION
With the effort to support the `@CreationPolicy` for polymorphic aggregates as requested in #3171, we accidentally removed support for these methods on aggregate interfaces.
This pull request resolves that misser by falling back to the `AggregateModel#entityClass` whenever the `factoryPerType` collection does not have a concrete factory for the given type.
This concrete factory can only not be found in case of interfaces, so moving up the model chain is a worthwhile solution to this issue.

I've tested the fall back to work by adjusting the creation policy test to have an interface for some of the `@CreationPolicy` annotated methods.
And, by not having the `@CreationPolicy` annotations on the concrete implementation.

As this issue originated from fixing #3171, we can regard it as if it should've been a part of this issue to begin with.