### PR TITLE
Change update checker request parameters

### DIFF
--- a/messaging/src/main/java/org/axonframework/updates/api/Artifact.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/Artifact.java
@@ -35,4 +35,31 @@ public record Artifact(
         @Nonnull String version
 ) {
 
+    /**
+     * Returns a short version of the group ID, to save bytes over the wire.
+     *
+     * @return The short version of the group ID, or the original if it can't be shortened.
+     */
+    public String shortGroupId() {
+        if (groupId.startsWith("org.axonframework.extensions")) {
+            if(groupId.length() == 28) {
+                return "ext";
+            }
+            return "ext." + groupId.substring(29);
+        }
+        if (groupId.startsWith("org.axonframework")) {
+            if(groupId.length() == 17) {
+                return "fw";
+            }
+            return "fw." + groupId.substring(18);
+        }
+        if (groupId.startsWith("io.axoniq")) {
+            if(groupId.length() == 9) {
+                return "iq";
+            }
+            return "iq." + groupId.substring(10);
+        }
+        return groupId;
+    }
+
 }

--- a/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
@@ -62,12 +62,11 @@ public record UpdateCheckRequest(
      */
     public String toQueryString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("&os=").append(encode(osName + "; " + osVersion + "; " + osArch))
+        sb.append("os=").append(encode(osName + "; " + osVersion + "; " + osArch))
           .append("&java=").append(encode(jvmVersion + "; " + jvmVendor))
           .append("&kotlin=").append(encode(kotlinVersion));
         for (Artifact library : libraries) {
-            String stringLib = library.groupId() + ':' + library.artifactId() + ':' + library.version();
-            sb.append("&lib=").append(encode(stringLib));
+            sb.append("&lib-").append(library.shortGroupId()).append(".").append(library.artifactId()).append("=").append(encode(library.version()));
         }
         return sb.toString();
     }

--- a/messaging/src/test/java/org/axonframework/updates/api/UsageRequestTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/api/UsageRequestTest.java
@@ -38,6 +38,11 @@ class UpdateCheckRequestTest {
                 "1.8.22",
                 List.of(
                         new Artifact("org.axonframework", "axon-core", "5.0.0"),
+                        new Artifact("org.axonframework.something", "axon-something", "5.0.0"),
+                        new Artifact("org.axonframework.extensions", "axon-ext-bland", "5.0.0"),
+                        new Artifact("org.axonframework.extensions.kafka", "axon-ext-kafka", "5.0.0"),
+                        new Artifact("io.axoniq", "top-level-axoniq", "5.0.0"),
+                        new Artifact("io.axoniq.sub", "sub-level-axoniq", "5.0.0"),
                         new Artifact("org.example", "example-lib", "1.2.3")
                 )
         );
@@ -48,8 +53,13 @@ class UpdateCheckRequestTest {
         assertTrue(queryString.contains("os=Linux%3B+6.11.0-26-generic%3B+amd64"));
         assertTrue(queryString.contains("java=17.0.2%3B+AdoptOpenJDK"));
         assertTrue(queryString.contains("kotlin=1.8.22"));
-        assertTrue(queryString.contains("lib=org.axonframework%3Aaxon-core%3A5.0.0"));
-        assertTrue(queryString.contains("lib=org.example%3Aexample-lib%3A1.2.3"));
+        assertTrue(queryString.contains("lib-fw.axon-core=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-fw.something.axon-something=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-ext.axon-ext-bland=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-ext.kafka.axon-ext-kafka=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-iq.top-level-axoniq=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-iq.sub.sub-level-axoniq=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-org.example.example-lib=1.2.3"));
     }
 
     @Test


### PR DESCRIPTION
Repeating the `lib` GET parameter in the update checker was not a good idea, as the parsing does not happen correctly.

This PR introduces a different way, where each library gets their own GET parameter in the format: `lib-my.group.id.artifact-id=version`. To shorten the URL, some common prefixed have been replacd, like 'lib-fw.axon-messaging' for 'lib-org.axonframework.axon-messaging' and 'lib-iq.console-client' for 'lib-io.axonq.console-client'.