### PR TITLE
[#3073] Axon Framework 5 Test Fixture - Then phase splitted into assertions

### DIFF
--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
@@ -417,16 +417,16 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
         }
 
         @Override
-        public PublishedEventsAssertions publishedEvents() {
+        public PublishedEventsAssertions events() {
             return this;
         }
 
-        public DispatchedCommandsAssertions dispatchedCommands() {
+        public DispatchedCommandsAssertions commands() {
             return this;
         }
 
         @Override
-        public LastCommandResultAssertions commandResult() {
+        public LastCommandResultAssertions result() {
             return this;
         }
 

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
@@ -568,22 +568,25 @@ public interface AxonTestPhase {
          */
         Setup and();
 
-        default PublishedEventsAssertions publishedEvents(Consumer<PublishedEventsAssertions> assertions) {
-            var events = publishedEvents();
+        default PublishedEventsAssertions events(Consumer<PublishedEventsAssertions> assertions) {
+            var events = events();
             assertions.accept(events);
             return events;
         }
 
-        PublishedEventsAssertions publishedEvents();
+        PublishedEventsAssertions events();
 
-        default DispatchedCommandsAssertions dispatchedCommands(Consumer<DispatchedCommandsAssertions> assertions) {
-            var commands = dispatchedCommands();
+        default DispatchedCommandsAssertions commands(Consumer<DispatchedCommandsAssertions> assertions) {
+            var commands = commands();
             assertions.accept(commands);
             return commands;
         }
 
-        DispatchedCommandsAssertions dispatchedCommands();
+        DispatchedCommandsAssertions commands();
 
-        LastCommandResultAssertions commandResult();
+        /**
+         * Assert result of last command from the when phase.
+         */
+        LastCommandResultAssertions result();
     }
 }

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
@@ -386,142 +386,159 @@ public interface AxonTestPhase {
      */
     interface Then {
 
-        /**
-         * Expect the given set of events to have been published during the {@link When} phase.
-         * <p>
-         * All events are compared for equality using a shallow equals comparison on all the fields of the events. This
-         * means that all assigned values on the events' fields should have a proper equals implementation.
-         * <p>
-         * Note that the event identifier is ignored in the comparison.
-         *
-         * @param expectedEvents The expected events, in the exact order they are expected to be published.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then events(Object... expectedEvents);
+        interface PublishedEventsAssertions {
 
-        /**
-         * Expect the given set of event messages to have been published during the {@link When} phase.
-         * <p>
-         * All events are compared for equality using a shallow equals comparison on all the fields of the events. This
-         * means that all assigned values on the events' fields should have a proper equals implementation.
-         * Additionally, the metadata will be compared too.
-         * <p>
-         * Note that the event identifier is ignored in the comparison.
-         *
-         * @param expectedEvents The expected event messages, in the exact order they are expected to be published.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then events(EventMessage<?>... expectedEvents);
+            /**
+             * Expect the given set of events to have been published during the {@link When} phase.
+             * <p>
+             * All events are compared for equality using a shallow equals comparison on all the fields of the events.
+             * This means that all assigned values on the events' fields should have a proper equals implementation.
+             * <p>
+             * Note that the event identifier is ignored in the comparison.
+             *
+             * @param expectedEvents The expected events, in the exact order they are expected to be published.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            Then allOf(Object... expectedEvents);
 
-        /**
-         * Expect the published events during the {@link When} phase to match the given {@code matcher}.
-         * <p>
-         * Note: if no events were published, the matcher receives an empty List.
-         *
-         * @param matcher The matcher to match with the actually published events.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then events(Matcher<? extends List<? super EventMessage<?>>> matcher);
+            /**
+             * Expect the given set of event messages to have been published during the {@link When} phase.
+             * <p>
+             * All events are compared for equality using a shallow equals comparison on all the fields of the events.
+             * This means that all assigned values on the events' fields should have a proper equals implementation.
+             * Additionally, the metadata will be compared too.
+             * <p>
+             * Note that the event identifier is ignored in the comparison.
+             *
+             * @param expectedEvents The expected event messages, in the exact order they are expected to be published.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            Then allOf(EventMessage<?>... expectedEvents);
 
-        /**
-         * Expect no events to have been published during the {@link When} phase.
-         *
-         * @return the current Then instance, for fluent interfacing.
-         */
-        default Then noEvents() {
-            return events();
+            /**
+             * Expect the published events during the {@link When} phase to match the given {@code matcher}.
+             * <p>
+             * Note: if no events were published, the matcher receives an empty List.
+             *
+             * @param matcher The matcher to match with the actually published events.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            Then matches(Matcher<? extends List<? super EventMessage<?>>> matcher);
+
+            /**
+             * Expect no events to have been published during the {@link When} phase.
+             *
+             * @return the current Then instance, for fluent interfacing.
+             */
+            default Then none() {
+                return allOf();
+            }
+
+            Then then(); // or also/ andThen
         }
 
-        /**
-         * Expect a successful execution of the When phase, regardless of the actual return value.
-         *
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then success();
+        interface DispatchedCommandsAssertions {
 
-        /**
-         * Expect the last command handler from the When phase to return a result message that matches the given
-         * {@code matcher}. Take into account only commands executed explicitly with the {@link When#command}. Do not
-         * take into accounts commands published as side effects of the message handlers.
-         *
-         * @param matcher The matcher to verify the actual result message against.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then resultMessage(Matcher<? super CommandResultMessage<?>> matcher);
+            /**
+             * Expect the given set of commands to have been dispatched during the "when" phase.
+             * <p>
+             * All commands are compared for equality using a shallow equals comparison on all the fields of the
+             * commands. This means that all assigned values on the commands' fields should have a proper equals
+             * implementation.
+             *
+             * @param expectedCommands The expected commands, in the exact order they are expected to be dispatched.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            DispatchedCommandsAssertions commands(Object... expectedCommands);
 
-        /**
-         * Expect the last command handler from the When phase to return the given {@code expectedPayload} after
-         * execution. The actual and expected values are compared using their equals methods. Take into account only
-         * commands executed explicitly with the {@link When#command}. Do not take into accounts commands published as
-         * side effects of the message handlers.
-         *
-         * @param expectedPayload The expected result message payload of the command execution.
-         * @return the current Then, for fluent interfacing.
-         */
-        Then resultMessagePayload(Object expectedPayload);
+            /**
+             * Expect the given set of command messages to have been dispatched during the "when" phase.
+             * <p>
+             * All commands are compared for equality using a shallow equals comparison on all the fields of the
+             * commands. This means that all assigned values on the commands' fields should have a proper equals
+             * implementation. Additionally, the metadata will be compared too.
+             *
+             * @param expectedCommands The expected command messages, in the exact order they are expected to be
+             *                         dispatched.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            DispatchedCommandsAssertions commands(CommandMessage<?>... expectedCommands);
 
-        /**
-         * Expect the last command handler from the When phase to return a payload that matches the given
-         * {@code matcher} after execution. Take into account only commands executed explicitly with the
-         * {@link When#command}. Do not take into accounts commands published as side effects of the message handlers.
-         *
-         * @param matcher The matcher to verify the actual return value against.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then resultMessagePayloadMatching(Matcher<?> matcher);
+            /**
+             * Expect the given set of command messages to have been dispatched during the "when" phase. Only commands
+             * as a result of the event in the "when" phase of ths fixture are recorded.
+             *
+             * @return the current Then instance, for fluent interfacing.
+             */
+            DispatchedCommandsAssertions noCommands();
 
-        /**
-         * Expect the given {@code expectedException} to occur during the When phase execution. The actual exception
-         * should be exactly of that type, subclasses are not accepted. Take into account only commands executed
-         * explicitly with the {@link When#command}. Do not take into accounts commands published as side effects of the
-         * message handlers.
-         *
-         * @param expectedException The type of exception expected from the When phase execution.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then exception(Class<? extends Throwable> expectedException);
+            Then then(); // or also/ andThen
+        }
 
-        /**
-         * Expect an exception to occur during the When phase that matches with the given {@code matcher}. Take into
-         * account only commands executed explicitly with the {@link When#command}. Do not take into accounts commands
-         * published as side effects of the message handlers.
-         *
-         * @param matcher The matcher to validate the actual exception.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then exception(Matcher<?> matcher);
+        interface LastCommandResultAssertions {
 
-        /**
-         * Expect the given set of commands to have been dispatched during the "when" phase.
-         * <p>
-         * All commands are compared for equality using a shallow equals comparison on all the fields of the commands.
-         * This means that all assigned values on the commands' fields should have a proper equals implementation.
-         *
-         * @param expectedCommands The expected commands, in the exact order they are expected to be dispatched.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then commands(Object... expectedCommands);
+            /**
+             * Expect a successful execution of the When phase, regardless of the actual return value.
+             *
+             * @return the current Then instance, for fluent interfacing.
+             */
+            LastCommandResultAssertions isSuccess();
 
-        /**
-         * Expect the given set of command messages to have been dispatched during the "when" phase.
-         * <p>
-         * All commands are compared for equality using a shallow equals comparison on all the fields of the commands.
-         * This means that all assigned values on the commands' fields should have a proper equals implementation.
-         * Additionally, the metadata will be compared too.
-         *
-         * @param expectedCommands The expected command messages, in the exact order they are expected to be
-         *                         dispatched.
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then commands(CommandMessage<?>... expectedCommands);
+            /**
+             * Expect the last command handler from the When phase to return a result message that matches the given
+             * {@code matcher}. Take into account only commands executed explicitly with the {@link When#command}. Do
+             * not take into accounts commands published as side effects of the message handlers.
+             *
+             * @param matcher The matcher to verify the actual result message against.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            LastCommandResultAssertions isMessage(Matcher<? super CommandResultMessage<?>> matcher);
 
-        /**
-         * Expect the given set of command messages to have been dispatched during the "when" phase. Only commands as a
-         * result of the event in the "when" phase of ths fixture are recorded.
-         *
-         * @return the current Then instance, for fluent interfacing.
-         */
-        Then noCommands();
+            /**
+             * Expect the last command handler from the When phase to return the given {@code expectedPayload} after
+             * execution. The actual and expected values are compared using their equals methods. Take into account only
+             * commands executed explicitly with the {@link When#command}. Do not take into accounts commands published
+             * as side effects of the message handlers.
+             *
+             * @param expectedPayload The expected result message payload of the command execution.
+             * @return the current Then, for fluent interfacing.
+             */
+            LastCommandResultAssertions withPayload(Object expectedPayload);
+
+            /**
+             * Expect the last command handler from the When phase to return a payload that matches the given
+             * {@code matcher} after execution. Take into account only commands executed explicitly with the
+             * {@link When#command}. Do not take into accounts commands published as side effects of the message
+             * handlers.
+             *
+             * @param matcher The matcher to verify the actual return value against.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            LastCommandResultAssertions withPayload(Matcher<?> matcher);
+
+            /**
+             * Expect the given {@code expectedException} to occur during the When phase execution. The actual exception
+             * should be exactly of that type, subclasses are not accepted. Take into account only commands executed
+             * explicitly with the {@link When#command}. Do not take into accounts commands published as side effects of
+             * the message handlers.
+             *
+             * @param expectedException The type of exception expected from the When phase execution.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            LastCommandResultAssertions isException(Class<? extends Throwable> expectedException);
+
+            /**
+             * Expect an exception to occur during the When phase that matches with the given {@code matcher}. Take into
+             * account only commands executed explicitly with the {@link When#command}. Do not take into accounts
+             * commands published as side effects of the message handlers.
+             *
+             * @param matcher The matcher to validate the actual exception.
+             * @return the current Then instance, for fluent interfacing.
+             */
+            LastCommandResultAssertions isException(Matcher<?> matcher);
+
+            Then then(); // or also/ andThen
+        }
 
         /**
          * Returns to the setup phase to continue with additional test scenarios. This allows for chaining multiple test
@@ -550,5 +567,23 @@ public interface AxonTestPhase {
          * @return a {@link Setup} instance that allows configuring a new test scenario.
          */
         Setup and();
+
+        default PublishedEventsAssertions publishedEvents(Consumer<PublishedEventsAssertions> assertions) {
+            var events = publishedEvents();
+            assertions.accept(events);
+            return events;
+        }
+
+        PublishedEventsAssertions publishedEvents();
+
+        default DispatchedCommandsAssertions dispatchedCommands(Consumer<DispatchedCommandsAssertions> assertions) {
+            var commands = dispatchedCommands();
+            assertions.accept(commands);
+            return commands;
+        }
+
+        DispatchedCommandsAssertions dispatchedCommands();
+
+        LastCommandResultAssertions commandResult();
     }
 }

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
@@ -50,7 +50,7 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
@@ -65,7 +65,7 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
@@ -79,7 +79,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
@@ -93,7 +93,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .commandResult()
+               .result()
                .isSuccess();
     }
 
@@ -107,7 +107,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .commandResult()
+               .result()
                .isMessage(Matchers.nullValue());
     }
 
@@ -121,7 +121,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .commandResult()
+               .result()
                .isSuccess()
                .withPayload(new CommandResult("Result name-1"));
     }
@@ -137,10 +137,10 @@ class AxonTestFixtureMessagingTest {
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-2"))
                .then()
-               .commandResult()
+               .result()
                .withPayload(new CommandResult("Result name-2"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(
                        studentNameChangedEvent("my-studentId-1", "name-1", 1),
                        studentNameChangedEvent("my-studentId-1", "name-2", 1)
@@ -148,7 +148,7 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .then()
-               .commandResult()
+               .result()
                .isSuccess()
                .withPayload(new CommandResult("Result name-3"));
     }
@@ -182,7 +182,7 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 2));
     }
 
@@ -204,7 +204,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .event(new StudentNameChangedEvent("my-studentId-1", "name-1", 1))
                .then()
-               .dispatchedCommands()
+               .commands()
                .commands(new ChangeStudentNameCommand("id", "name"));
     }
 
@@ -227,7 +227,7 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .commandResult()
+               .result()
                .isException(RuntimeException.class);
     }
 

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
@@ -50,7 +50,8 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
     @Test
@@ -64,7 +65,8 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
     @Test
@@ -77,7 +79,8 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
     @Test
@@ -90,7 +93,8 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .success();
+               .commandResult()
+               .isSuccess();
     }
 
     @Test
@@ -103,8 +107,8 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .success()
-               .resultMessage(Matchers.nullValue());
+               .commandResult()
+               .isMessage(Matchers.nullValue());
     }
 
     @Test
@@ -117,8 +121,9 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .success()
-               .resultMessagePayload(new CommandResult("Result name-1"));
+               .commandResult()
+               .isSuccess()
+               .withPayload(new CommandResult("Result name-1"));
     }
 
     @Test
@@ -132,16 +137,20 @@ class AxonTestFixtureMessagingTest {
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-2"))
                .then()
-               .resultMessagePayload(new CommandResult("Result name-2"))
-               .events(
+               .commandResult()
+               .withPayload(new CommandResult("Result name-2"))
+               .then()
+               .publishedEvents()
+               .allOf(
                        studentNameChangedEvent("my-studentId-1", "name-1", 1),
                        studentNameChangedEvent("my-studentId-1", "name-2", 1)
                ).and()
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .then()
-               .success()
-               .resultMessagePayload(new CommandResult("Result name-3"));
+               .commandResult()
+               .isSuccess()
+               .withPayload(new CommandResult("Result name-3"));
     }
 
     @Test
@@ -173,7 +182,8 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-1", 2));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 2));
     }
 
     @Test
@@ -194,6 +204,7 @@ class AxonTestFixtureMessagingTest {
         fixture.when()
                .event(new StudentNameChangedEvent("my-studentId-1", "name-1", 1))
                .then()
+               .dispatchedCommands()
                .commands(new ChangeStudentNameCommand("id", "name"));
     }
 
@@ -216,7 +227,8 @@ class AxonTestFixtureMessagingTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .exception(RuntimeException.class);
+               .commandResult()
+               .isException(RuntimeException.class);
     }
 
     private static GenericEventMessage<StudentNameChangedEvent> studentNameChangedEventMessage(

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -57,7 +57,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
         var changeToTheSameName = new ChangeStudentNameCommand("my-studentId-1", "name-1");
         fixture.given(given -> given.events(studentNameChanged))
                .when(when -> when.command(changeToTheSameName))
-               .then(then -> then.publishedEvents().none());
+               .then(then -> then.events().none());
     }
 
     @Test
@@ -74,7 +74,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(changeToTheAnotherName)
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-2", 2));
     }
 
@@ -92,7 +92,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(new StudentNameChangedEvent("my-studentId-1", "name-3", 3));
     }
 
@@ -110,7 +110,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-4"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(
                        new StudentNameChangedEvent("my-studentId-1", "name-3", 3),
                        new StudentNameChangedEvent("my-studentId-1", "name-4", 4)
@@ -130,7 +130,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .publishedEvents()
+               .events()
                .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -57,7 +57,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
         var changeToTheSameName = new ChangeStudentNameCommand("my-studentId-1", "name-1");
         fixture.given(given -> given.events(studentNameChanged))
                .when(when -> when.command(changeToTheSameName))
-               .then(then -> then.noEvents());
+               .then(then -> then.publishedEvents().none());
     }
 
     @Test
@@ -74,7 +74,8 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(changeToTheAnotherName)
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-2", 2));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-2", 2));
     }
 
 
@@ -91,7 +92,8 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .then()
-               .events(new StudentNameChangedEvent("my-studentId-1", "name-3", 3));
+               .publishedEvents()
+               .allOf(new StudentNameChangedEvent("my-studentId-1", "name-3", 3));
     }
 
     @Test
@@ -108,7 +110,8 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-4"))
                .then()
-               .events(
+               .publishedEvents()
+               .allOf(
                        new StudentNameChangedEvent("my-studentId-1", "name-3", 3),
                        new StudentNameChangedEvent("my-studentId-1", "name-4", 4)
                );
@@ -127,7 +130,8 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                .when()
                .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                .then()
-               .events(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
+               .publishedEvents()
+               .allOf(studentNameChangedEventMessage("my-studentId-1", "name-1", 1));
     }
 
     private static void registerSampleStatefulCommandHandler(MessagingConfigurer configurer) {


### PR DESCRIPTION
This pull request is based on:
https://github.com/AxonFramework/AxonFramework/pull/3352
**(I THINK IT MAY BE BETTER TO REVIEW / GET FAMILAR WITH THE MENTIONED PR FIRST)**

I need your opinion, which one is better (if I should proceed with changes introduced in this PR).
The AFTER approach, introduced in this PR is definitely more flexible, but I'm not sure if it's not too complex.

BEFORE:
```
 fixture.when()
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-2"))
               .then()
               .resultMessagePayload(new CommandResult("Result name-2"))
               .events(
                       studentNameChangedEvent("my-studentId-1", "name-1", 1),
                       studentNameChangedEvent("my-studentId-1", "name-2", 1)
               ).and()
               .when()
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
               .then()
               .success()
               .resultMessagePayload(new CommandResult("Result name-3"));
    }
```

AFTER:
```
        fixture.when()
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-2"))
               .then()
               .result()
               .withPayload(new CommandResult("Result name-2"))
               .then()
               .events()
               .allOf( // we may allow: none/ anyOf etc. but it's like creating our own testing framework like AssertJ!
                       studentNameChangedEvent("my-studentId-1", "name-1", 1),
                       studentNameChangedEvent("my-studentId-1", "name-2", 1)
               ).and()
               .when()
               .command(new ChangeStudentNameCommand("my-studentId-1", "name-3"))
               .then()
               .result()
               .isSuccess()
               .withPayload(new CommandResult("Result name-3"));
```

It gives us even the flexiblity (in the future) to have something like:
```
 fixture.when()
            .command(command1)
            .command(command2)
            .then()
            .result(command1).isSuccess()
            .result(command2).exception()
```
but it's still possible with previous approach:
```
 fixture.when()
            .command(command1)
            .then()
            .success()
            .and()
            .when()
            .command(command2)
            .then()
            .exception()
```

I like with AFTER we can be more explicit about events (allOf / none / anyOf etc.), but we also have matchers for that. 

What do you think? Probably we don't need that, but just to allow use matchers / consume events/commands with some assertions. I'm curious what's your opinion.