### PR TITLE
Fix thread deadlock for HSQLDB

### DIFF
--- a/messaging/src/test/resources/META-INF/persistence.xml
+++ b/messaging/src/test/resources/META-INF/persistence.xml
@@ -21,9 +21,9 @@
     <persistence-unit name="tokenstore" transaction-type="RESOURCE_LOCAL">
         <class>org.axonframework.eventhandling.tokenstore.jpa.TokenEntry</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
             <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:axontest"/>
+            <property name="hsqldb.log_size" value="0"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>
             <property name="jakarta.persistence.jdbc.password" value=""/>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
@@ -35,9 +35,9 @@
         <class>org.axonframework.eventhandling.deadletter.jpa.DeadLetterEventEntry</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
             <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:axontest"/>
+            <property name="hsqldb.log_size" value="0"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>
             <property name="jakarta.persistence.jdbc.password" value=""/>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
@@ -48,9 +48,9 @@
         <class>org.axonframework.common.jpa.TestJpaEntry</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
             <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:axontest"/>
+            <property name="hsqldb.log_size" value="0"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>
             <property name="jakarta.persistence.jdbc.password" value=""/>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>


### PR DESCRIPTION
The build of axon-messing hangs about 30-40% of the time on my local PC. There are also some Github builds that time out. After some investigation, I found a JVM-level deadlock in HSQLDB. I reported the deadlock here: https://sourceforge.net/p/hsqldb/bugs/1730/

As per the response, I have added the `hsqldb.log_size=0` to the test properties. This should have no other impact as far as I see (I have ran this build about 10 times now with success).