### PR TITLE
Style: Reformat query chain in lastSequenceNumberFor for better readability

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java
@@ -342,11 +342,12 @@ public class JpaEventStorageEngine extends BatchingEventStorageEngine {
 
     @Override
     public Optional<Long> lastSequenceNumberFor(@Nonnull String aggregateIdentifier) {
-        List<Long> results = entityManager().createQuery(
-                                                    "SELECT MAX(e.sequenceNumber) FROM " + domainEventEntryEntityName()
-                                                            + " e WHERE e.aggregateIdentifier = :aggregateId", Long.class)
-                                            .setParameter("aggregateId", aggregateIdentifier)
-                                            .getResultList();
+        List<Long> results = entityManager()
+                .createQuery(
+                        "SELECT MAX(e.sequenceNumber) FROM " + domainEventEntryEntityName()
+                                + " e WHERE e.aggregateIdentifier = :aggregateId", Long.class)
+                .setParameter("aggregateId", aggregateIdentifier)
+                .getResultList();
         if (results.isEmpty()) {
             return Optional.empty();
         }


### PR DESCRIPTION
### Summary

Reformatted the method call chain in `lastSequenceNumberFor` to improve readability and consistency with similar usages elsewhere in the codebase.

### Details

- Broke the method chain into multiple lines starting from `entityManager()` for better alignment and visual structure.
- This change aligns with the existing style observed in other parts of the project where `createQuery(...)` is placed on a new line when the method call is long.
- **File:**  
  `src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngine.java`

- **Method:**  
  `public Optional<Long> lastSequenceNumberFor(@Nonnull String aggregateIdentifier)`

No functional changes introduced. Purely formatting.

Let me know if a different style is preferred.
