### PR TITLE
[#3102] Mark the `Serializer` flow as deprecated

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/GrpcMetaDataAwareSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,9 @@ import jakarta.annotation.Nonnull;
  *
  * @author Marc Gathier
  * @since 4.0
+ * @deprecated Replaced entirely by the fact that metadata only accepts String-based values.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public final class GrpcMetaDataAwareSerializer implements Serializer {
 
     private final Serializer delegate;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcSerializedObject.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcSerializedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.axonframework.axonserver.connector.util;
 
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedType;
+import org.axonframework.serialization.Serializer;
 
 /**
  * Wrapper that allows clients to access a gRPC {@link io.axoniq.axonserver.grpc.SerializedObject} message as a {@link
@@ -25,7 +27,9 @@ import org.axonframework.serialization.SerializedType;
  *
  * @author Sara Pellegrini
  * @since 4.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class GrpcSerializedObject implements SerializedObject<byte[]> {
 
     private final io.axoniq.axonserver.grpc.SerializedObject payload;

--- a/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/AbstractXStreamSerializer.java
@@ -53,7 +53,9 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public abstract class AbstractXStreamSerializer implements Serializer {
 
     private final XStream xStream;

--- a/messaging/src/main/java/org/axonframework/serialization/GapAwareTrackingTokenConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/GapAwareTrackingTokenConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,9 @@ import java.util.TreeSet;
  *
  * @author Steven van Beelen
  * @since 4.7.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public final class GapAwareTrackingTokenConverter extends CollectionConverter {
 
     private static final String GAP_AWARE_TRACKING_TOKEN =

--- a/messaging/src/main/java/org/axonframework/serialization/SerializationException.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializationException.java
@@ -23,7 +23,9 @@ import org.axonframework.common.AxonNonTransientException;
  *
  * @author Allard Buijze
  * @since 0.6
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this exception becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SerializationException extends AxonNonTransientException {
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMetaData.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import java.util.Objects;
  * @param <T> The data type representing the serialized object
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SerializedMetaData<T> implements SerializedObject<T> {
 
     private static final String METADATA_CLASS_NAME = MetaData.class.getName();

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedObject.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ package org.axonframework.serialization;
  * @param <T> The data type representing the serialized object
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public interface SerializedObject<T> {
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedObjectHolder.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedObjectHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import java.util.Map;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SerializedObjectHolder {
 
     private final Message message;

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ package org.axonframework.serialization;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public interface SerializedType {
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/Serializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import jakarta.annotation.Nullable;
  *
  * @author Allard Buijze
  * @since 1.2
+ * @deprecated In favor of the simpler {@link Converter} interface.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public interface Serializer {
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/SimpleSerializedObject.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SimpleSerializedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ import static java.lang.String.format;
  * @param <T> The data type representing the serialized object
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SimpleSerializedObject<T> implements SerializedObject<T> {
 
     private final T data;

--- a/messaging/src/main/java/org/axonframework/serialization/SimpleSerializedType.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SimpleSerializedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import static java.lang.String.format;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SimpleSerializedType implements SerializedType {
 
     private static final SerializedType EMPTY_TYPE = new SimpleSerializedType("empty", null);

--- a/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/avro/AvroSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,9 @@ import static org.axonframework.common.BuilderUtils.assertThat;
  * @author Simon Zambrovski
  * @author Jan Galinski
  * @since 4.11.0
+ * @deprecated In favor of Avro-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class AvroSerializer implements Serializer {
 
     private final RevisionResolver revisionResolver;

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -56,7 +56,9 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  *
  * @author Allard Buijze
  * @since 2.2
+ * @deprecated in favor of a Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class JacksonSerializer implements Serializer {
 
     private final RevisionResolver revisionResolver;

--- a/messaging/src/main/java/org/axonframework/serialization/json/MetaDataDeserializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/MetaDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Converter;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -31,7 +32,9 @@ import java.util.Map;
  *
  * @author Allard Buijze
  * @since 2.4.2
+ * @deprecated in favor of a Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class MetaDataDeserializer extends JsonDeserializer<MetaData> {
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/xml/CompactDriver.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/CompactDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,9 @@ import java.net.URL;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class CompactDriver implements HierarchicalStreamDriver {
 
     private final XppDriver xppDriver = new XppDriver();

--- a/messaging/src/main/java/org/axonframework/serialization/xml/Dom4JToByteArrayConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/Dom4JToByteArrayConverter.java
@@ -19,6 +19,7 @@ package org.axonframework.serialization.xml;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.Converter;
 import org.dom4j.Document;
 
 import java.nio.charset.StandardCharsets;
@@ -31,7 +32,9 @@ import java.nio.charset.StandardCharsets;
  *
  * @author Allard Buijze
  * @since 2.0.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class Dom4JToByteArrayConverter implements ContentTypeConverter<Document, byte[]> {
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/xml/InputStreamToDom4jConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/InputStreamToDom4jConverter.java
@@ -18,8 +18,9 @@ package org.axonframework.serialization.xml;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import org.axonframework.serialization.ConversionException;
 import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.ConversionException;
+import org.axonframework.serialization.Converter;
 import org.dom4j.Document;
 import org.dom4j.io.STAXEventReader;
 
@@ -36,7 +37,9 @@ import javax.xml.stream.XMLStreamException;
  *
  * @author Allard Buijze
  * @since 2.0.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class InputStreamToDom4jConverter implements ContentTypeConverter<InputStream, Document> {
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/xml/InputStreamToXomConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/InputStreamToXomConverter.java
@@ -21,8 +21,9 @@ import jakarta.annotation.Nullable;
 import nu.xom.Builder;
 import nu.xom.Document;
 import nu.xom.ParsingException;
-import org.axonframework.serialization.ConversionException;
 import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.ConversionException;
+import org.axonframework.serialization.Converter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +37,9 @@ import java.io.InputStreamReader;
  *
  * @author Jochen Munz
  * @since 2.2.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class InputStreamToXomConverter implements ContentTypeConverter<InputStream, Document> {
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XStreamSerializer.java
@@ -50,7 +50,9 @@ import jakarta.annotation.Nonnull;
  * @author Allard Buijze
  * @see com.thoughtworks.xstream.XStream
  * @since 1.2
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class XStreamSerializer extends AbstractXStreamSerializer {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/messaging/src/main/java/org/axonframework/serialization/xml/XomToStringConverter.java
+++ b/messaging/src/main/java/org/axonframework/serialization/xml/XomToStringConverter.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import nu.xom.Document;
 import org.axonframework.serialization.ContentTypeConverter;
+import org.axonframework.serialization.Converter;
 
 /**
  * A {@link ContentTypeConverter} implementation that converts XOM {@link Document} instances to {@code Strings}.
@@ -28,7 +29,9 @@ import org.axonframework.serialization.ContentTypeConverter;
  *
  * @author Jochen Munz
  * @since 2.2.0
+ * @deprecated In favor of an XML-based Jackson-specific {@link Converter} implementation.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class XomToStringConverter implements ContentTypeConverter<Document, String> {
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/SerializedSaga.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/repository/jpa/SerializedSaga.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@ import org.axonframework.serialization.SimpleSerializedObject;
  *
  * @author Allard Buijze
  * @since 2.0
+ * @deprecated By shifting from the {@link Serializer} to the {@link Converter}, this class becomes obsolete.
  */
+@Deprecated(forRemoval = true, since = "5.0.0")
 public class SerializedSaga extends SimpleSerializedObject<byte[]> {
 
     /**


### PR DESCRIPTION
This pull request marks the `Serializer`, it's implementations, and other `Serializer`-specific interfaces and components as deprecated. 
This helps in the development of the `Converter` replacement, as it clarifies all the parts that should be adjusted.

In doing the above, this pull request is a part of issue #3102.