### PR TITLE
Introduce the `TopologyChangeListener`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     labels:
       - "Type: Dependency Upgrade"
       - "Priority 1: Must"
-    milestone: 114
+    milestone: 116
     groups:
       github-dependencies:
         update-types:
@@ -30,7 +30,7 @@ updates:
     labels:
       - "Type: Dependency Upgrade"
       - "Priority 1: Must"
-    milestone: 114
+    milestone: 116
     groups:
       maven-dependencies:
         update-types:

--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-server-connector</artifactId>

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -1,0 +1,54 @@
+package org.axonframework.axonserver.connector;
+
+import io.axoniq.axonserver.grpc.control.TopologyChange;
+
+import java.util.function.Consumer;
+
+/**
+ * A functional interface representing a listener that is notified when a {@link TopologyChange} occurs to a specific
+ * {@link AxonServerConfiguration#getContext() context}.
+ * <p>
+ * A {@code TopologyChange} can reflect any of the following {@link TopologyChange#getUpdateType() updates}:
+ * <ol>
+ *     <li>{@code ADD_COMMAND_HANDLER} - A <b>command</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@code REMOVE_COMMAND_HANDLER} - A <b>command</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@code ADD_QUERY_HANDLER} - A <b>query</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@code REMOVE_QUERY_HANDLER} - A <b>query</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@code RESET_ALL} - This signals the connection broke down of a specific instance for the context the listener is attached to.</li>
+ * </ol>
+ * <p>
+ * A {@code TopologyChange} includes more information to better comprehend the actual switch, being:
+ * <ul>
+ *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
+ *     <li>{@link TopologyChange#getClientId() The client id} - The identifier of the client (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
+ * </ul>
+ * <p>
+ * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
+ * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
+ * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
+ * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
+ * aggregates or sagas, for example.
+ *
+ * @author Steven van Beelen
+ * @since 4.12.0
+ */
+@FunctionalInterface
+public interface TopologyChangeListener extends Consumer<TopologyChange> {
+
+    @Override
+    default void accept(TopologyChange change) {
+        onChange(change);
+    }
+
+    /**
+     * A handler towards a {@link TopologyChange} from the {@link AxonServerConfiguration#getContext() context} this
+     * listener was registered to.
+     *
+     * @param change The {@code TopologyChange} that transpired for the
+     *               {@link AxonServerConfiguration#getContext() context} this listener was registered to.
+     */
+    void onChange(TopologyChange change);
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -25,6 +25,17 @@ import java.util.function.Consumer;
  *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
  *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
  * </ul>
+ * Here is an example {@code TopologyChange} for a command subscription:
+ * <pre>{@code
+ * context: "axoniq-university"
+ * client_id: "149466@axoniq-uni"
+ * client_stream_id: "149466@axoniq-uni.2bb5c0b4-59d9-4396-ad14-a32059f71d9a"
+ * component_name: "AxonIQ University"
+ * command {
+ *   name: "io.axoniq.demo.university.faculty.write.createcourse.CreateCourse"
+ *   load_factor: 100
+ * }
+ * }</pre>
  * <p>
  * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
  * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
@@ -38,6 +49,8 @@ import java.util.function.Consumer;
  * {@link io.axoniq.axonserver.connector.control.ControlChannel} from the {@code AxonServerConnectionManager} manually,
  * and invoke {@link io.axoniq.axonserver.connector.control.ControlChannel#registerTopologyChangeHandler(Consumer)} for
  * each change listener separately.
+ * <p>
+ * Note that Axon Server 2025.1.2 or up is required to use this feature!
  *
  * @author Steven van Beelen
  * @since 4.12.0

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -31,6 +31,13 @@ import java.util.function.Consumer;
  * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
  * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
  * aggregates or sagas, for example.
+ * <p>
+ * Registering this interface with the {@link org.axonframework.config.Configurer} will ensure it is registered with the
+ * {@link AxonServerConfiguration#getContext() default context} <b>only</b>! If you need to register several change
+ * listeners, either with the same context or with different contexts, you are required to retrieve the
+ * {@link io.axoniq.axonserver.connector.control.ControlChannel} from the {@code AxonServerConnectionManager} manually,
+ * and invoke {@link io.axoniq.axonserver.connector.control.ControlChannel#registerTopologyChangeHandler(Consumer)} for
+ * each change listener separately.
  *
  * @author Steven van Beelen
  * @since 4.12.0

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -20,9 +20,9 @@ import java.util.function.Consumer;
  * A {@code TopologyChange} includes more information to better comprehend the actual switch, being:
  * <ul>
  *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
- *     <li>{@link TopologyChange#getClientId() The client id} - The identifier of the client (e.g., the Axon Framework node) for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientId() The client id} - The {@link AxonServerConfiguration#getClientId() identifier of the client} for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred, defined by Axon Server.</li>
+ *     <li>{@link TopologyChange#getComponentName() The component name} - The {@link AxonServerConfiguration#getComponentName() name of the component} for which a topology change occurred.</li>
  *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
  * </ul>
  * Here is an example {@code TopologyChange} for a command subscription:
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
  * }</pre>
  * <p>
  * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
- * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
+ * newly connecting instance would mean a new {@link TopologyChange#getClientStreamId()} entered, while a disconnect is
  * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
  * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
  * aggregates or sagas, for example.

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-configuration</artifactId>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-coverage-report</artifactId>

--- a/disruptor/pom.xml
+++ b/disruptor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-disruptor</artifactId>

--- a/docs/old-reference-guide/modules/release-notes/pages/minor-releases.adoc
+++ b/docs/old-reference-guide/modules/release-notes/pages/minor-releases.adoc
@@ -5,6 +5,56 @@ Any patch release made for an Axon project is tailored towards resolving bugs. T
 
 == Release 4.11
 
+=== Release 4.11.3
+
+==== Bug fixes
+
+- Fix interruption handling in message handling link:https://github.com/AxonFramework/AxonFramework/pull/3542[#3542]
+- Unexpected Error Handling behavior with Spring Retry and Timeouts link:https://github.com/AxonFramework/AxonFramework/issues/3519[#3519]
+
+==== Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+- link:https://github.com/CodeDrivenMitch[@CodeDrivenMitch]
+
+=== Release 4.11.2
+
+==== Features
+
+- [#3170] Persistent streams - auto configuration link:https://github.com/AxonFramework/AxonFramework/pull/3339[#3339]
+- [#3170] Persistent streams - automatic configuration link:https://github.com/AxonFramework/AxonFramework/pull/3184[#3184]
+- Persistent streams - automatic configuration link:https://github.com/AxonFramework/AxonFramework/issues/3170[#3170]
+
+==== Enhancements
+
+- Ignore aggregates that have been `AggregateLifecycle#markDeleted` when using the Create-if-missing policy. link:https://github.com/AxonFramework/AxonFramework/pull/3333[#3333]
+- Split default Avro schema store creation from the schema scan link:https://github.com/AxonFramework/AxonFramework/pull/3329[#3329]
+- Separate AvroSchemaScan based detection of schemas and creation of a default Avro SchemaStore link:https://github.com/AxonFramework/AxonFramework/issues/3328[#3328]
+- Proper handling of attempts to recreate event sourcing aggregates marked as deleted link:https://github.com/AxonFramework/AxonFramework/issues/3323[#3323]
+
+==== Bug fixes
+
+- [#3385] Align interceptor behavior for Aggregate Members link:https://github.com/AxonFramework/AxonFramework/pull/3404[#3404]
+- CommandHandlerInterceptor on Aggregate Member only called if Aggregate has CommandHandlerInterceptor as well link:https://github.com/AxonFramework/AxonFramework/issues/3385[#3385]
+- Fix default Snapshotter throwing `IndexOutOfBoundsException` link:https://github.com/AxonFramework/AxonFramework/pull/3375[#3375]
+- fix Correlation data table link:https://github.com/AxonFramework/AxonFramework/pull/3370[#3370]
+- Fixes subscription query update permits issue link:https://github.com/AxonFramework/AxonFramework/pull/3356[#3356]
+- [#3171] Support `@CreationPolicy` annotated interface methods __again__ link:https://github.com/AxonFramework/AxonFramework/pull/3335[#3335]
+- Reset the `Coordinator's` processing gate if the `Coordinator` was aborted and rescheduled link:https://github.com/AxonFramework/AxonFramework/pull/3307[#3307]
+
+==== Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+- link:https://github.com/zambrovski[@zambrovski]
+- link:https://github.com/smcvb[@smcvb]
+- link:https://github.com/MGathier[@MGathier]
+- link:https://github.com/rsobies[@rsobies]
+- link:https://github.com/corradom[@corradom]
+- link:https://github.com/abuijze[@abuijze]
+- link:https://github.com/CodeDrivenMitch[@CodeDrivenMitch]
+
 === Release 4.11.1
 
 ==== Bug fixes

--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-eventsourcing</artifactId>

--- a/hibernate-6-integrationtests/pom.xml
+++ b/hibernate-6-integrationtests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-messaging</artifactId>

--- a/messaging/src/test/java/org/axonframework/messaging/timeout/AxonTimeLimitedTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/timeout/AxonTimeLimitedTaskTest.java
@@ -16,27 +16,37 @@
 package org.axonframework.messaging.timeout;
 
 import org.junit.jupiter.api.*;
-import org.mockito.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link AxonTimeLimitedTask}.
+ *
+ * @author Mitchell Herrijgers
+ */
 class AxonTimeLimitedTaskTest {
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        //noinspection ResultOfMethodCallIgnored | Awaiting termination to ensure none of the AxonTimeLimitedTask hang
+        AxonTaskJanitor.INSTANCE
+                .awaitTermination(250, TimeUnit.MILLISECONDS);
+    }
 
     @Test
     void correctlyInterruptsTaskWhenNoWarningWasConfiguredOnUncustomizedConstructor() {
-        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask(
-                "My test task",
-                100,
-                100,
-                1
-        );
-
+        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask("My test task", 100, 100, 1);
 
         assertThrows(InterruptedException.class, () -> {
             testSubject.start();
-            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up. We accept a 50ms delay.
+            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up.
+            // We accept a 150ms delay.
             Thread.sleep(150);
         });
 
@@ -47,17 +57,12 @@ class AxonTimeLimitedTaskTest {
 
     @Test
     void correctlyInterruptsTaskWithWarningWasConfiguredOnUncustomizedConstructor() {
-        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask(
-                "My test task",
-                100,
-                50,
-                10
-        );
-
+        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask("My test task", 100, 50, 10);
 
         assertThrows(InterruptedException.class, () -> {
             testSubject.start();
-            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up. We accept a 50ms delay.
+            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up.
+            // We accept a 150ms delay.
             Thread.sleep(150);
         });
 
@@ -67,46 +72,37 @@ class AxonTimeLimitedTaskTest {
 
     @Test
     void correctlyLogsWarningsAndInterruptsWhenWarningWasConfiguredOnCustomizedConstructor() {
-        Logger logger = Mockito.spy(LoggerFactory.getLogger("MyLogger"));
-        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask(
-                "My test task",
-                1000,
-                100,
-                100,
-                AxonTaskJanitor.INSTANCE,
-                logger
-        );
+        Logger logger = spy(LoggerFactory.getLogger("MyLogger"));
+        AxonTimeLimitedTask testSubject =
+                new AxonTimeLimitedTask("My test task", 1000, 100, 100, AxonTaskJanitor.INSTANCE, logger);
 
         assertThrows(InterruptedException.class, () -> {
             testSubject.start();
-            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up. We accept a 50ms delay.
+            // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up.
+            // We accept a 1500ms delay.
             Thread.sleep(1500);
         });
 
         assertTrue(testSubject.isInterrupted());
         assertFalse(testSubject.isCompleted());
-        Mockito.verify(logger, Mockito.atLeast(8)).warn(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),  Mockito.any());
+        verify(logger, atLeast(8)).warn(anyString(), any(), any(), any(), any(), any());
     }
-
 
     @Test
     void doesNotInterruptButLogsWarningsIfProcessWasCompletedBeforeTimeout() throws InterruptedException {
-        Logger logger = Mockito.spy(LoggerFactory.getLogger("MyLogger"));
-        AxonTimeLimitedTask testSubject = new AxonTimeLimitedTask(
-                "My test task",
-                1000,
-                100,
-                100,
-                AxonTaskJanitor.INSTANCE,
-                logger
-        );
+        Logger logger = spy(LoggerFactory.getLogger("MyLogger"));
+        AxonTimeLimitedTask testSubject =
+                new AxonTimeLimitedTask("My test task", 1000, 100, 100, AxonTaskJanitor.INSTANCE, logger);
 
         testSubject.start();
-        // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up. We accept a 50ms delay.
+        // Even though the timeout is 100ms, the InterruptedException apparently needs time to travel up.
+        // We accept a 500ms delay.
         Thread.sleep(500);
 
         assertFalse(testSubject.isInterrupted());
         assertFalse(testSubject.isCompleted());
-        Mockito.verify(logger, Mockito.atLeast(3)).warn(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),  Mockito.any());
+        // Complete manually to ensure it does not block the AxonTaskJanitor!
+        testSubject.complete();
+        verify(logger, atLeast(3)).warn(anyString(), any(), any(), any(), any(), any());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/timeout/CombinedTimeoutTests.java
+++ b/messaging/src/test/java/org/axonframework/messaging/timeout/CombinedTimeoutTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -40,6 +41,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * timeout behavior works as expected when both are used together.
  */
 class CombinedTimeoutTests {
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        //noinspection ResultOfMethodCallIgnored | Awaiting termination to ensure none of the AxonTimeLimitedTask hang
+        AxonTaskJanitor.INSTANCE
+                .awaitTermination(250, TimeUnit.MILLISECONDS);
+    }
 
     /**
      * Simple test where the message handling member takes longer than the timeout specified, and the batch fits inside

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-micrometer</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-metrics</artifactId>

--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-migration</artifactId>

--- a/modelling/pom.xml
+++ b/modelling/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-modelling</artifactId>

--- a/reactorless-test/pom.xml
+++ b/reactorless-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-boot-3-integrationtests/pom.xml
+++ b/spring-boot-3-integrationtests/pom.xml
@@ -20,12 +20,12 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>axon-spring-boot-3-integrationtests</artifactId>
-    <version>4.11.3-SNAPSHOT</version>
+    <version>4.11.4-SNAPSHOT</version>
 
     <name>Axon Framework - Spring Boot 3 Integration Tests</name>
     <description>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -17,11 +17,13 @@
 package org.axonframework.springboot.autoconfig;
 
 
+import io.axoniq.axonserver.connector.control.ControlChannel;
 import io.axoniq.axonserver.connector.event.PersistentStreamProperties;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
 import org.axonframework.axonserver.connector.TargetContextResolver;
+import org.axonframework.axonserver.connector.TopologyChangeListener;
 import org.axonframework.axonserver.connector.command.CommandLoadFactorProvider;
 import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventScheduler;
@@ -39,6 +41,7 @@ import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
+import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
@@ -53,6 +56,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -65,6 +69,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 
@@ -365,6 +370,22 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
                                                                );
                                                            })
         );
+    }
+
+    @Bean
+    @ConditionalOnBean
+    public ConfigurerModule topologyChangeListenerConfigurerModule(
+            AxonServerConnectionManager platformConnectionManager,
+            List<TopologyChangeListener> changeListeners
+    ) {
+        // ConditionalOnBean does not work for collections of beans, as it simply creates an empty collection.
+        if (changeListeners.isEmpty()) {
+            return configurer -> { /*Noop*/ };
+        }
+        return configurer -> configurer.onInitialize(config -> config.onStart(Phase.INSTRUCTION_COMPONENTS, () -> {
+            ControlChannel defaultControlChannel = platformConnectionManager.getConnection().controlChannel();
+            changeListeners.forEach(defaultControlChannel::registerTopologyChangeHandler);
+        }));
     }
 
     @Override

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
@@ -1,0 +1,99 @@
+package org.axonframework.springboot.autoconfig;
+
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.control.ControlChannel;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.TopologyChangeListener;
+import org.axonframework.springboot.utils.GrpcServerStub;
+import org.axonframework.springboot.utils.TcpUtils;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Autoconfiguration test class validating registration of the
+ * {@link org.axonframework.axonserver.connector.TopologyChangeListener} with the
+ * {@link io.axoniq.axonserver.connector.control.ControlChannel} for the default
+ * {@link AxonServerConfiguration#getContext() context}.
+ *
+ * @author Steven van Beelen
+ */
+class TopologyChangeListenerAutoConfigurationTest {
+
+    private ApplicationContextRunner testContext;
+
+    @BeforeEach
+    void setUp() {
+        testContext = new ApplicationContextRunner();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("axon.axonserver.servers", GrpcServerStub.DEFAULT_HOST + ":" + TcpUtils.findFreePort());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("axon.axonserver.servers");
+    }
+
+    @Test
+    void topologyChangeListenersAreInvokedForCommandHandlerRegistration() {
+        testContext.withUserConfiguration(TestContext.class).run(context -> {
+            TopologyChangeListener listenerOne = context.getBean("listenerOne", TopologyChangeListener.class);
+            TopologyChangeListener listenerTwo = context.getBean("listenerTwo", TopologyChangeListener.class);
+
+            ControlChannel mockedControlChannel = context.getBean("mockedControlChannel", ControlChannel.class);
+
+            verify(mockedControlChannel).registerTopologyChangeHandler(listenerOne);
+            verify(mockedControlChannel).registerTopologyChangeHandler(listenerTwo);
+        });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    private static class TestContext {
+
+        @Bean
+        public ControlChannel mockedControlChannel() {
+            return mock(ControlChannel.class);
+        }
+
+        @Bean
+        @Primary
+        public AxonServerConnectionManager connectionManager(ControlChannel mockedControlChannel) {
+            AxonServerConnection mockedConnection = mock(AxonServerConnection.class);
+            when(mockedConnection.controlChannel()).thenReturn(mockedControlChannel);
+            AxonServerConnectionManager mockedManager = mock(AxonServerConnectionManager.class);
+            when(mockedManager.getConnection()).thenReturn(mockedConnection);
+            when(mockedManager.getConnection(any())).thenReturn(mockedConnection);
+            return mockedManager;
+        }
+
+        @Bean
+        public TopologyChangeListener listenerOne() {
+            return change -> {
+                // Unimportant - only exists to validate the change listener registration.
+            };
+        }
+
+        @Bean
+        public TopologyChangeListener listenerTwo() {
+            return change -> {
+                // Unimportant - only exists to validate the change listener registration.
+            };
+        }
+
+        @Bean(initMethod = "start", destroyMethod = "shutdown")
+        public GrpcServerStub grpcServerStub(@Value("${axon.axonserver.servers}") String servers) {
+            return new GrpcServerStub(Integer.parseInt(servers.split(":")[1]));
+        }
+    }
+}

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <artifactId>axon</artifactId>
         <groupId>org.axonframework</groupId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>axon-spring-boot-starter</artifactId>
-    <version>4.11.3-SNAPSHOT</version>
+    <version>4.11.4-SNAPSHOT</version>
 
     <name>Spring Boot Starter module for Axon Framework</name>
 

--- a/spring-boot3-dummy/pom.xml
+++ b/spring-boot3-dummy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-spring-boot3-dummy</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-test</artifactId>

--- a/tracing-opentelemetry/pom.xml
+++ b/tracing-opentelemetry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>4.11.3-SNAPSHOT</version>
+        <version>4.11.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-tracing-opentelemetry</artifactId>


### PR DESCRIPTION
This pull request introduces the `TopologyChangeListener` functional interface.

This functional interface extends the `Consumer<TopologyChange>`.
As such, it perfectly fits the new `ControlChannel#registerTopologyChangeHandler(Consumer<TopologyChange>)` method that was introduced in [this](https://github.com/AxonIQ/axonserver-connector-java/pull/435) Axon Server Connector for Java PR (version 2024.1.4).

Although the `TopologyChangeListener` functional interface is strictly not necessary, it does provide clear hook into Axon Framework's `Configurer` API for the `ServerConnectorConfigurerModule`.
Furthermore, it serves as a spot to have a comprehensive bit of JavaDoc to explain what the topology change listener is for and how to use it.

Lastly, I have introduced a `ConfigurerModule` in the Spring Boot autoconfiguration that will:

1. Gather all `TopologyChangeListener` beans.
2. Register all of them with the `ControlChannel` for the default context.