### PR TITLE
Allow non-public @EventCriteriaBuilder methods

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolver.java
@@ -90,7 +90,7 @@ public class AnnotationBasedEventCriteriaResolver implements CriteriaResolver<Ob
         String annotationTagKey = (String) attributes.get("tagKey");
         this.tagKey = annotationTagKey.isEmpty() ? null : annotationTagKey;
 
-        Set<Method> eventCriteriaBuilders = Arrays.stream(entityType.getMethods())
+        Set<Method> eventCriteriaBuilders = Arrays.stream(entityType.getDeclaredMethods())
                                                   .filter(m -> m.isAnnotationPresent(EventCriteriaBuilder.class))
                                                   .collect(Collectors.toSet());
 
@@ -165,6 +165,7 @@ public class AnnotationBasedEventCriteriaResolver implements CriteriaResolver<Ob
                     "Method annotated with @EventCriteriaBuilder must be static. Violating method: %s".formatted(
                             ReflectionUtils.toDiscernibleSignature(m)));
         }
+        ReflectionUtils.ensureAccessible(m);
     }
 
     @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolverTest.java
@@ -142,6 +142,26 @@ class AnnotationBasedEventCriteriaResolverTest {
             );
         }
 
+
+        @EventSourcedEntity
+        class EntityWithPrivateEventCriteriaBuilder {
+
+            @EventCriteriaBuilder
+            private static EventCriteria buildCriteria(String id) {
+                return EventCriteria.match()
+                        .eventsOfAnyType()
+                        .withTags("aggregateIdentifier", id);
+            }
+        }
+
+        @Test
+        void testEventCriteriaBuilderWithPrivateBuilderWorks() {
+            var resolver = new AnnotationBasedEventCriteriaResolver(EntityWithPrivateEventCriteriaBuilder.class);
+            var criteria = resolver.resolve("id");
+            assertEquals(EventCriteria.match().eventsOfAnyType().withTags("aggregateIdentifier", "id"), criteria);
+        }
+
+
         @EventSourcedEntity
         class EntityWithVoidReturnValue {
 


### PR DESCRIPTION
Allow non-public @EventCriteriaBuilder methods, so users can choose to encapsulate it. 