### PR TITLE
Fix UpdateChecker test detection

### DIFF
--- a/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
@@ -90,6 +90,7 @@ public class UpdateChecker implements Runnable {
                 return;
             }
             if (TestEnvironmentDetector.isTestEnvironment()) {
+                started.set(false);
                 logger.debug("Skipping AxonIQ UpdateChecker as a testsuite environment was detected.");
                 return;
             }

--- a/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
@@ -89,11 +89,6 @@ public class UpdateChecker implements Runnable {
                 logger.debug("The AxonIQ UpdateChecker was already started.");
                 return;
             }
-            if (TestEnvironmentDetector.isTestEnvironment()) {
-                started.set(false);
-                logger.debug("Skipping AxonIQ UpdateChecker as a testsuite environment was detected.");
-                return;
-            }
             UsagePropertyProvider userProperties = UsagePropertyProvider.create();
             if (userProperties.getDisabled()) {
                 logger.info(

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancer.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancer.java
@@ -22,6 +22,8 @@ import org.axonframework.configuration.ComponentRegistry;
 import org.axonframework.configuration.ConfigurationEnhancer;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.axonframework.updates.detection.TestEnvironmentDetector;
+import org.slf4j.LoggerFactory;
 
 import static org.axonframework.configuration.ComponentDefinition.ofType;
 
@@ -35,9 +37,14 @@ import static org.axonframework.configuration.ComponentDefinition.ofType;
  */
 @Internal
 public class UpdateCheckerConfigurationEnhancer implements ConfigurationEnhancer {
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(UpdateCheckerConfigurationEnhancer.class);
 
     @Override
     public void enhance(@Nonnull ComponentRegistry componentRegistry) {
+        if (TestEnvironmentDetector.isTestEnvironment()) {
+            logger.debug("Skipping AxonIQ UpdateChecker as a testsuite environment was detected.");
+            return;
+        }
         componentRegistry.registerIfNotPresent(ofType(UsagePropertyProvider.class)
                                                        .withBuilder(c -> UsagePropertyProvider.create()))
                          .registerIfNotPresent(ofType(UpdateCheckerHttpClient.class)

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancer.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancer.java
@@ -23,6 +23,7 @@ import org.axonframework.configuration.ConfigurationEnhancer;
 import org.axonframework.lifecycle.Phase;
 import org.axonframework.updates.configuration.UsagePropertyProvider;
 import org.axonframework.updates.detection.TestEnvironmentDetector;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.axonframework.configuration.ComponentDefinition.ofType;
@@ -37,7 +38,7 @@ import static org.axonframework.configuration.ComponentDefinition.ofType;
  */
 @Internal
 public class UpdateCheckerConfigurationEnhancer implements ConfigurationEnhancer {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(UpdateCheckerConfigurationEnhancer.class);
+    private static final Logger logger = LoggerFactory.getLogger(UpdateCheckerConfigurationEnhancer.class);
 
     @Override
     public void enhance(@Nonnull ComponentRegistry componentRegistry) {

--- a/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
@@ -17,7 +17,6 @@
 package org.axonframework.updates.detection;
 
 import org.axonframework.common.annotation.Internal;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -46,8 +45,6 @@ public class TestEnvironmentDetector {
         if(System.getProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "false").equals("true")) {
             return false; // Skip detection if explicitly configured
         }
-        LoggerFactory.getLogger(TestEnvironmentDetector.class)
-                .warn("Is not a test environment", new Throwable("bla"));
         return Arrays.stream(Thread.currentThread().getStackTrace())
                 .anyMatch(TestEnvironmentDetector::isTestClass);
     }

--- a/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
@@ -17,6 +17,7 @@
 package org.axonframework.updates.detection;
 
 import org.axonframework.common.annotation.Internal;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -45,6 +46,8 @@ public class TestEnvironmentDetector {
         if(System.getProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "false").equals("true")) {
             return false; // Skip detection if explicitly configured
         }
+        LoggerFactory.getLogger(TestEnvironmentDetector.class)
+                .warn("Is not a test environment", new Throwable("bla"));
         return Arrays.stream(Thread.currentThread().getStackTrace())
                 .anyMatch(TestEnvironmentDetector::isTestClass);
     }

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UpdateCheckerConfigurationEnhancerTest {
 
     @Test
-    void configureShouldConfigureComponentsWithStartAndShutdown() {
+    void configureShouldConfigureComponents() {
         UpdateCheckerConfigurationEnhancer enhancer = new UpdateCheckerConfigurationEnhancer();
         DefaultComponentRegistry componentRegistry = new DefaultComponentRegistry();
         assertDoesNotThrow(() -> enhancer.enhance(componentRegistry));
@@ -41,14 +41,6 @@ class UpdateCheckerConfigurationEnhancerTest {
         Configuration config = componentRegistry.build(lifecycleRegistry);
 
         UpdateChecker checker = config.getComponent(UpdateChecker.class);
-        assertFalse(checker.isStarted());
-
-        lifecycleRegistry.start(config);
-
-        assertTrue(checker.isStarted());
-
-        lifecycleRegistry.shutdown(config);
-
         assertFalse(checker.isStarted());
     }
 }

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UpdateCheckerConfigurationEnhancerTest {
 
     @Test
-    void configureShouldConfigureComponents() {
+    void configureShouldConfigureComponentsWithStartAndShutdown() {
         UpdateCheckerConfigurationEnhancer enhancer = new UpdateCheckerConfigurationEnhancer();
         DefaultComponentRegistry componentRegistry = new DefaultComponentRegistry();
         assertDoesNotThrow(() -> enhancer.enhance(componentRegistry));
@@ -41,6 +41,14 @@ class UpdateCheckerConfigurationEnhancerTest {
         Configuration config = componentRegistry.build(lifecycleRegistry);
 
         UpdateChecker checker = config.getComponent(UpdateChecker.class);
+        assertFalse(checker.isStarted());
+
+        lifecycleRegistry.start(config);
+
+        assertTrue(checker.isStarted());
+
+        lifecycleRegistry.shutdown(config);
+
         assertFalse(checker.isStarted());
     }
 }

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerConfigurationEnhancerTest.java
@@ -22,9 +22,21 @@ import org.axonframework.updates.configuration.UsagePropertyProvider;
 import org.axonframework.utils.StubLifecycleRegistry;
 import org.junit.jupiter.api.*;
 
+import static org.axonframework.updates.detection.TestEnvironmentDetector.AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT;
 import static org.junit.jupiter.api.Assertions.*;
 
 class UpdateCheckerConfigurationEnhancerTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Reset the system property after tests
+        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
+    }
 
     @Test
     void configureShouldConfigureComponentsWithStartAndShutdown() {

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
@@ -45,14 +45,11 @@ class UpdateCheckerTest {
 
     @BeforeEach
     void setUp() {
-        System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
         updateChecker = new UpdateChecker(httpClient, reporter);
     }
 
     @AfterEach
     void tearDown() {
-        // Reset the system property after tests
-        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
         updateChecker.stop();
     }
 

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
@@ -17,8 +17,7 @@
 package org.axonframework.updates;
 
 import org.axonframework.updates.api.UpdateCheckResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,6 +47,13 @@ class UpdateCheckerTest {
     void setUp() {
         System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
         updateChecker = new UpdateChecker(httpClient, reporter);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Reset the system property after tests
+        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
+        updateChecker.stop();
     }
 
     @Test


### PR DESCRIPTION
The check for the `UpdateChecker` was part of the start lifecycle handler.
However, this is executed in a separate thread, and as such the testsuite detection did not work.

This PR moves the check to the ConfigurationEnhancer, which *is* called in the same thread. So the components are never registered, nor started. 