### PR TITLE
Introduce the `TopologyChangeListener`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChange.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChange.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.axonserver.connector;
 
 import io.axoniq.axonserver.grpc.control.UpdateType;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChange.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChange.java
@@ -1,0 +1,282 @@
+package org.axonframework.axonserver.connector;
+
+import io.axoniq.axonserver.grpc.control.UpdateType;
+
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/**
+ * Object representing a topology change at Axon Server.
+ * <p>
+ * Topology changes can be acted upon by registering a {@link TopologyChangeListener}.
+ *
+ * @author Steven van Beelen
+ * @see TopologyChangeListener
+ * @since 4.12.0
+ */
+public class TopologyChange {
+
+    private final Type type;
+    private final String context;
+    private final String clientId;
+    private final String clientStreamId;
+    private final String componentName;
+    private final HandlerSubscription handlerSubscription;
+
+    /**
+     * Constructs a {@code TopologyChange} based on the give {@code type}, {@code context}, {@code clientId},
+     * {@code clientStreamId}, {@code componentName}, and {@code handler}.
+     *
+     * @param type                The type of the {@code TopologyChange}.
+     * @param context             The {@link AxonServerConfiguration#getContext() context} for which a
+     *                            {@code TopologyChange} occurred.
+     * @param clientId            The {@link AxonServerConfiguration#getClientId() client identifier} for which a
+     *                            {@code TopologyChange} occurred.
+     * @param clientStreamId      The client stream identifier for which a {@code TopologyChange} occurred.
+     * @param componentName       The {@link AxonServerConfiguration#getComponentName() component name} for which a
+     *                            {@code TopologyChange} occurred.
+     * @param handlerSubscription The {@link HandlerSubscription} for which a {@code TopologyChange} occurred. Should be
+     *                            {@code null} for the {@link Type#RESET Type RESET}.
+     */
+    public TopologyChange(Type type,
+                          String context,
+                          String clientId,
+                          String clientStreamId,
+                          String componentName,
+                          HandlerSubscription handlerSubscription) {
+        this.type = type;
+        this.context = context;
+        this.clientId = clientId;
+        this.clientStreamId = clientStreamId;
+        this.componentName = componentName;
+        this.handlerSubscription = handlerSubscription;
+    }
+
+    /**
+     * Constructs a {@code TopologyChange} based on the given gRPC {@code change}.
+     *
+     * @param change The gRPC {@code TopologyChange} to construct an Axon Framework {@code TopologyChange} from.
+     */
+    public TopologyChange(io.axoniq.axonserver.grpc.control.TopologyChange change) {
+        this.type = mapToType(change.getUpdateType());
+        this.context = change.getContext();
+        this.clientId = change.getClientId();
+        this.clientStreamId = change.getClientStreamId();
+        this.componentName = change.getComponentName();
+        if (change.hasCommand()) {
+            this.handlerSubscription = new HandlerSubscription(change.getCommand().getName(),
+                                                               change.getCommand().getLoadFactor());
+        } else if (change.hasQuery()) {
+            this.handlerSubscription = new HandlerSubscription(change.getQuery().getName(), null);
+        } else {
+            this.handlerSubscription = null;
+        }
+    }
+
+    private Type mapToType(UpdateType updateType) {
+        Type result = null;
+        switch (updateType) {
+            case ADD_COMMAND_HANDLER:
+                result = Type.COMMAND_HANDLER_ADDED;
+                break;
+            case REMOVE_COMMAND_HANDLER:
+                result = Type.COMMAND_HANDLER_REMOVED;
+                break;
+            case ADD_QUERY_HANDLER:
+                result = Type.QUERY_HANDLER_ADDED;
+                break;
+            case REMOVE_QUERY_HANDLER:
+                result = Type.QUERY_HANDLER_REMOVED;
+                break;
+            case RESET_ALL:
+                result = Type.RESET;
+                break;
+        }
+        return result;
+    }
+
+    /**
+     * Returns the {@code Type} of the {@code TopologyChange}.
+     *
+     * @return The {@code Type} of the {@code TopologyChange}.
+     */
+    public Type type() {
+        return type;
+    }
+
+    /**
+     * Returns the {@link AxonServerConfiguration#getContext() context} for which a {@code TopologyChange} occurred.
+     *
+     * @return The {@link AxonServerConfiguration#getContext() context} for which a {@code TopologyChange} occurred.
+     */
+    public String context() {
+        return context;
+    }
+
+    /**
+     * Returns the {@link AxonServerConfiguration#getClientId() client identifier} for which a {@code TopologyChange}
+     * occurred.
+     *
+     * @return The {@link AxonServerConfiguration#getClientId() client identifier} for which a {@code TopologyChange}
+     * occurred.
+     */
+    public String clientId() {
+        return clientId;
+    }
+
+    /**
+     * Returns the client stream identifier for which a {@code TopologyChange} occurred.
+     *
+     * @return The client stream identifier for which a {@code TopologyChange} occurred.
+     */
+    public String clientStreamId() {
+        return clientStreamId;
+    }
+
+    /**
+     * Returns the {@link AxonServerConfiguration#getComponentName() component name} for which a {@code TopologyChange}
+     * occurred.
+     *
+     * @return The {@link AxonServerConfiguration#getComponentName() component name} for which a {@code TopologyChange}
+     * occurred.
+     */
+    public String componentName() {
+        return componentName;
+    }
+
+    /**
+     * Returns the {@code HandlerSubscription} for which a {@code TopologyChange} occurred.
+     * <p>
+     * Is {@code null} when {@link #type()} returns {@link Type#RESET}.
+     *
+     * @return The {@code HandlerSubscription} for which a {@code TopologyChange} occurred.
+     */
+    public HandlerSubscription handler() {
+        return handlerSubscription;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopologyChange that = (TopologyChange) o;
+        return type == that.type
+                && Objects.equals(context, that.context)
+                && Objects.equals(clientId, that.clientId)
+                && Objects.equals(clientStreamId, that.clientStreamId)
+                && Objects.equals(componentName, that.componentName)
+                && Objects.equals(handlerSubscription, that.handlerSubscription);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, context, clientId, clientStreamId, componentName, handlerSubscription);
+    }
+
+    @Override
+    public String toString() {
+        return "TopologyChange{" +
+                "type=" + type +
+                ", context='" + context + '\'' +
+                ", clientId='" + clientId + '\'' +
+                ", clientStreamId='" + clientStreamId + '\'' +
+                ", componentName='" + componentName + '\'' +
+                ", handlerSubscription=" + handlerSubscription +
+                '}';
+    }
+
+    /**
+     * The enumeration referencing the possible {@code TopologyChange} types.
+     */
+    public enum Type {
+        /**
+         * A change type signalling a command handler was added.
+         */
+        COMMAND_HANDLER_ADDED,
+        /**
+         * A change type signalling a command handler was removed.
+         */
+        COMMAND_HANDLER_REMOVED,
+        /**
+         * A change type signalling a query handler was added.
+         */
+        QUERY_HANDLER_ADDED,
+        /**
+         * A change type signalling a query handler was removed.
+         */
+        QUERY_HANDLER_REMOVED,
+        /**
+         * A change type signalling the connection broke down, willingly or not, resulting in a complete reset.
+         */
+        RESET,
+    }
+
+    /**
+     * The handler subscription of a {@link TopologyChange}.
+     * <p>
+     * Should be {@code null} whenever the {@link #type()} is {@link Type#RESET}.
+     */
+    public static class HandlerSubscription {
+
+        private final String name;
+        private final Integer loadFactor;
+
+        /**
+         * Constructs a {@code HandlerSubscription} for the given {@code name} and {@code loadFactor}.
+         *
+         * @param name       The name of the {@code HandlerSubscription}.
+         * @param loadFactor The load factor of the {@code HandlerSubscription}. Should be {@code null} when this
+         *                   {@code HandlerSubscription} is used when {@link #type()} contains
+         *                   {@link Type#QUERY_HANDLER_ADDED} or {@link Type#QUERY_HANDLER_REMOVED}.
+         */
+        public HandlerSubscription(String name, Integer loadFactor) {
+            this.name = name;
+            this.loadFactor = loadFactor;
+        }
+
+        /**
+         * Returns the name of the {@code HandlerSubscription}.
+         *
+         * @return The name of the {@code HandlerSubscription}.
+         */
+        public String name() {
+            return name;
+        }
+
+        /**
+         * Returns the load factor of the {@code HandlerSubscription}.
+         * <p>
+         * Should be {@code null} when this {@code HandlerSubscription} is used when {@link #type()} contains
+         * {@link Type#QUERY_HANDLER_ADDED} or {@link Type#QUERY_HANDLER_REMOVED}.
+         *
+         * @return The load factor of the {@code HandlerSubscription}.
+         */
+        public OptionalInt loadFactor() {
+            return loadFactor != null ? OptionalInt.of(loadFactor) : OptionalInt.empty();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            HandlerSubscription that = (HandlerSubscription) o;
+            return Objects.equals(name, that.name)
+                    && Objects.equals(loadFactor, that.loadFactor);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, loadFactor);
+        }
+
+        @Override
+        public String toString() {
+            return "HandlerSubscription{" +
+                    "name='" + name + '\'' +
+                    ", loadFactor=" + loadFactor +
+                    '}';
+        }
+    }
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -1,0 +1,54 @@
+package org.axonframework.axonserver.connector;
+
+import io.axoniq.axonserver.grpc.control.TopologyChange;
+
+import java.util.function.Consumer;
+
+/**
+ * A functional interface representing a listener that is notified when a {@link TopologyChange} occurs to a specific
+ * {@link AxonServerConfiguration#getContext() context}.
+ * <p>
+ * A {@code TopologyChange} can reflect any of the following {@link TopologyChange#getUpdateType() updates}:
+ * <ol>
+ *     <li>{@code ADD_COMMAND_HANDLER} - A <b>command</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@code REMOVE_COMMAND_HANDLER} - A <b>command</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@code ADD_QUERY_HANDLER} - A <b>query</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@code REMOVE_QUERY_HANDLER} - A <b>query</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@code RESET_ALL} - This signals the connection broke down of a specific instance for the context the listener is attached to.</li>
+ * </ol>
+ * <p>
+ * A {@code TopologyChange} includes more information to better comprehend the actual switch, being:
+ * <ul>
+ *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
+ *     <li>{@link TopologyChange#getClientId() The client id} - The identifier of the client (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
+ * </ul>
+ * <p>
+ * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
+ * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
+ * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
+ * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
+ * aggregates or sagas, for example.
+ *
+ * @author Steven van Beelen
+ * @since 4.12.0
+ */
+@FunctionalInterface
+public interface TopologyChangeListener extends Consumer<TopologyChange> {
+
+    @Override
+    default void accept(TopologyChange change) {
+        onChange(change);
+    }
+
+    /**
+     * A handler towards a {@link TopologyChange} from the {@link AxonServerConfiguration#getContext() context} this
+     * listener was registered to.
+     *
+     * @param change The {@code TopologyChange} that transpired for the
+     *               {@link AxonServerConfiguration#getContext() context} this listener was registered to.
+     */
+    void onChange(TopologyChange change);
+}

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -25,6 +25,17 @@ import java.util.function.Consumer;
  *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
  *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
  * </ul>
+ * Here is an example {@code TopologyChange} for a command subscription:
+ * <pre>{@code
+ * context: "axoniq-university"
+ * client_id: "149466@axoniq-uni"
+ * client_stream_id: "149466@axoniq-uni.2bb5c0b4-59d9-4396-ad14-a32059f71d9a"
+ * component_name: "AxonIQ University"
+ * command {
+ *   name: "io.axoniq.demo.university.faculty.write.createcourse.CreateCourse"
+ *   load_factor: 100
+ * }
+ * }</pre>
  * <p>
  * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
  * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
@@ -38,6 +49,8 @@ import java.util.function.Consumer;
  * {@link io.axoniq.axonserver.connector.control.ControlChannel} from the {@code AxonServerConnectionManager} manually,
  * and invoke {@link io.axoniq.axonserver.connector.control.ControlChannel#registerTopologyChangeHandler(Consumer)} for
  * each change listener separately.
+ * <p>
+ * Note that Axon Server 2025.1.2 or up is required to use this feature!
  *
  * @author Steven van Beelen
  * @since 4.12.0

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.axonserver.connector;
 
 import java.util.function.Consumer;

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -31,6 +31,13 @@ import java.util.function.Consumer;
  * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
  * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
  * aggregates or sagas, for example.
+ * <p>
+ * Registering this interface with the {@link org.axonframework.config.Configurer} will ensure it is registered with the
+ * {@link AxonServerConfiguration#getContext() default context} <b>only</b>! If you need to register several change
+ * listeners, either with the same context or with different contexts, you are required to retrieve the
+ * {@link io.axoniq.axonserver.connector.control.ControlChannel} from the {@code AxonServerConnectionManager} manually,
+ * and invoke {@link io.axoniq.axonserver.connector.control.ControlChannel#registerTopologyChangeHandler(Consumer)} for
+ * each change listener separately.
  *
  * @author Steven van Beelen
  * @since 4.12.0

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
  *     <li>{@code RESET_ALL} - This signals the connection broke down of a specific instance for the context the listener is attached to.</li>
  * </ol>
  * <p>
- * A {@code TopologyChange} includes more information to better comprehend the actual switch, being:
+ * A {@code TopologyChange} includes more information to better comprehend the actual change, being:
  * <ul>
  *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
  *     <li>{@link TopologyChange#getClientId() The client id} - The {@link AxonServerConfiguration#getClientId() identifier of the client} for which a topology change occurred.</li>

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -1,45 +1,47 @@
 package org.axonframework.axonserver.connector;
 
-import io.axoniq.axonserver.grpc.control.TopologyChange;
-
 import java.util.function.Consumer;
 
 /**
  * A functional interface representing a listener that is notified when a {@link TopologyChange} occurs to a specific
  * {@link AxonServerConfiguration#getContext() context}.
  * <p>
- * A {@code TopologyChange} can reflect any of the following {@link TopologyChange#getUpdateType() updates}:
+ * A {@code TopologyChange} can reflect any of the following {@link TopologyChange#type() updates}:
  * <ol>
- *     <li>{@code ADD_COMMAND_HANDLER} - A <b>command</b> handler was added by a specific instance to the context the listener is attached to.</li>
- *     <li>{@code REMOVE_COMMAND_HANDLER} - A <b>command</b> handler was removed from a specific instance for the context the listener is attached to.</li>
- *     <li>{@code ADD_QUERY_HANDLER} - A <b>query</b> handler was added by a specific instance to the context the listener is attached to.</li>
- *     <li>{@code REMOVE_QUERY_HANDLER} - A <b>query</b> handler was removed from a specific instance for the context the listener is attached to.</li>
- *     <li>{@code RESET_ALL} - This signals the connection broke down of a specific instance for the context the listener is attached to.</li>
+ *     <li>{@link org.axonframework.axonserver.connector.TopologyChange.Type#COMMAND_HANDLER_ADDED} - A <b>command</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@link org.axonframework.axonserver.connector.TopologyChange.Type#COMMAND_HANDLER_REMOVED} - A <b>command</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@link org.axonframework.axonserver.connector.TopologyChange.Type#QUERY_HANDLER_ADDED} - A <b>query</b> handler was added by a specific instance to the context the listener is attached to.</li>
+ *     <li>{@link org.axonframework.axonserver.connector.TopologyChange.Type#QUERY_HANDLER_REMOVED} - A <b>query</b> handler was removed from a specific instance for the context the listener is attached to.</li>
+ *     <li>{@link org.axonframework.axonserver.connector.TopologyChange.Type#RESET} - This signals the connection broke down of a specific instance for the context the listener is attached to.</li>
  * </ol>
  * <p>
  * A {@code TopologyChange} includes more information to better comprehend the actual change, being:
  * <ul>
- *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
- *     <li>{@link TopologyChange#getClientId() The client id} - The {@link AxonServerConfiguration#getClientId() identifier of the client} for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred, defined by Axon Server.</li>
- *     <li>{@link TopologyChange#getComponentName() The component name} - The {@link AxonServerConfiguration#getComponentName() name of the component} for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
+ *     <li>{@link TopologyChange#type() The type} - The type of update.</li>
+ *     <li>{@link TopologyChange#context() The context} - The context from which the change originates.</li>
+ *     <li>{@link TopologyChange#clientId() The client id} - The {@link AxonServerConfiguration#getClientId() identifier of the client} for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#clientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred, defined by Axon Server.</li>
+ *     <li>{@link TopologyChange#componentName() The component name} - The {@link AxonServerConfiguration#getComponentName() name of the component} for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#handler() The handler subscription} - The handler subscription containing the {@link TopologyChange.HandlerSubscription#name()} and an optional {@link TopologyChange.HandlerSubscription#loadFactor()} that is only present for command handler subscriptions.</li>
  * </ul>
- * Here is an example {@code TopologyChange} for a command subscription:
+ * Here is an example {@link TopologyChange#toString()} for a {@link org.axonframework.axonserver.connector.TopologyChange.Type#COMMAND_HANDLER_ADDED}:
  * <pre>{@code
- * context: "axoniq-university"
- * client_id: "149466@axoniq-uni"
- * client_stream_id: "149466@axoniq-uni.2bb5c0b4-59d9-4396-ad14-a32059f71d9a"
- * component_name: "AxonIQ University"
- * command {
- *   name: "io.axoniq.demo.university.faculty.write.createcourse.CreateCourse"
- *   load_factor: 100
+ * TopologyChange{
+ *     type=COMMAND_HANDLER_ADDED,
+ *     context='axoniq-university',
+ *     clientId='149466@axoniq-uni',
+ *     clientStreamId='149466@axoniq-uni.2bb5c0b4-59d9-4396-ad14-a32059f71d9a',
+ *     componentName='AxonIQ University',
+ *     handlerSubscription=HandlerSubscription{
+ *         name='io.axoniq.demo.university.faculty.write.createcourse.CreateCourse',
+ *         loadFactor=100
+ *     }
  * }
  * }</pre>
  * <p>
  * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
- * newly connecting instance would mean a new {@link TopologyChange#getClientStreamId()} entered, while a disconnect is
- * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
+ * newly connecting instance would mean a new {@link TopologyChange#clientStreamId()} entered, while a disconnect is
+ * signaled by the {@link TopologyChange.Type#RESET} {@link TopologyChange#type()}. Such a coarse topology change means the
  * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
  * aggregates or sagas, for example.
  * <p>
@@ -56,11 +58,11 @@ import java.util.function.Consumer;
  * @since 4.12.0
  */
 @FunctionalInterface
-public interface TopologyChangeListener extends Consumer<TopologyChange> {
+public interface TopologyChangeListener extends Consumer<io.axoniq.axonserver.grpc.control.TopologyChange> {
 
     @Override
-    default void accept(TopologyChange change) {
-        onChange(change);
+    default void accept(io.axoniq.axonserver.grpc.control.TopologyChange change) {
+        onChange(new TopologyChange(change));
     }
 
     /**

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/TopologyChangeListener.java
@@ -20,9 +20,9 @@ import java.util.function.Consumer;
  * A {@code TopologyChange} includes more information to better comprehend the actual switch, being:
  * <ul>
  *     <li>{@link TopologyChange#getContext() The context} - The context from which the change originates.</li>
- *     <li>{@link TopologyChange#getClientId() The client id} - The identifier of the client (e.g., the Axon Framework node) for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred.</li>
- *     <li>{@link TopologyChange#getComponentName() The component name} - The name of the component (e.g., the Axon Framework node) for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientId() The client id} - The {@link AxonServerConfiguration#getClientId() identifier of the client} for which a topology change occurred.</li>
+ *     <li>{@link TopologyChange#getClientStreamId() The client stream id} - The identifier of the stream/connection for a client (e.g., the Axon Framework node) for which a topology change occurred, defined by Axon Server.</li>
+ *     <li>{@link TopologyChange#getComponentName() The component name} - The {@link AxonServerConfiguration#getComponentName() name of the component} for which a topology change occurred.</li>
  *     <li>{@link TopologyChange#getCommand() The command subscription identifier} <b>or</b> {@link TopologyChange#getQuery() The query subscription identifier} - The identifier of the handler that was added or removed</li>
  * </ul>
  * Here is an example {@code TopologyChange} for a command subscription:
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
  * }</pre>
  * <p>
  * An example use case of this functional interface, is to get notified when a new instance connects or disconnects. A
- * newly connecting instance would mean a new {@link TopologyChange#getClientId()} entered, while a disconnect is
+ * newly connecting instance would mean a new {@link TopologyChange#getClientStreamId()} entered, while a disconnect is
  * signaled by the {@code RESET_ALL} {@link TopologyChange#getUpdateType()}. Such a coarse topology change means the
  * routing of commands will change, which impacts {@link org.axonframework.common.caching.Cache} hits for your
  * aggregates or sagas, for example.

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/TopologyChangeTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/TopologyChangeTest.java
@@ -1,0 +1,167 @@
+package org.axonframework.axonserver.connector;
+
+import io.axoniq.axonserver.grpc.control.CommandSubscription;
+import io.axoniq.axonserver.grpc.control.QuerySubscription;
+import io.axoniq.axonserver.grpc.control.UpdateType;
+import org.junit.jupiter.api.*;
+
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link TopologyChange}.
+ *
+ * @author Steven van Beelen
+ */
+class TopologyChangeTest {
+
+    private static final String TEST_CONTEXT = "context";
+    private static final String TEST_CLIENT_ID = "clientId";
+    private static final String TEST_CLIENT_STREAM_ID = "clientStreamId";
+    private static final String TEST_COMPONENT_NAME = "componentName";
+    private static final String TEST_COMMAND_NAME = "commandName";
+    private static final int TEST_LOAD_FACTOR = 42;
+    private static final String TEST_QUERY_NAME = "queryName";
+
+    @Test
+    void mapsGrpcBasedAddCommandChange() {
+        CommandSubscription commandSubscription = CommandSubscription.newBuilder()
+                                                                     .setName(TEST_COMMAND_NAME)
+                                                                     .setLoadFactor(TEST_LOAD_FACTOR)
+                                                                     .build();
+        io.axoniq.axonserver.grpc.control.TopologyChange grpcBasedChange =
+                io.axoniq.axonserver.grpc.control.TopologyChange.newBuilder()
+                                                                .setUpdateType(UpdateType.ADD_COMMAND_HANDLER)
+                                                                .setContext(TEST_CONTEXT)
+                                                                .setClientId(TEST_CLIENT_ID)
+                                                                .setClientStreamId(TEST_CLIENT_STREAM_ID)
+                                                                .setComponentName(TEST_COMPONENT_NAME)
+                                                                .setCommand(commandSubscription)
+                                                                .build();
+
+        TopologyChange testSubject = new TopologyChange(grpcBasedChange);
+        System.out.println(testSubject);
+
+        assertEquals(TopologyChange.Type.COMMAND_HANDLER_ADDED, testSubject.type());
+        assertEquals(TEST_CONTEXT, testSubject.context());
+        assertEquals(TEST_CLIENT_ID, testSubject.clientId());
+        assertEquals(TEST_CLIENT_STREAM_ID, testSubject.clientStreamId());
+        assertEquals(TEST_COMPONENT_NAME, testSubject.componentName());
+        TopologyChange.HandlerSubscription handlerSubscription = testSubject.handler();
+        assertNotNull(handlerSubscription);
+        assertEquals(TEST_COMMAND_NAME, handlerSubscription.name());
+        OptionalInt optionalLoadFactor = handlerSubscription.loadFactor();
+        assertTrue(optionalLoadFactor.isPresent());
+        assertEquals(TEST_LOAD_FACTOR, optionalLoadFactor.getAsInt());
+    }
+
+    @Test
+    void mapsGrpcBasedRemoveCommandChange() {
+        CommandSubscription commandSubscription = CommandSubscription.newBuilder()
+                                                                     .setName(TEST_COMMAND_NAME)
+                                                                     .setLoadFactor(TEST_LOAD_FACTOR)
+                                                                     .build();
+        io.axoniq.axonserver.grpc.control.TopologyChange grpcBasedChange =
+                io.axoniq.axonserver.grpc.control.TopologyChange.newBuilder()
+                                                                .setUpdateType(UpdateType.REMOVE_COMMAND_HANDLER)
+                                                                .setContext(TEST_CONTEXT)
+                                                                .setClientId(TEST_CLIENT_ID)
+                                                                .setClientStreamId(TEST_CLIENT_STREAM_ID)
+                                                                .setComponentName(TEST_COMPONENT_NAME)
+                                                                .setCommand(commandSubscription)
+                                                                .build();
+
+        TopologyChange testSubject = new TopologyChange(grpcBasedChange);
+
+        assertEquals(TopologyChange.Type.COMMAND_HANDLER_REMOVED, testSubject.type());
+        assertEquals(TEST_CONTEXT, testSubject.context());
+        assertEquals(TEST_CLIENT_ID, testSubject.clientId());
+        assertEquals(TEST_CLIENT_STREAM_ID, testSubject.clientStreamId());
+        assertEquals(TEST_COMPONENT_NAME, testSubject.componentName());
+        TopologyChange.HandlerSubscription handlerSubscription = testSubject.handler();
+        assertNotNull(handlerSubscription);
+        assertEquals(TEST_COMMAND_NAME, handlerSubscription.name());
+        OptionalInt optionalLoadFactor = handlerSubscription.loadFactor();
+        assertTrue(optionalLoadFactor.isPresent());
+        assertEquals(TEST_LOAD_FACTOR, optionalLoadFactor.getAsInt());
+    }
+
+    @Test
+    void mapsGrpcBasedAddQueryChange() {
+        QuerySubscription querySubscription = QuerySubscription.newBuilder()
+                                                               .setName(TEST_QUERY_NAME)
+                                                               .build();
+        io.axoniq.axonserver.grpc.control.TopologyChange grpcBasedChange =
+                io.axoniq.axonserver.grpc.control.TopologyChange.newBuilder()
+                                                                .setUpdateType(UpdateType.ADD_QUERY_HANDLER)
+                                                                .setContext(TEST_CONTEXT)
+                                                                .setClientId(TEST_CLIENT_ID)
+                                                                .setClientStreamId(TEST_CLIENT_STREAM_ID)
+                                                                .setComponentName(TEST_COMPONENT_NAME)
+                                                                .setQuery(querySubscription)
+                                                                .build();
+
+        TopologyChange testSubject = new TopologyChange(grpcBasedChange);
+
+        assertEquals(TopologyChange.Type.QUERY_HANDLER_ADDED, testSubject.type());
+        assertEquals(TEST_CONTEXT, testSubject.context());
+        assertEquals(TEST_CLIENT_ID, testSubject.clientId());
+        assertEquals(TEST_CLIENT_STREAM_ID, testSubject.clientStreamId());
+        assertEquals(TEST_COMPONENT_NAME, testSubject.componentName());
+        TopologyChange.HandlerSubscription handlerSubscription = testSubject.handler();
+        assertNotNull(handlerSubscription);
+        assertEquals(TEST_QUERY_NAME, handlerSubscription.name());
+        assertFalse(handlerSubscription.loadFactor().isPresent());
+    }
+
+    @Test
+    void mapsGrpcBasedRemoveQueryChange() {
+        QuerySubscription querySubscription = QuerySubscription.newBuilder()
+                                                               .setName(TEST_QUERY_NAME)
+                                                               .build();
+        io.axoniq.axonserver.grpc.control.TopologyChange grpcBasedChange =
+                io.axoniq.axonserver.grpc.control.TopologyChange.newBuilder()
+                                                                .setUpdateType(UpdateType.REMOVE_QUERY_HANDLER)
+                                                                .setContext(TEST_CONTEXT)
+                                                                .setClientId(TEST_CLIENT_ID)
+                                                                .setClientStreamId(TEST_CLIENT_STREAM_ID)
+                                                                .setComponentName(TEST_COMPONENT_NAME)
+                                                                .setQuery(querySubscription)
+                                                                .build();
+
+        TopologyChange testSubject = new TopologyChange(grpcBasedChange);
+
+        assertEquals(TopologyChange.Type.QUERY_HANDLER_REMOVED, testSubject.type());
+        assertEquals(TEST_CONTEXT, testSubject.context());
+        assertEquals(TEST_CLIENT_ID, testSubject.clientId());
+        assertEquals(TEST_CLIENT_STREAM_ID, testSubject.clientStreamId());
+        assertEquals(TEST_COMPONENT_NAME, testSubject.componentName());
+        TopologyChange.HandlerSubscription handlerSubscription = testSubject.handler();
+        assertNotNull(handlerSubscription);
+        assertEquals(TEST_QUERY_NAME, handlerSubscription.name());
+        assertFalse(handlerSubscription.loadFactor().isPresent());
+    }
+
+    @Test
+    void mapsGrpcBasedResetChange() {
+        io.axoniq.axonserver.grpc.control.TopologyChange grpcBasedChange =
+                io.axoniq.axonserver.grpc.control.TopologyChange.newBuilder()
+                                                                .setUpdateType(UpdateType.RESET_ALL)
+                                                                .setContext(TEST_CONTEXT)
+                                                                .setClientId(TEST_CLIENT_ID)
+                                                                .setClientStreamId(TEST_CLIENT_STREAM_ID)
+                                                                .setComponentName(TEST_COMPONENT_NAME)
+                                                                .build();
+
+
+        TopologyChange testSubject = new TopologyChange(grpcBasedChange);
+
+        assertEquals(TopologyChange.Type.RESET, testSubject.type());
+        assertEquals(TEST_CONTEXT, testSubject.context());
+        assertEquals(TEST_CLIENT_ID, testSubject.clientId());
+        assertEquals(TEST_CLIENT_STREAM_ID, testSubject.clientStreamId());
+        assertEquals(TEST_COMPONENT_NAME, testSubject.componentName());
+        assertNull(testSubject.handler());
+    }
+}

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/TopologyChangeTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/TopologyChangeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.axonserver.connector;
 
 import io.axoniq.axonserver.grpc.control.CommandSubscription;

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/AxonServerAutoConfiguration.java
@@ -17,11 +17,13 @@
 package org.axonframework.springboot.autoconfig;
 
 
+import io.axoniq.axonserver.connector.control.ControlChannel;
 import io.axoniq.axonserver.connector.event.PersistentStreamProperties;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ManagedChannelCustomizer;
 import org.axonframework.axonserver.connector.TargetContextResolver;
+import org.axonframework.axonserver.connector.TopologyChangeListener;
 import org.axonframework.axonserver.connector.command.CommandLoadFactorProvider;
 import org.axonframework.axonserver.connector.command.CommandPriorityCalculator;
 import org.axonframework.axonserver.connector.event.axon.AxonServerEventScheduler;
@@ -39,6 +41,7 @@ import org.axonframework.config.ConfigurerModule;
 import org.axonframework.config.EventProcessingConfiguration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
+import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.Message;
 import org.axonframework.queryhandling.LoggingQueryInvocationErrorHandler;
 import org.axonframework.queryhandling.QueryInvocationErrorHandler;
@@ -53,6 +56,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -65,6 +69,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.lang.Nullable;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nonnull;
 
@@ -365,6 +370,22 @@ public class AxonServerAutoConfiguration implements ApplicationContextAware {
                                                                );
                                                            })
         );
+    }
+
+    @Bean
+    @ConditionalOnBean
+    public ConfigurerModule topologyChangeListenerConfigurerModule(
+            AxonServerConnectionManager platformConnectionManager,
+            List<TopologyChangeListener> changeListeners
+    ) {
+        // ConditionalOnBean does not work for collections of beans, as it simply creates an empty collection.
+        if (changeListeners.isEmpty()) {
+            return configurer -> { /*Noop*/ };
+        }
+        return configurer -> configurer.onInitialize(config -> config.onStart(Phase.INSTRUCTION_COMPONENTS, () -> {
+            ControlChannel defaultControlChannel = platformConnectionManager.getConnection().controlChannel();
+            changeListeners.forEach(defaultControlChannel::registerTopologyChangeHandler);
+        }));
     }
 
     @Override

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.springboot.autoconfig;
 
 import io.axoniq.axonserver.connector.AxonServerConnection;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/autoconfig/TopologyChangeListenerAutoConfigurationTest.java
@@ -1,0 +1,99 @@
+package org.axonframework.springboot.autoconfig;
+
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.control.ControlChannel;
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
+import org.axonframework.axonserver.connector.AxonServerConnectionManager;
+import org.axonframework.axonserver.connector.TopologyChangeListener;
+import org.axonframework.springboot.utils.GrpcServerStub;
+import org.axonframework.springboot.utils.TcpUtils;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Autoconfiguration test class validating registration of the
+ * {@link org.axonframework.axonserver.connector.TopologyChangeListener} with the
+ * {@link io.axoniq.axonserver.connector.control.ControlChannel} for the default
+ * {@link AxonServerConfiguration#getContext() context}.
+ *
+ * @author Steven van Beelen
+ */
+class TopologyChangeListenerAutoConfigurationTest {
+
+    private ApplicationContextRunner testContext;
+
+    @BeforeEach
+    void setUp() {
+        testContext = new ApplicationContextRunner();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("axon.axonserver.servers", GrpcServerStub.DEFAULT_HOST + ":" + TcpUtils.findFreePort());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("axon.axonserver.servers");
+    }
+
+    @Test
+    void topologyChangeListenersAreInvokedForCommandHandlerRegistration() {
+        testContext.withUserConfiguration(TestContext.class).run(context -> {
+            TopologyChangeListener listenerOne = context.getBean("listenerOne", TopologyChangeListener.class);
+            TopologyChangeListener listenerTwo = context.getBean("listenerTwo", TopologyChangeListener.class);
+
+            ControlChannel mockedControlChannel = context.getBean("mockedControlChannel", ControlChannel.class);
+
+            verify(mockedControlChannel).registerTopologyChangeHandler(listenerOne);
+            verify(mockedControlChannel).registerTopologyChangeHandler(listenerTwo);
+        });
+    }
+
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    private static class TestContext {
+
+        @Bean
+        public ControlChannel mockedControlChannel() {
+            return mock(ControlChannel.class);
+        }
+
+        @Bean
+        @Primary
+        public AxonServerConnectionManager connectionManager(ControlChannel mockedControlChannel) {
+            AxonServerConnection mockedConnection = mock(AxonServerConnection.class);
+            when(mockedConnection.controlChannel()).thenReturn(mockedControlChannel);
+            AxonServerConnectionManager mockedManager = mock(AxonServerConnectionManager.class);
+            when(mockedManager.getConnection()).thenReturn(mockedConnection);
+            when(mockedManager.getConnection(any())).thenReturn(mockedConnection);
+            return mockedManager;
+        }
+
+        @Bean
+        public TopologyChangeListener listenerOne() {
+            return change -> {
+                // Unimportant - only exists to validate the change listener registration.
+            };
+        }
+
+        @Bean
+        public TopologyChangeListener listenerTwo() {
+            return change -> {
+                // Unimportant - only exists to validate the change listener registration.
+            };
+        }
+
+        @Bean(initMethod = "start", destroyMethod = "shutdown")
+        public GrpcServerStub grpcServerStub(@Value("${axon.axonserver.servers}") String servers) {
+            return new GrpcServerStub(Integer.parseInt(servers.split(":")[1]));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the `TopologyChangeListener` functional interface.

This functional interface extends the `Consumer<TopologyChange>`.
As such, it perfectly fits the new `ControlChannel#registerTopologyChangeHandler(Consumer<TopologyChange>)` method that was introduced in [this](https://github.com/AxonIQ/axonserver-connector-java/pull/435) Axon Server Connector for Java PR (version 2024.1.4).

Although the `TopologyChangeListener` functional interface is strictly not necessary, it does provide clear hook into Axon Framework's `Configurer` API for the `ServerConnectorConfigurerModule`.
Furthermore, it serves as a spot to have a comprehensive bit of JavaDoc to explain what the topology change listener is for and how to use it.

Lastly, I have introduced a `ConfigurerModule` in the Spring Boot autoconfiguration that will:

1. Gather all `TopologyChangeListener` beans.
2. Register all of them with the `ControlChannel` for the default context.