### PR TITLE
Register start/shutdown handlers of "local" `Components` as `SmartLifecycle` beans 

### DIFF
--- a/spring/src/main/java/org/axonframework/spring/config/SpringComponentRegistry.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringComponentRegistry.java
@@ -424,6 +424,8 @@ public class SpringComponentRegistry implements
                                          )
                                          .getBeanDefinition();
             ((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(name, definition);
+            // Initialize the components lifecycle handlers, by adapting them into SmartLifecycle beans through the SpringLifecycleRegistry.
+            component.initLifecycle(configuration, lifecycleRegistry);
         });
     }
 

--- a/spring/src/main/java/org/axonframework/spring/config/SpringLifecycleRegistry.java
+++ b/spring/src/main/java/org/axonframework/spring/config/SpringLifecycleRegistry.java
@@ -81,7 +81,7 @@ public class SpringLifecycleRegistry implements BeanFactoryAware, LifecycleRegis
                 phase,
                 () -> shutdownHandler.run(beanFactory.getBean(AxonConfiguration.class))
         );
-        beanFactory.registerSingleton(getBeanName("shutdown") + uniqueId.getAndIncrement(), springShutdownHandler);
+        beanFactory.registerSingleton(getBeanName("shutdown"), springShutdownHandler);
         return this;
     }
 


### PR DESCRIPTION
The new Spring integration has roughly two flows of components, being:

1. Components coming from Spring's Application Context.
2. Components coming through Axon Framework's configuration API.

The former are _public_ by nature, while the latter are initially **local** to the `SpringComponentRegistry`.
To make these available to Spring's Application Context, we register each `Component` separately.

It **that** bit of code that did not yet initialize the lifecycle of a `Component`.
Initializing the lifecycle of a component in Spring comes down to registering dedicated `SmartLifecycle` beans for every start- or shutdown-handler that's part of the `Component`.

This pull request resolves this bug by invoking `Component#initLifecycle(SpringConfiguration, SpringLifecycleRegistry)`.
By passing the `SpringLifecycleRegistry` to this operation, we construct the aforementioned `SmartLifecycle` as expected.