### PR TITLE
Fixes subscription query update permits issue

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -518,8 +518,8 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus>, Life
                                                .subscriptionQuery(
                                                        subscriptionSerializer.serializeQuery(interceptedQuery),
                                                        subscriptionSerializer.serializeUpdateType(interceptedQuery),
-                                                       configuration.getQueryFlowControl().getPermits(),
-                                                       configuration.getQueryFlowControl().getNrOfNewPermits()
+                                                       Math.max(32, updateBufferSize),
+                                                       Math.max(4, updateBufferSize >> 3)
                                                );
             return new AxonServerSubscriptionQueryResult<>(
                     interceptedQuery,

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -684,6 +684,22 @@ class AxonServerQueryBusTest {
     }
 
     @Test
+    void subscriptionQueryRequestsPermitsBasedOnBufferSize() {
+        when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt())).thenReturn(new SimpleSubscriptionQueryResult("result"));
+        testSubject.subscriptionQuery(new GenericSubscriptionQueryMessage<Object, Object, Object>("test", "test", instanceOf(Object.class), instanceOf(Object.class)), 124);
+
+        verify(mockQueryChannel).subscriptionQuery(any(), any(), eq(124), eq(15));
+    }
+
+    @Test
+    void subscriptionQueryUpdateBufferSizeIsNEverLowerThan32() {
+        when(mockQueryChannel.subscriptionQuery(any(), any(), anyInt(), anyInt())).thenReturn(new SimpleSubscriptionQueryResult("result"));
+        testSubject.subscriptionQuery(new GenericSubscriptionQueryMessage<>("test", "test", instanceOf(String.class), instanceOf(String.class)), 31);
+
+        verify(mockQueryChannel).subscriptionQuery(any(), any(), eq(32), eq(4));
+    }
+
+    @Test
     void disconnectCancelsQueriesInProgressIfAwaitDurationIsSurpassed() {
         AxonServerQueryBus queryInProgressTestSubject =
                 AxonServerQueryBus.builder()


### PR DESCRIPTION
The permits were based on the configuration of Query permits, rather than the updateBufferSize which can be provided by clients based on their expectations and performance characteristics.

This commit ensures that the updateBufferSize is respected.