### PR TITLE
Ignore installations without user.home

### DIFF
--- a/messaging/src/main/java/org/axonframework/updates/detection/MachineId.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/MachineId.java
@@ -59,6 +59,11 @@ public class MachineId {
     private void initialize() {
         try {
             File file = getFile();
+            if(file == null) {
+                logger.debug("Could not determine user home directory. Machine ID will not be stored.");
+                machineId = UUID.randomUUID().toString();
+                return;
+            }
             if (file.exists()) {
                 machineId = new String(Files.readAllBytes(file.toPath()));
                 return;
@@ -76,6 +81,9 @@ public class MachineId {
 
     private File getFile() {
         String pwdDir = System.getProperty("user.home");
+        if(pwdDir == null) {
+            return null;
+        }
         String installationIdFilePath = pwdDir + MACHINE_ID_PATH;
         return new File(installationIdFilePath);
     }


### PR DESCRIPTION
The UpdateChecker creates a property file if one is not found. However, in some rare cases the `user.home` system property may be null. This happens, for example, during maven surefire test execution.

This PR changes the implementation of this, and ignores the property file if this occurs.