### PR TITLE
[#3434] Do `Class#isAssignableFrom` to retrieve components and match decorators in the `Configurer`

### DIFF
--- a/messaging/src/main/java/org/axonframework/configuration/Component.java
+++ b/messaging/src/main/java/org/axonframework/configuration/Component.java
@@ -17,14 +17,17 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
+
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 import static org.axonframework.common.Assert.nonEmpty;
 
 /**
- * Describes a component defined in a {@link Configuration}, that may depend on other component for its
- * initialization or during it's startup/shutdown operations.
+ * Describes a component defined in a {@link Configuration}, that may depend on other component for its initialization
+ * or during it's startup/shutdown operations.
  * <p>
  * Note: This interface is not expected to be used outside of Axon Framework!
  *
@@ -87,11 +90,12 @@ public interface Component<C> extends DescribableComponent {
     /**
      * A tuple representing a {@code Component's} uniqueness, consisting out of a {@code type} and {@code name}.
      *
-     * @param type The type of the component this object identifiers, typically an interface.
-     * @param name The name of the component this object identifiers.
-     * @param <C>  The type of the component this object identifiers, typically an interface.
+     * @param type The type of the component this object identifies, typically an interface.
+     * @param name The name of the component this object identifies, potentially {@code null} when unimportant. Will
+     *             throw an {@link IllegalArgumentException} for an empty {@code name}.
+     * @param <C>  The type of the component this object identifies, typically an interface.
      */
-    record Identifier<C>(@Nonnull Class<C> type, @Nonnull String name) {
+    record Identifier<C>(@Nonnull Class<C> type, @Nullable String name) {
 
         /**
          * Compact constructor asserting whether the {@code type} and {@code name} are non-null and not empty.
@@ -101,7 +105,9 @@ public interface Component<C> extends DescribableComponent {
          */
         public Identifier {
             requireNonNull(type, "The given type is unsupported because it is null.");
-            nonEmpty(name, "The given name is unsupported because it is null or empty.");
+            if (name != null) {
+                nonEmpty(name, "The given name is unsupported because it is empty.");
+            }
         }
 
         @Override

--- a/messaging/src/main/java/org/axonframework/configuration/Component.java
+++ b/messaging/src/main/java/org/axonframework/configuration/Component.java
@@ -110,6 +110,19 @@ public interface Component<C> extends DescribableComponent {
             }
         }
 
+        /**
+         * Validate whether the given {@code other Identifier} matches with {@code this Identifier}, by matching the
+         * {@link #name() names} and checking if the {@link #type()}  is {@link Class#isAssignableFrom(Class)} to give
+         * {@code other} type.
+         *
+         * @param other The other identifier to compare with this identifier.
+         * @return {@code true} if the {@link #type()} is assignable from the {@code other} type <b>and</b> the
+         * {@link #name()} is identical, {@code false} otherwise.
+         */
+        public boolean matches(@Nonnull Identifier<?> other) {
+            return type.isAssignableFrom(other.type()) && Objects.equals(other.name(), name);
+        }
+
         @Override
         public String toString() {
             return type.getName() + ":" + name;

--- a/messaging/src/main/java/org/axonframework/configuration/ComponentDecorator.java
+++ b/messaging/src/main/java/org/axonframework/configuration/ComponentDecorator.java
@@ -17,6 +17,7 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * A functional interface describing how to decorate a component of type {@code C}.
@@ -34,8 +35,8 @@ import jakarta.annotation.Nonnull;
 public interface ComponentDecorator<C, D> {
 
     /**
-     * Decorates the given {@code delegate} into a mutated or replaced instance of type {@code D}, which must be the
-     * same or a subclass of {@code C}.
+     * Decorates the given {@code delegate} into a mutated or replaced instance of type {@code D}, which <b>must be</b>
+     * the same or a subclass of {@code C}.
      * <p>
      * Decorating can roughly take two angles. One, it may choose to wrap the {@code delegate} into a new instance of
      * type {@code C}. Second, it could mutate the state of the {@code delegate}.
@@ -52,8 +53,9 @@ public interface ComponentDecorator<C, D> {
      * @param name     The name of the component to be decorated.
      * @param delegate The delegate of type {@code C} to be decorated.
      * @return A decorated component of type {@code C}, typically based on the given {@code delegate}.
+     * @throws ClassCastException When this decorator does not return a subclass of {@code C}.
      */
     D decorate(@Nonnull Configuration config,
-               @Nonnull String name,
+               @Nullable String name,
                @Nonnull C delegate);
 }

--- a/messaging/src/main/java/org/axonframework/configuration/ComponentDefinition.java
+++ b/messaging/src/main/java/org/axonframework/configuration/ComponentDefinition.java
@@ -17,17 +17,16 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import static java.util.Objects.requireNonNull;
-
 /**
- * Defines the structure of a {@link Component} that is available in the {@link Configuration} of the application or
- * one of its {@link Module Modules}.
+ * Defines the structure of a {@link Component} that is available in the {@link Configuration} of the application or one
+ * of its {@link Module Modules}.
  * <p>
  * Components are identified by a combination of their declared type and a name. The declared type is generally an
  * interface that all implementations are expected to implement. The name can be any non-empty string value that
@@ -77,7 +76,7 @@ public sealed interface ComponentDefinition<C> permits ComponentDefinition.Compo
      * @see #ofTypeAndName(Class, String)
      */
     static <C> IncompleteComponentDefinition<C> ofType(@Nonnull Class<C> type) {
-        return ofTypeAndName(type, requireNonNull(type, "The type cannot be null.").getSimpleName());
+        return ofTypeAndName(type, null);
     }
 
     /**
@@ -85,11 +84,12 @@ public sealed interface ComponentDefinition<C> permits ComponentDefinition.Compo
      * component is expected to be used, consider using {@link #ofType(Class)} instead.
      *
      * @param type The declared type of this component.
-     * @param name The name of this component.
+     * @param name The name of this component. Use {@code null} when there is no name or use {@link #ofType(Class)}
+     *             instead.
      * @param <C>  The declared type of this component.
      * @return A builder to complete the creation of a {@code ComponentDefinition}.
      */
-    static <C> IncompleteComponentDefinition<C> ofTypeAndName(@Nonnull Class<C> type, @Nonnull String name) {
+    static <C> IncompleteComponentDefinition<C> ofTypeAndName(@Nonnull Class<C> type, @Nullable String name) {
         return new IncompleteComponentDefinition<>() {
 
             @Override

--- a/messaging/src/main/java/org/axonframework/configuration/ComponentNotFoundException.java
+++ b/messaging/src/main/java/org/axonframework/configuration/ComponentNotFoundException.java
@@ -17,6 +17,7 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * A {@code RuntimeException} dedicated when a {@link Component} cannot be found in the {@link Configuration}.
@@ -32,9 +33,15 @@ public class ComponentNotFoundException extends RuntimeException {
      * found for the given {@code type} and {@code name}.
      *
      * @param type The type of the component that could not be found, typically an interface.
-     * @param name The name of the component that could not be found.
+     * @param name The name of the component that could not be found, potentially {@code null} when unimportant.
      */
-    public ComponentNotFoundException(@Nonnull Class<?> type, @Nonnull String name) {
-        super("No component found for type [" + type + "] name [" + name + "]");
+    public ComponentNotFoundException(@Nonnull Class<?> type, @Nullable String name) {
+        super(exceptionMessageFor(type, name));
+    }
+
+    private static String exceptionMessageFor(Class<?> type, String name) {
+        return name != null
+                ? "No component found for type [" + type + "] name [" + name + "]."
+                : "No component found for type [" + type + "].";
     }
 }

--- a/messaging/src/main/java/org/axonframework/configuration/ComponentOverrideException.java
+++ b/messaging/src/main/java/org/axonframework/configuration/ComponentOverrideException.java
@@ -17,6 +17,7 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * A {@link RuntimeException} thrown whenever a {@link Component} has been overridden in a {@link ComponentRegistry}.
@@ -33,9 +34,17 @@ public class ComponentOverrideException extends RuntimeException {
      * identifier of the {@link Component} that has been overridden in a {@link ApplicationConfigurer}.
      *
      * @param type The type of the component this object identifiers, typically an interface.
-     * @param name The name of the component this object identifiers.
+     * @param name The name of the component this object identifiers, potentially {@code null} when unimportant.
      */
-    public ComponentOverrideException(@Nonnull Class<?> type, @Nonnull String name) {
-        super("Cannot override Component with type [" + type + "] and name [" + name + "]; it is already registered.");
+    public ComponentOverrideException(@Nonnull Class<?> type, @Nullable String name) {
+        super(exceptionMessageFor(type, name));
+    }
+
+    private static String exceptionMessageFor(Class<?> type, String name) {
+        if (name != null) {
+            return "Cannot override Component with type [" + type + "] and name ["
+                    + name + "]; it is already registered.";
+        }
+        return "Cannot override Component with type [" + type + "]; it is already registered.";
     }
 }

--- a/messaging/src/main/java/org/axonframework/configuration/ComponentRegistry.java
+++ b/messaging/src/main/java/org/axonframework/configuration/ComponentRegistry.java
@@ -17,6 +17,7 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.configuration.Component.Identifier;
 
@@ -66,7 +67,8 @@ public interface ComponentRegistry extends DescribableComponent {
      * {@code type} and {@code name} combination.
      *
      * @param type    The declared type of the component to build, typically an interface.
-     * @param name    The name of the component to build.
+     * @param name    The name of the component to build. Use {@code null} when there is no name or use
+     *                {@link #registerComponent(Class, ComponentBuilder)} instead.
      * @param builder The builder building the component.
      * @param <C>     The type of component the {@code builder} builds.
      * @return The current instance of the {@code Configurer} for a fluent API.
@@ -75,7 +77,7 @@ public interface ComponentRegistry extends DescribableComponent {
      *                                    with the same type and name is already defined.
      */
     default <C> ComponentRegistry registerComponent(@Nonnull Class<C> type,
-                                                    @Nonnull String name,
+                                                    @Nullable String name,
                                                     @Nonnull ComponentBuilder<? extends C> builder) {
         return registerComponent(ComponentDefinition.ofTypeAndName(type, name)
                                                     .withBuilder(builder));
@@ -165,7 +167,7 @@ public interface ComponentRegistry extends DescribableComponent {
      * otherwise.
      */
     default boolean hasComponent(@Nonnull Class<?> type) {
-        return hasComponent(type, type.getSimpleName());
+        return hasComponent(type, null);
     }
 
     /**
@@ -173,12 +175,13 @@ public interface ComponentRegistry extends DescribableComponent {
      * {@code name} combination.
      *
      * @param type The type of the {@link Component} to check if it exists, typically an interface.
-     * @param name The name of the {@link Component} to check if it exists.
+     * @param name The name of the {@link Component} to check if it exists. Use {@code null} when there is no name or
+     *             use {@link #hasComponent(Class)} instead.
      * @return {@code true} when there is a {@link Component} registered under the given {@code type} and
      * {@code name combination}, {@code false} otherwise.
      */
     boolean hasComponent(@Nonnull Class<?> type,
-                         @Nonnull String name);
+                         @Nullable String name);
 
     /**
      * Registers an {@link ConfigurationEnhancer} with this {@code ComponentRegistry}.

--- a/messaging/src/main/java/org/axonframework/configuration/Components.java
+++ b/messaging/src/main/java/org/axonframework/configuration/Components.java
@@ -24,7 +24,6 @@ import org.axonframework.configuration.Component.Identifier;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,7 +71,7 @@ public class Components implements DescribableComponent {
     private <C> List<Component<C>> getComponentsAssignableTo(Identifier<C> identifier) {
         //noinspection unchecked
         List<Component<C>> matches = components.entrySet().stream()
-                                               .filter(entry -> assignableTypeAndEqualName(entry.getKey(), identifier))
+                                               .filter(entry -> identifier.matches(entry.getKey()))
                                                .map(Map.Entry::getValue)
                                                .map(component -> (Component<C>) component)
                                                .toList();
@@ -87,12 +86,6 @@ public class Components implements DescribableComponent {
             );
         }
         return matches;
-    }
-
-    private static <C> boolean assignableTypeAndEqualName(Identifier<?> storedId,
-                                                          Identifier<C> givenId) {
-        return givenId.type().isAssignableFrom(storedId.type())
-                && Objects.equals(givenId.name(), storedId.name());
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/configuration/Configuration.java
+++ b/messaging/src/main/java/org/axonframework/configuration/Configuration.java
@@ -44,7 +44,7 @@ public interface Configuration extends DescribableComponent {
      */
     @Nonnull
     default <C> C getComponent(@Nonnull Class<C> type) {
-        return getComponent(type, type.getSimpleName());
+        return getComponent(type, (String) null);
     }
 
     /**
@@ -52,7 +52,8 @@ public interface Configuration extends DescribableComponent {
      * {@link NullPointerException} if it does not exist.
      *
      * @param type The type of component, typically the interface the component implements.
-     * @param name The name of the component to retrieve.
+     * @param name The name of the component to retrieve. Use {@code null} when there is no name or use
+     *             {@link #getComponent(Class)} instead.
      * @param <C>  The type of component.
      * @return The component registered for the given {@code type} and {@code name}.
      * @throws ComponentNotFoundException Whenever there is no component present for the given {@code type} and
@@ -60,7 +61,7 @@ public interface Configuration extends DescribableComponent {
      */
     @Nonnull
     default <C> C getComponent(@Nonnull Class<C> type,
-                               @Nonnull String name) {
+                               @Nullable String name) {
         return getOptionalComponent(type, name)
                 .orElseThrow(() -> new ComponentNotFoundException(type, name));
     }
@@ -74,20 +75,21 @@ public interface Configuration extends DescribableComponent {
      * there is no component present for the given {@code type}.
      */
     default <C> Optional<C> getOptionalComponent(@Nonnull Class<C> type) {
-        return getOptionalComponent(type, type.getSimpleName());
+        return getOptionalComponent(type, null);
     }
 
     /**
      * Returns the component declared under the given {@code type} and {@code name} within an {@code Optional}.
      *
      * @param type The type of component, typically the interface the component implements.
-     * @param name The name of the component to retrieve.
+     * @param name The name of the component to retrieve. Use {@code null} when there is no name or use
+     *             {@link #getOptionalComponent(Class)} instead.
      * @param <C>  The type of component.
      * @return An {@code Optional} wrapping the component registered for the given {@code type} and {@code name}. Might
      * be empty when there is no component present for the given {@code type} and {@code name}.
      */
     <C> Optional<C> getOptionalComponent(@Nonnull Class<C> type,
-                                         @Nonnull String name);
+                                         @Nullable String name);
 
     /**
      * Returns the component declared under the given {@code type}, reverting to the given {@code defaultImpl} if no
@@ -104,7 +106,7 @@ public interface Configuration extends DescribableComponent {
     @Nonnull
     default <C> C getComponent(@Nonnull Class<C> type,
                                @Nonnull Supplier<C> defaultImpl) {
-        return getComponent(type, type.getSimpleName(), defaultImpl);
+        return getComponent(type, null, defaultImpl);
     }
 
     /**
@@ -114,7 +116,8 @@ public interface Configuration extends DescribableComponent {
      * When no component was previously registered, the default is then configured as the component for the given type.
      *
      * @param type        The type of component, typically the interface the component implements.
-     * @param name        The name of the component to retrieve.
+     * @param name        The name of the component to retrieve. Use {@code null} when there is no name or use
+     *                    {@link #getComponent(Class, Supplier)} instead.
      * @param defaultImpl The supplier of the default component to return if it was not registered.
      * @param <C>         The type of component.
      * @return The component declared under the given {@code type} and {@code name}, reverting to the given
@@ -122,7 +125,7 @@ public interface Configuration extends DescribableComponent {
      */
     @Nonnull
     <C> C getComponent(@Nonnull Class<C> type,
-                       @Nonnull String name,
+                       @Nullable String name,
                        @Nonnull Supplier<C> defaultImpl);
 
     /**

--- a/messaging/src/main/java/org/axonframework/configuration/DecoratorDefinition.java
+++ b/messaging/src/main/java/org/axonframework/configuration/DecoratorDefinition.java
@@ -72,7 +72,7 @@ public sealed interface DecoratorDefinition<C, D extends C> permits DecoratorDef
         return new PartialDecoratorDefinition<>() {
             @Override
             public <D extends C> DecoratorDefinition<C, D> with(@Nonnull ComponentDecorator<C, D> decorator) {
-                return new DefaultDecoratorDefinition<>(id -> Objects.equals(type, id.type()), decorator);
+                return new DefaultDecoratorDefinition<>(id -> type.isAssignableFrom(id.type()), decorator);
             }
         };
     }
@@ -97,7 +97,7 @@ public sealed interface DecoratorDefinition<C, D extends C> permits DecoratorDef
             @Override
             public <D extends C> DecoratorDefinition<C, D> with(@Nonnull ComponentDecorator<C, D> decorator) {
                 return new DefaultDecoratorDefinition<>(
-                        id -> Objects.equals(type, id.type()) && Objects.equals(name, id.name()),
+                        id -> type.isAssignableFrom(id.type()) && Objects.equals(name, id.name()),
                         decorator
                 );
             }

--- a/messaging/src/main/java/org/axonframework/configuration/DefaultAxonApplication.java
+++ b/messaging/src/main/java/org/axonframework/configuration/DefaultAxonApplication.java
@@ -17,6 +17,7 @@
 package org.axonframework.configuration;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.infra.ComponentDescriptor;
@@ -237,13 +238,13 @@ class DefaultAxonApplication implements ApplicationConfigurer, LifecycleRegistry
         }
 
         @Override
-        public <C> Optional<C> getOptionalComponent(@Nonnull Class<C> type, @Nonnull String name) {
+        public <C> Optional<C> getOptionalComponent(@Nonnull Class<C> type, @Nullable String name) {
             return config.getOptionalComponent(type, name);
         }
 
         @Nonnull
         @Override
-        public <C> C getComponent(@Nonnull Class<C> type, @Nonnull String name, @Nonnull Supplier<C> defaultImpl) {
+        public <C> C getComponent(@Nonnull Class<C> type, @Nullable String name, @Nonnull Supplier<C> defaultImpl) {
             return config.getComponent(type, name, defaultImpl);
         }
 
@@ -266,7 +267,7 @@ class DefaultAxonApplication implements ApplicationConfigurer, LifecycleRegistry
 
         @Nonnull
         @Override
-        public <C> C getComponent(@Nonnull Class<C> type, @Nonnull String name) {
+        public <C> C getComponent(@Nonnull Class<C> type, @Nullable String name) {
             return config.getComponent(type, name);
         }
 

--- a/messaging/src/main/java/org/axonframework/configuration/DefaultComponentRegistry.java
+++ b/messaging/src/main/java/org/axonframework/configuration/DefaultComponentRegistry.java
@@ -102,7 +102,7 @@ public class DefaultComponentRegistry implements ComponentRegistry {
 
     @Override
     public boolean hasComponent(@Nonnull Class<?> type,
-                                @Nonnull String name) {
+                                @Nullable String name) {
         return components.contains(new Identifier<>(type, name));
     }
 
@@ -301,7 +301,7 @@ public class DefaultComponentRegistry implements ComponentRegistry {
         @Nonnull
         @Override
         public <C> Optional<C> getOptionalComponent(@Nonnull Class<C> type,
-                                                    @Nonnull String name) {
+                                                    @Nullable String name) {
             return components.get(new Identifier<>(type, name))
                              .map(c -> c.resolve(this))
                              .or(() -> {
@@ -318,7 +318,7 @@ public class DefaultComponentRegistry implements ComponentRegistry {
         @Nonnull
         @Override
         public <C> C getComponent(@Nonnull Class<C> type,
-                                  @Nonnull String name,
+                                  @Nullable String name,
                                   @Nonnull Supplier<C> defaultImpl) {
             Identifier<C> identifier = new Identifier<>(type, name);
             Object component = components.computeIfAbsent(

--- a/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
@@ -178,6 +178,18 @@ public abstract class ApplicationConfigurerTestSuite<C extends ApplicationConfig
         }
 
         @Test
+        void registerComponentForTypeExposesRegisteredComponentOnGetWhenAssignableFrom() {
+            SpecificTestComponent testComponent = SPECIFIC_TEST_COMPONENT;
+            testSubject.componentRegistry(
+                    cr -> cr.registerComponent(SpecificTestComponent.class, c -> testComponent)
+            );
+
+            Configuration config = testSubject.build();
+
+            assertEquals(testComponent, config.getComponent(TestComponent.class));
+        }
+
+        @Test
         void registerComponentForTypeAndNameExposesRegisteredComponentOnGet() {
             TestComponent testComponent = TEST_COMPONENT;
             String testName = "some-name";
@@ -207,6 +219,21 @@ public abstract class ApplicationConfigurerTestSuite<C extends ApplicationConfig
         void registerComponentForTypeExposesRegisteredComponentOnOptionalGet() {
             TestComponent testComponent = TEST_COMPONENT;
             testSubject.componentRegistry(cr -> cr.registerComponent(TestComponent.class, c -> testComponent));
+
+            Configuration config = testSubject.build();
+
+            Optional<TestComponent> result = config.getOptionalComponent(TestComponent.class);
+
+            assertTrue(result.isPresent());
+            assertEquals(testComponent, result.get());
+        }
+
+        @Test
+        void registerComponentForTypeExposesRegisteredComponentOnOptionalGetWhenAssignableFrom() {
+            SpecificTestComponent testComponent = SPECIFIC_TEST_COMPONENT;
+            testSubject.componentRegistry(
+                    cr -> cr.registerComponent(SpecificTestComponent.class, c -> testComponent)
+            );
 
             Configuration config = testSubject.build();
 

--- a/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
@@ -362,15 +362,6 @@ public abstract class ApplicationConfigurerTestSuite<C extends ApplicationConfig
         }
 
         @Test
-        void registerComponentThrowsIllegalArgumentExceptionForNullName() {
-            //noinspection DataFlowIssue
-            assertThrows(IllegalArgumentException.class,
-                         () -> testSubject.componentRegistry(cr -> cr.registerComponent(Object.class,
-                                                                                        null,
-                                                                                        c -> new Object())));
-        }
-
-        @Test
         void registerComponentThrowsIllegalArgumentExceptionForEmptyName() {
             assertThrows(IllegalArgumentException.class,
                          () -> testSubject.componentRegistry(cr -> cr.registerComponent(Object.class,

--- a/messaging/src/test/java/org/axonframework/configuration/ComponentTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/configuration/ComponentTestSuite.java
@@ -175,12 +175,6 @@ abstract class ComponentTestSuite<D extends Component<String>> {
     }
 
     @Test
-    void identifierConstructorThrowsIllegalArgumentExceptionForNullName() {
-        //noinspection DataFlowIssue
-        assertThrows(IllegalArgumentException.class, () -> new Identifier<>(String.class, null));
-    }
-
-    @Test
     void identifierConstructorThrowsIllegalArgumentExceptionForEmptyName() {
         assertThrows(IllegalArgumentException.class, () -> new Identifier<>(String.class, ""));
     }

--- a/messaging/src/test/java/org/axonframework/configuration/ComponentsTest.java
+++ b/messaging/src/test/java/org/axonframework/configuration/ComponentsTest.java
@@ -70,6 +70,31 @@ class ComponentsTest {
     }
 
     @Test
+    void getReturnsPutComponentWhenComponentTypeIsAssignableToGivenIdType() {
+        Component<String> testComponent = new InstantiatedComponentDefinition<>(IDENTIFIER, "some-state");
+        Identifier<Object> testId = new Identifier<>(Object.class, "id");
+
+        testSubject.put(testComponent);
+
+        Optional<Component<Object>> result = testSubject.get(testId);
+        assertTrue(result.isPresent());
+        assertEquals(testComponent, result.get());
+    }
+
+    @Test
+    void getThrowsIllegalArgumentExceptionWhenMultipleComponentsAreAssignableToGivenIdType() {
+        Component<String> stringTestComponent = new InstantiatedComponentDefinition<>(IDENTIFIER, "some-state");
+        Component<Integer> integerTestComponent =
+                new InstantiatedComponentDefinition<>(new Identifier<>(Integer.class, "id"), 42);
+        Identifier<Object> testId = new Identifier<>(Object.class, "id");
+
+        testSubject.put(stringTestComponent);
+        testSubject.put(integerTestComponent);
+
+        assertThrows(IllegalArgumentException.class, () -> testSubject.get(testId));
+    }
+
+    @Test
     void computeIfAbsentDoesNotComputeIfIdentifierIsAlreadyPresent() {
         Component<String> testComponent = new InstantiatedComponentDefinition<>(IDENTIFIER, "some-state");
         AtomicBoolean invoked = new AtomicBoolean(false);

--- a/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
+++ b/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
@@ -21,6 +21,7 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.configuration.ComponentRegistry;
 import org.axonframework.configuration.ConfigurationEnhancer;
 import org.axonframework.eventhandling.EventSink;
+import org.axonframework.eventsourcing.eventstore.EventStore;
 
 import java.util.Objects;
 
@@ -29,12 +30,16 @@ class MessagesRecordingConfigurationEnhancer implements ConfigurationEnhancer {
     @Override
     public void enhance(@Nonnull ComponentRegistry registry) {
         Objects.requireNonNull(registry, "Cannot enhance a null ComponentRegistry.")
+               .registerDecorator(EventStore.class,
+                                  Integer.MAX_VALUE,
+                                  (config, name, delegate) -> new RecordingEventStore(delegate))
                .registerDecorator(EventSink.class,
                                   Integer.MAX_VALUE,
-                                  (c, name, d) -> new RecordingEventSink(d))
+                                  (config, name, delegate) -> EventStore.class.isAssignableFrom(delegate.getClass())
+                                          ? delegate : new RecordingEventSink(delegate))
                .registerDecorator(CommandBus.class,
                                   Integer.MAX_VALUE,
-                                  (c, name, d) -> new RecordingCommandBus(d));
+                                  (config, name, delegate) -> new RecordingCommandBus(delegate));
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
@@ -19,16 +19,24 @@ package org.axonframework.test.fixture;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventSink;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.axonframework.messaging.unitofwork.ProcessingContext;
-
+/**
+ * An {@link EventSink} implementation recording all the events that are
+ * {@link #publish(ProcessingContext, List) published}.
+ * <p>
+ * The recorded events can then be used to assert expectations with test cases.
+ *
+ * @author Mateusz Nowak
+ * @since 5.0.0
+ */
 class RecordingEventSink implements EventSink {
 
-    private final EventSink delegate;
+    protected final EventSink delegate;
     private final List<EventMessage<?>> recorded;
 
     RecordingEventSink(EventSink delegate) {

--- a/test/src/main/java/org/axonframework/test/fixture/RecordingEventStore.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingEventStore.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * An {@link EventStore} implementation recording all the events that are
+ * {@link #publish(ProcessingContext, List) published}.
+ * <p>
+ * The recorded events can then be used to assert expectations with test cases.
+ *
+ * @author Allard Buijze
+ * @author Mateusz Nowak
+ * @since 5.0.0
+ */
+class RecordingEventStore extends RecordingEventSink implements EventStore {
+
+    RecordingEventStore(EventStore delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public EventStoreTransaction transaction(@NotNull ProcessingContext processingContext) {
+        return ((EventStore) super.delegate).transaction(processingContext);
+    }
+
+    @Override
+    public void describeTo(@NotNull ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+    }
+}


### PR DESCRIPTION
This pull request adjusts three spots in the configuration logic, being:

1. How we retrieve `Components` from the `Configuration`.
2. When we decide to decorate a `Component`
3. The name of a `Component` is now nullable.

Instead of a direct equals check on the given type and the stored type, this PR changes that behavior to an `Class#isAssignableFrom`.

In doing so, we and users can register decorators for (for example) all `CommandGateway` implementations present with a single `ComponentRegistry#registerDecorator` invocation.
Furthermore, retrieval of components is simplified where we or the users do not care about the concrete implementation, but simply desire the (for example) `EventStore` that's present in the configuration.

Lastly, by making the name of a `Component` nullable throughout the configuration, thus removing the `Class#getSimpleName` default name, we better align with the API.
Differently put, if somebody doesn't provide a `name`, then the `name` is apparently not important. Consequently, when retrieving a `Component` just for a type (potentially assignable), the validation will work as expected since we no longer keep a faulty `name`.

In doing the above, this pull request resolves #3434