### PR TITLE
[#3348] Document `@MessageHandlerInterceptor` behavior for `@EventSourcingHandlers` on Aggregate Members

### DIFF
--- a/docs/old-reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
+++ b/docs/old-reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
@@ -345,6 +345,17 @@ By default, it reacts to any `Message` implementation.
 If an `EventMessage` specific interceptor is desired, the `messageType` parameter on the annotation should be set to `EventMessage.class`.
 . For even more fine-grained control of which messages should react to the interceptor, the `payloadType` contained in the `Message` to handle can be specified.
 
+[Note]
+.Intercepting `@EventSourcingHandler` annotated methods on Aggregate Members
+====
+The `@MessageHandlerInterceptor` **is not** intended to intercept events that are passed to `@EventSourcingHandler` annotated methods in aggregates.
+Although it works for the aggregate root, this is a mere side effect of the implemented handler support.
+Due to this, `@EventSourcingHandler` annotated methods on aggregate members does not work at all.
+
+This is clear discrepancy with all other message handler annotated methods that we cannot easily adjust with Axon Framework 4 it's structure.
+As such, it is not recommended to rely on the invocation of `@MessageHandlerInterceptor` annotated methods while sourcing an aggregate.
+====
+
 The following snippets shows some possible approaches of using the `@MessageHandlerInterceptor` annotation:
 
 *Simple `@MessageHandlerInterceptor` method*

--- a/docs/old-reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
+++ b/docs/old-reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
@@ -345,17 +345,6 @@ By default, it reacts to any `Message` implementation.
 If an `EventMessage` specific interceptor is desired, the `messageType` parameter on the annotation should be set to `EventMessage.class`.
 . For even more fine-grained control of which messages should react to the interceptor, the `payloadType` contained in the `Message` to handle can be specified.
 
-[Note]
-.Intercepting `@EventSourcingHandler` annotated methods on Aggregate Members
-====
-The `@MessageHandlerInterceptor` **is not** intended to intercept events that are passed to `@EventSourcingHandler` annotated methods in aggregates.
-Although it works for the aggregate root, this is a mere side effect of the implemented handler support.
-Due to this, `@EventSourcingHandler` annotated methods on aggregate members does not work at all.
-
-This is clear discrepancy with all other message handler annotated methods that we cannot easily adjust with Axon Framework 4 it's structure.
-As such, it is not recommended to rely on the invocation of `@MessageHandlerInterceptor` annotated methods while sourcing an aggregate.
-====
-
 The following snippets shows some possible approaches of using the `@MessageHandlerInterceptor` annotation:
 
 *Simple `@MessageHandlerInterceptor` method*
@@ -423,6 +412,52 @@ public class CardSummaryProjection {
     }
 }
 ----
+
+*`@MessageHandlerInterceptor` method hierarchy on an Aggregate Member and Aggregate Root*
+
+[source,java]
+----
+public class GiftCard {
+
+    @AggregateIdentifier
+    private String id;
+
+    @AggregateMember
+    private List<GiftCardTransaction> transactions = new ArrayList<>();
+
+    @MessageHandlerInterceptor
+    public void intercept(Message<?> message) {
+        // This interceptor will be invoked FIRST!
+    }
+    // omitted constructors, command and event sourcing handlers
+}
+
+public class GiftCardTransaction {
+
+    @EntityId
+    private String transactionId;
+
+    @MessageHandlerInterceptor
+    public void intercept(Message<?> message) {
+        // This interceptor will be invoked SECOND!
+    }
+    // omitted constructor, command and event sourcing handlers and equals/hashCode
+}
+----
+
+[Note]
+.`@MessageHandlerInterceptor` method hierarchy for `@EventSourcingHandler` annotated methods
+====
+As explained above, `@MessageHandlerInterceptor` follow the aggregate hierarchy when applicable.
+More concrete, if an aggregate root has an interceptor, as well as one or several of the entities, the interceptor chain will "move up" the hierarchy.
+
+However, this support **does not** exist for event sourcing handlers!
+Instead, only the interceptors on that level of the hierarchy are invoked.
+Thus, in the example above, when the `GiftCardTransaction` is event sourced, only its interceptor is invoked, disregarding the one on the `GiftCard` class.
+
+This is clear discrepancy with all other message handler annotated methods that we cannot easily adjust with Axon Framework 4 it's structure.
+As such, it is not recommended to rely on an invocation hierarchy for `@MessageHandlerInterceptor` annotated methods while sourcing an aggregate.
+====
 
 Next to the message, payload and `InterceptorChain`, a `@MessageHandlerInterceptor` annotated method can resolve other parameters as well.
 Which parameters the framework can resolve on such a function, is based on the type of `Message` being handled by the interceptor.


### PR DESCRIPTION
This pull request adds a note to describe the unintended behavior of invoking `@MessageHandlerInterceptor` for `@EventSourcingHandler` annotated methods.
Due to this unintended side effect, event sourcing handlers on aggregate members do not cause the invocation of message handler interceptors.
As such, the note suggests not to use this behavior, which in most cases should not be used any how.

By adding this note, this pull request resolves #3348 