### PR TITLE
Remove `? extends` from many MessageStream results.

### DIFF
--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandBus.java
@@ -53,6 +53,6 @@ public interface CommandBus extends CommandHandlerRegistry<CommandBus>, Describa
      * @throws NoHandlerForCommandException when no {@link CommandHandler command handler} is registered for the given
      *                                      {@code command}'s name.
      */
-    CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                     @Nullable ProcessingContext processingContext);
+    CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                        @Nullable ProcessingContext processingContext);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandHandler.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandHandler.java
@@ -43,6 +43,6 @@ public interface CommandHandler extends MessageHandler {
      * @return A {@code MessagesStream.Single} of a {@link CommandResultMessage}.
      */
     @Nonnull
-    MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                   @Nonnull ProcessingContext context);
+    MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                         @Nonnull ProcessingContext context);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandBus.java
@@ -126,8 +126,8 @@ public class SimpleCommandBus implements CommandBus {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                            @Nullable ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                               @Nullable ProcessingContext processingContext) {
         return findCommandHandlerFor(command)
                 .map(handler -> handle(command, handler))
                 .orElseGet(() -> CompletableFuture.failedFuture(new NoHandlerForCommandException(format(
@@ -145,8 +145,8 @@ public class SimpleCommandBus implements CommandBus {
      * @param command The actual command to handle.
      * @param handler The handler that must be invoked for this command.
      */
-    protected CompletableFuture<? extends Message<?>> handle(@Nonnull CommandMessage<?> command,
-                                                             @Nonnull CommandHandler handler) {
+    protected CompletableFuture<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                @Nonnull CommandHandler handler) {
         if (logger.isDebugEnabled()) {
             logger.debug("Handling command [{} ({})]", command.getIdentifier(), command.type());
         }

--- a/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/SimpleCommandHandlingComponent.java
@@ -86,8 +86,8 @@ public class SimpleCommandHandlingComponent implements
 
     @Nonnull
     @Override
-    public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                          @Nonnull ProcessingContext context) {
+    public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                @Nonnull ProcessingContext context) {
         QualifiedName qualifiedName = requireNonNull(command, "The command message cannot be null.")
                 .type()
                 .qualifiedName();

--- a/messaging/src/main/java/org/axonframework/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
@@ -138,7 +138,7 @@ public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComp
 
     @Nonnull
     @Override
-    public MessageStream.Single<? extends CommandResultMessage<?>> handle(
+    public MessageStream.Single<CommandResultMessage<?>> handle(
             @Nonnull CommandMessage<?> command,
             @Nonnull ProcessingContext processingContext
     ) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/Connector.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/Connector.java
@@ -17,6 +17,7 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
@@ -32,8 +33,8 @@ import java.util.function.BiConsumer;
  */
 public interface Connector {
 
-    CompletableFuture<? extends Message<?>> dispatch(CommandMessage<?> command,
-                                                     ProcessingContext processingContext);
+    CompletableFuture<CommandResultMessage<?>> dispatch(CommandMessage<?> command,
+                                                        ProcessingContext processingContext);
 
     void subscribe(String commandName, int loadFactor);
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/DistributedCommandBus.java
@@ -21,8 +21,8 @@ import jakarta.annotation.Nullable;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.common.infra.ComponentDescriptor;
-import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
@@ -79,8 +79,8 @@ public class DistributedCommandBus implements CommandBus {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                            @Nullable ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                               @Nullable ProcessingContext processingContext) {
         return connector.dispatch(command, processingContext);
     }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/PayloadConvertingConnector.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/PayloadConvertingConnector.java
@@ -17,6 +17,7 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.serialization.PayloadConverter;
@@ -64,8 +65,8 @@ public class PayloadConvertingConnector<T> implements Connector {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(CommandMessage<?> command,
-                                                            ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(CommandMessage<?> command,
+                                                               ProcessingContext processingContext) {
         CommandMessage<T> serializedCommand = converter.convertPayload(command, representation);
         return delegate.dispatch(serializedCommand, processingContext);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/PriorityResolvingConnector.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/PriorityResolvingConnector.java
@@ -17,7 +17,7 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
-import org.axonframework.messaging.Message;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.concurrent.CompletableFuture;
@@ -49,8 +49,8 @@ public class PriorityResolvingConnector implements Connector {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(CommandMessage<?> command,
-                                                            ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(CommandMessage<?> command,
+                                                               ProcessingContext processingContext) {
         priorityResolver.priorityFor(command);
         return delegate.dispatch(command, processingContext);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/RoutingKeyResolvingConnector.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/RoutingKeyResolvingConnector.java
@@ -17,6 +17,7 @@
 package org.axonframework.commandhandling.distributed;
 
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
@@ -34,8 +35,8 @@ public class RoutingKeyResolvingConnector implements Connector {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(CommandMessage<?> command,
-                                                            ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(CommandMessage<?> command,
+                                                               ProcessingContext processingContext) {
         String routingKey = routingStrategy.getRoutingKey(command);
         if (routingKey == null) {
             return delegate.dispatch(command, processingContext);

--- a/messaging/src/main/java/org/axonframework/commandhandling/tracing/TracingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/tracing/TracingCommandBus.java
@@ -23,7 +23,6 @@ import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.common.infra.ComponentDescriptor;
-import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
@@ -68,8 +67,8 @@ public class TracingCommandBus implements CommandBus {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                            @Nullable ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                               @Nullable ProcessingContext processingContext) {
         Span span = spanFactory.createDispatchCommandSpan(
                 requireNonNull(command, "The command message cannot be null."), false
         );
@@ -92,7 +91,7 @@ public class TracingCommandBus implements CommandBus {
 
         @Nonnull
         @Override
-        public MessageStream.Single<? extends CommandResultMessage<?>> handle(
+        public MessageStream.Single<CommandResultMessage<?>> handle(
                 @Nonnull CommandMessage<?> message,
                 @Nonnull ProcessingContext processingContext
         ) {

--- a/messaging/src/main/java/org/axonframework/messaging/DefaultInterceptorChain.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DefaultInterceptorChain.java
@@ -61,7 +61,7 @@ public class DefaultInterceptorChain<T extends Message<?>, R extends Message<?>>
     }
 
     @Override
-    public MessageStream<? extends R> proceed(T message, ProcessingContext processingContext) {
+    public MessageStream<R> proceed(T message, ProcessingContext processingContext) {
         if (chain.hasNext()) {
             return chain.next().interceptOnHandle(message, processingContext, this);
         } else {

--- a/messaging/src/main/java/org/axonframework/messaging/InterceptorChain.java
+++ b/messaging/src/main/java/org/axonframework/messaging/InterceptorChain.java
@@ -42,7 +42,7 @@ public interface InterceptorChain<M extends Message<?>, R extends Message<?>> {
     /**
      * TODO Add documentation
      */
-    default MessageStream<? extends R> proceed(M message, ProcessingContext processingContext) {
+    default MessageStream<R> proceed(M message, ProcessingContext processingContext) {
         try {
             return MessageStream.fromFuture(CompletableFuture.completedFuture((R) proceedSync()));
         } catch (Exception e) {

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptor.java
@@ -59,9 +59,9 @@ public interface MessageDispatchInterceptor<T extends Message<?>> {
     BiFunction<Integer, T, T> handle(@Nonnull List<? extends T> messages);
 
 
-    default <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnDispatch(@Nonnull M message,
-                                                                                               @Nullable ProcessingContext context,
-                                                                                               @Nonnull InterceptorChain<M, R> interceptorChain) {
+    default <M extends T, R extends Message<?>> MessageStream<R> interceptOnDispatch(@Nonnull M message,
+                                                                                     @Nullable ProcessingContext context,
+                                                                                     @Nonnull InterceptorChain<M, R> interceptorChain) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageHandler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageHandler.java
@@ -41,7 +41,7 @@ public interface MessageHandler<T extends Message<?>, R extends Message<?>> {
     /**
      * TODO Add documentation
      */
-    default MessageStream<? extends R> handle(T message, ProcessingContext processingContext) {
+    default MessageStream<R> handle(T message, ProcessingContext processingContext) {
         try {
             return MessageStream.just((R) GenericResultMessage.asResultMessage(handleSync(message)));
         } catch (Exception e) {

--- a/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptor.java
@@ -52,9 +52,9 @@ public interface MessageHandlerInterceptor<T extends Message<?>> {
     Object handle(@Nonnull LegacyUnitOfWork<? extends T> unitOfWork,
                   @Nonnull InterceptorChain interceptorChain) throws Exception;
 
-    default <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(@Nonnull M message,
-                                                                          @Nonnull ProcessingContext context,
-                                                                          @Nonnull InterceptorChain<M, R> interceptorChain) {
+    default <M extends T, R extends Message<?>> MessageStream<R> interceptOnHandle(@Nonnull M message,
+                                                                                   @Nonnull ProcessingContext context,
+                                                                                   @Nonnull InterceptorChain<M, R> interceptorChain) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/InterceptorChainParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/InterceptorChainParameterResolverFactory.java
@@ -78,10 +78,10 @@ public class InterceptorChainParameterResolverFactory
      * @param action           The action to invoke
      * @return The response from the invocation of given {@code action}
      */
-    public static <M extends Message<?>, T extends Message<?>> MessageStream<? extends T> callWithInterceptorChain(
+    public static <M extends Message<?>, T extends Message<?>> MessageStream<T> callWithInterceptorChain(
             ProcessingContext processingContext,
             InterceptorChain<M, T> interceptorChain,
-            Function<ProcessingContext, MessageStream<? extends T>> action
+            Function<ProcessingContext, MessageStream<T>> action
     ) {
         ProcessingContext newProcessingContext = new ResourceOverridingProcessingContext<>(processingContext,
                                                                                            INTERCEPTOR_CHAIN_KEY,

--- a/messaging/src/main/java/org/axonframework/messaging/configuration/CommandModelComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/configuration/CommandModelComponent.java
@@ -75,8 +75,8 @@ public class CommandModelComponent
 
     @Nonnull
     @Override
-    public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                          @Nonnull ProcessingContext context) {
+    public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                @Nonnull ProcessingContext context) {
         return commandComponent.handle(command, context);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/configuration/GenericMessageHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/configuration/GenericMessageHandlingComponent.java
@@ -114,8 +114,8 @@ public class GenericMessageHandlingComponent implements MessageHandlingComponent
 
     @Nonnull
     @Override
-    public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                          @Nonnull ProcessingContext context) {
+    public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                @Nonnull ProcessingContext context) {
         QualifiedName messageType = command.type().qualifiedName();
         // TODO #3103 - add interceptor knowledge
         CommandHandler handler = commandHandlersByName.get(messageType);

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
@@ -67,21 +67,22 @@ public class BeanValidationInterceptor<T extends Message<?>>
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnDispatch(@Nonnull M message,
-                                                                           @Nullable ProcessingContext context,
-                                                                           @Nonnull InterceptorChain<M, R> interceptorChain) {
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnDispatch(@Nonnull M message,
+                                                                                    @Nullable ProcessingContext context,
+                                                                                    @Nonnull InterceptorChain<M, R> interceptorChain) {
         return intercept(message, context, interceptorChain);
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(@Nonnull M message,
-                                                                         @Nonnull ProcessingContext context,
-                                                                         @Nonnull InterceptorChain<M, R> interceptorChain) {
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnHandle(@Nonnull M message,
+                                                                                  @Nonnull ProcessingContext context,
+                                                                                  @Nonnull InterceptorChain<M, R> interceptorChain) {
         return intercept(message, context, interceptorChain);
     }
 
-    private <M extends T, R extends Message<?>> MessageStream<? extends R> intercept(M message, @Nullable ProcessingContext context,
-                                                                  InterceptorChain<M, R> interceptorChain) {
+    private <M extends T, R extends Message<?>> MessageStream<R> intercept(M message,
+                                                                           @Nullable ProcessingContext context,
+                                                                           InterceptorChain<M, R> interceptorChain) {
         Set<ConstraintViolation<Object>> violations = validate(message);
         if (!violations.isEmpty()) {
             return MessageStream.fromFuture(CompletableFuture.failedFuture(new JSR303ViolationException(violations)));

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptor.java
@@ -70,7 +70,7 @@ public class CorrelationDataInterceptor<T extends Message<?>> implements Message
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnHandle(
             @Nonnull M message,
             ProcessingContext context,
             InterceptorChain<M, R> interceptorChain

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
@@ -21,8 +21,8 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageStream;
-import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,17 +69,17 @@ public class LoggingInterceptor<T extends Message<?>>
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnDispatch(@Nonnull M message,
-                                                                           @Nullable ProcessingContext context,
-                                                                           @Nonnull InterceptorChain<M, R> interceptorChain) {
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnDispatch(@Nonnull M message,
+                                                                                    @Nullable ProcessingContext context,
+                                                                                    @Nonnull InterceptorChain<M, R> interceptorChain) {
         logger.info("Dispatched message: [{}]", message.getPayloadType().getSimpleName());
         return interceptorChain.proceed(message, context);
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(@Nonnull M message,
-                                                                         @Nonnull ProcessingContext context,
-                                                                         @Nonnull InterceptorChain<M, R> interceptorChain) {
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnHandle(@Nonnull M message,
+                                                                                  @Nonnull ProcessingContext context,
+                                                                                  @Nonnull InterceptorChain<M, R> interceptorChain) {
         logger.info("Incoming message: [{}]", message.getPayloadType().getSimpleName());
         return interceptorChain.proceed(message, context)
                                .map(returnValue -> {

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptor.java
@@ -56,9 +56,9 @@ public class TransactionManagingInterceptor<T extends Message<?>> implements Mes
     }
 
     @Override
-    public <M extends T, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(@Nonnull M message,
-                                                                                            @Nonnull ProcessingContext context,
-                                                                                            @Nonnull InterceptorChain<M, R> interceptorChain) {
+    public <M extends T, R extends Message<?>> MessageStream<R> interceptOnHandle(@Nonnull M message,
+                                                                                  @Nonnull ProcessingContext context,
+                                                                                  @Nonnull InterceptorChain<M, R> interceptorChain) {
         Transaction transaction = transactionManager.startTransaction();
         context.runOnCommit(u -> transaction.commit());
         context.onError((u, p, e) -> transaction.rollback());

--- a/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
@@ -279,18 +279,18 @@ class InterceptingCommandBusTest {
 
         @SuppressWarnings("unchecked")
         @Override
-        public <M1 extends M, R extends Message<?>> MessageStream<? extends R> interceptOnDispatch(@Nonnull M1 message,
-                                                                                                   @Nullable ProcessingContext context,
-                                                                                                   @Nonnull InterceptorChain<M1, R> interceptorChain) {
+        public <M1 extends M, R extends Message<?>> MessageStream<R> interceptOnDispatch(@Nonnull M1 message,
+                                                                                         @Nullable ProcessingContext context,
+                                                                                         @Nonnull InterceptorChain<M1, R> interceptorChain) {
             return interceptorChain.proceed((M1) message.andMetaData(Map.of(key, buildValue(message))), context)
                                    .mapMessage(m -> (R) ((Message<?>) m).andMetaData(Map.of(key, buildValue(m))));
         }
 
         @SuppressWarnings("unchecked")
         @Override
-        public <M1 extends M, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(@Nonnull M1 message,
-                                                                                                 @Nonnull ProcessingContext context,
-                                                                                                 @Nonnull InterceptorChain<M1, R> interceptorChain) {
+        public <M1 extends M, R extends Message<?>> MessageStream<R> interceptOnHandle(@Nonnull M1 message,
+                                                                                       @Nonnull ProcessingContext context,
+                                                                                       @Nonnull InterceptorChain<M1, R> interceptorChain) {
             return interceptorChain.proceed((M1) message.andMetaData(Map.of(key, buildValue(message))), context)
                                    .mapMessage(m -> (R) m.andMetaData(Map.of(key, buildValue(m))));
         }

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -174,8 +174,8 @@ class SimpleCommandBusTest {
         var commandHandler = new StubCommandHandler("ok") {
             @Nonnull
             @Override
-            public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                                  @Nonnull ProcessingContext processingContext) {
+            public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                        @Nonnull ProcessingContext processingContext) {
                 throw new MockException("Simulating exception");
             }
         };
@@ -279,7 +279,7 @@ class SimpleCommandBusTest {
 
         @Nonnull
         @Override
-        public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+        public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
                                                                               @Nonnull ProcessingContext processingContext) {
             if (result instanceof Throwable error) {
                 return MessageStream.failed(error);

--- a/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurationDefaultsTest.java
+++ b/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurationDefaultsTest.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nullable;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.SimpleCommandBus;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
@@ -30,7 +31,6 @@ import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.gateway.DefaultEventGateway;
 import org.axonframework.eventhandling.gateway.EventGateway;
 import org.axonframework.messaging.ClassBasedMessageTypeResolver;
-import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTypeResolver;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
@@ -98,8 +98,8 @@ class MessagingConfigurationDefaultsTest {
     private static class TestCommandBus implements CommandBus {
 
         @Override
-        public CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                                @Nullable ProcessingContext processingContext) {
+        public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                                   @Nullable ProcessingContext processingContext) {
             throw new UnsupportedOperationException();
         }
 

--- a/messaging/src/test/java/org/axonframework/messaging/configuration/NewMessageHandlerRegistrationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/configuration/NewMessageHandlerRegistrationTest.java
@@ -202,8 +202,8 @@ class NewMessageHandlerRegistrationTest {
 
         @Override
         @Nonnull
-        public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                              @Nonnull ProcessingContext context) {
+        public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                    @Nonnull ProcessingContext context) {
             return MessageStream.just(new GenericCommandResultMessage<>(new MessageType("command-response"), "done!"));
         }
     }
@@ -271,7 +271,7 @@ class NewMessageHandlerRegistrationTest {
 
         @Nonnull
         @Override
-        public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+        public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
                                                                               @Nonnull ProcessingContext context) {
             return MessageStream.empty().cast();
         }

--- a/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandler.java
@@ -55,7 +55,7 @@ public interface StatefulCommandHandler extends MessageHandler {
      * @return A {@code MessagesStream} of a {@link CommandResultMessage}.
      */
     @Nonnull
-    MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                   @Nonnull StateManager state,
-                                                                   @Nonnull ProcessingContext context);
+    MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                         @Nonnull StateManager state,
+                                                         @Nonnull ProcessingContext context);
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlingComponent.java
@@ -91,8 +91,8 @@ public class StatefulCommandHandlingComponent implements
 
     @Nonnull
     @Override
-    public MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
-                                                                          @Nonnull ProcessingContext context) {
+    public MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
+                                                                @Nonnull ProcessingContext context) {
         return handlingComponent.handle(command, context);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedCommandHandlerInterceptor.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedCommandHandlerInterceptor.java
@@ -23,8 +23,8 @@ import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.annotation.InterceptorChainParameterResolverFactory;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
-import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import javax.annotation.Nonnull;
 
@@ -63,7 +63,7 @@ public class AnnotatedCommandHandlerInterceptor<T> implements MessageHandlerInte
     }
 
     @Override
-    public <M extends CommandMessage<?>, R extends Message<?>> MessageStream<? extends R> interceptOnHandle(
+    public <M extends CommandMessage<?>, R extends Message<?>> MessageStream<R> interceptOnHandle(
             @Nonnull M message,
             @Nonnull ProcessingContext context,
             @Nonnull InterceptorChain<M, R> interceptorChain

--- a/test/src/main/java/org/axonframework/test/fixture/RecordingCommandBus.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingCommandBus.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nullable;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.commandhandling.CommandMessage;
+import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.QualifiedName;
@@ -41,8 +42,8 @@ class RecordingCommandBus implements CommandBus {
     }
 
     @Override
-    public CompletableFuture<? extends Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                            @Nullable ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                               @Nullable ProcessingContext processingContext) {
         recorded.put(command, null);
         var commandResult = delegate.dispatch(command, processingContext);
         commandResult.thenApply(result -> {

--- a/test/src/main/java/org/axonframework/test/utils/RecordingCommandBus.java
+++ b/test/src/main/java/org/axonframework/test/utils/RecordingCommandBus.java
@@ -52,8 +52,8 @@ public class RecordingCommandBus implements CommandBus {
     private CallbackBehavior callbackBehavior = new DefaultCallbackBehavior();
 
     @Override
-    public CompletableFuture<Message<?>> dispatch(@Nonnull CommandMessage<?> command,
-                                                  @Nullable ProcessingContext processingContext) {
+    public CompletableFuture<CommandResultMessage<?>> dispatch(@Nonnull CommandMessage<?> command,
+                                                               @Nullable ProcessingContext processingContext) {
         dispatchedCommands.add(command);
         try {
             return CompletableFuture.completedFuture(asCommandResultMessage(


### PR DESCRIPTION
I experienced problems while creating tests for command handling components. It was very hard to get components to capture the generic type correctly due to the `? extends`.

That's when I wondered if we couldn't remove it. It definitely would look a lot more clear on the interfaces for the user.

Turns out we can. I am making this PR as a proposal. Perhaps I missed something obvious, the reason why the wildcard was there, but if we can remove it, I think we should.

In short, this PR makes it possible to have this method on the (end user facing)  CommandHandler interface:

```java
    MessageStream.Single<CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
                                                         @Nonnull ProcessingContext context);
```

Instead of:
```java

 MessageStream.Single<? extends CommandResultMessage<?>> handle(@Nonnull CommandMessage<?> command,
                                                                   @Nonnull ProcessingContext context);
```


If we don't do this, Mockito is unable to capture the generic. And mocking a handler will looks like:

```java
OngoingStubbing<? extends MessageStream.Single<? extends CommandResultMessage<?>>> stubbingCall = when(
        entityModel.handle(eq(commandMessage), eq(mockEntity), any()));
((OngoingStubbing<MessageStream.Single<? extends CommandResultMessage<?>>>) stubbingCall).thenReturn(
        entityResult);
```

Or, more short:
```java

OngoingStubbing<MessageStream.Single<? extends CommandResultMessage<?>>> stubbingCall = when(
        entityModel.handle(eq(commandMessage), eq(mockEntity), any()));
stubbingCall.thenReturn(entityResult);
```
