### PR TITLE
Added caching for unknown classes

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -58,6 +60,8 @@ public abstract class AbstractXStreamSerializer implements Serializer {
     private final Charset charset;
     private final RevisionResolver revisionResolver;
     private final Converter converter;
+    private final Set<String> unknownClasses = new ConcurrentSkipListSet<>();
+    private final boolean cacheUnknownClasses;
 
     /**
      * Instantiate a {@link AbstractXStreamSerializer} based on the fields contained in the {@link Builder}.
@@ -70,6 +74,7 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         this.xStream = builder.xStream;
         this.converter = builder.converter;
         this.revisionResolver = builder.revisionResolver;
+        this.cacheUnknownClasses = builder.cacheUnknownClasses;
 
         if (converter instanceof ChainingConverter) {
             registerConverters((ChainingConverter) converter);
@@ -167,9 +172,14 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         if (SerializedType.emptyType().equals(type)) {
             return Void.class;
         }
+        String className = type.getName();
+        if (cacheUnknownClasses && unknownClasses.contains(className)) {
+            return UnknownSerializedType.class;
+        }
         try {
-            return xStream.getMapper().realClass(type.getName());
+            return xStream.getMapper().realClass(className);
         } catch (CannotResolveClassException e) {
+            unknownClasses.add(className);
             return UnknownSerializedType.class;
         }
     }
@@ -287,6 +297,7 @@ public abstract class AbstractXStreamSerializer implements Serializer {
         private boolean lenientDeserialization = false;
         private boolean axonTypeSecurity = true;
         private ClassLoader classLoader;
+        private boolean cacheUnknownClasses = true;
 
         /**
          * Sets the {@link XStream} used to perform the serialization of objects to XML, and vice versa.
@@ -379,6 +390,19 @@ public abstract class AbstractXStreamSerializer implements Serializer {
          */
         public Builder disableAxonTypeSecurity() {
             this.axonTypeSecurity = false;
+            return this;
+        }
+
+        /**
+         * Disables the caching of the names for classes which couldn't be resolved to a class.
+         * <p>
+         * It is recommended to disable this in case the class loading is dynamic, and classes that are not available at
+         * one point in time, may become available at any time later.
+         *
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder disableCachingOfUnknownClasses() {
+            this.cacheUnknownClasses = false;
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,32 @@
 package org.axonframework.serialization.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.MetaData;
-import org.axonframework.serialization.*;
+import org.axonframework.serialization.AnnotationRevisionResolver;
+import org.axonframework.serialization.ChainingConverter;
+import org.axonframework.serialization.Converter;
+import org.axonframework.serialization.RevisionResolver;
+import org.axonframework.serialization.SerializationException;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.axonframework.serialization.SimpleSerializedType;
+import org.axonframework.serialization.UnknownSerializedType;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
+import javax.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -263,13 +277,13 @@ public class JacksonSerializer implements Serializer {
      */
     public static class Builder {
 
-        private boolean cacheUnknownClasses = true;
         private RevisionResolver revisionResolver = new AnnotationRevisionResolver();
         private Converter converter = new ChainingConverter();
         private ObjectMapper objectMapper = new ObjectMapper();
         private boolean lenientDeserialization = false;
         private boolean defaultTyping = false;
         private ClassLoader classLoader;
+        private boolean cacheUnknownClasses = true;
 
         /**
          * Sets the {@link RevisionResolver} used to resolve the revision from an object to be serialized. Defaults to
@@ -341,15 +355,15 @@ public class JacksonSerializer implements Serializer {
         }
 
         /**
-         * Indicated whether to cache the names for classes which couldn't be resolved to a class. Defaults to {@code true}.
+         * Disables the caching of the names for classes which couldn't be resolved to a class.
          * <p>
-         * It is recommended to disable this in case the class loading is dynamic, and classes that are not available
-         * at one point in time, may become available at any time later.
+         * It is recommended to disable this in case the class loading is dynamic, and classes that are not available at
+         * one point in time, may become available at any time later.
          *
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder cacheUnknownClasses(boolean cacheUnknownClasses) {
-            this.cacheUnknownClasses = cacheUnknownClasses;
+        public Builder disableCachingOfUnknownClasses() {
+            this.cacheUnknownClasses = false;
             return this;
         }
 

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,6 +216,12 @@ public class XStreamSerializer extends AbstractXStreamSerializer {
         @Override
         public Builder disableAxonTypeSecurity() {
             super.disableAxonTypeSecurity();
+            return this;
+        }
+
+        @Override
+        public Builder disableCachingOfUnknownClasses() {
+            super.disableCachingOfUnknownClasses();
             return this;
         }
 

--- a/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/json/JacksonSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,11 +148,14 @@ class JacksonSerializerTest {
     @Test
     void readUnknownSerializedTypeCachesLookupResults() {
         ObjectMapper spiedMapper = spy(objectMapper);
-        testSubject = JacksonSerializer.builder().objectMapper(spiedMapper).build();
-        SerializedObject<String> serialized = new SimpleSerializedObject<>("{\"data\" : \"value\"}", String.class, "my.nonexistent.Class", null);
+        testSubject = JacksonSerializer.builder()
+                                       .objectMapper(spiedMapper)
+                                       .build();
+        SerializedObject<String> testObject =
+                new SimpleSerializedObject<>("{\"data\" : \"value\"}", String.class, "my.nonexistent.Class", null);
 
         for (int i = 0; i < 10; i++) {
-            Class<?> actual = testSubject.classForType(serialized.getType());
+            Class<?> actual = testSubject.classForType(testObject.getType());
             assertEquals(UnknownSerializedType.class, actual);
         }
 
@@ -162,11 +165,15 @@ class JacksonSerializerTest {
     @Test
     void readUnknownSerializedTypeWithCachingDisabled() {
         ObjectMapper spiedMapper = spy(objectMapper);
-        testSubject = JacksonSerializer.builder().cacheUnknownClasses(false).objectMapper(spiedMapper).build();
-        SerializedObject<String> serialized = new SimpleSerializedObject<>("{\"data\" : \"value\"}", String.class, "my.nonexistent.Class", null);
+        testSubject = JacksonSerializer.builder()
+                                       .objectMapper(spiedMapper)
+                                       .disableCachingOfUnknownClasses()
+                                       .build();
+        SerializedObject<String> testObject =
+                new SimpleSerializedObject<>("{\"data\" : \"value\"}", String.class, "my.nonexistent.Class", null);
 
         for (int i = 0; i < 10; i++) {
-            Class<?> actual = testSubject.classForType(serialized.getType());
+            Class<?> actual = testSubject.classForType(testObject.getType());
             assertEquals(UnknownSerializedType.class, actual);
         }
 


### PR DESCRIPTION
Resolving classes based on a name that did not yield any results was very slow. This meant that processing a stream of event where the majority of events aren't represented as classes was slower than a case where the classes are available on the class path.