### PR TITLE
Fix flaky `StorageEngineTestSuite` test, and disable AS download message

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -153,6 +153,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!-- Silence the AS download message -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Daxon.axonserver.suppressDownloadMessage=true</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
@@ -212,10 +212,13 @@ public abstract class StorageEngineTestSuite<ESE extends EventStorageEngine> {
 
     @Test
     void transactionRejectedWithConflictingEventsInStore() throws Exception {
-        testSubject.appendEvents(AppendCondition.none(),
-                                 taggedEventMessage("event-0", TEST_CRITERIA_TAGS),
-                                 taggedEventMessage("event-1", TEST_CRITERIA_TAGS))
-                   .thenApply(AppendTransaction::commit)
+        testSubject.appendEvents(
+                           AppendCondition.none(),
+                           taggedEventMessage("event-0", TEST_CRITERIA_TAGS),
+                           taggedEventMessage("event-1", TEST_CRITERIA_TAGS)
+                   )
+                   .get(5, TimeUnit.SECONDS)
+                   .commit()
                    .get(5, TimeUnit.SECONDS);
 
         AppendCondition testCondition = AppendCondition.withCriteria(TEST_CRITERIA);

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -133,12 +133,6 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -262,6 +256,15 @@
                         <phase>package</phase>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Silence the AS download message -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Daxon.axonserver.suppressDownloadMessage=true</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,12 @@
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
                 <version>${mysql-connector-java.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -256,6 +256,15 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!-- Silence the AS download message -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Daxon.axonserver.suppressDownloadMessage=true</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The `StorageEngineTestSuite` had a flaky test. After some investigation, this is caused by not awaiting the `CompletableFuture` of the commit to Axon Server. 

Apparently, the append is in two stages; sending the events (CF one), and the committing (CF two). Only the first one was awaited. This could lead to test failures. 

In addition, to clean up the logs, this PR adds surefire configuration to suppress the Axon Server download message during the boot of the docker container. 