### PR TITLE
[#3385] Align interceptor behavior for Aggregate Members

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.axonframework.messaging.annotation;
 
-import org.axonframework.messaging.Message;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -27,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +33,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
@@ -340,37 +336,5 @@ public class AnnotatedHandlerInspector<T> {
                             .map(AnnotatedHandlerInspector::getAllInspectedTypes)
                             .forEach(inspectedTypes::addAll);
         return Collections.unmodifiableSet(inspectedTypes);
-    }
-
-    private static class ChainedMessageHandlerInterceptorMember<T> implements MessageHandlerInterceptorMemberChain<T> {
-        private final MessageHandlingMember<? super T> delegate;
-        private final MessageHandlerInterceptorMemberChain<T> next;
-
-        private ChainedMessageHandlerInterceptorMember(Class<?> targetType, Iterator<MessageHandlingMember<? super T>> iterator) {
-            this.delegate = iterator.next();
-            if (iterator.hasNext()) {
-                this.next = new ChainedMessageHandlerInterceptorMember<>(targetType, iterator);
-            } else {
-                this.next = NoMoreInterceptors.instance();
-            }
-        }
-
-        @Override
-        public Object handle(@Nonnull Message<?> message, @Nonnull T target,
-                             @Nonnull MessageHandlingMember<? super T> handler) throws Exception {
-            return InterceptorChainParameterResolverFactory.callWithInterceptorChain(() -> next.handle(message,
-                                                                                                       target,
-                                                                                                       handler),
-                                                                                     () -> doHandle(message,
-                                                                                                    target,
-                                                                                                    handler));
-        }
-
-        private Object doHandle(Message<?> message, T target, MessageHandlingMember<? super T> handler) throws Exception {
-            if (delegate.canHandle(message)) {
-                return delegate.handle(message, target);
-            }
-            return next.handle(message, target, handler);
-        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/ChainedMessageHandlerInterceptorMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/ChainedMessageHandlerInterceptorMember.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.annotation;
+
+import org.axonframework.messaging.Message;
+
+import java.util.Iterator;
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link MessageHandlerInterceptorMemberChain} implementation that constructs a chain of instances of itself based on
+ * a given {@code iterator} of {@link MessageHandlingMember MessageHandlingMembers}.
+ *
+ * @param <T> The type that declares the handlers in this chain.
+ * @author Allard Buijze
+ * @since 4.4.0
+ */
+public class ChainedMessageHandlerInterceptorMember<T> implements MessageHandlerInterceptorMemberChain<T> {
+
+    private final MessageHandlingMember<? super T> delegate;
+    private final MessageHandlerInterceptorMemberChain<T> next;
+
+    /**
+     * Constructs a chained message handling interceptor for the given {@code handlerType}, constructing a chain from
+     * the given {@code iterator}.
+     * <p>
+     * The {@code iterator} should <em>at least</em>> have a single {@link MessageHandlingMember}. If there are more
+     * {@code MessageHandlingMembers} present in the given {@code iterator}, this constructor will be invoked again.
+     *
+     * @param handlerType The type for which to construct a message handler interceptor chain.
+     * @param iterator    The {@code MessageHandlingMembers} from which to construct the chain.
+     */
+    public ChainedMessageHandlerInterceptorMember(Class<?> handlerType,
+                                                  Iterator<MessageHandlingMember<? super T>> iterator) {
+        this.delegate = iterator.next();
+        this.next = iterator.hasNext()
+                ? new ChainedMessageHandlerInterceptorMember<>(handlerType, iterator)
+                : NoMoreInterceptors.instance();
+    }
+
+    @Override
+    public Object handle(@Nonnull Message<?> message,
+                         @Nonnull T target,
+                         @Nonnull MessageHandlingMember<? super T> handler) throws Exception {
+        return InterceptorChainParameterResolverFactory.callWithInterceptorChain(
+                () -> next.handle(message, target, handler),
+                () -> doHandle(message, target, handler)
+        );
+    }
+
+    private Object doHandle(Message<?> message, T target,
+                            MessageHandlingMember<? super T> handler) throws Exception {
+        return delegate.canHandle(message)
+                ? delegate.handle(message, target)
+                : next.handle(message, target, handler);
+    }
+}

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -28,7 +28,11 @@ import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.correlation.SimpleCorrelationDataProvider;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.axonframework.modelling.command.*;
+import org.axonframework.modelling.command.AggregateEntityNotFoundException;
+import org.axonframework.modelling.command.AggregateIdentifier;
+import org.axonframework.modelling.command.AggregateMember;
+import org.axonframework.modelling.command.CommandHandlerInterceptor;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.mockito.*;
@@ -91,7 +95,7 @@ class FixtureTest_CommandInterceptors {
 
         TestCommand expectedCommand = new TestCommand(AGGREGATE_IDENTIFIER);
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(expectedCommand);
+               .when(expectedCommand);
 
         //noinspection unchecked
         ArgumentCaptor<GenericCommandMessage<?>> firstCommandMessageCaptor =
@@ -111,8 +115,8 @@ class FixtureTest_CommandInterceptors {
     @Test
     void registeredCommandDispatchInterceptorIsInvokedAndAltersAppliedEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
 
         fixture.registerCommandDispatchInterceptor(new TestCommandDispatchInterceptor());
 
@@ -120,8 +124,8 @@ class FixtureTest_CommandInterceptors {
                 new MetaData(Collections.singletonMap(DISPATCH_META_DATA_KEY, DISPATCH_META_DATA_VALUE));
 
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedValues));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedValues));
     }
 
     @Test
@@ -132,8 +136,8 @@ class FixtureTest_CommandInterceptors {
                 new MetaData(Collections.singletonMap(DISPATCH_META_DATA_KEY, DISPATCH_META_DATA_VALUE));
 
         fixture.givenCommands(new CreateStandardAggregateCommand(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedValues));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedValues));
     }
 
     @Test
@@ -149,7 +153,7 @@ class FixtureTest_CommandInterceptors {
         expectedMetaDataMap.put(HANDLER_META_DATA_KEY, HANDLER_META_DATA_VALUE);
 
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(expectedCommand, expectedMetaDataMap);
+               .when(expectedCommand, expectedMetaDataMap);
 
         //noinspection unchecked
         ArgumentCaptor<UnitOfWork<? extends CommandMessage<?>>> unitOfWorkCaptor =
@@ -165,8 +169,8 @@ class FixtureTest_CommandInterceptors {
     @Test
     void registeredCommandHandlerInterceptorIsInvokedAndAltersEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
 
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
 
@@ -174,8 +178,8 @@ class FixtureTest_CommandInterceptors {
         expectedMetaDataMap.put(HANDLER_META_DATA_KEY, HANDLER_META_DATA_VALUE);
 
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER), expectedMetaDataMap)
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedMetaDataMap));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER), expectedMetaDataMap)
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedMetaDataMap));
     }
 
     @Test
@@ -186,15 +190,15 @@ class FixtureTest_CommandInterceptors {
         expectedMetaDataMap.put(HANDLER_META_DATA_KEY, HANDLER_META_DATA_VALUE);
 
         fixture.givenCommands(new CreateStandardAggregateCommand(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER), expectedMetaDataMap)
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedMetaDataMap));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER), expectedMetaDataMap)
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, expectedMetaDataMap));
     }
 
     @Test
     void registeredCommandDispatchAndHandlerInterceptorAreBothInvokedAndAlterEvent() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, Collections.emptyMap()));
 
         fixture.registerCommandDispatchInterceptor(new TestCommandDispatchInterceptor());
         fixture.registerCommandHandlerInterceptor(new TestCommandHandlerInterceptor());
@@ -206,8 +210,8 @@ class FixtureTest_CommandInterceptors {
         expectedMetaDataMap.put(DISPATCH_META_DATA_KEY, DISPATCH_META_DATA_VALUE);
 
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER), testMetaDataMap)
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, new MetaData(expectedMetaDataMap)));
+               .when(new TestCommand(AGGREGATE_IDENTIFIER), testMetaDataMap)
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, new MetaData(expectedMetaDataMap)));
     }
 
     @Test
@@ -220,9 +224,9 @@ class FixtureTest_CommandInterceptors {
         });
 
         fixture.givenCommands(new CreateStandardAggregateCommand(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, MetaData.emptyInstance()))
-                .expectSuccessfulHandlerExecution();
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, MetaData.emptyInstance()))
+               .expectSuccessfulHandlerExecution();
 
         assertEquals(2, invocations.get());
     }
@@ -236,9 +240,9 @@ class FixtureTest_CommandInterceptors {
         });
 
         fixture.givenCommands(new CreateStandardAggregateCommand(AGGREGATE_IDENTIFIER))
-                .when(new TestCommand(AGGREGATE_IDENTIFIER))
-                .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, MetaData.emptyInstance()))
-                .expectSuccessfulHandlerExecution();
+               .when(new TestCommand(AGGREGATE_IDENTIFIER))
+               .expectEvents(new TestEvent(AGGREGATE_IDENTIFIER, MetaData.emptyInstance()))
+               .expectSuccessfulHandlerExecution();
 
         assertEquals(2, invocations.get());
     }
@@ -246,18 +250,18 @@ class FixtureTest_CommandInterceptors {
     @Test
     void interceptorChainIsInvokedWhenInterceptorForEntityWiresInterceptorChainWithoutExistingEntity() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new DoWithEntityCommand(AGGREGATE_IDENTIFIER))
-                .expectSuccessfulHandlerExecution()
-                .expectNoEvents()
-                .expectResultMessagePayload("invoked-without-entity");
+               .when(new DoWithEntityCommand(AGGREGATE_IDENTIFIER))
+               .expectSuccessfulHandlerExecution()
+               .expectNoEvents()
+               .expectResultMessagePayload("invoked-without-entity");
     }
 
     @Test
     void interceptorChainIsNotInvokedWhenInterceptorForEntityDoesNotWireInterceptorChainWithoutExistingEntity() {
         fixture.given(new StandardAggregateCreatedEvent(AGGREGATE_IDENTIFIER))
-                .when(new DoWithEntityWithoutInterceptorCommand(AGGREGATE_IDENTIFIER))
-                .expectNoEvents()
-                .expectException(AggregateEntityNotFoundException.class);
+               .when(new DoWithEntityWithoutInterceptorCommand(AGGREGATE_IDENTIFIER))
+               .expectNoEvents()
+               .expectException(AggregateEntityNotFoundException.class);
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -342,8 +342,10 @@ class FixtureTest_CommandInterceptors {
     private static class InterceptorEntity {
 
         @CommandHandlerInterceptor
-        public void intercept(Object command) {
+        public void intercept(final CommandMessage<?> command,
+                              final InterceptorChain interceptorChain) throws Exception {
             intercepted.set(true);
+            interceptorChain.proceed();
         }
 
         @CommandHandler

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -342,8 +342,8 @@ class FixtureTest_CommandInterceptors {
     private static class InterceptorEntity {
 
         @CommandHandlerInterceptor
-        public void intercept(final CommandMessage<?> command,
-                              final InterceptorChain interceptorChain) throws Exception {
+        public void intercept(CommandMessage<?> command,
+                              InterceptorChain interceptorChain) throws Exception {
             intercepted.set(true);
             interceptorChain.proceed();
         }


### PR DESCRIPTION
The `ChildForwardingCommandMessageHandlingMember` followed a different paradigm for deciding which Annotated Message Handler Interceptors to pick.
More specifically, it checked if the interceptors match with the message that's being handled.
Although not inherently wrong, if somebody used the `InterceptorChain` parameter, it would simply fail.

This failure stems from the way we set the `InterceptorChain` for parameter resolution. Namely, on a `ThreadLocal`.
For this process to succeed, we first want to invoke the chain before validating if the message can be handled.
The component that ensure that (1) the `InterceptorChain` is present on a `ThreadLocal` and (2) invokes all interceptors and the final handler, is the `ChainedMessageHandlerInterceptorMember`.

Hence, the old behavior made it so that aggregates with aggregate members, **with** interceptors ONLY on those aggregate members, didn't have their interceptors invoked IF those included the `InterceptorChain` parameter.

To resolve this, I moved the `ChainedMessageHandlerInterceptorMember` out of the `AnnotatedHandlerInspector`.
This allowed me to reuse the `ChainedMessageHandlerInterceptorMember` inside the `ChildForwardingCommandMessageHandlingMember`.

By doing so, I aligned the interceptor behavior for aggregate and child entities (also called aggregate members).
This resolves issue #3385.