### PR TITLE
Update Checker with Anonymous Usage Analytics 

### DIFF
--- a/config/src/main/java/org/axonframework/config/UpdateCheckerConfigurerModule.java
+++ b/config/src/main/java/org/axonframework/config/UpdateCheckerConfigurerModule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.config;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.updates.LoggingUpdateCheckerReporter;
+import org.axonframework.updates.UpdateChecker;
+import org.axonframework.updates.UpdateCheckerHttpClient;
+import org.axonframework.updates.UpdateCheckerReporter;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.axonframework.updates.detection.TestEnvironmentDetector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A {@link ConfigurerModule} that registers the {@link UpdateChecker} component. This component is responsible for
+ * reporting anonymous usage data to the AxonIQ servers. It is registered during the external connections phase of the
+ * lifecycle.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class UpdateCheckerConfigurerModule implements ConfigurerModule {
+
+    private static final Logger logger = LoggerFactory.getLogger(UpdateCheckerConfigurerModule.class);
+
+    @Override
+    public void configureModule(@Nonnull Configurer configurer) {
+        if (TestEnvironmentDetector.isTestEnvironment()) {
+            logger.debug("Skipping AxonIQ UpdateChecker as a testsuite environment was detected.");
+            return;
+        }
+        configurer.registerComponent(UsagePropertyProvider.class, c -> UsagePropertyProvider.create())
+                  .registerComponent(UpdateCheckerHttpClient.class,
+                                     c -> {
+                                         UsagePropertyProvider propertyProvider = c.getComponent(
+                                                 UsagePropertyProvider.class);
+                                         return new UpdateCheckerHttpClient(propertyProvider);
+                                     })
+                  .registerComponent(UpdateCheckerReporter.class, c -> new LoggingUpdateCheckerReporter())
+                  .registerComponent(UpdateChecker.class,
+                                     c -> new UpdateChecker(
+                                             c.getComponent(UpdateCheckerHttpClient.class),
+                                             c.getComponent(UpdateCheckerReporter.class)
+                                     ));
+    }
+
+    @Override
+    public int order() {
+        // Ensure this runs last so users can override components such as the UpdateCheckerReporter
+        return Integer.MAX_VALUE;
+    }
+}

--- a/config/src/main/resources/META-INF/services/org.axonframework.config.ConfigurerModule
+++ b/config/src/main/resources/META-INF/services/org.axonframework.config.ConfigurerModule
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2018. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.axonframework.config.UpdateCheckerConfigurerModule

--- a/config/src/test/java/org/axonframework/config/UpdateCheckerConfigurerModuleTest.java
+++ b/config/src/test/java/org/axonframework/config/UpdateCheckerConfigurerModuleTest.java
@@ -1,0 +1,49 @@
+package org.axonframework.config;
+
+import org.axonframework.updates.UpdateChecker;
+import org.axonframework.updates.UpdateCheckerHttpClient;
+import org.axonframework.updates.UpdateCheckerReporter;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.junit.jupiter.api.*;
+
+import static org.axonframework.updates.detection.TestEnvironmentDetector.AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UpdateCheckerConfigurerModuleTest {
+
+    @BeforeEach
+    void setUp() {
+        System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Reset the system property after tests
+        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
+    }
+
+    @Test
+    void configureShouldConfigureComponentsWithStartAndShutdown() {
+        UpdateCheckerConfigurerModule enhancer = new UpdateCheckerConfigurerModule();
+        Configurer testConfigurer = DefaultConfigurer.defaultConfiguration();
+        assertDoesNotThrow(() -> enhancer.configureModule(testConfigurer));
+
+        Configuration resultConfig = testConfigurer.buildConfiguration();
+
+        assertNotNull(resultConfig.getComponent(UsagePropertyProvider.class));
+        assertNotNull(resultConfig.getComponent(UpdateCheckerHttpClient.class));
+        assertNotNull(resultConfig.getComponent(UpdateCheckerReporter.class));
+        UpdateChecker checker = resultConfig.getComponent(UpdateChecker.class);
+        assertNotNull(checker);
+
+        assertFalse(checker.isStarted());
+
+        resultConfig.start();
+
+        assertTrue(checker.isStarted());
+
+        resultConfig.shutdown();
+
+        assertFalse(checker.isStarted());
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/LoggingUpdateCheckerReporter.java
+++ b/messaging/src/main/java/org/axonframework/updates/LoggingUpdateCheckerReporter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.Artifact;
+import org.axonframework.updates.api.DetectedVulnerability;
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * An {@link UpdateCheckerReporter} implementation that logs the results of the update check.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class LoggingUpdateCheckerReporter implements UpdateCheckerReporter {
+
+    @SuppressWarnings("FieldMayBeFinal") // For testing purposes, we need to be able to mock this logger
+    private static Logger logger = LoggerFactory.getLogger(LoggingUpdateCheckerReporter.class);
+
+    @Override
+    public void report(UpdateCheckRequest request,
+                       UpdateCheckResponse updateCheckResponse) {
+        boolean hasUpgrades = !updateCheckResponse.upgrades().isEmpty();
+        boolean hasVulnerabilities = !updateCheckResponse.vulnerabilities().isEmpty();
+        if (hasVulnerabilities) {
+            logger.error("AxonIQ has found the following vulnerabilities in your Axon libraries:");
+            logVulnerabilities(updateCheckResponse);
+
+            if (hasUpgrades) {
+                logger.info("Additionally, AxonIQ has found an upgrade(s) for your Axon libraries:");
+                logUpgrades(request, updateCheckResponse);
+            }
+        } else if (hasUpgrades) {
+            logger.info("AxonIQ has found the following dependency upgrade(s):");
+            logUpgrades(request, updateCheckResponse);
+            logger.info("No vulnerabilities have been found in your Axon libraries.");
+        } else {
+            logger.info("All your AxonIQ libraries are up-to-date, no upgrades or vulnerabilities found.");
+        }
+    }
+
+    private void logUpgrades(UpdateCheckRequest requestBody, UpdateCheckResponse updateCheckResponse) {
+        int nameLength = calculateStringLength(requestBody.libraries(),
+                                               upgrade -> upgrade.groupId() + ":" + upgrade.artifactId()) + 2;
+        int versionLength = calculateStringLength(requestBody.libraries(), Artifact::version);
+
+        updateCheckResponse.upgrades().forEach(upgrade -> {
+            String currentVersion = getCurrentVersionForArtifact(requestBody, upgrade.groupId(), upgrade.artifactId());
+            logger.info("{} {} -> {}",
+                        rightPad(upgrade.groupId() + ":" + upgrade.artifactId(), nameLength, '.'),
+                        rightPad(currentVersion, versionLength, ' '),
+                        upgrade.latestVersion()
+            );
+        });
+    }
+
+    private static String getCurrentVersionForArtifact(UpdateCheckRequest requestBody, String groupId,
+                                                       String artifactId) {
+        return requestBody.libraries().stream()
+                          .filter(v -> v.artifactId().equals(artifactId) && v.groupId().equals(groupId))
+                          .findFirst()
+                          .map(Artifact::version)
+                          .orElse("unknown");
+    }
+
+    private <T> int calculateStringLength(List<T> items, Function<T, String> stringExtractor) {
+        return items.stream()
+                    .map(stringExtractor)
+                    .mapToInt(String::length)
+                    .max()
+                    .orElse(0);
+    }
+
+    private String rightPad(String str, int length, char padChar) {
+        if (str.length() >= length) {
+            return str;
+        }
+        StringBuilder sb = new StringBuilder(str);
+        for (int i = 0; i < length - str.length(); i++) {
+            sb.append(padChar);
+        }
+        return sb.toString();
+    }
+
+    private void logVulnerabilities(UpdateCheckResponse updateCheckResponse) {
+        int nameLength = calculateStringLength(updateCheckResponse.vulnerabilities(),
+                                               upgrade -> upgrade.groupId() + ":" + upgrade.artifactId()) + 2;
+
+        int severityLength = calculateStringLength(updateCheckResponse.vulnerabilities(),
+                                                   vulnerability -> vulnerability.severity().toString());
+
+        int fixVersionLength = calculateStringLength(updateCheckResponse.vulnerabilities(),
+                                                     DetectedVulnerability::fixVersion);
+
+        updateCheckResponse.vulnerabilities().forEach(vulnerability -> {
+            logger.error("[{}] {} [Fixed in: {}] Description: {}",
+                         rightPad(vulnerability.severity().toString(), severityLength, ' '),
+                         rightPad(vulnerability.groupId() + ":" + vulnerability.artifactId(), nameLength, '.'),
+                         rightPad(vulnerability.fixVersion(), fixVersionLength, ' '),
+                         vulnerability.description()
+            );
+        });
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateChecker.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.lifecycle.Lifecycle;
+import org.axonframework.lifecycle.Phase;
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.axonframework.updates.detection.AxonVersionDetector;
+import org.axonframework.updates.detection.KotlinVersion;
+import org.axonframework.updates.detection.MachineId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nonnull;
+
+/**
+ * The UpdateChecker reports Anonymous usage data to AxonIQ periodically. In return, it receives information about
+ * available upgrades and vulnerabilities in the AxonIQ libraries used. These upgrades and vulnerabilities are reported
+ * to the configured {@code UpdateCheckerReporter}.
+ * <p>
+ * The task will not run if the user has opted out of anonymous usage reporting. There are three ways to disable the
+ * anonymous usage reporting:
+ * <ol>
+ *     <li>Set the environment variable {@code AXONIQ_UPDATE_CHECKER_DISABLED=true}.</li>
+ *     <li>Run the JVM with {@code -Daxoniq.update-checker.disabled=true}.</li>
+ *     <li>Create the file {@code $HOME/.axoniq/update-checker.properties} with content {@code disabled=true}</li>
+ * </ol>
+ * These methods are listed in order of precedence, meaning that if the environment variable is set, it will take precedence over the JVM property and the file.
+ * Explicitly setting the property to {@code disabled=false} in a method of higher precedence will ignore the lower precedence disabled.
+ * <p>
+ * This class is not intended to be in use during the running of test suites and therefore does not run when it detects one.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class UpdateChecker implements Runnable, Lifecycle {
+
+    private final static Logger logger = LoggerFactory.getLogger(UpdateChecker.class);
+
+    private final UpdateCheckerHttpClient client;
+    private final MachineId machineId;
+    private final UpdateCheckerReporter reporter;
+    private final ScheduledExecutorService executor;
+
+    private boolean firstRequest = true;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private int errorRetryBackoffFactor = 1;
+
+    /**
+     * Creates a new instance of {@code UpdateCheckTask} with the given {@link UpdateCheckerHttpClient}.
+     *
+     * @param client   The HTTP client used to send requests to the telemetry endpoint.
+     * @param reporter The reporter that will handle the response from the telemetry endpoint.
+     */
+    public UpdateChecker(UpdateCheckerHttpClient client,
+                         UpdateCheckerReporter reporter) {
+        this(client, reporter, Executors.newScheduledThreadPool(1));
+    }
+
+    public UpdateChecker(UpdateCheckerHttpClient client,
+                         UpdateCheckerReporter reporter,
+                         ScheduledExecutorService executor) {
+        BuilderUtils.assertNonNull(client, "The client must not be null.");
+        BuilderUtils.assertNonNull(reporter, "The reporter must not be null.");
+        BuilderUtils.assertNonNull(executor, "The executor must not be null.");
+        this.client = client;
+        this.machineId = new MachineId();
+        this.reporter = reporter;
+        this.executor = executor;
+    }
+
+    @Override
+    public void registerLifecycleHandlers(@Nonnull LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.EXTERNAL_CONNECTIONS, this::start);
+        lifecycle.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::stop);
+    }
+
+    /**
+     * Starts the anonymous usage reporting task. If the user has opted out of anonymous usage reporting, or a testsuite
+     * is detected, the task will not be started.
+     */
+    public void start() {
+        try {
+            if (!started.compareAndSet(false, true)) {
+                logger.debug("The AxonIQ UpdateChecker was already started.");
+                return;
+            }
+            UsagePropertyProvider userProperties = UsagePropertyProvider.create();
+            if (userProperties.getDisabled()) {
+                logger.info(
+                        "You have opted out of the AxonIQ UpdateChecker. No updates or vulnerabilities will be checked. See https://www.axoniq.io/update-check for more information.");
+                return;
+            }
+            logger.info(
+                    "Your AxonIQ libraries will be checked for updates periodically. See https://www.axoniq.io/update-check for more information.");
+
+            executor.schedule(this, 1000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            logger.warn("Failed to start the UpdateChecker task.", e);
+        }
+    }
+
+    @Override
+    public void run() {
+        if (!started.get()) {
+            return;
+        }
+        try {
+            UpdateCheckRequest requestBody = buildRequest();
+            Optional<UpdateCheckResponse> response = client.sendRequest(requestBody, firstRequest);
+            if (!response.isPresent()) {
+                scheduleErrorRetry();
+                return;
+            }
+
+            UpdateCheckResponse updateCheckResponse = response.get();
+            reporter.report(requestBody, updateCheckResponse);
+
+            logger.debug("AxonIQ will check library updates and vulnerabilities again in {} seconds.",
+                         updateCheckResponse);
+            executor.schedule(this, updateCheckResponse.checkInterval() * 1000L, TimeUnit.MILLISECONDS);
+            errorRetryBackoffFactor = 1; // Reset backoff factor on a successful report
+            firstRequest = false;
+        } catch (Exception e) {
+            logger.warn("The AxonIQ UpdateChecker failed to fetch updates and vulnerabilities.", e);
+            scheduleErrorRetry();
+        }
+    }
+
+    /**
+     * Allows the task to be stopped, preventing any further updates from being checked. Useful for terminating the task
+     * gracefully, for example, when the application is shutting down.
+     */
+    public void stop() {
+        if (started.compareAndSet(true, false)) {
+            logger.info("Stopped the AxonIQ UpdateChecker. No further updates will be checked.");
+            executor.shutdown();
+        }
+    }
+
+    private void scheduleErrorRetry() {
+        errorRetryBackoffFactor++;
+        int nextInvocationTime = Math.min((int) ((Math.pow(2, errorRetryBackoffFactor)) * 1000), 60000);
+        executor.schedule(this, nextInvocationTime, TimeUnit.MILLISECONDS);
+    }
+
+    private UpdateCheckRequest buildRequest() {
+        String jvmVendor = System.getProperty("java.vendor");
+        String javaVersion = System.getProperty("java.version");
+        String osName = System.getProperty("os.name");
+        String osArch = System.getProperty("os.arch");
+        String osVersion = System.getProperty("os.version");
+        String installationId = UUID.randomUUID().toString();
+
+        return new UpdateCheckRequest(
+                machineId.get(),
+                installationId,
+                osName,
+                osVersion,
+                osArch,
+                javaVersion,
+                jvmVendor,
+                KotlinVersion.get(),
+                AxonVersionDetector.safeDetectAxonModules()
+        );
+    }
+
+    /**
+     * Checks if the UpdateChecker has been started.
+     *
+     * @return {@code true} if the UpdateChecker has been started, {@code false} otherwise.
+     */
+    public boolean isStarted() {
+        return started.get();
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.common.BuilderUtils;
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Client for checking for updates and sending anonymous usage data to the AxonIQ servers. This client uses the
+ * {@link UsagePropertyProvider} to determine the URL to send the data to.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class UpdateCheckerHttpClient {
+
+    private final static Logger logger = LoggerFactory.getLogger(UpdateCheckerHttpClient.class);
+
+    private final UsagePropertyProvider userProperties;
+
+    /**
+     * Creates a new {@code UpdateCheckerHttpClient} with the given {@link UsagePropertyProvider}. The client will use
+     * the properties to determine the URL to send the usage data to.
+     *
+     * @param userProperties The {@link UsagePropertyProvider} to use for retrieving the URL and other properties.
+     */
+    public UpdateCheckerHttpClient(UsagePropertyProvider userProperties) {
+        BuilderUtils.assertNonNull(userProperties, "The userProperties must not be null.");
+        this.userProperties = userProperties;
+    }
+
+    /**
+     * Sends a usage request to the AxonIQ servers. If {@code firstRequest} is true, it will send a POST request,
+     * otherwise it will send a PUT request.
+     *
+     * @param updateCheckRequest The {@link UpdateCheckRequest} to send.
+     * @param firstRequest       Whether this is the first request or not.
+     * @return An {@link Optional} containing the {@link UpdateCheckResponse} if the request was successful, or empty if
+     * it failed.
+     */
+    public Optional<UpdateCheckResponse> sendRequest(UpdateCheckRequest updateCheckRequest,
+                                                     boolean firstRequest) {
+        String url = userProperties.getUrl() + "?" + updateCheckRequest.toQueryString();
+
+        try {
+            logger.debug("Reporting anonymous usage data to AxonIQ servers at: {}", url);
+
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(10000); // 10 seconds
+            connection.setReadTimeout(10000); // 10 seconds
+            connection.setInstanceFollowRedirects(true);
+            // Set headers
+            connection.setRequestProperty("User-Agent", updateCheckRequest.toUserAgent());
+            connection.setRequestProperty("X-Machine-Id", updateCheckRequest.machineId());
+            connection.setRequestProperty("X-Instance-Id", updateCheckRequest.instanceId());
+            connection.setRequestProperty("X-Uptime", String.valueOf(ManagementFactory.getRuntimeMXBean().getUptime()));
+            connection.setRequestProperty("X-First-Run", firstRequest ? "true" : "false");
+
+            int statusCode = connection.getResponseCode();
+            if (statusCode != 200) {
+                logger.info("Failed to report anonymous usage data, received status code: {}", statusCode);
+                return Optional.empty();
+            }
+
+            // Read response
+            String responseBody = readResponse(connection);
+            logger.debug("Reported anonymous usage data successfully, received response: {}", responseBody);
+            return Optional.of(UpdateCheckResponse.fromRequest(responseBody));
+        } catch (Exception e) {
+            logger.warn("Failed to report anonymous usage data", e);
+            return Optional.empty();
+        }
+    }
+
+    private String readResponse(HttpURLConnection connection) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(),
+                                                                              StandardCharsets.UTF_8))) {
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+            return response.toString();
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerReporter.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerReporter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.axonframework.updates.api.UpdateCheckResponse;
+
+/**
+ * Interface for reporting the response of the update checker to the user. Implementations of this interface should
+ * handle how the response is communicated to the user.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public interface UpdateCheckerReporter {
+
+    /**
+     * Reports the given {@code response} of the update checker to the user.
+     *
+     * @param request  The request that was made to the update checker.
+     * @param response The response to report.
+     */
+    void report(UpdateCheckRequest request, UpdateCheckResponse response);
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/Artifact.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/Artifact.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+import java.util.Objects;
+
+/**
+ * Represents an artifact with its group ID, artifact ID, and version.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class Artifact {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    /**
+     * Constructs a {@code DetectedVulnerability} with the given {@code groupId}, {@code artifactId}, and
+     * {@code version}.
+     *
+     * @param groupId    The group ID of the artifact.
+     * @param artifactId The artifact ID of the artifact.
+     * @param version    The version of the artifact.
+     */
+    public Artifact(String groupId,
+                    String artifactId,
+                    String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    /**
+     * Returns the group identifier of this artifact.
+     *
+     * @return The group identifier of this artifact.
+     */
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * Returns a short version of the group ID, to save bytes over the wire.
+     *
+     * @return The short version of the group ID, or the original if it can't be shortened.
+     */
+    public String shortGroupId() {
+        if (groupId.startsWith("org.axonframework.extensions")) {
+            if (groupId.length() == 28) {
+                return "ext";
+            }
+            return "ext." + groupId.substring(29);
+        }
+        if (groupId.startsWith("org.axonframework")) {
+            if (groupId.length() == 17) {
+                return "fw";
+            }
+            return "fw." + groupId.substring(18);
+        }
+        if (groupId.startsWith("io.axoniq")) {
+            if (groupId.length() == 9) {
+                return "iq";
+            }
+            return "iq." + groupId.substring(10);
+        }
+        return groupId;
+    }
+
+    /**
+     * Returns the artifact identifier of this artifact.
+     *
+     * @return The artifact identifier of this artifact.
+     */
+    public String artifactId() {
+        return artifactId;
+    }
+
+    /**
+     * Returns the version of this artifact.
+     *
+     * @return The version of this artifact.
+     */
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Artifact artifact = (Artifact) o;
+        return Objects.equals(groupId, artifact.groupId)
+                && Objects.equals(artifactId, artifact.artifactId)
+                && Objects.equals(version, artifact.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version);
+    }
+
+    @Override
+    public String toString() {
+        return "Artifact{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/ArtifactAvailableUpgrade.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/ArtifactAvailableUpgrade.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+import java.util.Objects;
+
+/**
+ * Represents an upgrade suggestion for a specific artifact version by the AxonIQ Update Checker API.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class ArtifactAvailableUpgrade {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String latestVersion;
+
+    /**
+     * Constructs an {@code ArtifactAvailableUpgrade} with the given {@code groupId}, {@code artifactId}, and
+     * {@code latestVersion}.
+     *
+     * @param groupId       The group ID of the library.
+     * @param artifactId    The artifact ID of the library.
+     * @param latestVersion The latest version of the library available for upgrade.
+     */
+    public ArtifactAvailableUpgrade(String groupId,
+                                    String artifactId,
+                                    String latestVersion) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.latestVersion = latestVersion;
+    }
+
+    /**
+     * Returns the group identifier of this available artifact upgrade.
+     *
+     * @return The group identifier of this available artifact upgrade.
+     */
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * Returns the artifact identifier of this available artifact upgrade.
+     *
+     * @return The artifact identifier of this available artifact upgrade.
+     */
+    public String artifactId() {
+        return artifactId;
+    }
+
+    /**
+     * Returns the latest version of this available artifact upgrade.
+     *
+     * @return The latest version of this available artifact upgrade.
+     */
+    public String latestVersion() {
+        return latestVersion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArtifactAvailableUpgrade that = (ArtifactAvailableUpgrade) o;
+        return Objects.equals(groupId, that.groupId)
+                && Objects.equals(artifactId, that.artifactId)
+                && Objects.equals(latestVersion, that.latestVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, latestVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "ArtifactAvailableUpgrade{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", latestVersion='" + latestVersion + '\'' +
+                '}';
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/DetectedVulnerability.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/DetectedVulnerability.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+import java.util.Objects;
+
+/**
+ * Represents a vulnerability in an AxonIQ Artifact in use. This object contains information about the artifact's group
+ * ID, artifact ID, severity of the vulnerability, the recommended fix version, and a description of the vulnerability.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class DetectedVulnerability {
+
+    private final String groupId;
+    private final String artifactId;
+    private final DetectedVulnerabilitySeverity severity;
+    private final String fixVersion;
+    private final String description;
+
+    /**
+     * Constructs a {@code DetectedVulnerability} with the given {@code groupId}, {@code artifactId}, {@code severity},
+     * {@code fixVersion}, and {@code description}.
+     *
+     * @param groupId     The group ID of the artifact.
+     * @param artifactId  The artifact ID of the artifact.
+     * @param severity    The severity of the vulnerability, represented by the {@link DetectedVulnerabilitySeverity}
+     *                    enum.
+     * @param fixVersion  The recommended version to fix the vulnerability.
+     * @param description A description of the vulnerability, providing details about its nature and impact.
+     */
+    public DetectedVulnerability(String groupId,
+                                 String artifactId,
+                                 DetectedVulnerabilitySeverity severity,
+                                 String fixVersion,
+                                 String description) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.severity = severity;
+        this.fixVersion = fixVersion;
+        this.description = description;
+    }
+
+    /**
+     * Returns the group identifier of this detected vulnerability.
+     *
+     * @return The group identifier of this detected vulnerability.
+     */
+    public String groupId() {
+        return groupId;
+    }
+
+    /**
+     * Returns the artifact identifier of this detected vulnerability.
+     *
+     * @return The artifact identifier of this detected vulnerability.
+     */
+    public String artifactId() {
+        return artifactId;
+    }
+
+    /**
+     * Returns the severity of this detected vulnerability.
+     *
+     * @return The severity of this detected vulnerability.
+     */
+    public DetectedVulnerabilitySeverity severity() {
+        return severity;
+    }
+
+    /**
+     * Returns the fix version of this detected vulnerability.
+     *
+     * @return The fix version of this detected vulnerability.
+     */
+    public String fixVersion() {
+        return fixVersion;
+    }
+
+    /**
+     * Returns the description of this detected vulnerability.
+     *
+     * @return The description of this detected vulnerability.
+     */
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DetectedVulnerability that = (DetectedVulnerability) o;
+        return Objects.equals(groupId, that.groupId)
+                && Objects.equals(artifactId, that.artifactId)
+                && severity == that.severity
+                && Objects.equals(fixVersion, that.fixVersion)
+                && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, severity, fixVersion, description);
+    }
+
+    @Override
+    public String toString() {
+        return "DetectedVulnerability{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", severity=" + severity +
+                ", fixVersion='" + fixVersion + '\'' +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/DetectedVulnerabilitySeverity.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/DetectedVulnerabilitySeverity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+/**
+ * Represents the severity of a vulnerability in an AxonIQ artifact. This enum defines various levels of severity that
+ * can be assigned to a vulnerability, ranging from unknown to critical.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public enum DetectedVulnerabilitySeverity {
+    /**
+     * The severity of the vulnerability is unknown.
+     */
+    UNKNOWN,
+    /**
+     * The vulnerability has a low severity.
+     */
+    LOW,
+    /**
+     * The vulnerability has a medium severity.
+     */
+    MEDIUM,
+    /**
+     * The vulnerability has a high severity.
+     */
+    HIGH,
+    /**
+     * The vulnerability has a critical severity.
+     */
+    CRITICAL
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents an UpdateChecker request, including machine and instance identifiers, operating system details, JVM
+ * information, Kotlin version, and a list of library versions.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class UpdateCheckRequest {
+
+    private final String machineId;
+    private final String instanceId;
+    private final String osName;
+    private final String osVersion;
+    private final String osArch;
+    private final String jvmVersion;
+    private final String jvmVendor;
+    private final String kotlinVersion;
+    private final List<Artifact> libraries;
+
+    /**
+     * Constructs an {@code UpdateCheckRequest} with the given {@code machineId}, {@code instanceId}, {@code osName},
+     * {@code osVersion}, {@code osArch}, {@code jvmVersion}, {@code jvmVendor}, {@code kotlinVersion}, and
+     * {@code libraries}.
+     *
+     * @param machineId     The unique identifier for the machine. This is a UUID that is generated and stored in the
+     *                      user's home directory.
+     * @param instanceId    The unique identifier for the instance of the application. This is a UUID that is generated
+     *                      for each JVM instance.
+     * @param osName        The name of the operating system (e.g., "Linux", "Windows").
+     * @param osVersion     The version of the operating system (e.g., "6.11.0-26-generic").
+     * @param osArch        The architecture of the operating system (e.g., "amd64", "x86_64").
+     * @param jvmVersion    The version of the Java Virtual Machine (JVM) (e.g., "17.0.2").
+     * @param jvmVendor     The vendor of the JVM (e.g., "AdoptOpenJDK", "Oracle").
+     * @param kotlinVersion The version of Kotlin used in the application, or "none" if Kotlin is not used.
+     * @param libraries     A list of library versions used in the application, each represented by a {@link Artifact}
+     *                      object containing the group ID, artifact ID, and version of the library.
+     */
+    public UpdateCheckRequest(String machineId,
+                              String instanceId,
+                              String osName,
+                              String osVersion,
+                              String osArch,
+                              String jvmVersion,
+                              String jvmVendor,
+                              String kotlinVersion,
+                              List<Artifact> libraries) {
+        this.machineId = machineId;
+        this.instanceId = instanceId;
+        this.osName = osName;
+        this.osVersion = osVersion;
+        this.osArch = osArch;
+        this.jvmVersion = jvmVersion;
+        this.jvmVendor = jvmVendor;
+        this.kotlinVersion = kotlinVersion;
+        this.libraries = libraries;
+    }
+
+    /**
+     * Returns the machine identifier of this update check request.
+     *
+     * @return The machine identifier of this update check request.
+     */
+    public String machineId() {
+        return machineId;
+    }
+
+    /**
+     * Returns the instance identifier of this update check request.
+     *
+     * @return The instance identifier of this update check request.
+     */
+    public String instanceId() {
+        return instanceId;
+    }
+
+    /**
+     * Returns the operating system name of this update check request.
+     *
+     * @return The operating system name of this update check request.
+     */
+    public String osName() {
+        return osName;
+    }
+
+    /**
+     * Returns the operating system version of this update check request.
+     *
+     * @return The operating system version of this update check request.
+     */
+    public String osVersion() {
+        return osVersion;
+    }
+
+    /**
+     * Returns the operating system architecture of this update check request.
+     *
+     * @return The operating system architecture of this update check request.
+     */
+    public String osArch() {
+        return osArch;
+    }
+
+    /**
+     * Returns the JVM version of this update check request.
+     *
+     * @return The JVM version of this update check request.
+     */
+    public String jvmVersion() {
+        return jvmVersion;
+    }
+
+    /**
+     * Returns the JVM vendor of this update check request.
+     *
+     * @return The JVM vendor of this update check request.
+     */
+    public String jvmVendor() {
+        return jvmVendor;
+    }
+
+    /**
+     * Returns the kotlin version of this update check request.
+     *
+     * @return The kotlin version of this update check request.
+     */
+    public String kotlinVersion() {
+        return kotlinVersion;
+    }
+
+    /**
+     * Returns the collection of {@link Artifact libraries} of this update check request.
+     *
+     * @return The collection of {@link Artifact libraries} of this update check request.
+     */
+    public List<Artifact> libraries() {
+        return libraries;
+    }
+
+    /**
+     * Converts the usage request into a query string format suitable for HTTP requests. All values are properly URL
+     * encoded.
+     *
+     * @return The query string representation of the usage request.
+     */
+    public String toQueryString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("os=").append(encode(osName + "; " + osVersion + "; " + osArch))
+          .append("&java=").append(encode(jvmVersion + "; " + jvmVendor))
+          .append("&kotlin=").append(encode(kotlinVersion));
+        for (Artifact library : libraries) {
+            sb.append("&lib-").append(library.shortGroupId()).append(".").append(library.artifactId()).append("=")
+              .append(encode(library.version()));
+        }
+        return sb.toString();
+    }
+
+    private String encode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to encode [" + value + "] to an URL.", e);
+        }
+    }
+
+    /**
+     * Converts the usage request into a user agent string format.
+     *
+     * @return The user agent string representation of the usage request.
+     */
+    public String toUserAgent() {
+        String axonBaseVersion = getAxonBaseVersion();
+        return String.format(
+                "AxonIQ UpdateChecker/%s (Java %s %s; %s; %s; %s)",
+                axonBaseVersion,
+                jvmVersion, jvmVendor, osName, osVersion, osArch
+        );
+    }
+
+    private String getAxonBaseVersion() {
+        return libraries.stream()
+                        .filter(a -> a.groupId().equals("org.axonframework"))
+                        .filter(a -> a.artifactId().equals("axon-messaging"))
+                        .map(Artifact::version)
+                        .findFirst().orElse("5.0.0");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateCheckRequest that = (UpdateCheckRequest) o;
+        return Objects.equals(machineId, that.machineId)
+                && Objects.equals(instanceId, that.instanceId)
+                && Objects.equals(osName, that.osName)
+                && Objects.equals(osVersion, that.osVersion)
+                && Objects.equals(osArch, that.osArch)
+                && Objects.equals(jvmVersion, that.jvmVersion)
+                && Objects.equals(jvmVendor, that.jvmVendor)
+                && Objects.equals(kotlinVersion, that.kotlinVersion)
+                && Objects.equals(libraries, that.libraries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(machineId,
+                            instanceId,
+                            osName,
+                            osVersion,
+                            osArch,
+                            jvmVersion,
+                            jvmVendor,
+                            kotlinVersion,
+                            libraries);
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateCheckRequest{" +
+                "machineId='" + machineId + '\'' +
+                ", instanceId='" + instanceId + '\'' +
+                ", osName='" + osName + '\'' +
+                ", osVersion='" + osVersion + '\'' +
+                ", osArch='" + osArch + '\'' +
+                ", jvmVersion='" + jvmVersion + '\'' +
+                ", jvmVendor='" + jvmVendor + '\'' +
+                ", kotlinVersion='" + kotlinVersion + '\'' +
+                ", libraries=" + libraries +
+                '}';
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckResponse.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckResponse.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the response from the UpdateChecker API, containing information about version upgrades and vulnerabilities
+ * found in the artifacts used by the application.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class UpdateCheckResponse {
+
+    private final int checkInterval;
+    private final List<ArtifactAvailableUpgrade> upgrades;
+    private final List<DetectedVulnerability> vulnerabilities;
+
+    /**
+     * Constructs an {@code UpdateCheckResponse} with the given {@code checkInterval}, {@code upgrades}, and
+     * {@code vulnerabilities}.
+     *
+     * @param checkInterval   The interval in seconds at which the usage data should be checked.
+     * @param upgrades        A list of found version upgrades, each containing details about the artifact and its
+     *                        latest version.
+     * @param vulnerabilities A list of found vulnerabilities, each containing details about the artifact, its severity,
+     *                        fix version, and a URL for more information.
+     */
+    public UpdateCheckResponse(int checkInterval,
+                               List<ArtifactAvailableUpgrade> upgrades,
+                               List<DetectedVulnerability> vulnerabilities) {
+        this.checkInterval = checkInterval;
+        this.upgrades = upgrades;
+        this.vulnerabilities = vulnerabilities;
+    }
+
+    /**
+     * Returns the check interval of this update check response.
+     *
+     * @return The check interval of this update check response.
+     */
+    public int checkInterval() {
+        return checkInterval;
+    }
+
+    /**
+     * Returns the collection of {@link ArtifactAvailableUpgrade upgrades} of this update check response.
+     *
+     * @return The collection of {@link ArtifactAvailableUpgrade upgrades} of this update check response.
+     */
+    public List<ArtifactAvailableUpgrade> upgrades() {
+        return upgrades;
+    }
+
+    /**
+     * Returns the collection of {@link DetectedVulnerability vulnerabilities} of this update check response.
+     *
+     * @return The collection of {@link DetectedVulnerability vulnerabilities} of this update check response.
+     */
+    public List<DetectedVulnerability> vulnerabilities() {
+        return vulnerabilities;
+    }
+
+    /**
+     * Parses the response body from the anonymous usage reporter into a {@code UsageResponse} object. The body is
+     * expected to be in a specific format where each line contains a key-value pair. The expected keys are:
+     * <ul>
+     *     <li>cd - Check interval in seconds</li>
+     *     <li>vul - Vulnerability information in the format:
+     *            groupId:artifactId:fixVersion:severity:moreInformationUrl</li>
+     *     <li>upd - Update information in the format: groupId:artifactId:latestVersion</li>
+     * </ul>
+     * <p>
+     * An example of the expected format:
+     * <pre>
+     * cd=86400
+     * vul=org.axonframework:axon-serialization:1.0.0:HIGH:"https://example.com/vulnerability"
+     * upd=org.axonframework:axon-messaging:5.0.1
+     * </pre>
+     *
+     * @param body The response body as a string.
+     * @return A {@code UsageResponse} object containing the parsed data.
+     */
+    public static UpdateCheckResponse fromRequest(String body) {
+        int checkInterval = 86400; // Default to 24 hours, in case request didn't work
+        List<ArtifactAvailableUpgrade> upgrades = new ArrayList<>();
+        List<DetectedVulnerability> vulnerabilities = new ArrayList<>();
+        if (body == null || body.isEmpty()) {
+            return new UpdateCheckResponse(checkInterval, Collections.emptyList(), Collections.emptyList());
+        }
+        String[] lines = body.split("\\r?\\n");
+        for (String line : lines) {
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            String[] parts = line.split("=", 2);
+            if (parts.length < 2) {
+                continue; // Skip lines without a value
+            }
+            String key = parts[0].trim();
+            String value = parts[1].trim();
+
+            switch (key) {
+                case "cd":
+                    checkInterval = parseCheckInterval(value);
+                    break;
+                case "vul":
+                    parseVulnerability(value, vulnerabilities);
+                    break;
+                case "upd":
+                    parseUpdate(value, vulnerabilities, upgrades);
+                    break;
+            }
+        }
+        return new UpdateCheckResponse(checkInterval, upgrades, vulnerabilities);
+    }
+
+    private static void parseUpdate(String val, List<DetectedVulnerability> vulnerabilities,
+                                    List<ArtifactAvailableUpgrade> upgrades) {
+        // Format: upd=groupId:artifactId:latestVersion
+        String[] parts = parseIntoParts(val);
+        if (parts.length == 3) {
+            String groupId = parts[0];
+            String artifactId = parts[1];
+            String latestVersion = parts[2];
+            upgrades.add(new ArtifactAvailableUpgrade(
+                    groupId, artifactId, latestVersion
+            ));
+        }
+    }
+
+    private static void parseVulnerability(String val, List<DetectedVulnerability> vulnerabilities) {
+        // Format: vul=groupId:artifactId:fixVersion:severity:moreInformationUrl
+        String[] parts = parseIntoParts(val);
+        if (parts.length == 5) {
+            String groupId = parts[0];
+            String artifactId = parts[1];
+            String fixVersion = parts[2];
+            DetectedVulnerabilitySeverity severity = parseVulnerability(parts[3]);
+            String moreInformationUrl = parts[4];
+            vulnerabilities.add(new DetectedVulnerability(
+                    groupId, artifactId, severity, fixVersion, moreInformationUrl
+            ));
+        }
+    }
+
+    /**
+     * Parses a string into parts, splitting on ':' while respecting quoted sections. Quoted sections can contain colons
+     * without splitting, similar to how CSV parsing works.
+     *
+     * @param val the string to parse
+     * @return an array of parts
+     */
+    private static String[] parseIntoParts(String val) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < val.length(); i++) {
+            char c = val.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == ':' && !inQuotes) {
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        parts.add(current.toString());
+        return parts.toArray(new String[0]);
+    }
+
+    private static DetectedVulnerabilitySeverity parseVulnerability(String value) {
+        DetectedVulnerabilitySeverity severity;
+        try {
+            severity = DetectedVulnerabilitySeverity.valueOf(value);
+        } catch (Exception e) {
+            severity = DetectedVulnerabilitySeverity.UNKNOWN;
+        }
+        return severity;
+    }
+
+    private static int parseCheckInterval(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return 86400; // Default to 24 hours, in case request didn't work;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateCheckResponse that = (UpdateCheckResponse) o;
+        return checkInterval == that.checkInterval
+                && Objects.equals(upgrades, that.upgrades)
+                && Objects.equals(vulnerabilities, that.vulnerabilities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(checkInterval, upgrades, vulnerabilities);
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateCheckResponse{" +
+                "checkInterval=" + checkInterval +
+                ", upgrades=" + upgrades +
+                ", vulnerabilities=" + vulnerabilities +
+                '}';
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/CommandLineUsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/CommandLineUsagePropertyProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+/**
+ * A {@link UsagePropertyProvider} implementation that reads the usage properties from the command line system
+ * properties. This is the highest priority provider, meaning any defined property will override the others.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class CommandLineUsagePropertyProvider implements UsagePropertyProvider {
+
+    /**
+     * The system property key to check if the update checker is disabled.
+     */
+    public static final String DISABLED_KEY = "axoniq.update-checker.disabled";
+    /**
+     * The system property key to retrieve the URL for the usage collection endpoint.
+     */
+    public static final String URL_KEY = "axoniq.usage.url";
+
+    @Override
+    public Boolean getDisabled() {
+        String property = System.getProperty(DISABLED_KEY, null);
+        if (property != null) {
+            return Boolean.parseBoolean(property);
+        }
+        return null;
+    }
+
+    @Override
+    public String getUrl() {
+        return System.getProperty(URL_KEY, null);
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/DefaultUsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/DefaultUsagePropertyProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+/**
+ * Default implementation of the {@link UsagePropertyProvider} interface. This implementation provides default values
+ * for the properties used in the Axon Framework usage API. It is used when no other provider has a value.
+ * <p>
+ * As there is no dependent state and holds default values, this class is implemented as a singleton. Retrieve the
+ * instance using {@link #INSTANCE}.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class DefaultUsagePropertyProvider implements UsagePropertyProvider {
+
+    /**
+     * Singleton instance of the {@link DefaultUsagePropertyProvider}.
+     */
+    public static DefaultUsagePropertyProvider INSTANCE = new DefaultUsagePropertyProvider();
+
+    @Override
+    public Boolean getDisabled() {
+        return false;
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://get.axoniq.io/updates/framework";
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MIN_VALUE;
+    }
+
+    private DefaultUsagePropertyProvider() {
+        // Private constructor to prevent instantiation
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/EnvironmentVariableUsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/EnvironmentVariableUsagePropertyProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.axonframework.common.BuilderUtils;
+
+/**
+ * A {@link UsagePropertyProvider} implementation that reads the usage properties from the environment variables. The
+ * priority is half of max integer value, meaning it will be overridden by the command-line properties provider.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class EnvironmentVariableUsagePropertyProvider implements UsagePropertyProvider {
+
+    /**
+     * The environment variable key to check if the update checker is disabled.
+     */
+    public static final String DISABLED_KEY = "AXONIQ_UPDATE_CHECKER_DISABLED";
+    /**
+     * The environment variable key to retrieve the URL for the usage collection endpoint.
+     */
+    public static final String URL_KEY = "AXONIQ_UPDATE_CHECKER_URL";
+
+    private final EnvironmentVariableSupplier envSupplier;
+
+    /**
+     * Creates a new {@code EnvironmentVariableUsagePropertyProvider} that reads properties from the system environment.
+     * This constructor uses {@link System#getenv()} as the default supplier for environment variables.
+     */
+    public EnvironmentVariableUsagePropertyProvider() {
+        this(System::getenv);
+    }
+
+    /**
+     * Creates a new {@code EnvironmentVariableUsagePropertyProvider} that reads properties from the provided
+     * {@link EnvironmentVariableSupplier}. This allows for custom implementations to provide environment variable
+     * values, which can be useful for testing or when the default {@link System#getenv()} is not suitable.
+     *
+     * @param envSupplier The supplier to use for retrieving environment variables.
+     */
+    public EnvironmentVariableUsagePropertyProvider(EnvironmentVariableSupplier envSupplier) {
+        BuilderUtils.assertNonNull(envSupplier, "The envSupplier must not be null.");
+        this.envSupplier = envSupplier;
+    }
+
+    @Override
+    public Boolean getDisabled() {
+        String property = envSupplier.get(DISABLED_KEY);
+        if (property != null) {
+            return Boolean.parseBoolean(property);
+        }
+        return null;
+    }
+
+    @Override
+    public String getUrl() {
+        return envSupplier.get(URL_KEY);
+    }
+
+    @Override
+    public int priority() {
+        return Integer.MAX_VALUE / 2;
+    }
+
+    /**
+     * A functional interface to supply environment variables. This allows for custom implementations to provide
+     * environment variable values, which can be useful for testing or when the default {@link System#getenv()} is not
+     * suitable.
+     */
+    @FunctionalInterface
+    public interface EnvironmentVariableSupplier {
+
+        /**
+         * Retrieves the value of the specified environment variable.
+         *
+         * @param key The name of the environment variable to retrieve.
+         * @return The value of the environment variable, or {@code null} if it is not set.
+         */
+        String get(String key);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/HierarchicalUsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/HierarchicalUsagePropertyProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.axonframework.common.BuilderUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Combines multiple {@link UsagePropertyProvider} instances into a single provider. It will return the first non-null
+ * value for each property from the list of providers, sorted by their priority.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class HierarchicalUsagePropertyProvider implements UsagePropertyProvider {
+
+    private final List<UsagePropertyProvider> providers;
+
+    /**
+     * Creates a new {@code HierarchicalUsagePropertyProvider} with the given list of providers. The providers will be
+     * sorted by their priority in descending order, meaning the highest priority provider will be checked first.
+     *
+     * @param providers The list of {@link UsagePropertyProvider} instances to combine.
+     */
+    public HierarchicalUsagePropertyProvider(List<UsagePropertyProvider> providers) {
+        BuilderUtils.assertNonNull(providers, "The providers may not be null.");
+        this.providers = providers.stream()
+                                  .sorted(Comparator.comparingInt(UsagePropertyProvider::priority).reversed())
+                                  .collect(Collectors.toList());
+    }
+
+    @Override
+    public Boolean getDisabled() {
+        return providers.stream()
+                        .map(UsagePropertyProvider::getDisabled)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(false);
+    }
+
+    @Override
+    public String getUrl() {
+        return providers.stream().map(UsagePropertyProvider::getUrl)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse("");
+    }
+
+    @Override
+    public int priority() {
+        // Does not matter for the combined provider, as it is not used directly.
+        return 0;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/PropertyFileUsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/PropertyFileUsagePropertyProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+/**
+ * A {@link UsagePropertyProvider} that reads the AxonIQ Data Collection properties from a file located at
+ * `~/.axoniq/data-collection.properties`. If the file does not exist, it creates a default file with the default
+ * telemetry endpoint and opt-out settings.
+ * <p>
+ * If the file cannot be written, it will log a debug message and skip the property provider.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class PropertyFileUsagePropertyProvider implements UsagePropertyProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(PropertyFileUsagePropertyProvider.class);
+    private static final String AXONIQ_PROPERTIES_PATH = "/.axoniq/update-checker.properties";
+
+    private Boolean optOut;
+    private String telemetryEndpoint;
+    private boolean loaded = false;
+
+    @Override
+    public Boolean getDisabled() {
+        ensureLoaded();
+        return optOut;
+    }
+
+    @Override
+    public String getUrl() {
+        ensureLoaded();
+        return telemetryEndpoint;
+    }
+
+    private void ensureLoaded() {
+        if (!loaded) {
+            load();
+            loaded = true;
+        }
+    }
+
+    private void load() {
+        try {
+            File installationIdFile = getFile();
+            if (installationIdFile == null) {
+                logger.debug("Could not determine user home directory. Skipping property provider from file.");
+                return;
+            }
+            Properties properties = new Properties();
+            if (!installationIdFile.exists()) {
+                createDefaultFile();
+            }
+            properties.load(Files.newInputStream(installationIdFile.toPath()));
+            this.telemetryEndpoint = properties.getProperty("telemetry_url");
+            this.optOut = Boolean.valueOf(properties.getProperty("disabled"));
+        } catch (Exception e) {
+            logger.debug("Failed to load AxonIQ properties from file: {}. Skipping property provider from file.",
+                         getFile().getAbsolutePath(), e);
+        }
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    private void createDefaultFile() throws IOException {
+        File file = getFile();
+        if (file == null) {
+            logger.debug("Could not determine user home directory. Skipping creation of default properties file.");
+            return;
+        }
+        logger.info("Creating default AxonIQ Data Collection properties file at: {}", file.getAbsolutePath());
+        Properties properties = new Properties();
+        properties.setProperty("telemetry_url", DefaultUsagePropertyProvider.INSTANCE.getUrl());
+        properties.setProperty("opted_out", String.valueOf(DefaultUsagePropertyProvider.INSTANCE.getDisabled()));
+        // Ensure the parent directory exists
+        File parentDir = file.getParentFile();
+        if (!parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Failed to create parent directory: " + parentDir.getAbsolutePath());
+        }
+        properties.store(Files.newOutputStream(file.toPath()), "AxonIQ Anonymous Usage Reporting");
+    }
+
+    private File getFile() {
+        String pwdDir = System.getProperty("user.home");
+        if (pwdDir == null) {
+            return null;
+        }
+        String installationIdFilePath = pwdDir + AXONIQ_PROPERTIES_PATH;
+        return new File(installationIdFilePath);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/configuration/UsagePropertyProvider.java
+++ b/messaging/src/main/java/org/axonframework/updates/configuration/UsagePropertyProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import java.util.Arrays;
+
+/**
+ * Provides properties related to the Anonymous Usage Collection feature. This interface allows for different
+ * implementations to provide properties such as whether the collection is disabled and the URL for the collection
+ * endpoint.
+ * <p>
+ * To use this, please {@link #create()} to obtain an instance that combines multiple property providers, such as
+ * command line, property file, and default providers.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public interface UsagePropertyProvider {
+
+    /**
+     * Returns whether the Anonymous Usage Collection is disabled.
+     *
+     * @return {@code true} if the collection is disabled, {@code null} if not specified, or {@code false} if enabled.
+     */
+    Boolean getDisabled();
+
+    /**
+     * Returns the URL for the Anonymous Usage Collection endpoint.
+     *
+     * @return The URL as a {@link String}, or {@code null} if not specified.
+     */
+    String getUrl();
+
+    /**
+     * Returns the priority of this property provider. Higher values indicate higher priority. Providers with higher
+     * priority will be checked first when retrieving properties.
+     *
+     * @return An {@code int} representing the priority of this provider.
+     */
+    int priority();
+
+    /**
+     * Creates a new instance of {@code UsagePropertyProvider} that combines multiple property providers. The providers
+     * are sorted by their priority, with the highest priority provider checked first.
+     *
+     * @return A new {@code UsagePropertyProvider} instance.
+     */
+    static UsagePropertyProvider create() {
+        return new HierarchicalUsagePropertyProvider(Arrays.asList(
+                new CommandLineUsagePropertyProvider(),
+                new EnvironmentVariableUsagePropertyProvider(),
+                new PropertyFileUsagePropertyProvider(),
+                DefaultUsagePropertyProvider.INSTANCE
+        ));
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/detection/AxonVersionDetector.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/AxonVersionDetector.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.axonframework.updates.api.Artifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class to detect Axon Framework versions from the classpath. It scans for Maven's {@code pom.properties} files
+ * in the classpath and extracts the Axon Framework module versions. If an error occurs during detection, it logs the
+ * error and returns an empty list.
+ * <p>
+ * Will only detect Axon Framework modules that are part of the Axon Framework or AxonIQ ecosystem, as defined by the
+ * group IDs:
+ * <ul>
+ *     <li>org.axonframework</li>
+ *     <li>io.axoniq</li>
+ * </ul>
+ * <p>
+ * This class is not intended to be instantiated, and all methods are static.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public final class AxonVersionDetector {
+
+    private static final Logger logger = LoggerFactory.getLogger(AxonVersionDetector.class);
+
+    private static final List<String> GROUP_IDS = Arrays.asList(
+            "org/axonframework",
+            "io/axoniq"
+    );
+
+    private AxonVersionDetector() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Detects Axon Framework modules in the classpath and returns their versions. If an error occurs during detection,
+     * it logs the error and returns an empty list.
+     *
+     * @return A list of detected Axon Framework modules with their versions.
+     */
+    public static List<Artifact> safeDetectAxonModules() {
+        try {
+            return detectAxonModules()
+                    .stream()
+                    .distinct()
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Failed to detect Axon Framework modules", e);
+            return Collections.emptyList();
+        }
+    }
+
+    private static List<Artifact> detectAxonModules() {
+        List<Artifact> foundVersions = new LinkedList<>();
+        List<URL> urlsToCheck = new LinkedList<>();
+        for (String groupId : GROUP_IDS) {
+            try {
+                Enumeration<URL> resources = Thread.currentThread().getContextClassLoader()
+                                                   .getResources("META-INF/maven/");
+                while (resources.hasMoreElements()) {
+                    urlsToCheck.add(resources.nextElement());
+                }
+            } catch (IOException e) {
+                logger.debug("Failed to retrieve Axon Framework modules for group ID: {}", groupId, e);
+            }
+        }
+        for (URL url : urlsToCheck) {
+            try {
+                String filePath = url.getFile();
+                if (GROUP_IDS.stream().noneMatch(filePath::contains) && !filePath.contains("test-classes")) {
+                    continue; // Skip URLs that do not match the AxonIQ group IDs
+                }
+                if (url.getProtocol().equals("jar")) {
+                    foundVersions.addAll(extractVersionFromJar(url));
+                } else if (url.getProtocol().equals("file")) {
+                    foundVersions.addAll(extractVersionFromDirectory(url));
+                }
+            } catch (Exception e) {
+                logger.debug("Failed to read Axon Framework module at URL: {}", url, e);
+            }
+        }
+        return foundVersions;
+    }
+
+    private static List<Artifact> extractVersionFromJar(URL url) throws IOException {
+        // The URL format for JAR files is typically "file:/path/to/jarfile.jar!/META-INF/maven/...".
+        // We need to extract the path to the JAR file, so we remove the "file:" prefix and everything after the "!" character.
+        String jarFilePath = url.getPath().substring(5, url.getPath().indexOf("!"));
+        try (JarFile jarFile = new JarFile(new File(jarFilePath))) {
+            return jarFile.stream()
+                          .filter(entry -> entry.getName().startsWith("META-INF/maven/"))
+                          .filter(entry -> entry.getName().endsWith("/pom.properties"))
+                          .map(entry -> {
+                              try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                                  return mapToAxonVersion(inputStream);
+                              } catch (IOException e) {
+                                  logger.debug("Failed to read pom.properties from JAR entry: {}", entry.getName(), e);
+                                  return null;
+                              }
+                          })
+                          .collect(Collectors.toList());
+        }
+    }
+
+    private static Artifact mapToAxonVersion(InputStream inputStream) throws IOException {
+        Properties mavenProps = new Properties();
+        mavenProps.load(inputStream);
+        return new Artifact(
+                mavenProps.getProperty("groupId"),
+                mavenProps.getProperty("artifactId"),
+                mavenProps.getProperty("version")
+        );
+    }
+
+    private static List<Artifact> extractVersionFromDirectory(URL url) throws URISyntaxException {
+        File file = new File(url.toURI());
+        List<Artifact> foundVersions = new LinkedList<>();
+        if (file.isDirectory()) {
+            List<File> filesToCheck = scanDirectoryForPomProperties(file);
+            for (File pomFile : filesToCheck) {
+                try {
+                    Artifact version = mapToAxonVersion(Files.newInputStream(pomFile.toPath()));
+                    foundVersions.add(version);
+                } catch (Exception e) {
+                    logger.debug("Unexpected error while processing pom.properties file: {}",
+                                 pomFile.getAbsolutePath(), e);
+                }
+            }
+        }
+        return foundVersions;
+    }
+
+    private static List<File> scanDirectoryForPomProperties(File dir) {
+        List<File> files = new LinkedList<>();
+        scanRecursivelyForPomProperties(dir, files);
+        return files;
+    }
+
+    private static void scanRecursivelyForPomProperties(File dir, List<File> files) {
+        File[] children = dir.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (File child : children) {
+            if (child.isDirectory()) {
+                scanRecursivelyForPomProperties(child, files);
+            } else if (child.getName().equals("pom.properties")) {
+                files.add(child);
+            }
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/detection/KotlinVersion.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/KotlinVersion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+/**
+ * Utility class to retrieve the current Kotlin version at runtime. It attempts to access the `kotlin.KotlinVersion`
+ * class and invoke its `getCurrent` method. If the class or method is not found, it returns "none".
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class KotlinVersion {
+
+    private static String KOTLIN_VERSION = null;
+
+    /**
+     * Returns the current Kotlin version as a string. If the Kotlin library is not present, it returns "none".
+     *
+     * @return the current Kotlin version or "none" if not available
+     */
+    public static String get() {
+        if (KOTLIN_VERSION == null || KOTLIN_VERSION.isEmpty()) {
+            KOTLIN_VERSION = detect();
+        }
+        return KOTLIN_VERSION;
+    }
+
+    private static String detect() {
+        try {
+            Class<?> versionClass = Class.forName("kotlin.KotlinVersion");
+            return versionClass.getDeclaredMethod("getCurrent").invoke(null).toString();
+        } catch (Exception e) {
+            return "none";
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/detection/MachineId.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/MachineId.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
+
+/**
+ * Loads and stores a unique machine ID in the user's home directory. This ID is used to identify the machine for usage
+ * tracking purposes. If the ID can't be stored or read, it will generate a new UUID.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class MachineId {
+
+    private static final Logger logger = LoggerFactory.getLogger(MachineId.class);
+
+    private static final String MACHINE_ID_PATH = "/.axoniq/.machine-id";
+
+    private String machineId;
+
+    /**
+     * Creates a new instance of {@code MachineId}.
+     */
+    public MachineId() {
+        this.initialize();
+    }
+
+    /**
+     * Returns the unique machine ID. If it has not been initialized yet, it will initialize it first.
+     *
+     * @return The unique machine ID.
+     */
+    public String get() {
+        return machineId;
+    }
+
+    private void initialize() {
+        try {
+            File file = getFile();
+            if (file == null) {
+                logger.debug("Could not determine user home directory. Machine ID will not be stored.");
+                machineId = UUID.randomUUID().toString();
+                return;
+            }
+            if (file.exists()) {
+                machineId = new String(Files.readAllBytes(file.toPath()));
+                return;
+            }
+            File parentDir = getFile().getParentFile();
+            if (!parentDir.exists() && !parentDir.mkdirs()) {
+                throw new IOException("Failed to create parent directory: " + parentDir.getAbsolutePath());
+            }
+            machineId = UUID.randomUUID().toString();
+            Files.write(file.toPath(), machineId.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            logger.debug("Failed to initialize machine id", e);
+        }
+    }
+
+    private File getFile() {
+        String pwdDir = System.getProperty("user.home");
+        if (pwdDir == null) {
+            return null;
+        }
+        String installationIdFilePath = pwdDir + MACHINE_ID_PATH;
+        return new File(installationIdFilePath);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
+++ b/messaging/src/main/java/org/axonframework/updates/detection/TestEnvironmentDetector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import java.util.Arrays;
+
+/**
+ * This class detects whether the usage reporter is being used in a unit test environment, such as a JUnit test or
+ * another testing framework.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.12.0
+ */
+public class TestEnvironmentDetector {
+
+    /**
+     * System property to force the usage reporter to assume it's not a test environment. This is useful for testing
+     * purposes, where you want to skip the detection logic.
+     */
+    public static final String AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT = "axoniq.usage.force-test-environment";
+
+    /**
+     * Checks whether the current environment is a test environment.
+     *
+     * @return {@code true} if the current environment is a test environment, {@code false} otherwise.
+     */
+    public static boolean isTestEnvironment() {
+        if (System.getProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "false").equals("true")) {
+            return false; // Skip detection if explicitly configured
+        }
+        return Arrays.stream(Thread.currentThread().getStackTrace())
+                     .anyMatch(TestEnvironmentDetector::isTestClass);
+    }
+
+    private static boolean isTestClass(StackTraceElement stackTraceElement) {
+        String className = stackTraceElement.getClassName();
+        return className.startsWith("org.junit") // JUnit 4, JUnit Vintage
+                || className.startsWith("org.testng") // TestNG
+                || className.startsWith("org.spockframework") // Spock
+                || className.startsWith("org.mockito") // Mockito
+                || className.startsWith("io.cucumber") // Cucumber (modern)
+                || className.startsWith("org.cucumber") // Cucumber (legacy)
+                || className.startsWith("org.assertj") // AssertJ
+                || className.startsWith("org.hamcrest") // Hamcrest
+                || className.startsWith("org.jboss.arquillian") // Arquillian
+                || className.startsWith("org.arquillian") // Arquillian (alt)
+                || className.startsWith("org.springframework.test") // Spring Test
+                || className.startsWith("org.springframework.boot.test") // Spring Boot Test
+                || className.startsWith("io.kotest") // Kotest
+                || className.startsWith("io.kotlintest") // KotlinTest (legacy)
+                || className.startsWith("org.scalatest") // ScalaTest
+                || className.startsWith("org.jbehave") // JBehave
+                || className.startsWith("org.easymock") // EasyMock
+                || className.startsWith("org.powermock") // PowerMock
+                || className.startsWith("org.spekframework") // Spek
+                || className.startsWith("net.jqwik") // Jqwik
+                || className.startsWith("org.quicktheories") // QuickTheories
+                || className.startsWith("fit.") // FitNesse
+                || className.startsWith("fitnesse.") // FitNesse
+                || className.startsWith("org.concordion") // Concordion
+                || className.startsWith("com.consol.citrus") // Citrus
+                || className.startsWith("org.pitest") // PIT Mutation Testing
+                || className.startsWith("org.testcontainers") // Testcontainers
+                || className.startsWith("org.robolectric") // Robolectric
+                || className.startsWith("net.serenitybdd") // Serenity BDD
+                || className.startsWith("geb.") // Geb
+                || className.startsWith("cucumber.api") // Cucumber-JVM (legacy)
+                || className.startsWith("org.jmock") // JMock
+                || className.startsWith("mockit") // JMockit
+                || className.startsWith("play.test") // Play Framework Test
+                || className.startsWith("com.codeborne.selenide") // Selenide
+                || className.startsWith("org.openqa.selenium") // Selenium
+                || className.startsWith("junitparams") // JUnitParams
+                || className.startsWith("org.testfx") // TestFX
+                || className.startsWith("com.intellij") // IntelliJ IDEA runner
+                || className.startsWith("org.gradle.api.internal.tasks.testing"); // Gradle test runner
+    }
+}
+

--- a/messaging/src/test/java/org/axonframework/updates/LoggingUpdateCheckerReporterTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/LoggingUpdateCheckerReporterTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.Artifact;
+import org.axonframework.updates.api.ArtifactAvailableUpgrade;
+import org.axonframework.updates.api.DetectedVulnerability;
+import org.axonframework.updates.api.DetectedVulnerabilitySeverity;
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.junit.jupiter.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoggingUpdateCheckerReporterTest {
+
+    private LoggingUpdateCheckerReporter reporter;
+    private Logger originalLogger;
+    private Logger mockLogger;
+
+    private final UpdateCheckRequest sampleRequest = new UpdateCheckRequest(
+            "my-machine-id-1234",
+            "my-instance-id-5678",
+            "Linux",
+            "6",
+            "x64",
+            "21.0.2",
+            "Oracle",
+            "none",
+            Arrays.asList(
+                    new Artifact("org.axonframework", "axon-framework", "5.0.1"),
+                    new Artifact("org.axonframework", "axon-messaging", "5.0.0"),
+                    new Artifact("io.axoniq.console", "framework-client-spring-boot-starter", "2.1.10")
+            )
+    );
+
+    @BeforeEach
+    void setUp() throws Exception {
+        reporter = new LoggingUpdateCheckerReporter();
+
+        // Get and store the original logger
+        Field loggerField = LoggingUpdateCheckerReporter.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        originalLogger = (Logger) loggerField.get(null);
+
+        // Create and set the spied logger
+        mockLogger = spy(LoggerFactory.getLogger(LoggingUpdateCheckerReporter.class));
+        loggerField.set(null, mockLogger);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        // Restore the original logger
+        Field loggerField = LoggingUpdateCheckerReporter.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        loggerField.set(null, originalLogger);
+    }
+
+    @Test
+    void logsCorrectlyWithOnlyUpgrades() {
+        UpdateCheckResponse updateCheckResponse = new UpdateCheckResponse(500, Arrays.asList(
+                new ArtifactAvailableUpgrade("org.axonframework", "axon-framework", "5.2.0"),
+                new ArtifactAvailableUpgrade("org.axonframework", "axon-messaging", "5.1.0"),
+                new ArtifactAvailableUpgrade("io.axoniq.console", "framework-client-spring-boot-starter", "2.2.0")
+        ), Collections.emptyList());
+
+        reporter.report(sampleRequest, updateCheckResponse);
+
+        verify(mockLogger).info("AxonIQ has found the following dependency upgrade(s):");
+        verify(mockLogger).info("{} {} -> {}",
+                                "org.axonframework:axon-framework........................",
+                                "5.0.1 ",
+                                "5.2.0");
+        verify(mockLogger).info("{} {} -> {}",
+                                "org.axonframework:axon-messaging........................",
+                                "5.0.0 ",
+                                "5.1.0");
+        verify(mockLogger).info("{} {} -> {}",
+                                "io.axoniq.console:framework-client-spring-boot-starter..",
+                                "2.1.10",
+                                "2.2.0");
+        verify(mockLogger).info("No vulnerabilities have been found in your Axon libraries.");
+    }
+
+    @Test
+    void logsCorrectlyWithOnlyVulnerabilities() {
+        UpdateCheckResponse updateCheckResponse = new UpdateCheckResponse(500, Collections.emptyList(), Arrays.asList(
+                new DetectedVulnerability("org.axonframework",
+                                          "axon-framework",
+                                          DetectedVulnerabilitySeverity.HIGH,
+                                          "5.0.1",
+                                          "CVE-2025-1234: Security vulnerability in message handling"),
+                new DetectedVulnerability("org.axonframework",
+                                          "axon-messaging",
+                                          DetectedVulnerabilitySeverity.CRITICAL,
+                                          "5.0.0",
+                                          "CVE-2025-67890: Remote code execution vulnerability"),
+                new DetectedVulnerability("io.axoniq.console",
+                                          "framework-client-spring-boot-starter",
+                                          DetectedVulnerabilitySeverity.MEDIUM,
+                                          "2.1.10",
+                                          "CVE-2025-54321: Information disclosure vulnerability")
+        ));
+
+        reporter.report(sampleRequest, updateCheckResponse);
+
+        verify(mockLogger).error("AxonIQ has found the following vulnerabilities in your Axon libraries:");
+        verify(mockLogger).error("[{}] {} [Fixed in: {}] Description: {}",
+                                 "HIGH    ",
+                                 "org.axonframework:axon-framework........................",
+                                 "5.0.1 ",
+                                 "CVE-2025-1234: Security vulnerability in message handling");
+        verify(mockLogger).error("[{}] {} [Fixed in: {}] Description: {}",
+                                 "CRITICAL",
+                                 "org.axonframework:axon-messaging........................",
+                                 "5.0.0 ",
+                                 "CVE-2025-67890: Remote code execution vulnerability");
+        verify(mockLogger).error("[{}] {} [Fixed in: {}] Description: {}",
+                                 "MEDIUM  ",
+                                 "io.axoniq.console:framework-client-spring-boot-starter..",
+                                 "2.1.10",
+                                 "CVE-2025-54321: Information disclosure vulnerability");
+    }
+
+    @Test
+    void logsCorrectlyWithBothUpgradesAndVulnerabilities() {
+        UpdateCheckResponse updateCheckResponse = new UpdateCheckResponse(
+                500,
+                Arrays.asList(
+                        new ArtifactAvailableUpgrade("org.axonframework", "axon-framework", "5.2.0"),
+                        new ArtifactAvailableUpgrade("org.axonframework", "axon-messaging", "5.1.0")
+                ),
+                Arrays.asList(
+                        new DetectedVulnerability("org.axonframework",
+                                                  "axon-framework",
+                                                  DetectedVulnerabilitySeverity.HIGH,
+                                                  "5.0.1",
+                                                  "CVE-2025-1234: Security vulnerability in message handling")
+                )
+        );
+
+        reporter.report(sampleRequest, updateCheckResponse);
+
+        verify(mockLogger).error("AxonIQ has found the following vulnerabilities in your Axon libraries:");
+        verify(mockLogger).error(
+                "[{}] {} [Fixed in: {}] Description: {}",
+                "HIGH",
+                "org.axonframework:axon-framework..",
+                "5.0.1",
+                "CVE-2025-1234: Security vulnerability in message handling");
+        verify(mockLogger).info("Additionally, AxonIQ has found an upgrade(s) for your Axon libraries:");
+        verify(mockLogger).info(
+                "{} {} -> {}",
+                "org.axonframework:axon-framework........................",
+                "5.0.1 ",
+                "5.2.0"
+        );
+        verify(mockLogger).info(
+                "{} {} -> {}",
+                "org.axonframework:axon-messaging........................",
+                "5.0.0 ",
+                "5.1.0"
+        );
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckRequestTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckRequestTest.java
@@ -1,0 +1,69 @@
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.Artifact;
+import org.axonframework.updates.api.UpdateCheckRequest;
+import org.junit.jupiter.api.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UpdateCheckRequestTest {
+
+    @Test
+    void toQueryString() {
+        UpdateCheckRequest request = new UpdateCheckRequest(
+                "machine-1234",
+                "instance-5678",
+                "Linux",
+                "6.11.0-26-generic",
+                "amd64",
+                "17.0.2",
+                "AdoptOpenJDK",
+                "1.8.22",
+                Arrays.asList(
+                        new Artifact("org.axonframework", "axon-core", "5.0.0"),
+                        new Artifact("org.axonframework.something", "axon-something", "5.0.0"),
+                        new Artifact("org.axonframework.extensions", "axon-ext-bland", "5.0.0"),
+                        new Artifact("org.axonframework.extensions.kafka", "axon-ext-kafka", "5.0.0"),
+                        new Artifact("io.axoniq", "top-level-axoniq", "5.0.0"),
+                        new Artifact("io.axoniq.sub", "sub-level-axoniq", "5.0.0"),
+                        new Artifact("org.example", "example-lib", "1.2.3")
+                )
+        );
+
+        String queryString = request.toQueryString();
+
+        // Verify that all parameters are present and properly encoded
+        assertTrue(queryString.contains("os=Linux%3B+6.11.0-26-generic%3B+amd64"));
+        assertTrue(queryString.contains("java=17.0.2%3B+AdoptOpenJDK"));
+        assertTrue(queryString.contains("kotlin=1.8.22"));
+        assertTrue(queryString.contains("lib-fw.axon-core=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-fw.something.axon-something=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-ext.axon-ext-bland=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-ext.kafka.axon-ext-kafka=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-iq.top-level-axoniq=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-iq.sub.sub-level-axoniq=5.0.0"), queryString);
+        assertTrue(queryString.contains("lib-org.example.example-lib=1.2.3"));
+    }
+
+    @Test
+    void toUserAgent() {
+        UpdateCheckRequest request = new UpdateCheckRequest(
+                "machine-1234",
+                "instance-5678",
+                "Linux",
+                "6.11.0-26-generic",
+                "amd64",
+                "17.0.2",
+                "AdoptOpenJDK",
+                "1.8.22",
+                Collections.singletonList(new Artifact("org.axonframework", "axon-messaging", "5.0.1"))
+        );
+
+        String userAgent = request.toUserAgent();
+        assertEquals("AxonIQ UpdateChecker/5.0.1 (Java 17.0.2 AdoptOpenJDK; Linux; 6.11.0-26-generic; amd64)",
+                     userAgent);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UpdateCheckerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateCheckerTest {
+
+    @Mock
+    private UpdateCheckerHttpClient httpClient;
+
+    @Mock
+    private UpdateCheckerReporter reporter;
+
+    private UpdateChecker updateChecker;
+
+    @BeforeEach
+    void setUp() {
+        updateChecker = new UpdateChecker(httpClient, reporter);
+    }
+
+    @AfterEach
+    void tearDown() {
+        updateChecker.stop();
+    }
+
+    @Test
+    void shouldExecuteRepeatedly() {
+        // Given
+        UpdateCheckResponse response1 = new UpdateCheckResponse(1, Collections.emptyList(), Collections.emptyList());
+        UpdateCheckResponse response2 = new UpdateCheckResponse(2, Collections.emptyList(), Collections.emptyList());
+
+        // When
+        when(httpClient.sendRequest(any(), eq(true)))
+                .thenReturn(Optional.of(response1));
+        when(httpClient.sendRequest(any(), eq(false)))
+                .thenReturn(Optional.of(response2));
+
+        // First call on start()
+        updateChecker.start();
+
+        // Then
+        // Wait for first report
+        await().atMost(Duration.ofSeconds(2))
+               .untilAsserted(() -> verify(reporter, times(1)).report(any(), eq(response1)));
+
+        // Wait for second report
+        await().atMost(Duration.ofSeconds(3))
+               .untilAsserted(() -> verify(reporter, times(1)).report(any(), eq(response2)));
+
+        // Cleanup
+        updateChecker.stop();
+    }
+
+    @Test
+    void shouldHandleErrorsWithExponentialBackoff() {
+        // Given
+        UpdateCheckResponse successResponse =
+                new UpdateCheckResponse(1, Collections.emptyList(), Collections.emptyList());
+        AtomicInteger requestCount = new AtomicInteger();
+
+        // When
+        when(httpClient.sendRequest(any(), anyBoolean())).thenAnswer(invocation -> {
+            int count = requestCount.incrementAndGet();
+            if (count < 4) {
+                return Optional.empty(); // First three calls - error
+            } else {
+                return Optional.of(successResponse); // Fourth call - success
+            }
+        });
+
+        // Start the checker
+        updateChecker.start();
+
+        // Then
+        // Verify that we eventually get 3 HTTP requests with exponential backoff
+        await().atMost(Duration.ofSeconds(30))
+               .untilAsserted(() -> verify(httpClient, times(3)).sendRequest(any(), anyBoolean()));
+
+        // Cleanup
+        updateChecker.stop();
+    }
+
+    @Test
+    void shouldHandleExceptionsGracefully() {
+        // Given
+        UpdateCheckResponse successResponse =
+                new UpdateCheckResponse(1, Collections.emptyList(), Collections.emptyList());
+        AtomicInteger requestCount = new AtomicInteger();
+
+        // When
+        when(httpClient.sendRequest(any(), anyBoolean())).thenAnswer(invocation -> {
+            int count = requestCount.incrementAndGet();
+            if (count == 1) {
+                throw new RuntimeException("Test exception");
+            } else {
+                return Optional.of(successResponse);
+            }
+        });
+
+        // Start the checker
+        updateChecker.start();
+
+        // Then
+        // Verify that we eventually get 2 HTTP requests (first throws exception, second succeeds)
+        await().atMost(Duration.ofSeconds(6))
+               .untilAsserted(() -> verify(httpClient, times(2)).sendRequest(any(), anyBoolean()));
+
+        // Verify that we get a report after the second call
+        await().atMost(Duration.ofSeconds(2))
+               .untilAsserted(() -> verify(reporter, times(1)).report(any(), any()));
+
+        // Cleanup
+        updateChecker.stop();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/UsageResponseTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/UsageResponseTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates;
+
+import org.axonframework.updates.api.DetectedVulnerabilitySeverity;
+import org.axonframework.updates.api.UpdateCheckResponse;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsageResponseTest {
+
+    @Test
+    void parsesTheResponseCorrectly() {
+        String body = "cd=12345\n"
+                + "upd=org.axonframework:axon-messaging:5.0.1\n"
+                + "upd=org.axonframework:axon-modelling:5.0.1\n"
+                + "upd=io.axoniq.console:console-framework-client-spring-boot-starter:2.1.0\n"
+                + "vul=org.axonframework:axon-modelling:5.0.1:MEDIUM:\"The EntityModel can be abused as a Denial of Service attack vector: https://axoniq.io/vulnerabilities/2023-01-01\"\n"
+                + "vul=org.axonframework:axon-messaging:5.0.1:HIGH:\"The Jackson version supplied by default has an NSA-backdoor built int. Please upgrade Jackson to version 1337.0\"";
+        UpdateCheckResponse response = UpdateCheckResponse.fromRequest(body);
+        assertEquals(12345, response.checkInterval());
+        assertEquals(3, response.upgrades().size());
+
+        assertEquals("org.axonframework", response.upgrades().get(0).groupId());
+        assertEquals("axon-messaging", response.upgrades().get(0).artifactId());
+        assertEquals("5.0.1", response.upgrades().get(0).latestVersion());
+        assertEquals("org.axonframework", response.upgrades().get(1).groupId());
+        assertEquals("axon-modelling", response.upgrades().get(1).artifactId());
+        assertEquals("5.0.1", response.upgrades().get(1).latestVersion());
+        assertEquals("io.axoniq.console", response.upgrades().get(2).groupId());
+        assertEquals("console-framework-client-spring-boot-starter", response.upgrades().get(2).artifactId());
+        assertEquals("2.1.0", response.upgrades().get(2).latestVersion());
+
+        assertEquals(2, response.vulnerabilities().size());
+        assertEquals("org.axonframework", response.vulnerabilities().get(0).groupId());
+        assertEquals("axon-modelling", response.vulnerabilities().get(0).artifactId());
+        assertEquals("5.0.1", response.vulnerabilities().get(0).fixVersion());
+        assertEquals(DetectedVulnerabilitySeverity.MEDIUM, response.vulnerabilities().get(0).severity());
+        assertEquals(
+                "The EntityModel can be abused as a Denial of Service attack vector: https://axoniq.io/vulnerabilities/2023-01-01",
+                response.vulnerabilities().get(0).description()
+        );
+
+        assertEquals("org.axonframework", response.vulnerabilities().get(1).groupId());
+        assertEquals("axon-messaging", response.vulnerabilities().get(1).artifactId());
+        assertEquals("5.0.1", response.vulnerabilities().get(1).fixVersion());
+        assertEquals(DetectedVulnerabilitySeverity.HIGH, response.vulnerabilities().get(1).severity());
+        assertEquals(
+                "The Jackson version supplied by default has an NSA-backdoor built int. Please upgrade Jackson to version 1337.0",
+                response.vulnerabilities().get(1).description()
+        );
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/configuration/CommandLineUsagePropertyProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/configuration/CommandLineUsagePropertyProviderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandLineUsagePropertyProviderTest {
+
+    private final CommandLineUsagePropertyProvider provider = new CommandLineUsagePropertyProvider();
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty(CommandLineUsagePropertyProvider.DISABLED_KEY);
+        System.clearProperty(CommandLineUsagePropertyProvider.URL_KEY);
+    }
+
+    @Test
+    void getDisabledTrue() {
+        System.setProperty(CommandLineUsagePropertyProvider.DISABLED_KEY, "true");
+        assertTrue(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabledFalse() {
+        System.setProperty(CommandLineUsagePropertyProvider.DISABLED_KEY, "false");
+        assertFalse(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabledNullWhenUnset() {
+        assertNull(provider.getDisabled());
+    }
+
+    @Test
+    void getUrl() {
+        System.setProperty(CommandLineUsagePropertyProvider.URL_KEY, "https://custom.url");
+        assertEquals("https://custom.url", provider.getUrl());
+    }
+
+    @Test
+    void getUrlNullWhenUnset() {
+        assertNull(provider.getUrl());
+    }
+
+    @Test
+    void priority() {
+        assertEquals(Integer.MAX_VALUE, provider.priority());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/configuration/DummyProvider.java
+++ b/messaging/src/test/java/org/axonframework/updates/configuration/DummyProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+class DummyProvider implements UsagePropertyProvider {
+
+    private final Boolean disabled;
+    private final String url;
+    private final int priority;
+
+    DummyProvider(Boolean disabled, String url, int priority) {
+        this.disabled = disabled;
+        this.url = url;
+        this.priority = priority;
+    }
+
+    @Override
+    public Boolean getDisabled() {
+        return disabled;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public int priority() {
+        return priority;
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/configuration/EnvironmentVariableUsagePropertyProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/configuration/EnvironmentVariableUsagePropertyProviderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.junit.jupiter.api.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvironmentVariableUsagePropertyProviderTest {
+
+    private final Map<String, String> env = new HashMap<>();
+    private EnvironmentVariableUsagePropertyProvider provider;
+
+    @BeforeEach
+    void setup() {
+        env.clear();
+        provider = new EnvironmentVariableUsagePropertyProvider(env::get);
+    }
+
+    @Test
+    void getDisabledTrue() {
+        env.put(EnvironmentVariableUsagePropertyProvider.DISABLED_KEY, "true");
+        assertTrue(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabledFalse() {
+        env.put(EnvironmentVariableUsagePropertyProvider.DISABLED_KEY, "false");
+        assertFalse(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabledNullWhenUnset() {
+        assertNull(provider.getDisabled());
+    }
+
+    @Test
+    void getUrl() {
+        env.put(EnvironmentVariableUsagePropertyProvider.URL_KEY, "https://env.url");
+        assertEquals("https://env.url", provider.getUrl());
+    }
+
+    @Test
+    void getUrlNullWhenUnset() {
+        assertNull(provider.getUrl());
+    }
+
+    @Test
+    void priority() {
+        assertEquals(Integer.MAX_VALUE / 2, provider.priority());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/configuration/HierarchicalUsagePropertyProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/configuration/HierarchicalUsagePropertyProviderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.junit.jupiter.api.*;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HierarchicalUsagePropertyProviderTest {
+
+    @Test
+    void getDisabled_returnsFirstNonNullByPriority() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider mid = new DummyProvider(false, null, 5);
+        UsagePropertyProvider high = new DummyProvider(true, null, 10);
+        HierarchicalUsagePropertyProvider provider =
+                new HierarchicalUsagePropertyProvider(Arrays.asList(low, mid, high));
+        // high has highest priority and non-null value
+        assertTrue(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabled_skipsNullsAndReturnsNext() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider high = new DummyProvider(null, null, 10);
+        UsagePropertyProvider mid = new DummyProvider(false, null, 5);
+        HierarchicalUsagePropertyProvider provider =
+                new HierarchicalUsagePropertyProvider(Arrays.asList(low, mid, high));
+        // mid is the first non-null
+        assertFalse(provider.getDisabled());
+    }
+
+    @Test
+    void getDisabled_returnsFalseIfAllNull() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider high = new DummyProvider(null, null, 10);
+        HierarchicalUsagePropertyProvider provider = new HierarchicalUsagePropertyProvider(Arrays.asList(low, high));
+        assertFalse(provider.getDisabled());
+    }
+
+    @Test
+    void getUrl_returnsFirstNonNullByPriority() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider mid = new DummyProvider(null, "http://mid", 5);
+        UsagePropertyProvider high = new DummyProvider(null, "http://high", 10);
+        HierarchicalUsagePropertyProvider provider =
+                new HierarchicalUsagePropertyProvider(Arrays.asList(low, mid, high));
+        assertEquals("http://high", provider.getUrl());
+    }
+
+    @Test
+    void getUrl_skipsNullsAndReturnsNext() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider high = new DummyProvider(null, null, 10);
+        UsagePropertyProvider mid = new DummyProvider(null, "http://mid", 5);
+        HierarchicalUsagePropertyProvider provider =
+                new HierarchicalUsagePropertyProvider(Arrays.asList(low, mid, high));
+        assertEquals("http://mid", provider.getUrl());
+    }
+
+    @Test
+    void getUrl_returnsEmptyIfAllNull() {
+        UsagePropertyProvider low = new DummyProvider(null, null, 1);
+        UsagePropertyProvider high = new DummyProvider(null, null, 10);
+        HierarchicalUsagePropertyProvider provider =
+                new HierarchicalUsagePropertyProvider(Arrays.asList(low, high));
+        assertEquals("", provider.getUrl());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/configuration/PropertyFileUsagePropertyProviderTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/configuration/PropertyFileUsagePropertyProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.configuration;
+
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PropertyFileUsagePropertyProviderTest {
+
+    private final PropertyFileUsagePropertyProvider provider = new PropertyFileUsagePropertyProvider();
+    private Path tempHome;
+    private File propFile;
+
+    @BeforeEach
+    void setup() throws Exception {
+        tempHome = Files.createTempDirectory("axon-test-home");
+        System.setProperty("user.home", tempHome.toString());
+        propFile = new File(tempHome.toString() + "/.axoniq/update-checker.properties");
+        if (propFile.exists()) {
+            propFile.delete();
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        System.clearProperty("user.home");
+        if (propFile.exists()) {
+            propFile.delete();
+        }
+        File parent = propFile.getParentFile();
+        if (parent.exists()) {
+            parent.delete();
+        }
+        Files.deleteIfExists(tempHome);
+    }
+
+    @Test
+    void readsExistingPropertiesFile() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("telemetry_url", "https://custom.url");
+        props.setProperty("disabled", "true");
+        propFile.getParentFile().mkdirs();
+        try (FileOutputStream out = new FileOutputStream(propFile)) {
+            props.store(out, "Test");
+        }
+        assertTrue(provider.getDisabled());
+        assertEquals("https://custom.url", provider.getUrl());
+    }
+
+    @Test
+    void createsFileWithDefaultValuesIfNotExists() throws Exception {
+        assertFalse(propFile.exists());
+        // Should create the file
+        assertEquals(DefaultUsagePropertyProvider.INSTANCE.getDisabled(), provider.getDisabled());
+        assertEquals(DefaultUsagePropertyProvider.INSTANCE.getUrl(), provider.getUrl());
+        assertTrue(propFile.exists());
+        Properties props = new Properties();
+        try (InputStream in = Files.newInputStream(propFile.toPath())) {
+            props.load(in);
+        }
+        assertEquals(DefaultUsagePropertyProvider.INSTANCE.getUrl(), props.getProperty("telemetry_url"));
+        assertEquals(String.valueOf(DefaultUsagePropertyProvider.INSTANCE.getDisabled()),
+                     props.getProperty("opted_out"));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/detection/AxonVersionDetectorTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/detection/AxonVersionDetectorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.axonframework.updates.api.Artifact;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the {@link AxonVersionDetector} as best as possible. However, detection from JARs has had to be tested
+ * manually, as there is no jar dependency available in the test resources to test against. This test might be expanded
+ * if the Update Checker is moved out to a separate module, allowing for a dependency on axon-messaging to be detected.
+ */
+class AxonVersionDetectorTest {
+
+    /**
+     * Tests that the version detector can parse the pom.properties in the test resources under
+     * META-INF/maven/org.axonframework/axon-modelling/pom.properties.
+     */
+    @Test
+    void detectsFilePomProperties() {
+        List<Artifact> versions = AxonVersionDetector.safeDetectAxonModules();
+        assertFalse(versions.isEmpty(), "Expected at least one Axon module version to be detected");
+        assertTrue(versions.stream().anyMatch(v -> v.groupId().equals("org.axonframework") &&
+                           v.artifactId().equals("axon-modelling") &&
+                           v.version().equals("2.1-SNAPSHOT")),
+                   "Expected Axon Modelling module to be detected");
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/detection/KotlinVersionTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/detection/KotlinVersionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * As Axon Framework does not depend on Kotlin, we cannot test the Kotlin version detection in a meaningful way. This
+ * class is a placeholder for future meaningful tests when the update checker is moved.
+ */
+class KotlinVersionTest {
+
+    @Test
+    void doesNotDetectKotlinVersion() {
+        // This test is a placeholder. The Kotlin version detection is not tested here as Axon Framework does not depend on Kotlin.
+        // When the update checker is moved to a module that depends on Kotlin, this test can be updated to check the Kotlin version.
+        assertEquals("none", KotlinVersion.get());
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/detection/MachineIdTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/detection/MachineIdTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MachineIdTest {
+
+    private Path tempHome;
+    private File idFile;
+    private String originalUserHome;
+
+    @BeforeEach
+    void setup() throws IOException {
+        originalUserHome = System.getProperty("user.home");
+        tempHome = Files.createTempDirectory("axon-machineid-test");
+        System.setProperty("user.home", tempHome.toString());
+        idFile = new File(tempHome.toString() + "/.axoniq/.machine-id");
+        if (idFile.exists()) {
+            idFile.delete();
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        if (originalUserHome != null) {
+            System.setProperty("user.home", originalUserHome);
+        } else {
+            System.clearProperty("user.home");
+        }
+        if (idFile.exists()) {
+            idFile.delete();
+        }
+        File parent = idFile.getParentFile();
+        if (parent.exists()) {
+            parent.delete();
+        }
+        Files.deleteIfExists(tempHome);
+    }
+
+    @Test
+    void returnsExistingIdIfFileExists() throws Exception {
+        String expectedId = UUID.randomUUID().toString();
+        idFile.getParentFile().mkdirs();
+        Files.write(idFile.toPath(), expectedId.getBytes(StandardCharsets.UTF_8));
+        MachineId machineId = new MachineId();
+        assertEquals(expectedId, machineId.get());
+    }
+
+    @Test
+    void createsIdFileIfNotExists() throws Exception {
+        assertFalse(idFile.exists());
+        MachineId machineId = new MachineId();
+        String id = machineId.get();
+        assertTrue(idFile.exists());
+        String fileContent = new String(Files.readAllBytes(idFile.toPath()));
+        assertEquals(id, fileContent);
+        // Should be a valid UUID
+        assertDoesNotThrow(() -> UUID.fromString(id));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/updates/detection/TestEnvironmentDetectorTest.java
+++ b/messaging/src/test/java/org/axonframework/updates/detection/TestEnvironmentDetectorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.updates.detection;
+
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.axonframework.updates.detection.TestEnvironmentDetector.AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestEnvironmentDetectorTest {
+
+    @AfterEach
+    void cleanup() {
+        // Reset the system property after each test to avoid side effects
+        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
+    }
+
+    @Test
+    void shouldDetectTestEnvironment() {
+        // This one is easy. It's a test, so it should be detected as a test environment.
+        assertTrue(TestEnvironmentDetector.isTestEnvironment());
+    }
+
+    @Test
+    void forceShouldDisableTestEnvironmentDetection() {
+        // Force disable the test environment detection
+        System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
+
+        // Assert that the test environment is no longer detected
+        assertFalse(TestEnvironmentDetector.isTestEnvironment());
+    }
+
+    @Test
+    void shouldSeeNonTestEnvironment() {
+        AtomicReference<Boolean> isTestEnvironment = new AtomicReference<>(null);
+
+        // If we launch a new thread, the stacktrace won't contain the junit class, so it should not be detected as a test environment.
+        Thread nonTestThread = new Thread(() -> {
+            isTestEnvironment.set(TestEnvironmentDetector.isTestEnvironment());
+        });
+        nonTestThread.start();
+        try {
+            nonTestThread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("Thread was interrupted", e);
+        }
+        // Assert that the thread is not detected as a test environment
+        assertFalse(isTestEnvironment.get(), "The thread should not be detected as a test environment,");
+    }
+}

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/UpdateCheckerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/UpdateCheckerAutoConfiguration.java
@@ -1,0 +1,56 @@
+package org.axonframework.springboot.autoconfig;
+
+import org.axonframework.updates.LoggingUpdateCheckerReporter;
+import org.axonframework.updates.UpdateChecker;
+import org.axonframework.updates.UpdateCheckerHttpClient;
+import org.axonframework.updates.UpdateCheckerReporter;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.axonframework.updates.detection.TestEnvironmentDetector;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@AutoConfiguration
+public class UpdateCheckerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    @Conditional(TestEnvironmentCondition.class)
+    public UsagePropertyProvider usagePropertyProvider() {
+        return UsagePropertyProvider.create();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @Conditional(TestEnvironmentCondition.class)
+    public UpdateCheckerHttpClient updateCheckerHttpClient(UsagePropertyProvider usagePropertyProvider) {
+        return new UpdateCheckerHttpClient(usagePropertyProvider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @Conditional(TestEnvironmentCondition.class)
+    public UpdateCheckerReporter updateCheckerReporter() {
+        return new LoggingUpdateCheckerReporter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @Conditional(TestEnvironmentCondition.class)
+    public UpdateChecker updateChecker(UpdateCheckerHttpClient updateCheckerHttpClient,
+                                       UpdateCheckerReporter updateCheckerReporter) {
+        return new UpdateChecker(updateCheckerHttpClient, updateCheckerReporter);
+    }
+
+    static class TestEnvironmentCondition implements Condition {
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !TestEnvironmentDetector.isTestEnvironment();
+        }
+    }
+}

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -4,7 +4,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration,\
   org.axonframework.springboot.autoconfig.AvroSerializerAutoConfiguration,\
   org.axonframework.springboot.autoconfig.AxonAutoConfiguration,\
-org.axonframework.springboot.autoconfig.AxonTimeoutAutoConfiguration, \
+  org.axonframework.springboot.autoconfig.AxonTimeoutAutoConfiguration, \
   org.axonframework.springboot.autoconfig.AxonJobRunrAutoConfiguration,\
   org.axonframework.springboot.autoconfig.AxonDbSchedulerAutoConfiguration,\
   org.axonframework.springboot.autoconfig.legacyjpa.JpaJavaxAutoConfiguration,\
@@ -24,6 +24,7 @@ org.axonframework.springboot.autoconfig.AxonTimeoutAutoConfiguration, \
   org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration, \
   org.axonframework.springboot.autoconfig.AxonTracingAutoConfiguration, \
   org.axonframework.springboot.autoconfig.OpenTelemetryAutoConfiguration, \
+  org.axonframework.springboot.autoconfig.UpdateCheckerAutoConfiguration, \
   org.axonframework.springboot.autoconfig.SecurityAutoConfiguration
 org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
   org.axonframework.springboot.service.connection.AxonServerDockerComposeConnectionDetailsFactory, \

--- a/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -23,4 +23,5 @@ org.axonframework.springboot.autoconfig.CBORMapperAutoConfiguration
 org.axonframework.springboot.autoconfig.OpenTelemetryAutoConfiguration
 org.axonframework.springboot.autoconfig.SecurityAutoConfiguration
 org.axonframework.springboot.autoconfig.TransactionAutoConfiguration
+org.axonframework.springboot.autoconfig.UpdateCheckerAutoConfiguration
 org.axonframework.springboot.autoconfig.XStreamAutoConfiguration

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/UpdateCheckerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/UpdateCheckerAutoConfigurationTest.java
@@ -1,0 +1,107 @@
+package org.axonframework.springboot.autoconfig;
+
+import org.axonframework.updates.UpdateChecker;
+import org.axonframework.updates.UpdateCheckerHttpClient;
+import org.axonframework.updates.UpdateCheckerReporter;
+import org.axonframework.updates.configuration.UsagePropertyProvider;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.axonframework.updates.detection.TestEnvironmentDetector.AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link UpdateCheckerAutoConfiguration}.
+ *
+ * @author Steven van Beelen
+ */
+class UpdateCheckerAutoConfigurationTest {
+
+    private ApplicationContextRunner testContext;
+
+    @BeforeEach
+    void setUp() {
+        this.testContext = new ApplicationContextRunner()
+                .withUserConfiguration(DefaultContext.class)
+                .withPropertyValues("axon.axonserver.enabled:false");
+    }
+
+    @AfterEach
+    void cleanup() {
+        // Reset the system property after each test to avoid side effects
+        System.clearProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT);
+    }
+
+    @Test
+    void updateCheckerBeansAreRegisteredForNonTestEnvironment() {
+        // Force disable the test environment detection
+        System.setProperty(AXONIQ_USAGE_FORCE_TEST_ENVIRONMENT, "true");
+
+        testContext.run(context -> {
+            assertThat(context).hasBean("usagePropertyProvider");
+            assertThat(context).hasBean("updateCheckerHttpClient");
+            assertThat(context).hasBean("updateCheckerReporter");
+            assertThat(context).hasBean("updateChecker");
+        });
+    }
+
+    @Test
+    void updateCheckerBeansAreNotRegisteredForNonTestEnvironment() {
+        testContext.run(context -> {
+            assertThat(context).doesNotHaveBean("usagePropertyProvider");
+            assertThat(context).doesNotHaveBean("updateCheckerHttpClient");
+            assertThat(context).doesNotHaveBean("updateCheckerReporter");
+            assertThat(context).doesNotHaveBean("updateChecker");
+        });
+    }
+
+    @Test
+    void updateCheckerBeansCanBeOverwritten() {
+        testContext.withUserConfiguration(OverrideContext.class).run(context -> {
+            assertThat(context).hasBean("customUsagePropertyProvider");
+            assertThat(context).hasBean("customUpdateCheckerHttpClient");
+            assertThat(context).hasBean("customUpdateCheckerReporter");
+            assertThat(context).hasBean("customUpdateChecker");
+
+            assertThat(context).doesNotHaveBean("usagePropertyProvider");
+            assertThat(context).doesNotHaveBean("updateCheckerHttpClient");
+            assertThat(context).doesNotHaveBean("updateCheckerReporter");
+            assertThat(context).doesNotHaveBean("updateChecker");
+        });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    private static class DefaultContext {
+
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    private static class OverrideContext {
+
+        @Bean
+        public UsagePropertyProvider customUsagePropertyProvider() {
+            return mock(UsagePropertyProvider.class);
+        }
+
+        @Bean
+        public UpdateCheckerHttpClient customUpdateCheckerHttpClient() {
+            return mock(UpdateCheckerHttpClient.class);
+        }
+
+        @Bean
+        public UpdateCheckerReporter customUpdateCheckerReporter() {
+            return mock(UpdateCheckerReporter.class);
+        }
+
+        @Bean
+        public UpdateChecker customUpdateChecker() {
+            return mock(UpdateChecker.class);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the Anonymous Usage Analytics for Axon Framework, which report the Axon Framework version and machine identifier to the AxonIQ Servers. It then receives information about updates and potential vulnerabilities, reporting this to the end user. 
We drafted a dedicated page in the AxonIQ Docs for this, which you can find [here](https://docs.axoniq.io/axon-framework-update-checker/).

Note that this is a back-ported version of the Update Checker introduced in PR #3492, that's targeted to AF5, milestone 2.

## The goal

The primary goal is to get insight into how many developers are using the framework, which modules of it, and which version they are on. This can help us ([AxonIQ](https://www.axoniq.io/) - the company behind Axon Framework) make informed strategic decisions about support and further development of the Framework. 

The secondary goal is to notify users of newer versions and potential vulnerabilities in older ones, so users have a better experience with the framework while guaranteeing security of their environment.

# How it works
Upon boot of an Axon Framework application, the application will go through the following checks:

- Is Axon Framework being run in a testsuite such as JUnit? If so, we skip reporting analytics. 
- Has the user opted-out of the analytics? If so, we skip reporting  analytics. See the "Opting out" section on how to opt out. 
- If all checks complete, the request is sent to the servers. 
- Upon completion, any update or vulnerability is logged to the output. 
- This request is repeated every 8 hours, as this has the biggest possibility of the user seeing upgrade messages during their workday. 

When we find updates to your AxonIQ libraries, we will log them like follows:

```
13:52:29.074 [main] INFO UpdateChecker -- Your AxonIQ libraries will be checked for updates periodically. See https://go.axoniq.io/update-check for more information.
13:52:31.054 [virtual-48] INFO UpdateChecker -- AxonIQ has found the following dependency upgrade(s):
13:52:31.056 [virtual-48] INFO UpdateChecker -- io.axoniq.console:console-framework-client-spring-boot-starter .. 1.9.2 -> 1.9.3
13:52:31.057 [virtual-48] INFO UpdateChecker -- io.axoniq.console:console-framework-client-api .................. 1.9.2 -> 1.9.3
13:52:31.057 [virtual-48] INFO UpdateChecker -- io.axoniq.console:console-framework-client ...................... 1.9.2 -> 1.9.3
13:52:31.057 [virtual-48] INFO UpdateChecker -- org.axonframework:axon-configuration ............................ 4.6.8 -> 4.11.2
13:52:31.057 [virtual-48] INFO UpdateChecker -- org.axonframework:axon-eventsourcing ............................ 4.6.8 -> 4.11.2
13:52:31.057 [virtual-48] INFO UpdateChecker -- org.axonframework:axon-disruptor ................................ 4.6.8 -> 4.11.2
13:52:31.057 [virtual-48] INFO UpdateChecker -- org.axonframework:axon-modelling ................................ 4.6.8 -> 4.11.2
13:52:31.057 [virtual-48] INFO UpdateChecker -- org.axonframework:axon-messaging ................................ 4.6.8 -> 4.11.2

```
Or, if you are completely up-to-date:

```
13:54:31.690 [main] INFO UpdateChecker -- Your AxonIQ libraries will be checked for updates periodically. See https://go.axoniq.io/update-check for more information.
13:54:33.458 [virtual-48] INFO UpdateChecker -- All your AxonIQ libraries are up-to-date, no upgrades or vulnerabilities found.

```
## The data

The following data is sent to the servers:

  - `mid`: Machine ID (string): Unique UUID saved into the `$HOME/.axoniq/.machine-id` file. This is the same over multiple JVM instances on the same host. 
  - `iid`: Instance ID (string): A UUID unique to a single JVM (generated on start)
  - `osn`: OS Name (string)
  - `osv`: OS Version (string)
  - `osa`: OS Architecture (string)
  - `jvr`: Java Version (string)
  - `jvn`: Java Vendor (string)
  - `ktv`: Kotlin Version (string)
  - `lib`: Library in the format `groupId:artifactId:version` (multiple lines allowed)


So, for example, the request would look like:
```properties
# Machine ID
mid=e042ebcf-671d-4052-896f-023f03e632fc
# Instance ID
iid=f8c61eb2-7661-4b32-b7b5-f2b12513073b
# OS Name
osn=Linux
# OS Version
osv=6.11.0-26-generic
# OS Architecture
osa=amd64
# Java version
jvr=21.0.2
# Java vendor
jvn=Oracle Corporation
# Kotlin version
ktv=none
# Libraries related to Axon
lib=org.axonframework:axon-modelling:2.1-SNAPSHOT
lib=org.axonframework:axon-messaging:4.11.0
lib=org.axonframework:axon-configuration:4.6.8
lib=org.axonframework:axon-eventsourcing:4.6.8
lib=org.axonframework:axon-disruptor:4.6.8
lib=org.axonframework:axon-modelling:4.6.8
lib=org.axonframework:axon-messaging:4.6.8
lib=io.axoniq.console:console-framework-client-spring-boot-starter:1.9.3
lib=io.axoniq.console:console-framework-client-api:1.9.3
lib=io.axoniq.console:console-framework-client:1.9.3
```

The only libraries reported are the ones that contain `org.axonframework` or `io.axoniq`.
This list may be expanded in the future, but will always only contain AxonIQ-related coordinates. We will never share data about any other library. 

In return, the response would look like:

```properties
# Check delay # 8 hours
cd=28800
# Vulnerability
vul:org.axonframework:axon-messaging:4.11.0:HIGH:"4.11.1:CVE-2025-3892 - potential denial of service via crafted messages"
# Update
upd:org.axonframework:axon-messaging:4.11.1
```

## Opting out

Users can opt out in the following ways:

1. Start the JVM with `-Daxoniq.update-check.disabled=true`
2. Set the environment variable  `AXONIQ_UPDATE_CHECK_DISABLED=true`
3. Create or edit the file at `$HOME/.axoniq/update-check.properties`, defining `disabled=true`

So if you would like to opt out for any and all JVMs on your computer(s), the home-file method is the easiest and most complete.

## Further development

This is the first iteration of this tool. We have tried to provide benefit to both the community and ourselves (AxonIQ), and be transparent about any and all changes around this. We welcome any and all feedback.

This feature is currently a PR on the main Axon Framework repository for visibility. It will be in the Axon Framework 5.0.0-M2 release. We aim to move this to an extension in a future release, out of the main repository. 
