### PR TITLE
[#3102] Introduce `Message#payloadAs(Type, Converter)`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
@@ -18,15 +18,18 @@ package org.axonframework.axonserver.connector.query;
 
 import io.axoniq.axonserver.grpc.query.QueryRequest;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.axonserver.connector.util.GrpcMetaData;
 import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.axonframework.queryhandling.QueryMessage;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -99,6 +102,12 @@ public class GrpcBackedQueryMessage<P, R> implements QueryMessage<P, R> {
     @Override
     public P getPayload() {
         return serializedPayload.getObject();
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 
     @Override

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.axonserver.connector.query;
 
 import io.axoniq.axonserver.grpc.query.QueryResponse;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.util.GrpcMetaData;
 import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
@@ -25,10 +26,12 @@ import org.axonframework.messaging.IllegalPayloadAccessException;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.QueryResponseMessage;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -117,6 +120,12 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
             );
         }
         return serializedPayload == null ? null : serializedPayload.getObject();
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 
     @Override

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.axonserver.connector.query.subscription;
 
 import io.axoniq.axonserver.grpc.query.QueryUpdate;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.util.GrpcMetaData;
 import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
@@ -25,9 +26,11 @@ import org.axonframework.messaging.IllegalPayloadAccessException;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -117,6 +120,12 @@ class GrpcBackedQueryUpdateMessage<U> implements SubscriptionQueryUpdateMessage<
             );
         }
         return serializedPayload == null ? null : serializedPayload.getObject();
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 
     @Override

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.axonserver.connector.query.subscription;
 
 import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.axonserver.connector.query.GrpcBackedQueryMessage;
 import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
 import org.axonframework.messaging.MessageType;
@@ -25,9 +26,11 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryResult;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.LazyDeserializingObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -101,6 +104,12 @@ public class GrpcBackedSubscriptionQueryMessage<P, I, U> implements Subscription
     @Override
     public P getPayload() {
         return grpcBackedQueryMessage.getPayload();
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -21,11 +21,14 @@ import jakarta.annotation.Nullable;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedObjectHolder;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -190,6 +193,16 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     @Override
     public P getPayload() {
         return this.payload;
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        //noinspection unchecked,rawtypes
+        return type instanceof Class clazz && getPayloadType().isAssignableFrom(clazz)
+                ? (T) getPayload()
+                : Objects.requireNonNull(converter,
+                                         "Cannot convert payload to [" + type.getTypeName() + "] with null Converter.")
+                         .convert(getPayload(), type);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -18,10 +18,13 @@ package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -113,13 +116,79 @@ public interface Message<P> {
     MetaData getMetaData();
 
     /**
-     * Returns the payload of this {@code Message}.
+     * Returns the payload of this {@code Message} of generic type {@code P}.
      * <p>
      * The payload is the application-specific information.
      *
-     * @return The payload of this {@code Message}.
+     * @return The payload of this {@code Message} of generic type {@code P}.
      */
     P getPayload();
+
+    /**
+     * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
+     * <p>
+     * If {@link #getPayloadType()} is {@link Class#isAssignableFrom(Class) assignable from} the given {@code type},
+     * {@link #getPayload()} may be invoked instead of using the given {@code converter}.
+     * <p>
+     * Implementers of this operation may optimize by storing the converted payloads, thus saving a
+     * {@link Converter#convert(Object, Class)} invocation in the process. Only when this optimization is in place will
+     * a {@code null converter} result in a successful invocation of this method.
+     *
+     * @param type      The type to convert this {@code Message's} payload too.
+     * @param converter The converter to convert this {@code Message's} payload with.
+     * @param <T>       The generic type to convert this {@code Message's} payload too.
+     * @return The payload of this {@code Message}, converted to the given {@code type}.
+     * @throws NullPointerException When {@link Converter#convert(Object, Class) conversion} is mandatory but no
+     *                              {@code converter} is given.
+     */
+    default <T> T payloadAs(@Nonnull Class<T> type, @Nullable Converter converter) {
+        if (getPayloadType().isAssignableFrom(type)) {
+            return type.cast(getPayload());
+        }
+        return payloadAs(new TypeReference<>() {}, converter);
+    }
+
+    /**
+     * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
+     * <p>
+     * If {@link #getPayloadType()} is {@link Class#isAssignableFrom(Class) assignable from} the given
+     * {@link TypeReference#getType()}, {@link #getPayload()} may be invoked instead of using the given
+     * {@code converter}.
+     * <p>
+     * Implementers of this operation may optimize by storing the converted payloads, thus saving a
+     * {@link Converter#convert(Object, Class)} invocation in the process. Only when this optimization is in place will
+     * a {@code null converter} result in a successful invocation of this method.
+     *
+     * @param type      The type to convert this {@code Message's} payload too.
+     * @param converter The converter to convert this {@code Message's} payload with.
+     * @param <T>       The generic type to convert this {@code Message's} payload too.
+     * @return The payload of this {@code Message}, converted to the given {@code type}.
+     * @throws NullPointerException When {@link Converter#convert(Object, Class) conversion} is mandatory but no
+     *                              {@code converter} is given.
+     */
+    default <T> T payloadAs(@Nonnull TypeReference<T> type, @Nullable Converter converter) {
+        return payloadAs(type.getType(), converter);
+    }
+
+    /**
+     * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
+     * <p>
+     * If the given {@code type} is an instance of {@link Class} and {@link #getPayloadType()} is
+     * {@link Class#isAssignableFrom(Class) assignable from} that {@code Class}, {@link #getPayload()} may be invoked
+     * instead of using the given {@code converter}.
+     * <p>
+     * Implementers of this operation may optimize by storing the converted payloads, thus saving a
+     * {@link Converter#convert(Object, Class)} invocation in the process. Only when this optimization is in place will
+     * a {@code null converter} result in a successful invocation of this method.
+     *
+     * @param type      The type to convert this {@code Message's} payload too.
+     * @param converter The converter to convert this {@code Message's} payload with.
+     * @param <T>       The generic type to convert this {@code Message's} payload too.
+     * @return The payload of this {@code Message}, converted to the given {@code type}.
+     * @throws NullPointerException When {@link Converter#convert(Object, Class) conversion} is mandatory but no
+     *                              {@code converter} is given.
+     */
+    <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter);
 
     /**
      * Returns the type of the payload.

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -142,10 +142,7 @@ public interface Message<P> {
      *                              {@code converter} is given.
      */
     default <T> T payloadAs(@Nonnull Class<T> type, @Nullable Converter converter) {
-        if (getPayloadType().isAssignableFrom(type)) {
-            return type.cast(getPayload());
-        }
-        return payloadAs(new TypeReference<>() {}, converter);
+        return getPayloadType().isAssignableFrom(type) ? type.cast(getPayload()) : payloadAs((Type) type, converter);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -17,8 +17,12 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
+
+import java.lang.reflect.Type;
 
 /**
  * Abstract implementation of a {@link Message} that delegates to an existing message.
@@ -65,6 +69,11 @@ public abstract class MessageDecorator<P> implements Message<P> {
     @Override
     public P getPayload() {
         return delegate.getPayload();
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        return delegate.payloadAs(type, converter);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
@@ -17,13 +17,16 @@
 package org.axonframework.messaging.responsetypes;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.messaging.IllegalPayloadAccessException;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.queryhandling.QueryResponseMessage;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 
@@ -107,6 +110,18 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
             );
         }
         return expectedResponseType.convert(responseMessage.getPayload());
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        if (isExceptional()) {
+            throw new IllegalPayloadAccessException(
+                    "This result completed exceptionally, payload is not available. "
+                            + "Try calling 'exceptionResult' to see the cause of failure.",
+                    optionalExceptionResult().orElse(null)
+            );
+        }
+        return responseMessage.payloadAs(type, converter);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
@@ -17,10 +17,12 @@
 package org.axonframework.serialization;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.axonframework.messaging.AbstractMessage;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -97,6 +99,12 @@ public class SerializedMessage<P> extends AbstractMessage<P> {
         } catch (SerializationException e) {
             throw new SerializationException("Error while deserializing payload of message " + getIdentifier(), e);
         }
+    }
+
+    @Override
+    public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
+        // This class will be removed/replaced by the ConversionAwareMessage, so skipping implementation
+        return null;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.commandhandling;
 
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -30,9 +32,15 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Allard Buijze
  */
-class GenericCommandMessageTest {
+class GenericCommandMessageTest extends MessageTestSuite {
 
     private static final MessageType TEST_TYPE = new MessageType("command");
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(P payload) {
+        //noinspection unchecked
+        return (M) new GenericCommandMessage<>(new MessageType(payload.getClass()), payload);
+    }
 
     @Test
     void constructor() {

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling;
 
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -30,7 +32,13 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Allard Buijze
  */
-class GenericEventMessageTest {
+class GenericEventMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(P payload) {
+        //noinspection unchecked
+        return (M) new GenericEventMessage<>(new MessageType(payload.getClass()), payload);
+    }
 
     @Test
     void constructor() {

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling.replay;
 
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -30,10 +32,16 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Steven van Beelen
  */
-class GenericResetContextTest {
+class GenericResetContextTest extends MessageTestSuite {
 
     private static final MessageType TEST_TYPE = new MessageType("reset");
     private static final Object TEST_PAYLOAD = new Object();
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(P payload) {
+        //noinspection unchecked
+        return (M) new GenericResetContext<>(new MessageType(payload.getClass()), payload);
+    }
 
     @Test
     void constructor() {

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Rene de Waele
  */
-class GenericMessageTest {
+class GenericMessageTest extends MessageTestSuite {
 
     private final Map<String, String> correlationData = MetaData.from(Collections.singletonMap("foo", "bar"));
 
@@ -51,6 +51,12 @@ class GenericMessageTest {
         unitOfWork = mock(LegacyUnitOfWork.class);
         when(unitOfWork.getCorrelationData()).thenAnswer(invocation -> correlationData);
         CurrentUnitOfWork.set(unitOfWork);
+    }
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(P payload) {
+        //noinspection unchecked
+        return (M) new GenericMessage<>(new MessageType(payload.getClass()), payload);
     }
 
     @AfterEach

--- a/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+import org.axonframework.common.TypeReference;
+import org.axonframework.serialization.ChainingContentTypeConverter;
+import org.axonframework.serialization.Converter;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test suite to validate {@link Message} implementation.
+ *
+ * @author Steven van Beelen
+ */
+public abstract class MessageTestSuite {
+
+    private static final TypeReference<byte[]> BYTE_ARRAY_TYPE_REF = new TypeReference<>() {
+    };
+
+    /**
+     * Builds a {@link Message} used by this test suite.
+     *
+     * @param <P> The payload type for the {@link Message} implementation under test.
+     * @param <M> The {@link Message} implementation under test.
+     * @return a {@link Message} used by this test suite.
+     */
+    protected abstract <P, M extends Message<P>> M buildMessage(P payload);
+
+    @Test
+    void payloadAsWithClassAssignableFromPayloadTypeInvokesPayloadDirectly() {
+        String testPayload = "some-string-payload";
+        Converter testConverter = spy(new ChainingContentTypeConverter());
+
+        Message<String> testSubject = buildMessage(testPayload);
+
+        String result = testSubject.payloadAs(String.class, testConverter);
+
+        assertThat(testPayload).isEqualTo(result);
+        verifyNoInteractions(testConverter);
+    }
+
+    @Test
+    void payloadAsWithClassConvertsPayload() {
+        String testPayload = "some-string-payload";
+
+        Message<String> testSubject = buildMessage(testPayload);
+
+        byte[] result = testSubject.payloadAs(byte[].class, new ChainingContentTypeConverter());
+
+        assertThat(testPayload.getBytes()).isEqualTo(result);
+    }
+
+    @Test
+    void payloadAsWithClassThrowsNullPointerExceptionForNullConverter() {
+        Message<String> testSubject = buildMessage("some-string-payload");
+
+        assertThatThrownBy(() -> testSubject.payloadAs(byte[].class, null))
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void payloadAsWithTypeReferenceConvertsPayload() {
+        String testPayload = "some-string-payload";
+
+        Message<String> testSubject = buildMessage(testPayload);
+
+        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, new ChainingContentTypeConverter());
+
+        assertThat(testPayload.getBytes()).isEqualTo(result);
+    }
+
+    @Test
+    void payloadAsWithTypeReferenceThrowsNullPointerExceptionForNullConverter() {
+        Message<String> testSubject = buildMessage("some-string-payload");
+
+        assertThatThrownBy(() -> testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, null))
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void payloadAsWithTypeInstanceOfClassAndAssignableFromPayloadTypeInvokesPayloadDirectly() {
+        String testPayload = "some-string-payload";
+        Converter testConverter = spy(new ChainingContentTypeConverter());
+
+        Message<String> testSubject = buildMessage(testPayload);
+
+        String result = testSubject.payloadAs((Type) String.class, testConverter);
+
+        assertThat(testPayload).isEqualTo(result);
+        verifyNoInteractions(testConverter);
+    }
+
+    @Test
+    void payloadAsWithTypeConvertsPayload() {
+        String testPayload = "some-string-payload";
+
+        Message<String> testSubject = buildMessage(testPayload);
+
+        byte[] result = testSubject.payloadAs((Type) byte[].class, new ChainingContentTypeConverter());
+
+        assertThat(testPayload.getBytes()).isEqualTo(result);
+    }
+
+    @Test
+    void payloadAsWithTypeThrowsNullPointerExceptionForNullConverter() {
+        Message<String> testSubject = buildMessage("some-string-payload");
+
+        assertThatThrownBy(() -> testSubject.payloadAs((Type) byte[].class, null))
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
@@ -17,6 +17,8 @@
 package org.axonframework.queryhandling;
 
 import org.axonframework.messaging.GenericMessage;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.junit.jupiter.api.*;
@@ -31,7 +33,13 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Milan Savic
  */
-class GenericSubscriptionQueryUpdateMessageTest {
+class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(P payload) {
+        //noinspection unchecked
+        return (M) new GenericSubscriptionQueryUpdateMessage<>(new MessageType(payload.getClass()), payload);
+    }
 
     @Test
     void messageCreation() {


### PR DESCRIPTION
This pull request introduces a new way to retrieve the payload of a `Message` - with a `payloadAs` operation.
This method will users **and** allow Axon's infrastructure components to convert the payload upon retrieval from a `Message`.
The largest use case for this `payloadAs` operation I can currently imagine, is when an `EventProcessor` caters to a multitude of `EventHandlingComponents`, each with their own desired end-format for the event payload.
With the `payloadAs` operation, each `EventHandlingComponent` can simply request the format it requires, allowing the `EventProcessor` to pass along the `EventMessage<byte[]>` format it would receive from the Event Store.

We have introduced three versions of this method, being:

1. `Message#payloadAs(@Nonnull Class<T>, @Nullable Converter)`
2. `Message#payloadAs(@Nonnull TypeReference<T>, @Nullable Converter)`
3. `Message#payloadAs(@Nonnull Type, @Nullable Converter)`

The first version, the `Class<T>`-based solution, has a `default` implementation that invokes the `Type`-based solution by casting the given `Class` to a `Type`.
Furthermore, the this format will validate if the `Message#getPayloadType` is assignable from the given `Class`. If so, `Message#getPayload` will be invoked instead.

The second version, the `TypeReference<T>`-based solution, will invoke the `Type`-based` variant as well, with `TypeReference#getType`.
This second `default` implementation is mostly there to maintain the generic typing for the user, but still providing a means to request (e.g.) a `List<String>`.

The third `Type`-based variant is the one implemented by the `GenericMessage` right now, which (for at least this PR) forms the core of the process.
There are some other `Message` implementations that expected an implementation of `Message#payloadAs(Type, Converter)`, of which some simply delegate and others are not implemented **because** they will be removed in the near future.

On top of this PR, I will introduce a `ConversionAwareMessage`, which **will** override the `payloadAs(Type, Converter`) operation. This implementation will maintain the types it converted too, allowing down stream consumers of a `Message` to benefit from previous conversions.

Lastly, I have added a `MessageTestSuite` that validates all flows for the new `payloadAs` operation.
In a subsequent clean-up PR, I expect to add more validation to this test suite and add more concrete implementation of the test suite too (as numerous `Message` implementations are **not** tested at the moment).

This PR should be regarded as a part of #3102.