### PR TITLE
Fix exceptions not being propagates from start handlers.

### DIFF
--- a/messaging/src/main/java/org/axonframework/configuration/HierarchicalConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/configuration/HierarchicalConfiguration.java
@@ -80,7 +80,7 @@ public class HierarchicalConfiguration implements LifecycleRegistry {
     @Override
     public LifecycleRegistry onStart(int phase, @Nonnull LifecycleHandler startHandler) {
         parentLifecycleRegistry.onStart(phase, (parentConfiguration) -> {
-            startHandler.run(childConfiguration);
+            return startHandler.run(childConfiguration);
         });
         return this;
     }
@@ -88,7 +88,7 @@ public class HierarchicalConfiguration implements LifecycleRegistry {
     @Override
     public LifecycleRegistry onShutdown(int phase, @Nonnull LifecycleHandler shutdownHandler) {
         parentLifecycleRegistry.onShutdown(phase, (parentConfiguration) -> {
-            shutdownHandler.run(childConfiguration);
+            return shutdownHandler.run(childConfiguration);
         });
         return this;
     }


### PR DESCRIPTION
The `HierarchicalConfiguration` did not return the `CompletableFuture` of its caller. 
So the exception on start was lost and thus not propagated. This PR resolves that issue.