### PR TITLE
[#3518] Add Snapshot Event Upcasting section and `SnapshotFilter` usage warning

### DIFF
--- a/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
@@ -319,7 +319,7 @@ Although the description above leans towards event upcasting, note that all the 
 
 From the `abstract` upcaster implementations shared xref:provided_abstract_upcaster_implementations[earlier], the only feasible upcaster is the `SingleEventUpcaster`. We can logically deduce that a multi-upcaster would be incorrect, as only the last returned snapshot is used to load an aggregate. Furthermore, context-aware upcasters aren't necessary either, as any context-specific information in a snapshot is generated during event sourcing. Hence, if any data should carry over, simply reconstruct the snapshot instead.
 
-When upcasting events, the *type* to upcaster equals the fully qualified class name of the event itself.When upcasting snapshots, the type is the fully qualified class name of the *aggregate*.Knowing this detail, let's look at an example of a snapshot upcaster for the `GiftCard` aggregate (as exemplified xref:axon-framework-commands:modeling/aggregate.adoc[here]):
+When upcasting events, the *type* to upcaster equals the fully qualified class name of the event itself. When upcasting snapshots, the type is the fully qualified class name of the *aggregate*. Knowing this detail, let's look at an example of a snapshot upcaster for the `GiftCard` aggregate (as exemplified xref:axon-framework-commands:modeling/aggregate.adoc[here]):
 
 [source,java]
 ----

--- a/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
@@ -311,3 +311,50 @@ public class AxonConfig {
 ----
 --
 ====
+
+[#upcasting_snapshots]
+=== Upcasting Snapshots
+
+Although the description above leans towards event upcasting, note that all the given constructs can be used to upcast a xref:tuning:event-snapshots.adoc[snapshot].
+
+From the `abstract` upcaster implementations shared xref:provided_abstract_upcaster_implementations[earlier], the only feasible upcaster is the `SingleEventUpcaster`.We can logically deduce that a multi-upcaster would be incorrect, as only the last returned snapshot is used to load an aggregate.Furthermore, context-aware upcasters aren't necessary either, as any context-specific information in a snapshot is generated during event sourcing.Hence, if any data should carry over, simply reconstruct the snapshot instead.
+
+When upcasting events, the *type* to upcaster equals the fully qualified class name of the event itself.When upcasting snapshots, the type is the fully qualified class name of the *aggregate*.Knowing this detail, let's look at an example of a snapshot upcaster for the `GiftCard` aggregate (as exemplified xref:axon-framework-commands:modeling/aggregate.adoc[here]):
+
+[source,java]
+----
+public class GiftCardSnapshotNull_to_1Upcaster extends SingleEventUpcaster {
+
+   private static final SimpleSerializedType TARGET_TYPE =
+           new SimpleSerializedType(GiftCard.class.getTypeName(), null);
+
+   @Override
+   protected boolean canUpcast(IntermediateEventRepresentation intermediateRepresentation) {
+      return intermediateRepresentation.getType().equals(TARGET_TYPE);
+   }
+
+   @Override
+   protected IntermediateEventRepresentation doUpcast(
+           IntermediateEventRepresentation intermediateRepresentation
+   ) {
+      return intermediateRepresentation.upcastPayload(
+              new SimpleSerializedType(TARGET_TYPE.getName(), "1"),
+              org.dom4j.Document.class,
+                            com.fasterxml.jackson.databind.JsonNode.class,
+              event -> {
+                  ((ObjectNode) event).put("owner", "[owner-id]");
+                  return event;
+              }
+      );
+   }
+}
+----
+
+[WARNING]
+====
+Whenever constructing a snapshot upcaster, be mindful of xref:tuning:event-snapshots.adoc#_filtering_snapshot_events[`SnapshotFilters`].
+When using the `@Revision` annotation on your Aggregate, a `RevisionSnapshotFilter` is constructed by default.
+The `RevisionSnapshotFilter` will make it so that snapshot events *never* reach your upcaster.
+
+As such, it is advised to override the `SnapshotFilter` of an Aggregate to a no-op entry when you prefer to upcaster your snapshots.
+====

--- a/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
@@ -317,7 +317,7 @@ public class AxonConfig {
 
 Although the description above leans towards event upcasting, note that all the given constructs can be used to upcast a xref:tuning:event-snapshots.adoc[snapshot].
 
-From the `abstract` upcaster implementations shared xref:provided_abstract_upcaster_implementations[earlier], the only feasible upcaster is the `SingleEventUpcaster`.We can logically deduce that a multi-upcaster would be incorrect, as only the last returned snapshot is used to load an aggregate.Furthermore, context-aware upcasters aren't necessary either, as any context-specific information in a snapshot is generated during event sourcing.Hence, if any data should carry over, simply reconstruct the snapshot instead.
+From the `abstract` upcaster implementations shared xref:provided_abstract_upcaster_implementations[earlier], the only feasible upcaster is the `SingleEventUpcaster`. We can logically deduce that a multi-upcaster would be incorrect, as only the last returned snapshot is used to load an aggregate. Furthermore, context-aware upcasters aren't necessary either, as any context-specific information in a snapshot is generated during event sourcing. Hence, if any data should carry over, simply reconstruct the snapshot instead.
 
 When upcasting events, the *type* to upcaster equals the fully qualified class name of the event itself.When upcasting snapshots, the type is the fully qualified class name of the *aggregate*.Knowing this detail, let's look at an example of a snapshot upcaster for the `GiftCard` aggregate (as exemplified xref:axon-framework-commands:modeling/aggregate.adoc[here]):
 

--- a/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
@@ -22,7 +22,7 @@ Moreover, upcasters are processed in a chain, meaning that the output of one upc
 This allows you to update events in an incremental manner, writing an upcaster for each new event revision, making them small, isolated, and easy to understand.
 
 [TIP]
-.Benefits if Upcasters
+.Benefits of Upcasters
 ====
 Perhaps the greatest benefit of upcasting is that it allows you to do non-destructive refactoring.
 In other words, the complete event history remains intact.
@@ -65,6 +65,7 @@ During upcasting it is important to note what the format is of the `Intermediate
 To validate if the intermediate representation supports a given type, you can invoke `IntermediateEventRepresentation#canConvertDataTo(Class<?>)`.
 ====
 
+[#provided_abstract_upcaster_implementations]
 === Provided abstract Upcaster implementations
 
 As described earlier, the `Upcaster` interface does not upcast a single event; it requires a `Stream<IntermediateEventRepresentation>` and returns one.

--- a/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-versioning.adoc
@@ -313,7 +313,7 @@ public class AxonConfig {
 ====
 
 [#upcasting_snapshots]
-=== Upcasting Snapshots
+=== Upcasting snapshots
 
 Although the description above leans towards event upcasting, note that all the given constructs can be used to upcast a xref:tuning:event-snapshots.adoc[snapshot].
 

--- a/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
@@ -51,7 +51,7 @@ The `AggregateSnapshotter` provides one more property:
  Both provide the factory through the `EventSourcingRepository#getAggregateFactory` and `AggregateConfiguration#aggregateFactory` methods respectively.
  The result from either can be used to configure the same aggregate factories in the `Snapshotter` as the ones used by the Aggregate.
 
-=== Snapshotter Configuration
+=== Snapshotter configuration
 
 ==== Executor
 

--- a/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
@@ -69,9 +69,11 @@ The `@Revision` annotation has a dedicated, automatically configured `SnapshotFi
 So when the `@Revision` annotation is used on an aggregate the snapshots will be filtered out automatically. When the`@Revision` on an aggregate is missing a `RevisionSnapshotFilter` is configured for revision `null`.
 For more details on snapshot filtering, please read xref:_filtering_snapshot_events[here]
 
-____
-
-==== Axon Configuration API
+[tabs]
+====
+Axon Configuration API::
++
+--
 
 [source,java]
 ----
@@ -83,8 +85,11 @@ AggregateConfigurer<GiftCard> giftCardConfigurer =
 Configurer configurer = DefaultConfigurer.defaultConfiguration()
                                          .configureAggregate(giftCardConfigurer);
 ----
+--
 
-==== Spring Boot auto configuration
+Spring Boot auto configuration::
++
+--
 It is possible to define a custom `SnapshotTriggerDefinition` for an aggregate as a Spring bean.
 In order to tie the `SnapshotTriggerDefinition` bean to an aggregate, use the `snapshotTriggerDefinition` attribute on `@Aggregate` annotation.
 Listing below shows how to define a custom `EventCountSnapshotTriggerDefinition` which will take a snapshot every 500 events.
@@ -104,6 +109,8 @@ public SnapshotTriggerDefinition giftCardSnapshotTrigger(Snapshotter snapshotter
 @Aggregate(snapshotTriggerDefinition = "giftCardSnapshotTrigger")
 public class GiftCard {...}
 ----
+--
+====
 
 === Storing snapshot events
 
@@ -145,7 +152,11 @@ The latter allows combining several `SnapshotFilter`s together.
 
 The following snippets show how to configure a `SnapshotFilter`:
 
-==== Axon Configuration API
+[tabs]
+====
+Axon Configuration API::
++
+--
 
 [source,java]
 ----
@@ -157,8 +168,11 @@ AggregateConfigurer<GiftCard> giftCardConfigurer =
 Configurer configurer = DefaultConfigurer.defaultConfiguration()
                                          .configureAggregate(giftCardConfigurer);
 ----
+--
 
-==== Spring Boot auto configuration
+Spring Boot auto configuration::
++
+--
 It is possible to define a custom `SnapshotFilter` for an aggregate as a Spring bean.
 In order to tie the `SnapshotFilter` bean to an aggregate, use the `snapshotFilter` attribute on `@Aggregate` annotation. 
 
@@ -174,6 +188,8 @@ public SnapshotFilter giftCardSnapshotFilter() {
 @Aggregate(snapshotFilter = "giftCardSnapshotFilter")
 public class GiftCard {...}
 ----
+--
+====
 
 The above snippet would be feasible to follow _if_ fine-grained control is required when filtering snapshots from the store.
 For example, when your snapshots are not based on the Aggregate class (which is the default).

--- a/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
@@ -195,6 +195,14 @@ The above snippet would be feasible to follow _if_ fine-grained control is requi
 For example, when your snapshots are not based on the Aggregate class (which is the default).
 When this is not required, you can base yourself on the default `SnapshotFilter` - the `RevisionSnapshotFilter`.
 
+[WARNING]
+====
+If you have defined an xref:events:event-versioning.adoc#upcasting_snapshots[upcaster] for your snapshots, you must define the revision of the snapshots as well. As described, any use of the `@Revision` annotation automatically results in a `RevisionSnapshotFilter`.
+
+Any `SnapshotFilter` present will impact the snapshot events given to your upcasters!
+Hence, it is advised to override the default `SnapshotFilter` to a no-op entry when you prefer to upcast your snapshots instead.
+====
+
 To configure this `SnapshotFilter`, all you have to do is use the `@Revision` annotation on your Aggregate class.
 In doing so, the `RevisionSnapshotFilter` is set, filtering non-matching snapshots from the `Repository`'s loading process, based on the value maintained within the `@Revision` annotation.
 

--- a/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
@@ -51,18 +51,23 @@ The `AggregateSnapshotter` provides one more property:
  Both provide the factory through the `EventSourcingRepository#getAggregateFactory` and `AggregateConfiguration#aggregateFactory` methods respectively.
  The result from either can be used to configure the same aggregate factories in the `Snapshotter` as the ones used by the Aggregate.
 
-____
+=== Snapshotter Configuration
 
-*Snapshotter Configuration*
+==== Executor
 
 If you use an executor that executes snapshot creation in another thread, make sure you configure the correct transaction management for your underlying event store, if necessary.
+
+==== Default Snapshotter
 
 For both non-Spring and Spring users a default `Snapshotter` is provided.
 The former uses the Configuration API to provide a default `AggregateSnapshotter`, retrieving the aggregate factories from the registered Aggregates / `AggregateConfiguration`s.
 Spring uses a `SpringAggregateSnapshotter`, which will automatically looks up the right `AggregateFactory` instances from the application context when a snapshot needs to be created.
 
+==== Revision-based snapshot filter
+
 The `@Revision` annotation has a dedicated, automatically configured `SnapshotFilter` implementation. This implementation is used to filter out non-matching snapshots from the `Repository`'s loading process.
 So when the `@Revision` annotation is used on an aggregate the snapshots will be filtered out automatically. When the`@Revision` on an aggregate is missing a `RevisionSnapshotFilter` is configured for revision `null`.
+For more details on snapshot filtering, please read xref:_filtering_snapshot_events[here]
 
 ____
 


### PR DESCRIPTION
This pull request adds a section to the "Event Upcasting" page, specifically about upcasting aggregate snapshots.
Added, warnings are put in place whenever a `SnapshotFilter` is used, since the `SnapshotFilter` will make it so that a snapshot event **never** reaches the snapshot upcaster.
Lastly, I've done some minor tweaks on the pages that I've touched to enhance readability.

In doing the above, this pull request resolves #3518.