### PR TITLE
Fix default Snapshotter throwing `IndexOutOfBoundsException`

### DIFF
--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -731,6 +731,13 @@ public class DefaultConfigurer implements Configurer {
                                   .stream()
                                   .map(aggregateConfiguration -> (AggregateConfiguration<?>) aggregateConfiguration)
                                   .collect(Collectors.toList());
+                    if (aggregateConfigurations.isEmpty()) {
+                        // No configurations, so we return a no-op snapshotter, or retrieveHandlerDefinition will throw
+                        // an exception.
+                        return (aggregateType, aggregateIdentifier) -> {
+                            // No-op Snapshotter.
+                        };
+                    }
                     List<AggregateFactory<?>> aggregateFactories = new ArrayList<>();
                     for (AggregateConfiguration<?> aggregateConfiguration : aggregateConfigurations) {
                         aggregateFactories.add(aggregateConfiguration.aggregateFactory());

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -474,6 +474,16 @@ class DefaultConfigurerTest {
     }
 
     @Test
+    void defaultSnapshotterDefaultsToNoOpWhenNoAggregatesAreKnown() {
+        Snapshotter defaultSnapshotter =
+                DefaultConfigurer.jpaConfiguration(() -> entityManager)
+                                 .configureSerializer(configuration -> TestSerializer.xStreamSerializer())
+                                 .buildConfiguration().snapshotter();
+
+        assertFalse(defaultSnapshotter instanceof AggregateSnapshotter);
+    }
+
+    @Test
     void configureSnapshotterSetsCustomSnapshotter() {
         Snapshotter expectedSnapshotter = mock(Snapshotter.class);
 


### PR DESCRIPTION
The default `Snapshotter` set by the `DefaultConfigurer` depends on at least one aggregate having been registered.

While it is unlikely someone would retrieve this Component if there are none, it's still possible, and it would throw a puzzling exception.