### PR TITLE
Remove duplicate call to Eventstream.excludePayloadType when skipping an UnknownSerializedType

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
@@ -124,7 +124,6 @@ public class EventBuffer implements TrackingEventStream {
             if (UnknownSerializedType.class.equals(ignoredMessage.getPayloadType())) {
                 UnknownSerializedType unknownSerializedType = (UnknownSerializedType) ignoredMessage.getPayload();
                 serializedType = unknownSerializedType.serializedType();
-                delegate.excludePayloadType(serializedType.getName(), serializedType.getRevision());
             } else {
                 serializedType = serializer.typeForClass(ignoredMessage.getPayloadType());
             }


### PR DESCRIPTION
Fixes #3532