### PR TITLE
Introduce FirstTrackingToken and LatestTrackingToken (#3552)

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
@@ -1,0 +1,64 @@
+package org.axonframework.eventhandling;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * A special {@link TrackingToken} that indicates the very beginning of an event stream.
+ * <p>
+ * Used to explicitly represent the first position in a stream instead of using {@code null}.
+ */
+public final class FirstTrackingToken implements TrackingToken {
+
+    public static final FirstTrackingToken INSTANCE = new FirstTrackingToken();
+    private FirstTrackingToken() {
+
+    }
+
+    /**
+     * This token is always considered the lower bound since it represents the very beginning.
+     */
+    @Override
+    public TrackingToken lowerBound(TrackingToken other) {
+        return this;
+    }
+
+    /**
+     * The furthest known position is assumed to be the other token, since this token is the earliest possible one.
+     */
+    @Override
+    public TrackingToken upperBound(TrackingToken other) {
+        return other;
+    }
+
+    /**
+     * This token does not cover any other tokens (except itself).
+     */
+    @Override
+    public boolean covers(TrackingToken other) {
+        return this.equals(other);
+    }
+
+    /**
+     * The estimated position of this token is always 0.
+     */
+    @Override
+    public OptionalLong position() {
+        return OptionalLong.of(0L);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof FirstTrackingToken;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash("FirstTrackingToken");
+    }
+
+    @Override
+    public String toString() {
+        return "FirstTrackingToken";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventhandling;
 
 import java.util.Objects;
@@ -8,7 +24,7 @@ import java.util.OptionalLong;
  * <p>
  * Used to explicitly represent the first position in a stream instead of using {@code null}.
  */
-public final class FirstTrackingToken implements TrackingToken {
+final class FirstTrackingToken implements TrackingToken {
 
     public static final FirstTrackingToken INSTANCE = new FirstTrackingToken();
     private FirstTrackingToken() {

--- a/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/FirstTrackingToken.java
@@ -23,6 +23,9 @@ import java.util.OptionalLong;
  * A special {@link TrackingToken} that indicates the very beginning of an event stream.
  * <p>
  * Used to explicitly represent the first position in a stream instead of using {@code null}.
+ *
+ * @author TeraSeo
+ * @since 5.0.0
  */
 final class FirstTrackingToken implements TrackingToken {
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
@@ -1,0 +1,67 @@
+package org.axonframework.eventhandling;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * A special {@link TrackingToken} that represents the latest (tail) position in an event stream.
+ * <p>
+ * This can be used to indicate that a processor wants to start at the newest available event,
+ * skipping historical events.
+ */
+public final class LatestTrackingToken implements TrackingToken {
+
+    public static final LatestTrackingToken INSTANCE = new LatestTrackingToken();
+    private LatestTrackingToken() {
+
+    }
+
+    /**
+     * The lower bound between this and another token is always the other,
+     * since this represents the furthest point.
+     */
+    @Override
+    public TrackingToken lowerBound(TrackingToken other) {
+        return other;
+    }
+
+    /**
+     * The upper bound is always this token, since it's the most recent.
+     */
+    @Override
+    public TrackingToken upperBound(TrackingToken other) {
+        return this;
+    }
+
+    /**
+     * This token covers all others because it represents the latest point in the stream.
+     */
+    @Override
+    public boolean covers(TrackingToken other) {
+        return true;
+    }
+
+    /**
+     * Optionally provides a relative position.
+     * Returning Long.MAX_VALUE makes it easier for comparison or progress tracking.
+     */
+    @Override
+    public OptionalLong position() {
+        return OptionalLong.of(Long.MAX_VALUE);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof LatestTrackingToken;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash("LatestTrackingToken");
+    }
+
+    @Override
+    public String toString() {
+        return "LatestTrackingToken";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.eventhandling;
 
 import java.util.Objects;
@@ -9,7 +25,7 @@ import java.util.OptionalLong;
  * This can be used to indicate that a processor wants to start at the newest available event,
  * skipping historical events.
  */
-public final class LatestTrackingToken implements TrackingToken {
+final class LatestTrackingToken implements TrackingToken {
 
     public static final LatestTrackingToken INSTANCE = new LatestTrackingToken();
     private LatestTrackingToken() {

--- a/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/LatestTrackingToken.java
@@ -24,6 +24,9 @@ import java.util.OptionalLong;
  * <p>
  * This can be used to indicate that a processor wants to start at the newest available event,
  * skipping historical events.
+ *
+ * @author TeraSeo
+ * @since 5.0.0
  */
 final class LatestTrackingToken implements TrackingToken {
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
@@ -26,6 +26,14 @@ import java.util.OptionalLong;
  */
 public interface TrackingToken {
 
+    static TrackingToken firstToken() {
+        return FirstTrackingToken.INSTANCE;
+    }
+
+    static TrackingToken latestToken() {
+        return LatestTrackingToken.INSTANCE;
+    }
+
     /**
      * Returns a token that represents the lower bound between this and the {@code other} token. Effectively, the
      * returned token will cause messages not received by both this and the {@code other} token to be redelivered.

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingToken.java
@@ -26,13 +26,20 @@ import java.util.OptionalLong;
  */
 public interface TrackingToken {
 
-    static TrackingToken firstToken() {
-        return FirstTrackingToken.INSTANCE;
-    }
+    /**
+     * A special {@link TrackingToken} that indicates the very beginning of an event stream.
+     * <p>
+     * Used to explicitly represent the first position in a stream instead of using {@code null}.
+     */
+    TrackingToken FIRST = FirstTrackingToken.INSTANCE;
 
-    static TrackingToken latestToken() {
-        return LatestTrackingToken.INSTANCE;
-    }
+    /**
+     * A special {@link TrackingToken} that represents the latest (tail) position in an event stream.
+     * <p>
+     * This can be used to indicate that a processor wants to start at the newest available event,
+     * skipping historical events.
+     */
+    TrackingToken LATEST = LatestTrackingToken.INSTANCE;
 
     /**
      * Returns a token that represents the lower bound between this and the {@code other} token. Effectively, the


### PR DESCRIPTION
- Introduced FirstTrackingToken to explicitly represent the start of a stream, replacing the use of null.
- Introduced LatestTrackingToken to represent the tail position of a stream.
- Both tokens implement TrackingToken and are exposed as static constants.
- Added static methods `TrackingToken.firstToken()` and `TrackingToken.latestToken()` for convenient access.