### PR TITLE
[#3382] Add missing, and fine-tune existing, `api-changes` sections

### DIFF
--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -170,9 +170,25 @@ As can be expected, the `MessageStream` streams implementation of `Message`. Hen
 Framework uses this `Context` to add the aggregate identifier, aggregate type, and sequence number for events that
 originate from an aggregate-based event store (thus a pre-Dynamic Consistency Boundary event store).
 
-### Adjusted APIs
+## Adjusted APIs
 
-TODO - Start filling adjusted operation once the `MessageStream` generics discussion has been finalized.
+The changes incurred by the new [Unit of Work](#unit-of-work) and [Message Stream](#message-stream) combined form the
+basis to make Axon Framework what we have dubbed "Async Native." In other words, it is intended to make Axon Framework
+fully asynchronous, top to bottom, without requiring people to deal with asynchronous programming details (e.g.
+`CompletableFuture` / `Mono`) at each and every turn.
+
+This shift has an obvious impact on the API of Axon Framework's infrastructure components. The APIs now favor the use of
+the `ProcessingContext`, `MessageStream`, and are generally made asynchronous through the use of a `CompletableFuture`.
+As these APIs are in most cases not directly invoked by the user, they should typically not form an obstruction.
+Nonetheless, if you **do** use these operations, it is good to know they've changed with the desire to be async native.
+
+The following classes have undergone changes to accompany this shift:
+
+* The `EventStorageEngine`
+* The `EventStore`
+* The `Repository`
+* The `StreamableMessageSource`
+* The `CommandBus`
 
 ## ApplicationConfigurer and Configuration
 

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -63,7 +63,7 @@ Major API Changes
   resolves the predicament that you need to configure your application twice (for production and testing), making the
   chance slimmer that parts will be skipped. For more on this change, please check the [Test Fixtures](#test-fixtures)
   section of this document.
-* All annotation logic is moved to the annotation module.
+* The annotation logic of all modules is moved to a separate `annotation` package.
 * All reflection logic is moved to a dedicated "reflection" package per module.
 * We no longer support message handler annotated constructors. For example, the constructor of an aggregate can no
   longer contain the `@CommandHandler` annotation. Instead, the `@CreationPolicy` should be used.

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -603,6 +603,8 @@ Minor API Changes
   of a `BlockingStream`, taking a `StreamingCondition` (that can be based on a `TrackingToken`) as input. Lastly, all
   `TrackingToken` methods now return a `CompletableFuture<TrackingToken>`, signaling they're potential asynchronous
   operations.
+* To append events within an aggregate / entity, use the `EventAppender#append` instead of the
+  `AggregateLifecycle#apply` method.
 
 Stored Format Changes
 =====================

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -1,3 +1,19 @@
+API Changes
+===========
+
+As is to be expected of a new major release, a lot of things have changed compared to the previous major release. This
+document serves the purpose of containing all the changes that may proof breaking to users. Some of the changes have a
+lower chance of directly impact users of Axon Framework 4 (like the [Message Stream](#message-stream)), while others
+certainly impact all users (like the [Test Fixture](#test-fixtures) adjustment).
+
+This document can be broken down in five sections:
+
+1. [Version and Dependency Compatibility](#version-and-dependency-compatibility)
+2. [Major API Changes](#major-api-changes)
+3. [Minor API Changes](#minor-api-changes)
+4. [Stored Format Changes](#stored-format-changes)
+5. [Class and Method Changes](#class-and-method-changes)
+
 Version and Dependency Compatibility
 ====================================
 
@@ -102,7 +118,7 @@ To conclude, here is a list of changes to take into account concerning the `Unit
    components will pass along the current context by containing the `ProcessingContext` as a parameter throughout.
 
 Note that the rewrite of the `UnitOfWork` has caused _a lot_ of API changes and numerous removals. For an exhaustive
-list of the latter, please check [here](#removed).
+list of the latter, please check [here](#removed-classes).
 
 ## Message
 
@@ -447,7 +463,7 @@ We acknowledge that this shift is a massive breaking changes between Axon Framew
 test suites, we will provide a legacy installment of the old fixtures, albeit deprecated. This way, users are able to
 migrate the tests on their own pass.
 
-Other API changes
+Minor API Changes
 =================
 
 * The `EventBus` has been renamed to `EventSink`, with adjusted APIs. All publish methods now expect a `String context`
@@ -455,7 +471,7 @@ Other API changes
   `ProcessingContext` or the `publish` returning a `CompletableFuture<Void>` should be used, as these make it possible
   to perform the publication asynchronously.
 
-Stored format changes
+Stored Format Changes
 =====================
 
 ## Dead Letters
@@ -484,15 +500,17 @@ Stored format changes
 4. The dbscheduler `org.axonframework.deadline.dbscheduler.DbSchedulerHumanReadableDeadlineDetails` expects the
    `QualifiedName` to be present under the field `type`.
 
-Changed Classes
-======================
+Class and Method Changes
+========================
+
+## Class Changes
 
 This section contains two tables:
 
 1. A table of all the moved and renamed classes.
 2. A table of all the removed classes.
 
-### Moved / Renamed
+### Moved or Renamed Classes
 
 | Axon 4                                                       | Axon 5                                                        | Module change?                 |
 |--------------------------------------------------------------|---------------------------------------------------------------|--------------------------------|
@@ -512,7 +530,7 @@ This section contains two tables:
 | org.axonframework.commandhandling.CommandCallback            | org.axonframework.commandhandling.gateway.CommandResult       |                                |
 | org.axonframework.commandhandling.callbacks.FutureCallback   | org.axonframework.commandhandling.gateway.FutureCommandResult |                                |
 
-### Removed
+### Removed Classes
 
 | Class                                                           | Why                                                                                                                                            |
 |-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -525,13 +543,12 @@ This section contains two tables:
 | org.axonframework.messaging.unitofwork.MessageProcessingContext | Made obsolete through the rewrite of the `UnitOfWork` (see [Unit of Work](#unit-of-work))                                                      |
 | org.axonframework.eventsourcing.eventstore.AbstractEventStore   | Made obsolete through the rewrite of the `EventStore`.                                                                                         |
 
-Method signature changes
-========================
+## Method Signature Changes
 
 This section contains three subsections, called:
 
 1. [Parameter adjustments](#parameter-adjustments)
-2. [Moved methods and constructors](#moved-methods-and-constructors)
+2. [Moved methods and constructors](#moved--renamed-methods-and-constructors)
 3. [Removed methods and constructors](#removed-methods-and-constructors)
 
 ### Parameter adjustments
@@ -555,7 +572,7 @@ This section contains three subsections, called:
 | All none-copy org.axonframework.queryhandling.GenericQueryResponseMessage constructors     | Added the `MessageType` type | See [here](#message-type-and-qualified-name) |
 | All org.axonframework.queryhandling.GenericSubscriptionQueryUpdateMessage constructors     | Added the `MessageType` type | See [here](#message-type-and-qualified-name) |
 
-### Moved/renamed methods and constructors
+### Moved / Renamed Methods and Constructors
 
 | Constructor / Method                                                 | To where                                                   |
 |----------------------------------------------------------------------|------------------------------------------------------------|
@@ -568,7 +585,7 @@ This section contains three subsections, called:
 | `Configurer#registerComponent(Function<Configuration, ? extends C>)` | `ComponentRegistry#registerComponent(ComponentFactory<C>)` | 
 | `Configurer#registerModule(ModuleConfiguration)`                     | `ComponentRegistry#registerComponent(Module)`              | 
 
-### Removed methods and constructors
+### Removed Methods and Constructors
 
 | Constructor / Method                                                            | Why                                                                             | 
 |---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -470,6 +470,11 @@ Minor API Changes
   to define in which (bounded-)context an event should be published. Furthermore, either the method holding the
   `ProcessingContext` or the `publish` returning a `CompletableFuture<Void>` should be used, as these make it possible
   to perform the publication asynchronously.
+* The `StreamableEventSource` replaces the `StreamableMessageSource`, enforcing the `Message` type streamed to an
+  `EventMessage` implementation. Furthermore, the `StreamableMessageSource#openStream` returns a `MessageStream` instead
+  of a `BlockingStream`, taking a `StreamingCondition` (that can be based on a `TrackingToken`) as input. Lastly, all
+  `TrackingToken` methods now return a `CompletableFuture<TrackingToken>`, signaling they're potential asynchronous
+  operations.
 
 Stored Format Changes
 =====================
@@ -584,14 +589,19 @@ This section contains three subsections, called:
 | `ConfigurerModule#configureLifecyclePhaseTimeout`                    | `LifecycleRegistry#registerLifecyclePhaseTimeout`          | 
 | `Configurer#registerComponent(Function<Configuration, ? extends C>)` | `ComponentRegistry#registerComponent(ComponentFactory<C>)` | 
 | `Configurer#registerModule(ModuleConfiguration)`                     | `ComponentRegistry#registerComponent(Module)`              | 
+| `StreamableMessageSource#openStream(TrackingToken)`                  | `StreamableEventSource#open(SourcingCondition)`            | 
+| `StreamableMessageSource#createTailToken()`                          | `StreamableEventSource#headToken()`                        | 
+| `StreamableMessageSource#createHeadToken()`                          | `StreamableEventSource#tailToken()`                        | 
+| `StreamableMessageSource#createTokenAt(Instant)`                     | `StreamableEventSource#tokenAt(Instant)`                   | 
 
 ### Removed Methods and Constructors
 
-| Constructor / Method                                                            | Why                                                                             | 
-|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| `org.axonframework.config.ModuleConfiguration#initialize(Configuration)`        | Initialize is now replace fully by start and shutdown handlers.                 |
-| `org.axonframework.config.ModuleConfiguration#unwrap()`                         | Unwrapping never reached its intended use in AF3 and AF4 and is thus redundant. |
-| `org.axonframework.config.ModuleConfiguration#isType(Class<?>)`                 | Only use by `unwrap()` that's also removed.                                     |
-| `org.axonframework.config.Configuration#lifecycleRegistry()`                    | A round about way to support life cycle handler registration.                   |
-| `org.axonframework.config.Configurer#onInitialize(Consumer<Configuration>)`     | Fully replaced by start and shutdown handler registration.                      |
-| `org.axonframework.config.Configurer#defaultComponent(Class<T>, Configuration)` | Each Configurer now has get optional operation replacing this functionality.    |
+| Constructor / Method                                                             | Why                                                                                     | 
+|----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `org.axonframework.config.ModuleConfiguration#initialize(Configuration)`         | Initialize is now replace fully by start and shutdown handlers.                         |
+| `org.axonframework.config.ModuleConfiguration#unwrap()`                          | Unwrapping never reached its intended use in AF3 and AF4 and is thus redundant.         |
+| `org.axonframework.config.ModuleConfiguration#isType(Class<?>)`                  | Only use by `unwrap()` that's also removed.                                             |
+| `org.axonframework.config.Configuration#lifecycleRegistry()`                     | A round about way to support life cycle handler registration.                           |
+| `org.axonframework.config.Configurer#onInitialize(Consumer<Configuration>)`      | Fully replaced by start and shutdown handler registration.                              |
+| `org.axonframework.config.Configurer#defaultComponent(Class<T>, Configuration)`  | Each Configurer now has get optional operation replacing this functionality.            |
+| `org.axonframework.messaging.StreamableMessageSource#createTokenSince(Duration)` | Can be replaced by the user with an `StreamableEventSource#tokenAt(Instant)` invocation |

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -3,7 +3,7 @@ API Changes
 
 As is to be expected of a new major release, a lot of things have changed compared to the previous major release. This
 document serves the purpose of containing all the changes that may prove breaking to users. Some of the changes have a
-lower chance of directly impact users of Axon Framework 4 (like the [Message Stream](#message-stream)), while others
+lower chance of directly impacting users of Axon Framework 4 (like the [Message Stream](#message-stream)), while others
 certainly impact all users (like the [Test Fixture](#test-fixtures) adjustment).
 
 This document can be broken down in five sections:

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -148,7 +148,27 @@ users of the factory methods need to revert to using the constructor of the `Mes
 
 ## Message Stream
 
-TODO - provide description once the `MessageStream` generics discussion has been finalized.
+We have introduced the so-called `MessageStream` to allow people to draft both imperative **and** reactive message
+handlers. As such, the `MessageStream` is the expected result type from event handlers, command handlers, and query
+handlers. Furthermore, the `MessageStream` can mirror response of nothing (zero), one, or N, thus reflecting the
+expected behavior of an event handler (no response), a command handler (one response), and query handlers (N responses).
+Besides being **the** response for all message handlers in Axon Framework, it is also the return type when
+streaming and sourcing events from an `EventStore`.
+
+To achieve all this, the `MessageStream` has several creational methods, like:
+
+1. `MessageStream#fromIterable`
+2. `MessageStream#fromStream`
+3. `MessageStream#fromFlux`
+4. `MessageStream#fromFuture`
+5. `MessageStream#just`
+6. `MessageStream#empty`
+
+As can be expected, the `MessageStream` streams implementation of `Message`. Hence, the creational methods expect
+`Message` implementations when invoked. On top of that, you can add context-specific information to each entry in the
+`MessageStream`, by specifying a lambda that takes in the `Message` and returns a `Context` object. For example, Axon
+Framework uses this `Context` to add the aggregate identifier, aggregate type, and sequence number for events that
+originate from an aggregate-based event store (thus a pre-Dynamic Consistency Boundary event store).
 
 ### Adjusted APIs
 

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -466,6 +466,10 @@ migrate the tests on their own pass.
 Minor API Changes
 =================
 
+* The `Repository`, just as other components, has been made [async native](#adjusted-apis). This means methods return a
+  `CompletableFuture` instead of the loaded `Aggregate`. Furthermore, the notion of aggregate was removed from the
+  `Repository`, in favor of talking about `ManagedEntity` instances. This makes the `Repository` applicable for
+  non-aggregate solutions too.
 * The `EventBus` has been renamed to `EventSink`, with adjusted APIs. All publish methods now expect a `String context`
   to define in which (bounded-)context an event should be published. Furthermore, either the method holding the
   `ProcessingContext` or the `publish` returning a `CompletableFuture<Void>` should be used, as these make it possible
@@ -532,8 +536,9 @@ This section contains two tables:
 | org.axonframework.config.LifecycleHandler                    | org.axonframework.configuration.LifecycleHandler              | Yes. Moved to `axon-messaging` |
 | org.axonframework.config.LifecycleHandlerInspector           | org.axonframework.configuration.LifecycleHandlerInspector     | Yes. Moved to `axon-messaging` |
 | org.axonframework.config.LifecycleOperations                 | org.axonframework.configuration.LifecycleRegistry             | Yes. Moved to `axon-messaging` |
-| org.axonframework.commandhandling.CommandCallback            | org.axonframework.commandhandling.gateway.CommandResult       |                                |
-| org.axonframework.commandhandling.callbacks.FutureCallback   | org.axonframework.commandhandling.gateway.FutureCommandResult |                                |
+| org.axonframework.commandhandling.CommandCallback            | org.axonframework.commandhandling.gateway.CommandResult       | No                             |
+| org.axonframework.commandhandling.callbacks.FutureCallback   | org.axonframework.commandhandling.gateway.FutureCommandResult | No                             |
+| org.axonframework.modelling.command.Repository               | org.axonframework.modelling.repository.Repository             | No                             |
 
 ### Removed Classes
 
@@ -593,15 +598,20 @@ This section contains three subsections, called:
 | `StreamableMessageSource#createTailToken()`                          | `StreamableEventSource#headToken()`                        | 
 | `StreamableMessageSource#createHeadToken()`                          | `StreamableEventSource#tailToken()`                        | 
 | `StreamableMessageSource#createTokenAt(Instant)`                     | `StreamableEventSource#tokenAt(Instant)`                   | 
+| `Repository#newInstance(Callable<T>)`                                | `Repository#persist(ID, T, ProcessingContext)`             | 
+| `Repository#load(String)`                                            | `Repository#load(ID, ProcessingContext)`                   | 
+| `Repository#loadOrCreate(String, Callable<T>)`                       | `Repository#loadOrCreate(ID, ProcessingContext)`           | 
 
 ### Removed Methods and Constructors
 
-| Constructor / Method                                                             | Why                                                                                     | 
-|----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| `org.axonframework.config.ModuleConfiguration#initialize(Configuration)`         | Initialize is now replace fully by start and shutdown handlers.                         |
-| `org.axonframework.config.ModuleConfiguration#unwrap()`                          | Unwrapping never reached its intended use in AF3 and AF4 and is thus redundant.         |
-| `org.axonframework.config.ModuleConfiguration#isType(Class<?>)`                  | Only use by `unwrap()` that's also removed.                                             |
-| `org.axonframework.config.Configuration#lifecycleRegistry()`                     | A round about way to support life cycle handler registration.                           |
-| `org.axonframework.config.Configurer#onInitialize(Consumer<Configuration>)`      | Fully replaced by start and shutdown handler registration.                              |
-| `org.axonframework.config.Configurer#defaultComponent(Class<T>, Configuration)`  | Each Configurer now has get optional operation replacing this functionality.            |
-| `org.axonframework.messaging.StreamableMessageSource#createTokenSince(Duration)` | Can be replaced by the user with an `StreamableEventSource#tokenAt(Instant)` invocation |
+| Constructor / Method                                                                                | Why                                                                                      | 
+|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| `org.axonframework.config.ModuleConfiguration#initialize(Configuration)`                            | Initialize is now replace fully by start and shutdown handlers.                          |
+| `org.axonframework.config.ModuleConfiguration#unwrap()`                                             | Unwrapping never reached its intended use in AF3 and AF4 and is thus redundant.          |
+| `org.axonframework.config.ModuleConfiguration#isType(Class<?>)`                                     | Only use by `unwrap()` that's also removed.                                              |
+| `org.axonframework.config.Configuration#lifecycleRegistry()`                                        | A round about way to support life cycle handler registration.                            |
+| `org.axonframework.config.Configurer#onInitialize(Consumer<Configuration>)`                         | Fully replaced by start and shutdown handler registration.                               |
+| `org.axonframework.config.Configurer#defaultComponent(Class<T>, Configuration)`                     | Each Configurer now has get optional operation replacing this functionality.             |
+| `org.axonframework.messaging.StreamableMessageSource#createTokenSince(Duration)`                    | Can be replaced by the user with an `StreamableEventSource#tokenAt(Instant)` invocation. |
+| `org.axonframework.modelling.command.Repository#load(String, Long)`                                 | Leftover behavior to support aggregate validation on subsequent invocations.             |
+| `org.axonframework.modelling.command.Repository#newInstance(Callable<T>, Consumer<Aggregate<T>>)`   | No longer necessary with replacement `Repository#persist(ID, T, ProcessingContext)`      |

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -50,7 +50,7 @@ Major API Changes
 * Axon's `EventStore` implementations let go their aggregate-focus, instead following the "Dynamic Consistency
   Boundary" approach. This shift changed the `EventStore` and `EventStorageEngine` API heavily, providing a lot of
   flexibility in defining how entities are event sourced and how events are appended for them. Although most users won't
-  interact with the `EventStore` or `EventStorageEngine` directly, knowing the changes could still proof beneficial. For
+  interact with the `EventStore` or `EventStorageEngine` directly, knowing the changes could still prove beneficial. For
   those that are curious, be sure to read the [Event Store](#event-store) section.
 * The Configuration of Axon Framework has been flipped around. Instead of having a `axon-configuration` module that
   depends on all of Axon's modules to provide a global configuration, the core module (`axon-messaging`) of Axon now

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -134,11 +134,10 @@ For added flexibility with Axon Framework's `Message` API, we introduced two cla
 1. The `MessageType`, and
 2. the `QualifiedName`.
 
-The `MessageType` is a combination of a `QualifiedName` and a version (of type `String`). Furthermore, **every**
-`Message` implementation now has the `type()` method, returning its `MessageType`. The intent for this new class on the
-`Message`, is to ensure all messages clarify their version and qualified name
-within the domain they act in. Furthermore, both the `QualifiedName` and version are non-null variables on the
-`MessageType`, ensuring they are always present.
+The `MessageType` is a combination of a `QualifiedName` and a version (of type `String`). **Every** `Message`
+implementation now has the `type()` method, returning its `MessageType`. The intent for this new class on the `Message`,
+is to ensure all messages clarify their version and qualified name within the domain they act in. Note that both the
+`QualifiedName` and version are non-null variables on the `MessageType`, ensuring they are always present.
 
 This is a shift compared to Axon Framework 4 in roughly two areas, being:
 

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -2,7 +2,7 @@ API Changes
 ===========
 
 As is to be expected of a new major release, a lot of things have changed compared to the previous major release. This
-document serves the purpose of containing all the changes that may proof breaking to users. Some of the changes have a
+document serves the purpose of containing all the changes that may prove breaking to users. Some of the changes have a
 lower chance of directly impact users of Axon Framework 4 (like the [Message Stream](#message-stream)), while others
 certainly impact all users (like the [Test Fixture](#test-fixtures) adjustment).
 

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -47,6 +47,11 @@ Major API Changes
   aforementioned [Unit of Work](#unit-of-work) adjustments flow through most APIs, as well as the use of
   a [Message Stream](#message-stream) to provide a way to support imperative and reactive message handlers. See
   the [Adjusted APIs](#adjusted-apis) section for a list of all classes that have undergone changes.
+* Axon's `EventStore` implementations shifted let go their aggregate-focus, instead following the "Dynamic Consistency
+  Boundary" approach. This shift changed the `EventStore` and `EventStorageEngine` API heavily, providing a lot of
+  flexibility in defining how entities are event sourced and how events are appended for them. Although most users won't
+  interact with the `EventStore` or `EventStorageEngine` directly, knowing the changes could still proof beneficial. For
+  those that are curious, be sure to read the [Event Store](#event-store) section.
 * The Configuration of Axon Framework has been flipped around. Instead of having a `axon-configuration` module that
   depends on all of Axon's modules to provide a global configuration, the core module (`axon-messaging`) of Axon now
   contains a `Configurer` with a base set of operations. This `Configurer` can either take `Components` or `Modules`.

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -145,7 +145,7 @@ This is a shift compared to Axon Framework 4 in roughly two areas, being:
 1. The `version` (`revision` as it was called in AF4) is no longer an event-only thing. This makes it so that
    applications can describe the version of their commands and queries more easily, making it possible to construct
    converters or define default mappings between different application releases.
-2. The introduction of the `QualifiedName` makes it so that Axon Framework does not have to lean on the
+2. The introduction of the `QualifiedName` makes it so that Axon Framework does not have to rely on the
    `Message#getPayloadType` anymore as the defining factor of the `Message` in question.
 
 Thus, through the introduction of the `QualifiedName`, users are able to decouple their message class implementations

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -47,7 +47,7 @@ Major API Changes
   aforementioned [Unit of Work](#unit-of-work) adjustments flow through most APIs, as well as the use of
   a [Message Stream](#message-stream) to provide a way to support imperative and reactive message handlers. See
   the [Adjusted APIs](#adjusted-apis) section for a list of all classes that have undergone changes.
-* Axon's `EventStore` implementations shifted let go their aggregate-focus, instead following the "Dynamic Consistency
+* Axon's `EventStore` implementations let go their aggregate-focus, instead following the "Dynamic Consistency
   Boundary" approach. This shift changed the `EventStore` and `EventStorageEngine` API heavily, providing a lot of
   flexibility in defining how entities are event sourced and how events are appended for them. Although most users won't
   interact with the `EventStore` or `EventStorageEngine` directly, knowing the changes could still proof beneficial. For

--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -27,15 +27,20 @@ Major API Changes
   `MessageStream` changes **a lot** of (public) APIs within Axon Framework. Please check
   the [Message Stream](#message-stream) section for more details, like an exhaustive list of all the adjusted
   interfaces.
-* We no longer support message handler annotated constructors. For example, the constructor of an aggregate can no
-  longer contain the `@CommandHandler` annotation. Instead, the `@CreationPolicy` should be used.
-* All annotation logic is moved to the annotation module.
+* The API of all infrastructure components is rewritten to be "async native." This means that the
+  aforementioned [Unit of Work](#unit-of-work) adjustments flow through most APIs, as well as the use of
+  a [Message Stream](#message-stream) to provide a way to support imperative and reactive message handlers. See
+  the [Adjusted APIs](#adjusted-apis) section for a list of all classes that have undergone changes.
 * The Configuration of Axon Framework has been flipped around. Instead of having a `axon-configuration` module that
   depends on all of Axon's modules to provide a global configuration, the core module (`axon-messaging`) of Axon now
   contains a `Configurer` with a base set of operations. This `Configurer` can either take `Components` or `Modules`.
   The former typically represents an infrastructure component (e.g. the `CommandBus`) whereas modules are themselves
   configurers for a specific module of an application. For an exhaustive list of all the operations that have been
   removed, moved, or altered, see the [Configurer and Configuration](#applicationconfigurer-and-configuration) section.
+* All annotation logic is moved to the annotation module.
+* All reflection logic is moved to a dedicated "reflection" package per module.
+* We no longer support message handler annotated constructors. For example, the constructor of an aggregate can no
+  longer contain the `@CommandHandler` annotation. Instead, the `@CreationPolicy` should be used.
 
 ## Unit of Work
 

--- a/messaging/src/main/java/org/axonframework/messaging/StreamableMessageSource.java
+++ b/messaging/src/main/java/org/axonframework/messaging/StreamableMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import javax.annotation.Nullable;
  * Interface for a source of {@link Message messages} that processors can track.
  *
  * @author Rene de Waele
+ *@deprecated In favor of the {@code org.axonframework.eventsourcing.eventstore.StreamableEventSource}.
  */
+@Deprecated(since = "5.0.0")
 public interface StreamableMessageSource<M extends Message<?>> {
 
     /**

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateLifecycle.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateLifecycle.java
@@ -20,17 +20,21 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.Scope;
 import org.axonframework.messaging.ScopeDescriptor;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
  * Abstract base class of a component that models an aggregate's life cycle.
+ *
+ * @deprecated In favor of a multitude of operation, differing per method.
  */
+@Deprecated(since = "5.0.0")
 public abstract class AggregateLifecycle extends Scope {
 
     /**
-     * Apply a {@link org.axonframework.eventhandling.DomainEventMessage} with given payload and metadata (metadata
-     * from interceptors will be combined with the provided metadata). Applying events means they are immediately
-     * applied (published) to the aggregate and scheduled for publication to other event handlers.
+     * Apply a {@link org.axonframework.eventhandling.DomainEventMessage} with given payload and metadata (metadata from
+     * interceptors will be combined with the provided metadata). Applying events means they are immediately applied
+     * (published) to the aggregate and scheduled for publication to other event handlers.
      * <p/>
      * The event is applied on all entities part of this aggregate. If the event is applied from an event handler of the
      * aggregate and additional events need to be applied that depends on state changes brought about by the first event
@@ -40,7 +44,9 @@ public abstract class AggregateLifecycle extends Scope {
      * @param metaData any meta-data that must be registered with the Event
      * @return a gizmo to apply additional events after the given event has been processed by the entire aggregate
      * @see ApplyMore
+     * @deprecated In favor of {@link org.axonframework.eventhandling.gateway.EventAppender#append(List)}
      */
+    @Deprecated(since = "5.0.0")
     public static ApplyMore apply(Object payload, MetaData metaData) {
         return AggregateLifecycle.getInstance().doApply(payload, metaData);
     }
@@ -57,7 +63,9 @@ public abstract class AggregateLifecycle extends Scope {
      * @param payload the payload of the event to apply
      * @return a gizmo to apply additional events after the given event has been processed by the entire aggregate
      * @see ApplyMore
+     * @deprecated In favor of {@link org.axonframework.eventhandling.gateway.EventAppender#append(List)}
      */
+    @Deprecated(since = "5.0.0")
     public static ApplyMore apply(Object payload) {
         return AggregateLifecycle.getInstance().doApply(payload, MetaData.emptyInstance());
     }

--- a/modelling/src/main/java/org/axonframework/modelling/configuration/ModellingConfigurer.java
+++ b/modelling/src/main/java/org/axonframework/modelling/configuration/ModellingConfigurer.java
@@ -27,9 +27,6 @@ import org.axonframework.configuration.LifecycleRegistry;
 import org.axonframework.configuration.MessagingConfigurer;
 import org.axonframework.configuration.Module;
 import org.axonframework.configuration.ModuleBuilder;
-import org.axonframework.modelling.StateManager;
-import org.axonframework.modelling.HierarchicalStateManagerConfigurationEnhancer;
-import org.axonframework.modelling.annotation.InjectEntity;
 
 import java.util.function.Consumer;
 

--- a/modelling/src/main/java/org/axonframework/modelling/repository/ManagedEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/ManagedEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import java.util.function.UnaryOperator;
  * A wrapper around an entity whose lifecycle is being managed by an {@link Repository}.
  *
  * @param <ID> The type of identifier of the entity.
- * @param <T>  The type of the entity.
+ * @param <E>  The type of the entity.
  * @author Allard Buijze
  * @since 5.0.0
  */
-public interface ManagedEntity<ID, T> {
+public interface ManagedEntity<ID, E> {
 
     /**
      * The identifier of the entity.
@@ -40,7 +40,7 @@ public interface ManagedEntity<ID, T> {
      *
      * @return The current state of the entity.
      */
-    T entity();
+    E entity();
 
     /**
      * Change the current state of the entity using the given {code change} function.
@@ -48,5 +48,5 @@ public interface ManagedEntity<ID, T> {
      * @param change The function applying the requested change.
      * @return The state of the entity after the change.
      */
-    T applyStateChange(UnaryOperator<T> change);
+    E applyStateChange(UnaryOperator<E> change);
 }

--- a/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
@@ -28,13 +28,13 @@ import javax.annotation.Nonnull;
  * When interacting with the {@code Repository} the framework expects an active {@link ProcessingContext}. If there is
  * no active {@code UnitOfWork} an {@link IllegalStateException} is thrown.
  *
- * @param <T>  The type of entity this repository stores.
+ * @param <E>  The type of entity this repository stores.
  * @param <ID> The type of identifier for entities in this repository.
  * @author Allard Buijze
  * @implNote Implementations of this interface must implement {@link Repository.LifecycleManagement} instead.
  * @since 0.1
  */
-public sealed interface Repository<ID, T>
+public sealed interface Repository<ID, E>
         extends DescribableComponent
         permits Repository.LifecycleManagement {
 
@@ -44,7 +44,7 @@ public sealed interface Repository<ID, T>
      * @return The type of entity stored in this repository.
      */
     @Nonnull
-    Class<T> entityType();
+    Class<E> entityType();
 
     /**
      * The type of the identifier used to identify entities in this repository.
@@ -63,8 +63,8 @@ public sealed interface Repository<ID, T>
      * @return A {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier, or
      * {@code null} if it can't be found.
      */
-    CompletableFuture<ManagedEntity<ID, T>> load(@Nonnull ID identifier,
-                                                         @Nonnull ProcessingContext processingContext);
+    CompletableFuture<ManagedEntity<ID, E>> load(@Nonnull ID identifier,
+                                                 @Nonnull ProcessingContext processingContext);
 
     /**
      * Loads an entity from the repository.
@@ -74,7 +74,7 @@ public sealed interface Repository<ID, T>
      * @return A {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier, or a newly
      * constructed entity instance based on the {@code factoryMethod}.
      */
-    CompletableFuture<ManagedEntity<ID, T>> loadOrCreate(@Nonnull ID identifier,
+    CompletableFuture<ManagedEntity<ID, E>> loadOrCreate(@Nonnull ID identifier,
                                                          @Nonnull ProcessingContext processingContext);
 
     /**
@@ -85,22 +85,22 @@ public sealed interface Repository<ID, T>
      * @param processingContext The {@link ProcessingContext} in which the entity is active.
      * @return a {@link ManagedEntity} wrapping the entity managed in the {@link ProcessingContext}.
      */
-    ManagedEntity<ID, T> persist(@Nonnull ID identifier,
-                                 @Nonnull T entity,
+    ManagedEntity<ID, E> persist(@Nonnull ID identifier,
+                                 @Nonnull E entity,
                                  @Nonnull ProcessingContext processingContext);
 
     /**
-     * Specialization of the {@link Repository} interface that <em>must</em> be implemented by all implementations
-     * of the {@code AsyncRepository}. It exposes some methods that are required to perform lifecycle management
-     * operations that are not typically required outside of repository implementation.
+     * Specialization of the {@link Repository} interface that <em>must</em> be implemented by all implementations of
+     * the {@code AsyncRepository}. It exposes some methods that are required to perform lifecycle management operations
+     * that are not typically required outside of repository implementation.
      * <p>
      * More specifically, these methods are meant for implementations of a Repository wrapping another to be able to
      * properly have lifecycle operations registered with downstream {@code AsyncRepository} implementations.
      *
-     * @param <T>  The type of entity this repository stores.
+     * @param <E>  The type of entity this repository stores.
      * @param <ID> The type of identifier for entities in this repository.
      */
-    non-sealed interface LifecycleManagement<ID, T> extends Repository<ID, T> {
+    non-sealed interface LifecycleManagement<ID, E> extends Repository<ID, E> {
 
         /**
          * Ensures that the given {@code entity} has its lifecycle managed in the given {@code processingContext}. This
@@ -117,6 +117,6 @@ public sealed interface Repository<ID, T>
          * @param processingContext The processing context to link the lifecycle with.
          * @return The instance of the entity whose lifecycle is managed by this repository.
          */
-        ManagedEntity<ID, T> attach(@Nonnull ManagedEntity<ID, T> entity, @Nonnull ProcessingContext processingContext);
+        ManagedEntity<ID, E> attach(@Nonnull ManagedEntity<ID, E> entity, @Nonnull ProcessingContext processingContext);
     }
 }

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -117,7 +117,9 @@ import static org.axonframework.common.ReflectionUtils.*;
  * @param <T> The type of Aggregate tested in this Fixture
  * @author Allard Buijze
  * @since 0.6
+ * @deprecated In favor of the {@link org.axonframework.test.fixture.AxonTestFixture}.
  */
+@Deprecated(since = "5.0.0")
 public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExecutor<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(AggregateTestFixture.class);

--- a/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/FixtureConfiguration.java
@@ -93,7 +93,9 @@ import java.util.function.Supplier;
  * @param <T> The type of the aggregate under test
  * @author Allard Buijze
  * @since 0.6
+ * @deprecated In favor of the {@link org.axonframework.test.fixture.AxonTestFixture}.
  */
+@Deprecated(since = "5.0.0")
 public interface FixtureConfiguration<T> {
 
     /**

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,9 @@ import java.util.function.Consumer;
  * @param <T> The type of Aggregate under test
  * @author Allard Buijze
  * @since 0.6
+ * @deprecated In favor of the {@link org.axonframework.test.fixture.AxonTestFixture}.
  */
+@Deprecated(since = "5.0.0")
 public interface ResultValidator<T> {
 
     /**

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -56,7 +56,9 @@ import static org.hamcrest.CoreMatchers.*;
  *
  * @author Allard Buijze
  * @since 0.7
+ * @deprecated In favor of the {@link org.axonframework.test.fixture.AxonTestFixture}.
  */
+@Deprecated(since = "5.0.0")
 public class ResultValidatorImpl<T> implements ResultValidator<T> {
 
     private final List<EventMessage<?>> publishedEvents;

--- a/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/TestExecutor.java
@@ -34,7 +34,9 @@ import java.util.function.Consumer;
  * @param <T> The type of Aggregate under test
  * @author Allard Buijze
  * @since 0.6
+ * @deprecated In favor of the {@link org.axonframework.test.fixture.AxonTestFixture}.
  */
+@Deprecated(since = "5.0.0")
 public interface TestExecutor<T> {
 
     /**


### PR DESCRIPTION
This pull request provides a lot of changes to the `api-changes.md` file.
Since this file forms the basis for our to-be-constructed migration guide and code, it is paramount we keep this file up to date.
Granted, we should perform this tasks for every pull request, instead of performing the write down after the fact.
Thus, to safe us some effort in the feature, let's try to adjust this file as we go along.

That said, this PR makes the following adjustments to the `api-changes.md`:

* Adds an introduction section
* Adds a `MessageStream` section to the Major API block
* Adds a Test Fixture section to the Major API block
* Adds an `EventStore` section to the Major API block
* Fine-tuned the `MessageType`/`QualifiedName` section
* Fine-tuned the `MessageStream` section
* Fine-tuned the Configuration section
* Expanded the Minor API Changes section
* Fine-tuned and expanded the "Class and Method Changes" section

Besides the `api-changes.md` changes, this PR deprecates some classes we missed deprecating as part of milestone 1, as well as aligning some generics with other classes.
The only part that is clearly not covered, are the changes in the `CommandBus` and `CommandGateway`. 
As there are still discussion on going at this point in time, the documentation for those classes will be covered in issue #3408.

In doing the above, this pull request resolves #3382.