### PR TITLE
[#3313] Enable tests for record support.

### DIFF
--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -191,7 +191,6 @@ class AnnotationBasedEntityEvolvingComponentTest {
         }
     }
 
-    @Disabled("TODO #3313 - Event Sourcing Handler support for evolved state return")
     @Nested
     class RecordSupport {
 


### PR DESCRIPTION
I accidentally already built support for this in an earlier PR related to EntityModelling. As such, we can enable these already-working tests. This resolves #3313