### PR TITLE
Only use Jakarta for nullability annotations

### DIFF
--- a/axon-5-module-structure-suggestion/pom.xml
+++ b/axon-5-module-structure-suggestion/pom.xml
@@ -85,7 +85,6 @@
         <jakarta.persistence.version>3.0.0</jakarta.persistence.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <!-- Javax -->
-        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.cache-api.version>1.1.1</javax.cache-api.version>
         <javax.el-api.version>3.0.1-b06</javax.el-api.version>
         <javax.el-impl.version>2.2</javax.el-impl.version>
@@ -281,11 +280,6 @@
                 <version>${postgresql.version}</version>
             </dependency>
             <!-- Javax / Jakarta -->
-            <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotation-api.version}</version>
-            </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConnectionManager.java
@@ -39,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import javax.net.ssl.SSLException;
 
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModule.java
@@ -39,7 +39,7 @@ import org.axonframework.queryhandling.SimpleQueryBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Configurer module which is auto-loadable by the {@link LegacyDefaultConfigurer} that sets sensible

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
@@ -274,7 +274,7 @@ public class AggregateBasedAxonServerEventStorageEngine implements EventStorageE
     }
 
     @Override
-    public void describeTo(@javax.annotation.Nonnull ComponentDescriptor descriptor) {
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
         descriptor.describeProperty("connection", connection);
         descriptor.describeProperty("payloadConverter", payloadConverter);
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -77,7 +77,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Spliterator.*;
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
@@ -34,7 +34,7 @@ import org.axonframework.tracing.NoOpSpanFactory;
 import org.axonframework.tracing.SpanFactory;
 
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
@@ -24,7 +24,7 @@ import org.axonframework.serialization.Serializer;
 
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Wrapper around standard Axon Framework serializer that can deserialize Metadata from AxonServer events.

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamMessageSource.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/PersistentStreamMessageSource.java
@@ -25,7 +25,7 @@ import org.axonframework.messaging.SubscribableMessageSource;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link SubscribableMessageSource} that receives event from a persistent stream from Axon Server. The persistent

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/processor/EventProcessorControlService.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.stream.Collectors.toMap;
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -108,7 +108,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/PriorityExecutorService.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/PriorityExecutorService.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * This {@link ExecutorService} wraps an existing one, creating a {@link PriorityTask} for every {@link Runnable} that

--- a/config/src/main/java/org/axonframework/config/AxonIQConsoleModule.java
+++ b/config/src/main/java/org/axonframework/config/AxonIQConsoleModule.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * Module related to AxonIQ console, for now it's just logging information about AxonIQ console when it's not suppressed

--- a/config/src/main/java/org/axonframework/config/Component.java
+++ b/config/src/main/java/org/axonframework/config/Component.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A Component used in the Axon Configurer. A Component describes an object that needs to be created, possibly based on

--- a/config/src/main/java/org/axonframework/config/ConfigurerModule.java
+++ b/config/src/main/java/org/axonframework/config/ConfigurerModule.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.config;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a configurer for a module in the Axon Configuration API. Allows the registration of modules on

--- a/config/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingConfiguration.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Defines a contract for accessor methods regarding event processing configuration.

--- a/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingConfigurer.java
@@ -47,7 +47,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Defines a contract for configuring event processing.

--- a/config/src/main/java/org/axonframework/config/EventProcessingModule.java
+++ b/config/src/main/java/org/axonframework/config/EventProcessingModule.java
@@ -74,7 +74,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static java.util.Comparator.comparing;

--- a/config/src/main/java/org/axonframework/config/LegacyConfiguration.java
+++ b/config/src/main/java/org/axonframework/config/LegacyConfiguration.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing the Global Configuration for Axon components. It provides access to the components configured,

--- a/config/src/main/java/org/axonframework/config/LegacyConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/LegacyConfigurer.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Entry point of the Axon Configuration API.

--- a/config/src/main/java/org/axonframework/config/LegacyDefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/LegacyDefaultConfigurer.java
@@ -124,7 +124,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.stream.Collectors.toList;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
+++ b/config/src/main/java/org/axonframework/config/MessageHandlerRegistrar.java
@@ -27,7 +27,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerHandlerRegistrationTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerHandlerRegistrationTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/EventProcessingModuleTest.java
@@ -84,7 +84,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.ReflectionUtils.getFieldValue;
 import static org.axonframework.utils.AssertUtils.assertWithin;

--- a/config/src/test/java/org/axonframework/config/MessageCollectingMonitor.java
+++ b/config/src/test/java/org/axonframework/config/MessageCollectingMonitor.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public class MessageCollectingMonitor implements MessageMonitor<Message<?>> {
     private final List<Message<?>> messages = new ArrayList<>();

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotTrigger.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotTrigger.java
@@ -20,7 +20,7 @@ import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Abstract implementation of the {@link org.axonframework.eventsourcing.SnapshotTrigger} that schedules snapshots on

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractSnapshotter.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateLoadTimeSnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateLoadTimeSnapshotTriggerDefinition.java
@@ -17,7 +17,7 @@
 package org.axonframework.eventsourcing;
 
 import java.time.Clock;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A Snapshotter trigger mechanism which based on the loading time of an Aggregate decides when to trigger the creation

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateSnapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateSnapshotter.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventCountSnapshotTriggerDefinition.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventsourcing;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Snapshotter trigger mechanism that counts the number of events to decide when to create a snapshot. A snapshot is

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/LegacyEventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/LegacyEventSourcingRepository.java
@@ -38,7 +38,7 @@ import org.axonframework.modelling.command.inspection.AggregateModel;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/LegacyFilteringEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/LegacyFilteringEventStorageEngine.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of EventStorageEngine that delegates to another implementation, while filtering

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/NoSnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/NoSnapshotTriggerDefinition.java
@@ -18,7 +18,7 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.eventhandling.EventMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of {@link SnapshotTriggerDefinition} that doesn't trigger snapshots at all.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/SnapshotTrigger.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/SnapshotTrigger.java
@@ -18,7 +18,7 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.eventhandling.EventMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a mechanism that keeps track of an Aggregate's activity in order to trigger a snapshot. The

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/SnapshotTriggerDefinition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/SnapshotTriggerDefinition.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventsourcing;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing the mechanism for triggering Snapshots. The SnapshotTriggerDefinition creates specific trigger

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/Snapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/Snapshotter.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventsourcing;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing instances that are capable of creating snapshot events for aggregates. Although snapshotting is

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractLegacyEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractLegacyEventStorageEngine.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractLegacyEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AbstractLegacyEventStore.java
@@ -31,7 +31,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEmbeddedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEmbeddedEventStore.java
@@ -47,7 +47,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.stream.Collectors.toList;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEventStorageEngine.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.util.Arrays.asList;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacyEventStore.java
@@ -24,7 +24,7 @@ import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.messaging.StreamableMessageSource;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Provides a mechanism to open streams from events in the the underlying event storage.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacySequenceEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/LegacySequenceEventStorageEngine.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * EventStorageEngine implementation that combines the streams of two event storage engines. The first event storage

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StartingFrom.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StartingFrom.java
@@ -19,7 +19,7 @@ package org.axonframework.eventsourcing.eventstore;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.TrackingToken;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * An implementation of the {@link StreamingCondition} that will start

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/LegacyInMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/LegacyInMemoryEventStorageEngine.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.eventhandling.EventUtils.asTrackedEventMessage;
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
@@ -75,7 +75,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.Assert.isTrue;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageEngine.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import javax.sql.DataSource;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/LegacyJpaEventStorageOperations.java
@@ -34,7 +34,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AbstractSnapshotterTest.java
@@ -39,7 +39,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.eventsourcing.utils.EventStoreTestUtils.createEvent;
 import static org.axonframework.eventsourcing.utils.EventStoreTestUtils.createEvents;

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -29,7 +29,7 @@ import org.axonframework.eventsourcing.eventstore.SimpleEventStore;
 import org.axonframework.eventsourcing.eventstore.Tag;
 import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import java.util.Set;
@@ -90,7 +90,7 @@ class EventSourcingConfigurationDefaultsTest {
     private static class TestTagResolver implements TagResolver {
 
         @Override
-        public Set<Tag> resolve(@NotNull EventMessage<?> event) {
+        public Set<Tag> resolve(@Nonnull EventMessage<?> event) {
             throw new UnsupportedOperationException();
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageStream.Entry;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 import org.opentest4j.TestAbortedException;
 import reactor.test.StepVerifier;
@@ -523,7 +523,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         );
     }
 
-    private @NotNull Predicate<Entry<EventMessage<?>>> entryWithAggregateEvent(String expectedPayload,
+    private @Nonnull Predicate<Entry<EventMessage<?>>> entryWithAggregateEvent(String expectedPayload,
                                                                                int expectedSequence) {
         return e -> expectedPayload.equals(convertPayload(e.message()).getPayload())
                 && TEST_AGGREGATE_ID.equals(e.getResource(LegacyResources.AGGREGATE_IDENTIFIER_KEY))

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AnnotationBasedTagResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AnnotationBasedTagResolverTest.java
@@ -21,7 +21,7 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventsourcing.annotations.EventTag;
 import org.axonframework.eventsourcing.annotations.EventTags;
 import org.axonframework.messaging.MessageType;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -268,7 +268,7 @@ class AnnotationBasedTagResolverTest {
         static class CustomIterable implements Iterable<String> {
 
             @Override
-            public @NotNull Iterator<String> iterator() {
+            public @Nonnull Iterator<String> iterator() {
                 return Arrays.asList("one", "two", "three").iterator();
             }
         }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStoreTest.java
@@ -23,7 +23,7 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
@@ -88,13 +88,13 @@ class EventStoreTest {
         }
 
         @Override
-        public EventStoreTransaction transaction(@NotNull ProcessingContext processingContext) {
+        public EventStoreTransaction transaction(@Nonnull ProcessingContext processingContext) {
             this.processingContext.set(processingContext);
             return new TestEventStoreTransaction(appendedEvents);
         }
 
         @Override
-        public void describeTo(@NotNull ComponentDescriptor descriptor) {
+        public void describeTo(@Nonnull ComponentDescriptor descriptor) {
             throw new UnsupportedOperationException("We don't need this method to test the defaulted methods.");
         }
     }
@@ -108,17 +108,17 @@ class EventStoreTest {
         }
 
         @Override
-        public MessageStream<EventMessage<?>> source(@NotNull SourcingCondition condition) {
+        public MessageStream<EventMessage<?>> source(@Nonnull SourcingCondition condition) {
             throw new UnsupportedOperationException("We don't need this method to test the defaulted methods.");
         }
 
         @Override
-        public void appendEvent(@NotNull EventMessage<?> eventMessage) {
+        public void appendEvent(@Nonnull EventMessage<?> eventMessage) {
             appendedEvents.get().add(eventMessage);
         }
 
         @Override
-        public void onAppend(@NotNull Consumer<EventMessage<?>> callback) {
+        public void onAppend(@Nonnull Consumer<EventMessage<?>> callback) {
             throw new UnsupportedOperationException("We don't need this method to test the defaulted methods.");
         }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
@@ -25,7 +25,7 @@ import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.messaging.Context;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
@@ -233,7 +233,7 @@ class SimpleEventStoreTest {
         verify(descriptor).describeProperty("eventStorageEngine", mockStorageEngine);
     }
 
-    private static @NotNull MessageStream<EventMessage<?>> messageStreamOf(int messageCount) {
+    private static @Nonnull MessageStream<EventMessage<?>> messageStreamOf(int messageCount) {
         return MessageStream.fromStream(IntStream.range(0, messageCount).boxed(),
                                         SimpleEventStoreTest::eventMessage,
                                         i -> Context.with(ConsistencyMarker.RESOURCE_KEY,

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/jdbc/JdbcEventStoreBenchmark.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/jdbc/JdbcEventStoreBenchmark.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import javax.sql.DataSource;
 
 /**

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
@@ -37,7 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicESAggregateAnnotationCommandHandlerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicESAggregateAnnotationCommandHandlerTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Tests for ES aggregate polymorphism.

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicJpaAggregateAnnotationCommandHandlerTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/PolymorphicJpaAggregateAnnotationCommandHandlerTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.mockito.Mockito.*;
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MultiEntityCommandHandlingComponentTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MultiEntityCommandHandlingComponentTest.java
@@ -34,7 +34,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.modelling.annotation.InjectEntity;
 import org.axonframework.modelling.command.EntityIdResolver;
 import org.axonframework.modelling.repository.ManagedEntity;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import java.util.concurrent.ExecutionException;
@@ -180,7 +180,7 @@ class MultiEntityCommandHandlingComponentTest extends AbstractStudentTestSuite {
         public static class MentorIdResolver implements EntityIdResolver<String> {
 
             @Override
-            @NotNull
+            @Nonnull
             public String resolve(@Nonnull Message<?> command, @Nonnull ProcessingContext context) {
                 //noinspection unused
                 if (command.getPayload() instanceof AssignMentorCommand(String studentId, String mentorId)) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.MetaData;
 
 import java.util.Map;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Generic implementation of the {@link CommandMessage} interface.

--- a/messaging/src/main/java/org/axonframework/commandhandling/annotation/MethodCommandHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/annotation/MethodCommandHandlerDefinition.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Optional;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of a {@link HandlerEnhancerDefinition} that is used for {@link CommandHandler} annotated methods.

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.ReflectionUtils.*;
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/MetaDataRoutingStrategy.java
@@ -19,7 +19,7 @@ package org.axonframework.commandhandling.distributed;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.common.AxonConfigurationException;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * RoutingStrategy implementation that uses the value in the {@link org.axonframework.messaging.MetaData} of a

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/RoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/RoutingStrategy.java
@@ -19,7 +19,7 @@ package org.axonframework.commandhandling.distributed;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.messaging.Context.ResourceKey;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a mechanism that generates a routing key for a given command. Commands that should be handled by

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/UnresolvedRoutingKeyPolicy.java
@@ -20,7 +20,7 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.messaging.retry.RetryScheduler;
 
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -24,8 +24,8 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface towards the Command Handling components of an application.

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -26,8 +26,8 @@ import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Default implementation of the {@link CommandGateway} interface.

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGateway.java
@@ -23,8 +23,8 @@ import org.axonframework.serialization.Serializer;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
 

--- a/messaging/src/main/java/org/axonframework/common/AxonThreadFactory.java
+++ b/messaging/src/main/java/org/axonframework/common/AxonThreadFactory.java
@@ -18,7 +18,7 @@ package org.axonframework.common;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Thread factory that created threads in a given group.

--- a/messaging/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
+++ b/messaging/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 
 /**

--- a/messaging/src/main/java/org/axonframework/deadline/AbstractDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/AbstractDeadlineManager.java
@@ -32,7 +32,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Abstract implementation of the {@link DeadlineManager} to be implemented by concrete solutions for the

--- a/messaging/src/main/java/org/axonframework/deadline/DeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/DeadlineManager.java
@@ -23,8 +23,8 @@ import org.axonframework.messaging.ScopeDescriptor;
 
 import java.time.Duration;
 import java.time.Instant;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Contract for deadline managers. Contains methods for scheduling a deadline and for cancelling a deadline.

--- a/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
@@ -52,7 +52,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/deadline/annotation/DeadlineMethodMessageHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/deadline/annotation/DeadlineMethodMessageHandlerDefinition.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of a {@link HandlerEnhancerDefinition} that is used for {@link DeadlineHandler} annotated methods.

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetails.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetails.java
@@ -29,8 +29,8 @@ import org.axonframework.serialization.SimpleSerializedObject;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.lang.String.format;
 

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManager.java
@@ -64,8 +64,8 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.lang.String.format;
 import static java.util.Objects.isNull;

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManagerSupplier.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManagerSupplier.java
@@ -18,7 +18,7 @@ package org.axonframework.deadline.dbscheduler;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Default supplier for an {@link DbSchedulerDeadlineManager}. This makes it easier to use in context without more

--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/JobRunrDeadlineManager.java
@@ -56,8 +56,8 @@ import org.slf4j.Logger;
 
 import java.time.Instant;
 import java.util.UUID;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/LabelUtils.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/LabelUtils.java
@@ -20,7 +20,7 @@ import org.axonframework.common.digest.Digester;
 import org.axonframework.messaging.ScopeDescriptor;
 import org.axonframework.serialization.Serializer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Utility to create labels for use with JobRunr. As labels have a maximum length of 44, we hash a label whenever it

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/QuartzDeadlineManager.java
@@ -55,7 +55,7 @@ import java.time.Instant;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Date.from;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventBus.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.messaging.unitofwork.LegacyUnitOfWork.Phase.*;

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventProcessor.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;

--- a/messaging/src/main/java/org/axonframework/eventhandling/DirectEventProcessingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DirectEventProcessingStrategy.java
@@ -18,7 +18,7 @@ package org.axonframework.eventhandling;
 
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Event processing strategy that directly initiates event processing.

--- a/messaging/src/main/java/org/axonframework/eventhandling/ErrorContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ErrorContext.java
@@ -17,7 +17,7 @@
 package org.axonframework.eventhandling;
 
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Describes the context of an error.

--- a/messaging/src/main/java/org/axonframework/eventhandling/ErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ErrorHandler.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventhandling;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface of the error handler that will be invoked if event processing fails. The error handler is generally invoked

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventBus.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.SubscribableMessageSource;
 
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Specification of the mechanism on which the Event Listeners can subscribe for events and event publishers can publish

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventHandlerInvoker.java
@@ -19,8 +19,8 @@ package org.axonframework.eventhandling;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface for an event message handler that defers handling to one or more other handlers.

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventProcessingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventProcessingStrategy.java
@@ -18,7 +18,7 @@ package org.axonframework.eventhandling;
 
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a strategy for the processing of a batch of events. This is used by the {@link

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Generic implementation of a {@link DomainEventMessage} that is also a {@link TrackedEventMessage}.

--- a/messaging/src/main/java/org/axonframework/eventhandling/ListenerInvocationErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ListenerInvocationErrorHandler.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventhandling;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface of an error handler that is invoked when an exception is triggered as result of an {@link

--- a/messaging/src/main/java/org/axonframework/eventhandling/LoggingErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/LoggingErrorHandler.java
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of a {@link ListenerInvocationErrorHandler} that logs exceptions as errors but otherwise does nothing

--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiEventHandlerInvoker.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of {@link EventHandlerInvoker} with capabilities to invoke several different invokers.

--- a/messaging/src/main/java/org/axonframework/eventhandling/PropagatingErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/PropagatingErrorHandler.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventhandling;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Singleton ErrorHandler implementation that does not do anything.

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.messaging.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.beans.ConstructorProperties;
 import java.util.Objects;
 import java.util.Optional;

--- a/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventBus.java
@@ -21,7 +21,7 @@ import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.tracing.SpanFactory;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of the {@link EventBus} that dispatches events in the thread the publishes them.

--- a/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SimpleEventHandlerInvoker.java
@@ -31,8 +31,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.util.Arrays.asList;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/StreamingEventProcessor.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 
 /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/SubscribingEventProcessor.java
@@ -32,7 +32,7 @@ import org.axonframework.monitoring.NoOpMessageMonitor;
 
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessorConfiguration.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.*;
 import static org.axonframework.eventhandling.ReplayToken.createReplayToken;

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/AsynchronousEventProcessingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/AsynchronousEventProcessingStrategy.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Objects.requireNonNull;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/FullConcurrencyPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/FullConcurrencyPolicy.java
@@ -18,7 +18,7 @@ package org.axonframework.eventhandling.async;
 
 import org.axonframework.eventhandling.EventMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * SequencingPolicy that does not enforce any sequencing requirements on event processing.

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/MetaDataSequencingPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/MetaDataSequencingPolicy.java
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling.async;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/PropertySequencingPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/PropertySequencingPolicy.java
@@ -22,7 +22,7 @@ import org.axonframework.common.property.PropertyAccessStrategy;
 import org.axonframework.eventhandling.EventMessage;
 
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/SequencingPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/SequencingPolicy.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventhandling.async;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface to a policy definition for concurrent processing, for example event handling.

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPerAggregatePolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPerAggregatePolicy.java
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling.async;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Concurrency policy that requires sequential processing of events raised by the same aggregate. Events from different

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPolicy.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.eventhandling.async;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * SequencingPolicy that requires sequential handling of all events delivered to an event handler.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.messaging.deadletter.ThrowableCause.truncated;

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DeadLetterStatementFactory.java
@@ -28,7 +28,7 @@ import java.time.Instant;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A contract towards <b>all</b> {@link PreparedStatement PreparedStatements} a {@link JdbcSequencedDeadLetterQueue}

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -36,7 +36,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ObjectUtils.getOrDefault;

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueue.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.*;
 import static org.axonframework.common.ObjectUtils.getOrDefault;

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueue.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.*;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventAppender.java
@@ -25,7 +25,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Component that publishes events to an {@link EventSink} in the context of a {@link ProcessingContext}. The events

--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventGateway.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventGateway.java
@@ -20,7 +20,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface towards the Event Handling components of an application. This interface provides a friendlier API toward

--- a/messaging/src/main/java/org/axonframework/eventhandling/interceptors/EventLoggingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/interceptors/EventLoggingInterceptor.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Message Dispatch Interceptor that logs published events to a SLF4J logger. It does not alter or reject events.

--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessor.java
@@ -60,7 +60,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.IntStream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapper.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/ReplayAwareMessageHandlerWrapper.java
@@ -28,7 +28,7 @@ import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 import java.lang.reflect.Member;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singletonMap;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling.replay;
 import org.axonframework.messaging.Message;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link Message} initiating the reset of an Event Handling Component.

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
@@ -51,7 +51,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventSchedulerSupplier.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventSchedulerSupplier.java
@@ -20,7 +20,7 @@ import org.axonframework.deadline.dbscheduler.DbSchedulerDeadlineManager;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Default supplier for an {@link DbSchedulerEventScheduler}. This makes it easier to use in context without more

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
@@ -44,7 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -53,7 +53,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.eventhandling.GenericEventMessage.clock;

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/TokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/TokenStore.java
@@ -24,8 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Describes a component capable of storing and retrieving event tracking tokens. An {@link EventProcessor} that is

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/inmemory/InMemoryTokenStore.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jdbc/JdbcTokenStore.java
@@ -48,8 +48,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -42,8 +42,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptor.java
@@ -21,8 +21,8 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interceptor that allows messages to be intercepted and modified before they are dispatched. This interceptor provides

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptorSupport.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDispatchInterceptorSupport.java
@@ -18,7 +18,7 @@ package org.axonframework.messaging;
 
 import org.axonframework.common.Registration;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface marking components capable of registering Dispatch Interceptors. Generally, these are Messaging components

--- a/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptor.java
@@ -19,7 +19,7 @@ package org.axonframework.messaging;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Workflow interface that allows for customized message handler invocation chains. A MessageHandlerInterceptor can add

--- a/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptorSupport.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageHandlerInterceptorSupport.java
@@ -18,7 +18,7 @@ package org.axonframework.messaging;
 
 import org.axonframework.common.Registration;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface marking components capable of registering Handler Interceptors. Generally, these are Messaging components

--- a/messaging/src/main/java/org/axonframework/messaging/MetaData.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MetaData.java
@@ -27,8 +27,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Represents MetaData that is passed along with a payload in a Message. Typically, the MetaData contains information

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -22,7 +22,7 @@ import org.axonframework.serialization.Serializer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link Message} that represents a result of handling some form of request message.

--- a/messaging/src/main/java/org/axonframework/messaging/StreamableMessageSource.java
+++ b/messaging/src/main/java/org/axonframework/messaging/StreamableMessageSource.java
@@ -21,7 +21,7 @@ import org.axonframework.eventhandling.TrackingToken;
 
 import java.time.Duration;
 import java.time.Instant;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface for a source of {@link Message messages} that processors can track.

--- a/messaging/src/main/java/org/axonframework/messaging/SubscribableMessageSource.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SubscribableMessageSource.java
@@ -20,7 +20,7 @@ import org.axonframework.common.Registration;
 
 import java.util.List;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface for a source of {@link Message messages} to which message processors can subscribe.

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/HandlerEnhancerDefinition.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.messaging.annotation;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing objects that are capable of enhancing a {@link MessageHandler}, giving it additional

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MultiHandlerEnhancerDefinition.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * HandlerEnhancerDefinition instance that delegates to multiple other instances, in the order provided.

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/GenericDeadLetter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/GenericDeadLetter.java
@@ -24,7 +24,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Generic implementation of the {@link DeadLetter dead letter} allowing any type of {@link Message} to be dead

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/InMemorySequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/InMemorySequencedDeadLetterQueue.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertStrictPositive;
 

--- a/messaging/src/main/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueue.java
+++ b/messaging/src/main/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueue.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing the required functionality for a dead letter queue. Contains several FIFO-ordered sequences of

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interceptor that applies JSR303 bean validation on incoming {@link Message}s. When validation on a message fails, a

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/CorrelationDataInterceptor.java
@@ -25,7 +25,7 @@ import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/LoggingInterceptor.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * {@link MessageDispatchInterceptor} and {@link MessageHandlerInterceptor} implementation that logs dispatched and

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/TransactionManagingInterceptor.java
@@ -25,7 +25,7 @@ import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interceptor that uses a {@link TransactionManager} to start a new transaction before a Message is handled. When the

--- a/messaging/src/main/java/org/axonframework/messaging/retry/AsyncRetryScheduler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/AsyncRetryScheduler.java
@@ -31,8 +31,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.common.FutureUtils.unwrap;
 

--- a/messaging/src/main/java/org/axonframework/messaging/retry/ExponentialBackOffRetryPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/ExponentialBackOffRetryPolicy.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A RetryScheduler that uses a backoff strategy, doubling the retry delay after each attempt.

--- a/messaging/src/main/java/org/axonframework/messaging/retry/FilteringRetryPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/FilteringRetryPolicy.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 
 import java.util.List;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A RetryPolicy that delegates to another RetryPolicy when the latest exception matches a given predicate.

--- a/messaging/src/main/java/org/axonframework/messaging/retry/MaxAttemptsPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/MaxAttemptsPolicy.java
@@ -20,7 +20,7 @@ import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.Message;
 
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A retry policy that caps another policy to maximum number of retries

--- a/messaging/src/main/java/org/axonframework/messaging/retry/RetryPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/RetryPolicy.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Describes a policy for retrying failed messages. These could be commands, events, as well as queries where the

--- a/messaging/src/main/java/org/axonframework/messaging/retry/RetryScheduler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/retry/RetryScheduler.java
@@ -20,8 +20,8 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface towards a mechanism that decides whether to schedule a message for dispatching when a previous attempts

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/HandlerTimeoutHandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/HandlerTimeoutHandlerEnhancerDefinition.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.annotation.MessageHandlerTimeout;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.queryhandling.QueryMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Inspects message handler and wraps it in a {@link TimeoutWrappedMessageHandlingMember} if the handler should have a

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/TimeoutWrappedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/TimeoutWrappedMessageHandlingMember.java
@@ -20,7 +20,7 @@ import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 
 import java.util.concurrent.TimeoutException;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Represents a {@link MessageHandlingMember} that wraps another {@link MessageHandlingMember} and enforces a timeout on

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/UnitOfWorkTimeoutInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/UnitOfWorkTimeoutInterceptor.java
@@ -22,7 +22,7 @@ import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 import org.slf4j.Logger;
 
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Message handler interceptor that sets a timeout on the processing of the current {@link LegacyUnitOfWork}. If the

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyBatchingUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyBatchingUnitOfWork.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.messaging.GenericResultMessage.asResultMessage;
 

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyDefaultUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyDefaultUnitOfWork.java
@@ -26,7 +26,7 @@ import org.axonframework.messaging.ResultMessage;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.messaging.GenericResultMessage.asResultMessage;
 

--- a/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyUnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/unitofwork/LegacyUnitOfWork.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * This class represents a Unit of Work that monitors the processing of a {@link Message}.

--- a/messaging/src/main/java/org/axonframework/monitoring/MessageMonitor.java
+++ b/messaging/src/main/java/org/axonframework/monitoring/MessageMonitor.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Specifies a mechanism to monitor message processing. When a message is supplied to

--- a/messaging/src/main/java/org/axonframework/monitoring/MultiMessageMonitor.java
+++ b/messaging/src/main/java/org/axonframework/monitoring/MultiMessageMonitor.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Delegates messages and callbacks to the given list of message monitors

--- a/messaging/src/main/java/org/axonframework/monitoring/NoOpMessageMonitor.java
+++ b/messaging/src/main/java/org/axonframework/monitoring/NoOpMessageMonitor.java
@@ -18,7 +18,7 @@ package org.axonframework.monitoring;
 
 import org.axonframework.messaging.Message;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A message monitor that returns a NoOp message callback

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Arrays.asList;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/messaging/src/main/java/org/axonframework/queryhandling/LoggingQueryInvocationErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/LoggingQueryInvocationErrorHandler.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.MessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * The mechanism that dispatches Query objects to their appropriate QueryHandlers. QueryHandlers can subscribe and

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryGateway.java
@@ -24,7 +24,7 @@ import reactor.util.concurrent.Queues;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface towards the Query Handling components of an application. This interface provides a friendlier API toward

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryHandlerAdapter.java
@@ -17,7 +17,7 @@ package org.axonframework.queryhandling;
 
 import org.axonframework.common.Registration;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Describes a class capable of subscribing to the query bus.

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryInvocationErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryInvocationErrorHandler.java
@@ -18,7 +18,7 @@ package org.axonframework.queryhandling;
 
 import org.axonframework.messaging.MessageHandler;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a mechanism for the QueryMessage components to report errors.

--- a/messaging/src/main/java/org/axonframework/queryhandling/QuerySubscription.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QuerySubscription.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.responsetypes.ResponseType;
 
 import java.lang.reflect.Type;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Encapsulates the identifying fields of a Query Handler when one is subscribed to the

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
@@ -27,8 +27,8 @@ import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Component which informs subscription queries about updates, errors and when there are no more updates.

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -70,7 +70,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static java.util.Objects.isNull;

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitter.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/annotation/AnnotationQueryHandlerAdapter.java
@@ -32,7 +32,7 @@ import org.axonframework.queryhandling.QueryResponseMessage;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Adapter that turns any {@link QueryHandler @QueryHandler} annotated bean into a {@link MessageHandler}

--- a/messaging/src/main/java/org/axonframework/queryhandling/annotation/MethodQueryMessageHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/annotation/MethodQueryMessageHandlerDefinition.java
@@ -31,8 +31,8 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.Optional;
 import java.util.concurrent.Future;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.common.ReflectionUtils.resolvePrimitiveWrapperTypeIfPrimitive;
 import static org.axonframework.common.ReflectionUtils.unwrapIfType;

--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -41,7 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/serialization/Serializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/Serializer.java
@@ -17,8 +17,8 @@
 package org.axonframework.serialization;
 
 import java.lang.reflect.Type;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface describing a serialization mechanism. Implementations can serialize objects of given type {@code T} to an

--- a/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializer.java
@@ -25,8 +25,8 @@ import org.axonframework.serialization.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;

--- a/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializerStrategy.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializerStrategy.java
@@ -20,7 +20,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.axonframework.serialization.SerializedObject;
 
 import java.util.function.Predicate;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Serialization strategy for Avro Serializer.

--- a/messaging/src/main/java/org/axonframework/serialization/avro/AvroUtil.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/AvroUtil.java
@@ -35,7 +35,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility;
 

--- a/messaging/src/main/java/org/axonframework/serialization/avro/DefaultSchemaIncompatibilityChecker.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/DefaultSchemaIncompatibilityChecker.java
@@ -19,7 +19,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/messaging/src/main/java/org/axonframework/serialization/avro/SchemaIncompatibilityChecker.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/SchemaIncompatibilityChecker.java
@@ -20,7 +20,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
 import org.axonframework.serialization.SerializationException;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/messaging/src/main/java/org/axonframework/serialization/avro/SpecificRecordBaseSerializerStrategy.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/SpecificRecordBaseSerializerStrategy.java
@@ -32,7 +32,7 @@ import org.axonframework.serialization.SimpleSerializedType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -42,8 +42,8 @@ import org.axonframework.serialization.UnknownSerializedType;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -37,7 +37,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.Charset;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Serializer that uses XStream to serialize and deserialize arbitrary objects. The XStream instance is configured to

--- a/messaging/src/main/java/org/axonframework/tracing/SpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/SpanAttributesProvider.java
@@ -19,7 +19,7 @@ package org.axonframework.tracing;
 import org.axonframework.messaging.Message;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Represents a provider of attributes to a {@link Span}, based on a {@link Message}. It's the responsibility of the

--- a/messaging/src/main/java/org/axonframework/tracing/TracingHandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/tracing/TracingHandlerEnhancerDefinition.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Executable;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Enhances message handlers with the provided {@link SpanFactory}, wrapping handling of the message in a {@link Span}

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/AggregateIdentifierSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/AggregateIdentifierSpanAttributesProvider.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/MessageIdSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/MessageIdSpanAttributesProvider.java
@@ -20,7 +20,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singletonMap;
 

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/MessageNameSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/MessageNameSpanAttributesProvider.java
@@ -21,7 +21,7 @@ import org.axonframework.tracing.Span;
 import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singletonMap;
 

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/MessageTypeSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/MessageTypeSpanAttributesProvider.java
@@ -21,7 +21,7 @@ import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Adds the message type (simple class name) to the Span.

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/MetadataSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/MetadataSpanAttributesProvider.java
@@ -21,7 +21,7 @@ import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Adds the metadata of the message to the span as attributes.

--- a/messaging/src/main/java/org/axonframework/tracing/attributes/PayloadTypeSpanAttributesProvider.java
+++ b/messaging/src/main/java/org/axonframework/tracing/attributes/PayloadTypeSpanAttributesProvider.java
@@ -22,7 +22,7 @@ import org.axonframework.tracing.SpanAttributesProvider;
 
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Adds the {@link Message#getPayloadType payload type} as an attribute to the {@link Span}.

--- a/messaging/src/test/java/org/axonframework/common/StubExecutor.java
+++ b/messaging/src/test/java/org/axonframework/common/StubExecutor.java
@@ -19,7 +19,7 @@ package org.axonframework.common;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of the Executor that executes tasks in the calling threads. The {@link #enqueueTasks()} method can be

--- a/messaging/src/test/java/org/axonframework/configuration/LifecycleHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/configuration/LifecycleHandlerInspectorTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;

--- a/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventProcessorTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.*;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.utils.EventTestUtils.createEvent;
 import static org.axonframework.utils.EventTestUtils.createEvents;

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventHandlerInvokerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventHandlerInvokerTest.java
@@ -19,7 +19,7 @@ package org.axonframework.eventhandling;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.junit.jupiter.api.*;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import javax.sql.DataSource;
 
 import static org.awaitility.Awaitility.await;

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.awaitility.Awaitility.await;
 import static org.jobrunr.server.BackgroundJobServerConfiguration.usingStandardBackgroundJobServerConfiguration;

--- a/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.util.*;

--- a/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/annotation/HandlerComparatorTest.java
@@ -27,7 +27,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
@@ -32,7 +32,7 @@ import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/CapacityMonitor.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Calculates capacity by tracking, within the configured time window, the average message processing time

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/EventProcessorLatencyMonitor.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageCountingMonitor.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.monitoring.MessageMonitor;
 
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Counts the number of ingested, successful, failed and processed messages

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MessageTimerMonitor.java
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
+++ b/metrics-micrometer/src/main/java/org/axonframework/micrometer/MetricsConfigurerModule.java
@@ -19,7 +19,7 @@ package org.axonframework.micrometer;
 import org.axonframework.config.LegacyConfigurer;
 import org.axonframework.config.ConfigurerModule;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of the {@link ConfigurerModule} which uses the

--- a/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
+++ b/metrics-micrometer/src/test/java/org/axonframework/micrometer/GlobalMetricRegistryTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/metrics/src/main/java/org/axonframework/metrics/CapacityMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/CapacityMonitor.java
@@ -29,7 +29,7 @@ import org.axonframework.monitoring.MessageMonitor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Calculates capacity by tracking, within the configured time window, the average message processing time

--- a/metrics/src/main/java/org/axonframework/metrics/EventProcessorLatencyMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/EventProcessorLatencyMonitor.java
@@ -29,7 +29,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link MessageMonitor} implementation dedicated to {@link EventMessage EventMessages}.

--- a/metrics/src/main/java/org/axonframework/metrics/MessageCountingMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MessageCountingMonitor.java
@@ -24,7 +24,7 @@ import org.axonframework.monitoring.MessageMonitor;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Counts the number of ingested, successful, failed and processed messages

--- a/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MessageTimerMonitor.java
@@ -29,7 +29,7 @@ import org.axonframework.monitoring.MessageMonitor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/metrics/src/main/java/org/axonframework/metrics/MetricsConfigurerModule.java
+++ b/metrics/src/main/java/org/axonframework/metrics/MetricsConfigurerModule.java
@@ -19,7 +19,7 @@ package org.axonframework.metrics;
 import org.axonframework.config.LegacyConfigurer;
 import org.axonframework.config.ConfigurerModule;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of the {@link ConfigurerModule} which uses the {@link org.axonframework.metrics.GlobalMetricRegistry}

--- a/metrics/src/main/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapper.java
+++ b/metrics/src/main/java/org/axonframework/metrics/PayloadTypeMessageMonitorWrapper.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link MessageMonitor} implementation which creates a new MessageMonitor for every {@link Message} payload type

--- a/modelling/src/main/java/org/axonframework/modelling/command/AbstractLegacyRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AbstractLegacyRepository.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -56,8 +56,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;

--- a/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/modelling/src/main/java/org/axonframework/modelling/command/CommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/CommandTargetResolver.java
@@ -18,7 +18,7 @@ package org.axonframework.modelling.command;
 
 import org.axonframework.commandhandling.CommandMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface towards a mechanism that is capable of extracting an Aggregate Identifier and Version form a command that

--- a/modelling/src/main/java/org/axonframework/modelling/command/CreationPolicyAggregateFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/CreationPolicyAggregateFactory.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.modelling.command;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Interface to describe a way to create Aggregate instances based on an identifier when an instance has to be created

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.annotation.AnnotationUtils.findAnnotationAttributes;
 import static org.axonframework.common.property.PropertyAccessStrategy.getProperty;

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardNone.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardNone.java
@@ -19,7 +19,7 @@ package org.axonframework.modelling.command;
 import org.axonframework.messaging.Message;
 
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Forward no messages {@code T} regardless of their set up.

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardToAll.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardToAll.java
@@ -19,7 +19,7 @@ package org.axonframework.modelling.command;
 import org.axonframework.messaging.Message;
 
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Forward all messages {@code T} regardless of their set up.

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardingMode.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardingMode.java
@@ -21,7 +21,7 @@ import org.axonframework.modelling.command.inspection.EntityModel;
 
 import java.lang.reflect.Member;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing the required functionality to forward a message. An example implementation is the {@link

--- a/modelling/src/main/java/org/axonframework/modelling/command/LegacyGenericJpaRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LegacyGenericJpaRepository.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;

--- a/modelling/src/main/java/org/axonframework/modelling/command/LegacyLockingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LegacyLockingRepository.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.ObjectUtils.sameInstanceSupplier;

--- a/modelling/src/main/java/org/axonframework/modelling/command/LegacyRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LegacyRepository.java
@@ -22,8 +22,8 @@ import org.axonframework.modelling.repository.Repository;
 
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * The {@link LegacyRepository} provides an abstraction of the storage of aggregates.

--- a/modelling/src/main/java/org/axonframework/modelling/command/MetaDataCommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/MetaDataCommandTargetResolver.java
@@ -18,7 +18,7 @@ package org.axonframework.modelling.command;
 
 import org.axonframework.commandhandling.CommandMessage;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * CommandTargetResolver implementation that uses MetaData entries to extract the identifier and optionally the version

--- a/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/NoArgumentConstructorCreationPolicyAggregateFactory.java
@@ -18,8 +18,8 @@ package org.axonframework.modelling.command;
 
 import org.axonframework.common.ReflectionUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Default implementation of {@link CreationPolicyAggregateFactory} that invokes the default, no-arguments constructor

--- a/modelling/src/main/java/org/axonframework/modelling/command/RepositoryProvider.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/RepositoryProvider.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.modelling.command;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Provides a repository for given aggregate type.

--- a/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandler.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandler.java
@@ -24,7 +24,7 @@ import org.axonframework.messaging.configuration.MessageHandler;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.modelling.StateManager;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a stateful handler of {@link CommandMessage commands}. Receives a {@link StateManager} as

--- a/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlerRegistry.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlerRegistry.java
@@ -21,7 +21,7 @@ import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.modelling.StateManager;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Interface describing a registry of {@link StatefulCommandHandler stateful command handlers}. These command handlers

--- a/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/StatefulCommandHandlingComponent.java
@@ -29,7 +29,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.modelling.StateManager;
 
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Objects.requireNonNull;
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;

--- a/modelling/src/main/java/org/axonframework/modelling/command/VersionedAggregateIdentifier.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/VersionedAggregateIdentifier.java
@@ -19,7 +19,7 @@ package org.axonframework.modelling.command;
 import org.axonframework.common.Assert;
 
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Structure that holds an Aggregate Identifier and an expected version of an aggregate.

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
@@ -49,7 +49,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedCommandHandlerInterceptor.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedCommandHandlerInterceptor.java
@@ -26,7 +26,7 @@ import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Annotated command handler interceptor on aggregate. Will invoke the delegate to the real interceptor method.

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/ChildForwardingCommandMessageHandlingMember.java
@@ -29,8 +29,8 @@ import org.axonframework.modelling.entity.ChildEntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Implementation of a {@link CommandMessageHandlingMember} that forwards commands to a child entity.

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/MethodCommandHandlerInterceptorDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/MethodCommandHandlerInterceptorDefinition.java
@@ -26,7 +26,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.modelling.command.CommandHandlerInterceptor;
 
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of {@link HandlerEnhancerDefinition} used for {@link CommandHandlerInterceptor} annotated methods.

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/MethodCreationPolicyDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/MethodCreationPolicyDefinition.java
@@ -23,7 +23,7 @@ import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 import org.axonframework.modelling.command.AggregateCreationPolicy;
 import org.axonframework.modelling.command.CreationPolicy;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of {@link HandlerEnhancerDefinition} used for {@link CreationPolicy} annotated methods.

--- a/modelling/src/main/java/org/axonframework/modelling/repository/AccessSerializingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/AccessSerializingRepository.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Repository implementation that ensures safe concurrent access to entities stored in it. It delegates the actual

--- a/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
@@ -20,7 +20,7 @@ import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * The {@link Repository} provides an abstraction for the storage of entities.

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AbstractSagaManager.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSagaManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AnnotatedSagaManager.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/AssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/AssociationResolver.java
@@ -19,7 +19,7 @@ package org.axonframework.modelling.saga;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Used to derive the value of an association property as designated by the association property name.

--- a/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/EndSagaMessageHandlerDefinition.java
@@ -23,8 +23,8 @@ import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 
 import java.lang.reflect.Executable;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * A {@link HandlerEnhancerDefinition} inspecting the existence of the {@link EndSaga} annotation on

--- a/modelling/src/main/java/org/axonframework/modelling/saga/MetaDataAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/MetaDataAssociationResolver.java
@@ -19,7 +19,7 @@ package org.axonframework.modelling.saga;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Used to derive the value of an association property by looking it up the event message's {@link

--- a/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
@@ -25,7 +25,7 @@ import org.axonframework.messaging.annotation.MessageHandlingMember;
 import java.lang.reflect.Executable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlerDefinition.java
@@ -24,7 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 

--- a/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/SagaMethodMessageHandlingMember.java
@@ -21,7 +21,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.WrappedMessageHandlingMember;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A data holder containing information of {@link SagaEventHandler} annotated methods.

--- a/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.junit.jupiter.api.Assertions.*;

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
@@ -55,7 +55,7 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.modelling.saga.SagaLifecycle.removeAssociationWith;
 import static org.junit.jupiter.api.Assertions.*;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/PayLoadAssociationResolverTest.java
@@ -23,8 +23,8 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.junit.jupiter.api.*;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import static org.axonframework.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.modelling.utils.ConcurrencyUtils.testConcurrent;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.*;

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
@@ -34,7 +34,7 @@ import org.mockito.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.singleton;
 import static org.axonframework.messaging.unitofwork.LegacyDefaultUnitOfWork.startAndGet;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.java
@@ -102,7 +102,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -66,7 +66,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Configures Axon Server as implementation for the CommandBus, QueryBus and EventStore.

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonTimeoutAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonTimeoutAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.axonframework.messaging.timeout.HandlerTimeoutHandlerEnhancerDefiniti
 import org.axonframework.messaging.timeout.TaskTimeoutSettings;
 import org.axonframework.messaging.timeout.UnitOfWorkTimeoutInterceptor;
 import org.axonframework.springboot.TimeoutProperties;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -65,7 +65,7 @@ public class AxonTimeoutAutoConfiguration {
         }
 
         @Override
-        public void configureModule(@NotNull LegacyConfigurer configurer) {
+        public void configureModule(@Nonnull LegacyConfigurer configurer) {
             configurer.eventProcessing()
                       .registerDefaultHandlerInterceptor((c, name) -> {
                           TaskTimeoutSettings settings = getSettingsForProcessor(name);

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/PersistentStreamMessageSourceRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/PersistentStreamMessageSourceRegistrar.java
@@ -32,7 +32,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static io.axoniq.axonserver.connector.impl.ObjectUtils.nonNullOrDefault;
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/AbstractQualifiedBeanCondition.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/AbstractQualifiedBeanCondition.java
@@ -28,7 +28,7 @@ import org.springframework.util.MultiValueMap;
 
 import java.lang.invoke.MethodHandles;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.spring.SpringUtils.isQualifierMatch;
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/DeadLetterQueueProviderConfigurerModule.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/DeadLetterQueueProviderConfigurerModule.java
@@ -26,7 +26,7 @@ import org.axonframework.springboot.EventProcessorProperties;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link ConfigurerModule} implementation dedicated towards registering a {@link SequencedDeadLetterQueue} provider

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/DefaultEntityRegistrar.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/DefaultEntityRegistrar.java
@@ -24,7 +24,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class DefaultEntityRegistrar implements ImportBeanDefinitionRegistrar {

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/jpa/ContainerManagedEntityManagerProvider.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/util/jpa/ContainerManagedEntityManagerProvider.java
@@ -20,7 +20,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.axonframework.common.jpa.EntityManagerProvider;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * EntityManagerProvider implementation that expects the container to inject the default container managed

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/HandlerEnhancerDefinitionConfigurationTest.java
@@ -29,7 +29,7 @@ import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/TrackingEventProcessorIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.springboot;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.axonframework.common.stream.BlockingStream;
@@ -44,7 +45,6 @@ import org.axonframework.springboot.autoconfig.AxonServerActuatorAutoConfigurati
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration;
 import org.axonframework.springboot.utils.TestSerializer;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InfraConfigurationTest.java
@@ -57,7 +57,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InterceptorConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/InterceptorConfigurationTest.java
@@ -34,7 +34,7 @@ import org.axonframework.queryhandling.QueryGateway;
 import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.annotation.QueryHandler;
 import org.axonframework.springboot.utils.TestSerializer;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -605,9 +605,9 @@ class InterceptorConfigurationTest {
                 this.axonConfiguration = axonConfiguration;
             }
 
-            @NotNull
+            @Nonnull
             @Override
-            public BiFunction<Integer, T, T> handle(@NotNull List<? extends T> messages) {
+            public BiFunction<Integer, T, T> handle(@Nonnull List<? extends T> messages) {
                 axonConfiguration.tags();
                 return (index, message) -> {
                     invocation.countDown();
@@ -644,9 +644,9 @@ class InterceptorConfigurationTest {
                 this.eventHandlingOutcome = eventHandlingOutcome;
             }
 
-            @NotNull
+            @Nonnull
             @Override
-            public BiFunction<Integer, T, T> handle(@NotNull List<? extends T> messages) {
+            public BiFunction<Integer, T, T> handle(@Nonnull List<? extends T> messages) {
                 return (index, message) -> {
                     if (message instanceof CommandMessage) {
                         commandInvocation.countDown();
@@ -689,7 +689,7 @@ class InterceptorConfigurationTest {
                 this.eventHandlingOutcome = eventHandlingOutcome;
             }
 
-            @NotNull
+            @Nonnull
             @Override
             public Object handle(LegacyUnitOfWork<?> unitOfWork,
                                  InterceptorChain interceptorChain) throws Exception {
@@ -745,8 +745,8 @@ class InterceptorConfigurationTest {
         public static class MyCommandHandlerInterceptor implements MessageHandlerInterceptor<CommandMessage<?>> {
 
             @Override
-            public Object handle(@NotNull LegacyUnitOfWork<? extends CommandMessage<?>> unitOfWork,
-                                 @NotNull InterceptorChain interceptorChain) throws Exception {
+            public Object handle(@Nonnull LegacyUnitOfWork<? extends CommandMessage<?>> unitOfWork,
+                                 @Nonnull InterceptorChain interceptorChain) throws Exception {
                 return interceptorChain.proceedSync();
             }
         }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/integration/EventProcessingModuleWithInterceptorsTest.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/spring/src/main/java/org/axonframework/spring/authorization/MessageAuthorizationDispatchInterceptor.java
+++ b/spring/src/main/java/org/axonframework/spring/authorization/MessageAuthorizationDispatchInterceptor.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;

--- a/spring/src/main/java/org/axonframework/spring/authorization/MessageAuthorizationHandlerInterceptor.java
+++ b/spring/src/main/java/org/axonframework/spring/authorization/MessageAuthorizationHandlerInterceptor.java
@@ -27,7 +27,7 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/spring/src/main/java/org/axonframework/spring/authorization/SecuredMessageHandlerDefinition.java
+++ b/spring/src/main/java/org/axonframework/spring/authorization/SecuredMessageHandlerDefinition.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * MessageHandlerDefinition that verifies authorization based on

--- a/spring/src/main/java/org/axonframework/spring/config/MessageHandlerConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/MessageHandlerConfigurer.java
@@ -28,7 +28,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * An implementation of a {@link ConfigurerModule} that will register a list of beans as handlers for a specific type of

--- a/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/MessageHandlerLookup.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link BeanDefinitionRegistryPostProcessor} implementation that detects beans with Axon Message handlers and

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateConfigurer.java
@@ -37,7 +37,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import java.util.Set;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link ConfigurerModule} implementation that will configure an Aggregate with the Axon {@link

--- a/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringAggregateLookup.java
@@ -38,7 +38,7 @@ import org.springframework.core.ResolvableType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;

--- a/spring/src/main/java/org/axonframework/spring/config/SpringSagaConfigurer.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringSagaConfigurer.java
@@ -23,7 +23,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link ConfigurerModule} implementation that configures a Saga based on configuration found in the Application

--- a/spring/src/main/java/org/axonframework/spring/config/SpringSagaLookup.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringSagaLookup.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Saga types and registers a {@link

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/HandlerDefinitionFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/HandlerDefinitionFactoryBean.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.FactoryBean;
 
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Spring {@link FactoryBean} that creates a {@link HandlerDefinition} using configured {@link HandlerDefinition} and

--- a/spring/src/main/java/org/axonframework/spring/config/annotation/SpringParameterResolverFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/config/annotation/SpringParameterResolverFactoryBean.java
@@ -28,7 +28,7 @@ import org.springframework.context.ApplicationContextAware;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Spring factory bean that creates a ParameterResolverFactory instance that is capable of resolving parameter values as

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/java/SimpleEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/java/SimpleEventSchedulerFactoryBean.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Spring FactoryBean that creates a SimpleEventScheduler instance using resources found in the Spring Application

--- a/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzEventSchedulerFactoryBean.java
@@ -31,7 +31,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Spring FactoryBean that creates a QuartzEventScheduler instance using resources found in the Spring Application

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotter.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;
 

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBean.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringAggregateSnapshotterFactoryBean.java
@@ -45,7 +45,7 @@ import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncl
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of the {@link org.axonframework.eventsourcing.AggregateSnapshotter} that eases the configuration when

--- a/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactory.java
+++ b/spring/src/main/java/org/axonframework/spring/eventsourcing/SpringPrototypeAggregateFactory.java
@@ -29,7 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 

--- a/spring/src/main/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProvider.java
+++ b/spring/src/main/java/org/axonframework/spring/jdbc/SpringDataSourceConnectionProvider.java
@@ -22,7 +22,7 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import javax.sql.DataSource;
 
 /**

--- a/spring/src/main/java/org/axonframework/spring/messaging/ApplicationContextEventPublisher.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/ApplicationContextEventPublisher.java
@@ -25,7 +25,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.PayloadApplicationEvent;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Component that forward events received from a {@link SubscribableMessageSource} as Spring {@link ApplicationEvent} to

--- a/spring/src/main/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapter.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/InboundEventMessageChannelAdapter.java
@@ -26,7 +26,7 @@ import org.springframework.messaging.MessageHandler;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;

--- a/spring/src/main/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManager.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/unitofwork/SpringTransactionManager.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * TransactionManager implementation that uses a {@link org.springframework.transaction.PlatformTransactionManager} as

--- a/spring/src/main/java/org/axonframework/spring/serialization/avro/AvroSchemaPackages.java
+++ b/spring/src/main/java/org/axonframework/spring/serialization/avro/AvroSchemaPackages.java
@@ -53,7 +53,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Holder for package-based class scanning for Avro schema extraction.

--- a/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -54,7 +54,7 @@ import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
 import org.axonframework.modelling.saga.repository.SagaStore;
 import org.axonframework.tracing.TestSpanFactory;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1088,7 +1088,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
 
 
         @Override
-        public BiFunction<Integer, Message<?>, Message<?>> handle(@NotNull List<? extends Message<?>> messages) {
+        public BiFunction<Integer, Message<?>, Message<?>> handle(@Nonnull List<? extends Message<?>> messages) {
             return (i, m) -> m.andMetaData(MetaData.with(CUSTOM_CORRELATION_DATA_KEY, correlationData));
         }
     }

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/scheduling/java/ResultStoringScheduledExecutorService.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/scheduling/java/ResultStoringScheduledExecutorService.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Implementation of ScheduledExecutorService that delegates to another ScheduledExecutorService, while keeping track

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzTableMaker.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/scheduling/quartz/QuartzTableMaker.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * @author Allard Buijze

--- a/spring/src/test/java/org/axonframework/spring/eventsourcing/context/SpringWiredAggregate.java
+++ b/spring/src/test/java/org/axonframework/spring/eventsourcing/context/SpringWiredAggregate.java
@@ -21,7 +21,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * Plain aggregate wired through Spring with the {@link Aggregate} annotation.

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -105,7 +105,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.lang.String.format;
 import static org.axonframework.common.ReflectionUtils.*;

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -46,7 +46,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.test.matchers.Matchers.*;
 import static org.hamcrest.CoreMatchers.*;

--- a/test/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
+++ b/test/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
@@ -45,8 +45,8 @@ import java.util.NoSuchElementException;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Stub implementation of {@link DeadlineManager}. Records all scheduled, canceled and met deadlines.

--- a/test/src/main/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandler.java
+++ b/test/src/main/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandler.java
@@ -21,7 +21,7 @@ import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 
 import java.util.Optional;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * A wrapper around a {@link ListenerInvocationErrorHandler} that in itself also implements

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureRepositoryRegistrationTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureRepositoryRegistrationTest.java
@@ -32,7 +32,7 @@ import org.axonframework.modelling.command.LegacyRepository;
 import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.modelling.saga.SagaMethodMessageHandlerDefinition;
 import org.axonframework.test.FixtureExecutionException;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
@@ -97,7 +97,7 @@ class FixtureRepositoryRegistrationTest {
         assertThrows(FixtureExecutionException.class,
                      () -> testSubject.registerRepositoryProvider(new RepositoryProvider() {
                          @Override
-                         public <T> LegacyRepository<T> repositoryFor(@NotNull Class<T> aggregateType) {
+                         public <T> LegacyRepository<T> repositoryFor(@Nonnull Class<T> aggregateType) {
                              return null;
                          }
                      }));
@@ -110,7 +110,7 @@ class FixtureRepositoryRegistrationTest {
         assertThrows(FixtureExecutionException.class,
                      () -> testSubject.registerRepositoryProvider(new RepositoryProvider() {
                          @Override
-                         public <T> LegacyRepository<T> repositoryFor(@NotNull Class<T> aggregateType) {
+                         public <T> LegacyRepository<T> repositoryFor(@Nonnull Class<T> aggregateType) {
                              return null;
                          }
                      }));

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 import static org.junit.jupiter.api.Assertions.*;

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;

--- a/test/src/test/java/org/axonframework/test/saga/AssociationResolverStub.java
+++ b/test/src/test/java/org/axonframework/test/saga/AssociationResolverStub.java
@@ -5,7 +5,7 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.modelling.saga.AssociationResolver;
 import org.axonframework.modelling.saga.PayloadAssociationResolver;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 
 import static org.junit.Assert.*;
 
@@ -14,13 +14,13 @@ public class AssociationResolverStub implements AssociationResolver {
     private final PayloadAssociationResolver defaultResolver = new PayloadAssociationResolver();
 
     @Override
-    public <T> void validate(@NotNull String associationPropertyName, @NotNull MessageHandlingMember<T> handler) {
+    public <T> void validate(@Nonnull String associationPropertyName, @Nonnull MessageHandlingMember<T> handler) {
         defaultResolver.validate(associationPropertyName, handler);
     }
 
     @Override
-    public <T> Object resolve(@NotNull String associationPropertyName, @NotNull EventMessage<?> message,
-                              @NotNull MessageHandlingMember<T> handler) {
+    public <T> Object resolve(@Nonnull String associationPropertyName, @Nonnull EventMessage<?> message,
+                              @Nonnull MessageHandlingMember<T> handler) {
 
 
         if (!DomainEventMessage.class.isAssignableFrom(message.getClass())) {

--- a/test/src/test/java/org/axonframework/test/saga/FixtureMessageHandlerInterceptorTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureMessageHandlerInterceptorTest.java
@@ -26,7 +26,7 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
 import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.StartSaga;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import java.util.Objects;
@@ -68,8 +68,8 @@ class FixtureMessageHandlerInterceptorTest {
         }
 
         @Override
-        public Object handle(@NotNull LegacyUnitOfWork<? extends EventMessage<?>> unitOfWork,
-                             @NotNull InterceptorChain interceptorChain) throws Exception {
+        public Object handle(@Nonnull LegacyUnitOfWork<? extends EventMessage<?>> unitOfWork,
+                             @Nonnull InterceptorChain interceptorChain) throws Exception {
             unitOfWork.transformMessage(event -> event.withMetaData(MetaData.with(META_DATA_KEY, value)));
             return interceptorChain.proceedSync();
         }

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.test.matchers.Matchers.listWithAnyOf;
 import static org.axonframework.test.matchers.Matchers.predicate;

--- a/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/RecordingListenerInvocationErrorHandlerTest.java
@@ -21,7 +21,7 @@ import org.axonframework.eventhandling.EventMessageHandler;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
 import org.axonframework.messaging.MessageType;
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.*;
 
 import java.util.Optional;
@@ -114,8 +114,8 @@ class RecordingListenerInvocationErrorHandlerTest {
     private static class NoOpListenerInvocationErrorHandler implements ListenerInvocationErrorHandler {
 
         @Override
-        public void onError(@NotNull Exception exception, @NotNull EventMessage<?> event,
-                            @NotNull EventMessageHandler eventHandler) throws Exception {
+        public void onError(@Nonnull Exception exception, @Nonnull EventMessage<?> event,
+                            @Nonnull EventMessageHandler eventHandler) throws Exception {
             // No-op
         }
     }

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/MetadataContextGetter.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/MetadataContextGetter.java
@@ -19,7 +19,7 @@ package org.axonframework.tracing.opentelemetry;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import org.axonframework.messaging.Message;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * This {@link TextMapGetter} implementation is able to extract the parent OpenTelemetry span context from a

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/MetadataContextSetter.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/MetadataContextSetter.java
@@ -20,7 +20,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import org.axonframework.messaging.Message;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 /**
  * This {@link TextMapSetter} implementation is able to insert the current OpenTelemetry span context into a

--- a/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactory.java
+++ b/tracing-opentelemetry/src/main/java/org/axonframework/tracing/opentelemetry/OpenTelemetrySpanFactory.java
@@ -35,7 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static org.axonframework.tracing.SpanUtils.determineMessageName;
 


### PR DESCRIPTION
This is a very simple PR:
- Re-places all occurences of javax.annotations with jakarta.annotations
- Replaces all JetBrains annotations with the jakarta annotations
- Remove the javax annotations dependency to prevent misaligned imports in the future

Unfortunately, disabling jetbrains annotations is a setting each team member has to do individually. It's an IDEA feature. We should be careful when reviewing.