### PR TITLE
Rename `Message#getPayload` to `Message#payload`

### DIFF
--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -232,7 +232,8 @@ the long run.
 ### Message method renames
 
 We have renamed the "get-styled" getters **all** `Message` implementations by removing "get" from the signature.
-Thus, `Message#getIdentifier()` is now called `Message#identifier()`.
+Thus, `Message#getIdentifier()` is now called `Message#identifier()`, and `Message#getPayload()` is now called
+`Message#payload()`.
 
 ## Message Stream
 
@@ -1362,6 +1363,7 @@ This section contains four subsections, called:
 | `EventGateway#publish(List<?>)`                                                                                                 | `EventGateway#publish(ProcessingContext, List<?>)`                                                                     |
 | `SequencingPolicy#getSequenceIdentifierFor(Object)`                                                                             | `SequencingPolicy#getSequenceIdentifierFor(EventMessage<?>)`                                                           |
 | `Message#getIdentifier()`                                                                                                       | `Message#identifier()`                                                                                                 |
+| `Message#getPayload()`                                                                                                          | `Message#payload()`                                                                                                    |
 
 ### Removed Methods and Constructors
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerConnector.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/AxonServerConnector.java
@@ -110,7 +110,7 @@ public class AxonServerConnector implements Connector {
                        .build();
             }
         }
-        Object payload = command.getPayload();
+        Object payload = command.payload();
         return builder
                 .setMessageIdentifier(command.identifier())
                 .setName(command.type().name())
@@ -207,9 +207,9 @@ public class AxonServerConnector implements Connector {
                 logger.info(
                         "To share exceptional information with the recipient it is recommended to wrap the exception in a CommandExecutionException with provided details.");
             }
-        } else if (result.getPayload() != null) {
+        } else if (result.payload() != null) {
             responseBuilder.setPayload(SerializedObject.newBuilder()
-                                                       .setData(ByteString.copyFrom((byte[]) result.getPayload())));
+                                                       .setData(ByteString.copyFrom((byte[]) result.payload())));
         }
 
         return responseBuilder.build();

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
@@ -106,7 +106,7 @@ public class AggregateBasedAxonServerEventStorageEngine implements EventStorageE
         try {
             events.forEach(taggedEvent -> {
                 EventMessage<?> event = taggedEvent.event();
-                byte[] payload = payloadConverter.convert(event.getPayload(), byte[].class);
+                byte[] payload = payloadConverter.convert(event.payload(), byte[].class);
                 Event.Builder builder = Event.newBuilder()
                                              .setPayload(SerializedObject.newBuilder()
                                                                          .setData(ByteString.copyFrom(payload))

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AxonServerEventStorageEngine.java
@@ -66,7 +66,7 @@ public class AxonServerEventStorageEngine implements EventStorageEngine {
      * Constructs an {@code AxonServerEventStorageEngine} with the given {@code connection} and {@code converter}.
      *
      * @param connection The context-specific backing connection to Axon Server.
-     * @param converter  The converter to use to serialize {@link EventMessage#getPayload() payloads} and complex
+     * @param converter  The converter to use to serialize {@link EventMessage#payload() payloads} and complex
      *                   {@link org.axonframework.messaging.MetaData} values into bytes.
      */
     public AxonServerEventStorageEngine(@Nonnull AxonServerConnection connection,

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/EventConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/EventConverter.java
@@ -54,10 +54,10 @@ public class EventConverter implements DescribableComponent {
 
     /**
      * Constructs an {@code EventConverter} using the given {@code converter} to convert the
-     * {@link EventMessage#getPayload() event payload} and {@link EventMessage#getMetaData() metadata values}.
+     * {@link EventMessage#payload() event payload} and {@link EventMessage#getMetaData() metadata values}.
      *
      * @param converter The converter used to {@link Converter#convert(Object, Class)} the
-     *                  {@link EventMessage#getPayload()} and {@link EventMessage#getMetaData()} for the {@link Event}.
+     *                  {@link EventMessage#payload()} and {@link EventMessage#getMetaData()} for the {@link Event}.
      */
     public EventConverter(@Nonnull Converter converter) {
         this.converter = Objects.requireNonNull(converter, "The converter cannot be null.");
@@ -84,7 +84,7 @@ public class EventConverter implements DescribableComponent {
                     .setTimestamp(eventMessage.getTimestamp().toEpochMilli())
                     .setName(eventMessage.type().name())
                     .setVersion(eventMessage.type().version())
-                    .setPayload(convertPayload(eventMessage.getPayload()))
+                    .setPayload(convertPayload(eventMessage.payload()))
                     .putAllMetadata(convertMetaData(eventMessage.getMetaData()))
                     .build();
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactory.java
@@ -199,7 +199,7 @@ public class AxonServerEventStoreFactory {
         }
 
         /**
-         * Sets the {@link Serializer} used to de-/serialize the {@link EventMessage#getPayload() event payload} and
+         * Sets the {@link Serializer} used to de-/serialize the {@link EventMessage#payload() event payload} and
          * {@link EventMessage#getMetaData() meta data} with.
          * <p>
          * Defaults to a {@link XStreamSerializer}.
@@ -207,7 +207,7 @@ public class AxonServerEventStoreFactory {
          * This object is used by the Axon Server {@link AxonServerEventStore event store's} {@link LegacyEventStorageEngine}
          * implementation.
          *
-         * @param eventSerializer The serializer to de-/serialize the {@link EventMessage#getPayload() event payload}
+         * @param eventSerializer The serializer to de-/serialize the {@link EventMessage#payload() event payload}
          *                        and {@link EventMessage#getMetaData() meta data} with.
          * @return The current Builder instance, for fluent interfacing.
          */

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class EventBuffer implements TrackingEventStream {
         if (!disableIgnoredEventFiltering) {
             SerializedType serializedType;
             if (UnknownSerializedType.class.equals(ignoredMessage.getPayloadType())) {
-                UnknownSerializedType unknownSerializedType = (UnknownSerializedType) ignoredMessage.getPayload();
+                UnknownSerializedType unknownSerializedType = (UnknownSerializedType) ignoredMessage.payload();
                 serializedType = unknownSerializedType.serializedType();
             } else {
                 serializedType = serializer.typeForClass(ignoredMessage.getPayloadType());

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -392,7 +392,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
                     new MultipleInstancesResponseType<>(expectedResponseType);
             ConvertingResponseMessage<List<R>> convertingMessage =
                     new ConvertingResponseMessage<>(multiResponseType, responseMessage);
-            return Flux.fromStream(convertingMessage.getPayload()
+            return Flux.fromStream(convertingMessage.payload()
                                                     .stream()
                                                     .map(payload -> singleMessage(responseMessage,
                                                                                   payload,

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 /**
  * Wrapper that allows clients to access a gRPC {@link QueryRequest} as a {@link QueryMessage}.
  *
- * @param <P> A generic specifying the type of the {@link QueryMessage QueryMessage's} {@link #getPayload() payload}.
+ * @param <P> A generic specifying the type of the {@link QueryMessage QueryMessage's} {@link #payload() payload}.
  * @param <R> A generic specifying the expected {@link #getResponseType() response type} of the {@link QueryMessage}.
  * @author Marc Gathier
  * @since 4.0.0
@@ -100,7 +100,7 @@ public class GrpcBackedQueryMessage<P, R> implements QueryMessage<P, R> {
     }
 
     @Override
-    public P getPayload() {
+    public P payload() {
         return serializedPayload.getObject();
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
@@ -111,7 +111,7 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
     }
 
     @Override
-    public R getPayload() {
+    public R payload() {
         if (isExceptional()) {
             throw new IllegalPayloadAccessException(
                     "This result completed exceptionally, payload is not available. "

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/StreamableMultiInstanceResponse.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/StreamableMultiInstanceResponse.java
@@ -72,7 +72,7 @@ class StreamableMultiInstanceResponse<T> implements StreamableResponse {
         this.responseHandler = responseHandler;
         this.serializer = serializer;
         this.requestId = requestId;
-        List<T> payload = resultMessage.getPayload();
+        List<T> payload = resultMessage.payload();
         this.result = payload != null ? payload.iterator() : emptyIterator();
     }
 

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
@@ -111,7 +111,7 @@ class GrpcBackedQueryUpdateMessage<U> implements SubscriptionQueryUpdateMessage<
     }
 
     @Override
-    public U getPayload() {
+    public U payload() {
         if (isExceptional()) {
             throw new IllegalPayloadAccessException(
                     "This result completed exceptionally, payload is not available. "

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * {@link SubscriptionQueryMessage}.
  *
  * @param <P> A generic specifying the type of the {@link SubscriptionQueryMessage SubscriptionQueryMessage's}
- *            {@link #getPayload() payload}.
+ *            {@link #payload() payload}.
  * @param <I> A generic specifying the type of the {@link #getResponseType() initial result} of the
  *            {@link SubscriptionQueryResult}.
  * @param <U> A generic specifying the type of the {@link #getUpdateResponseType() subsequent updates} of the
@@ -102,8 +102,8 @@ public class GrpcBackedSubscriptionQueryMessage<P, I, U> implements Subscription
     }
 
     @Override
-    public P getPayload() {
-        return grpcBackedQueryMessage.getPayload();
+    public P payload() {
+        return grpcBackedQueryMessage.payload();
     }
 
     @Override

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventConverterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventConverterTest.java
@@ -185,7 +185,7 @@ class EventConverterTest {
         // then...
         assertEquals(EVENT_ID, result.identifier());
         assertEquals(EVENT_TYPE, result.type());
-        assertArrayEquals(eventPayloadByteArray, result.getPayload());
+        assertArrayEquals(eventPayloadByteArray, result.payload());
         assertEquals(EVENT_METADATA, result.getMetaData());
         assertEquals(EVENT_TIMESTAMP, result.getTimestamp().toEpochMilli());
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -137,7 +137,7 @@ class AxonServerEventStoreTest {
 
         List<String> received = new ArrayList<>();
         while (stream.hasNextAvailable(100, TimeUnit.MILLISECONDS)) {
-            received.add(stream.nextAvailable().getPayload().toString());
+            received.add(stream.nextAvailable().payload().toString());
         }
         stream.close();
 
@@ -182,12 +182,12 @@ class AxonServerEventStoreTest {
 
         DomainEventStream actual = testSubject.readEvents(AGGREGATE_ID);
         assertTrue(actual.hasNext());
-        assertEquals("Test1", actual.next().getPayload());
-        assertEquals("Test1", actual.next().getPayload());
-        assertEquals("Test2", actual.next().getPayload());
-        assertEquals("Test2", actual.next().getPayload());
-        assertEquals("Test3", actual.next().getPayload());
-        assertEquals("Test3", actual.next().getPayload());
+        assertEquals("Test1", actual.next().payload());
+        assertEquals("Test1", actual.next().payload());
+        assertEquals("Test2", actual.next().payload());
+        assertEquals("Test2", actual.next().payload());
+        assertEquals("Test3", actual.next().payload());
+        assertEquals("Test3", actual.next().payload());
         assertFalse(actual.hasNext());
     }
 
@@ -218,14 +218,14 @@ class AxonServerEventStoreTest {
         assertWithin(2, TimeUnit.SECONDS, () -> {
             DomainEventStream events = testSubject.readEvents(AGGREGATE_ID);
             assertTrue(events.hasNext());
-            assertEquals("Snapshot1", events.next().getPayload());
+            assertEquals("Snapshot1", events.next().payload());
         });
 
         DomainEventStream actual = testSubject.readEvents(AGGREGATE_ID);
         assertTrue(actual.hasNext());
-        assertEquals("Snapshot1", actual.next().getPayload());
-        assertEquals("Test3", actual.next().getPayload());
-        assertEquals("Test3", actual.next().getPayload());
+        assertEquals("Snapshot1", actual.next().payload());
+        assertEquals("Test3", actual.next().payload());
+        assertEquals("Test3", actual.next().payload());
         assertFalse(actual.hasNext());
     }
 
@@ -337,20 +337,20 @@ class AxonServerEventStoreTest {
         assertWithin(2, TimeUnit.SECONDS, () -> {
             DomainEventStream snapshotValidationStream = testSubject.readEvents(AGGREGATE_ID);
             assertTrue(snapshotValidationStream.hasNext());
-            assertEquals("Snapshot1", snapshotValidationStream.next().getPayload());
+            assertEquals("Snapshot1", snapshotValidationStream.next().payload());
         });
 
         DomainEventStream resultStream = testSubject.readEvents(AGGREGATE_ID);
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> resultSnapshot = resultStream.next();
-        assertEquals("Snapshot1", resultSnapshot.getPayload());
+        assertEquals("Snapshot1", resultSnapshot.payload());
         assertTrue(resultSnapshot.getMetaData().containsKey("key"));
         assertTrue(resultSnapshot.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> resultEvent = resultStream.next();
-        assertEquals("Test3", resultEvent.getPayload());
+        assertEquals("Test3", resultEvent.payload());
         assertTrue(resultEvent.getMetaData().containsKey("key"));
         assertTrue(resultEvent.getMetaData().containsValue("value"));
 
@@ -381,26 +381,26 @@ class AxonServerEventStoreTest {
         assertWithin(2, TimeUnit.SECONDS, () -> {
             DomainEventStream snapshotValidationStream = testSubject.readEvents(AGGREGATE_ID);
             assertTrue(snapshotValidationStream.hasNext());
-            assertEquals("Snapshot1", snapshotValidationStream.next().getPayload());
+            assertEquals("Snapshot1", snapshotValidationStream.next().payload());
         });
 
         DomainEventStream resultStream = testSubject.readEvents(AGGREGATE_ID, 0);
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> firstResultEvent = resultStream.next();
-        assertEquals("Test1", firstResultEvent.getPayload());
+        assertEquals("Test1", firstResultEvent.payload());
         assertTrue(firstResultEvent.getMetaData().containsKey("key"));
         assertTrue(firstResultEvent.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> secondResultEvent = resultStream.next();
-        assertEquals("Test2", secondResultEvent.getPayload());
+        assertEquals("Test2", secondResultEvent.payload());
         assertTrue(secondResultEvent.getMetaData().containsKey("key"));
         assertTrue(secondResultEvent.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> thirdResultEvent = resultStream.next();
-        assertEquals("Test3", thirdResultEvent.getPayload());
+        assertEquals("Test3", thirdResultEvent.payload());
         assertTrue(thirdResultEvent.getMetaData().containsKey("key"));
         assertTrue(thirdResultEvent.getMetaData().containsValue("value"));
 
@@ -444,26 +444,26 @@ class AxonServerEventStoreTest {
         assertWithin(2, TimeUnit.SECONDS, () -> {
             DomainEventStream snapshotValidationStream = testSubject.readEvents(AGGREGATE_ID);
             assertTrue(snapshotValidationStream.hasNext());
-            assertEquals("Snapshot1", snapshotValidationStream.next().getPayload());
+            assertEquals("Snapshot1", snapshotValidationStream.next().payload());
         });
 
         DomainEventStream resultStream = testSubject.readEvents(AGGREGATE_ID, -42);
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> firstResultEvent = resultStream.next();
-        assertEquals("Test1", firstResultEvent.getPayload());
+        assertEquals("Test1", firstResultEvent.payload());
         assertTrue(firstResultEvent.getMetaData().containsKey("key"));
         assertTrue(firstResultEvent.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> secondResultEvent = resultStream.next();
-        assertEquals("Test2", secondResultEvent.getPayload());
+        assertEquals("Test2", secondResultEvent.payload());
         assertTrue(secondResultEvent.getMetaData().containsKey("key"));
         assertTrue(secondResultEvent.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> thirdResultEvent = resultStream.next();
-        assertEquals("Test3", thirdResultEvent.getPayload());
+        assertEquals("Test3", thirdResultEvent.payload());
         assertTrue(thirdResultEvent.getMetaData().containsKey("key"));
         assertTrue(thirdResultEvent.getMetaData().containsValue("value"));
 
@@ -504,20 +504,20 @@ class AxonServerEventStoreTest {
         assertWithin(2, TimeUnit.SECONDS, () -> {
             DomainEventStream snapshotValidationStream = testSubject.readEvents(AGGREGATE_ID);
             assertTrue(snapshotValidationStream.hasNext());
-            assertEquals("Snapshot1", snapshotValidationStream.next().getPayload());
+            assertEquals("Snapshot1", snapshotValidationStream.next().payload());
         });
 
         DomainEventStream resultStream = testSubject.readEvents(AGGREGATE_ID);
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> firstResultEvent = resultStream.next();
-        assertEquals("Snapshot1", firstResultEvent.getPayload());
+        assertEquals("Snapshot1", firstResultEvent.payload());
         assertTrue(firstResultEvent.getMetaData().containsKey("key"));
         assertTrue(firstResultEvent.getMetaData().containsValue("value"));
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> thirdResultEvent = resultStream.next();
-        assertEquals("Test3", thirdResultEvent.getPayload());
+        assertEquals("Test3", thirdResultEvent.payload());
         assertTrue(thirdResultEvent.getMetaData().containsKey("key"));
         assertTrue(thirdResultEvent.getMetaData().containsValue("value"));
 
@@ -574,15 +574,15 @@ class AxonServerEventStoreTest {
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> firstResultEvent = resultStream.next();
-        assertEquals(testPayloadOne, firstResultEvent.getPayload());
+        assertEquals(testPayloadOne, firstResultEvent.payload());
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> secondResultEvent = resultStream.next();
-        assertEquals(testPayloadTwo, secondResultEvent.getPayload());
+        assertEquals(testPayloadTwo, secondResultEvent.payload());
 
         assertTrue(resultStream.hasNext());
         DomainEventMessage<?> thirdResultEvent = resultStream.next();
-        assertEquals(testPayloadThree, thirdResultEvent.getPayload());
+        assertEquals(testPayloadThree, thirdResultEvent.payload());
 
         assertFalse(resultStream.hasNext());
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -198,7 +198,7 @@ class AxonServerQueryBusTest {
                 new MessageType("query"), "Hello, World", instanceOf(String.class)
         );
 
-        assertEquals("test", testSubject.query(testQuery).get().getPayload());
+        assertEquals("test", testSubject.query(testQuery).get().payload());
 
         verify(targetContextResolver).resolveContext(testQuery);
         verify(localSegment, never()).query(testQuery);
@@ -267,7 +267,7 @@ class AxonServerQueryBusTest {
             ));
 
             StepVerifier.create(Flux.from(testSubject.streamingQuery(testStreamingQuery))
-                                    .map(Message::getPayload))
+                                    .map(Message::payload))
                         .expectNext("ok")
                         .verifyComplete();
 
@@ -455,7 +455,7 @@ class AxonServerQueryBusTest {
         when(mockQueryChannel.query(any())).thenReturn(stubResultStream);
 
         StepVerifier.create(Flux.from(testSubject.streamingQuery(testQuery))
-                                .map(Message::getPayload))
+                                .map(Message::payload))
                     .expectNext("1", "2", "3")
                     .verifyComplete();
 
@@ -481,7 +481,7 @@ class AxonServerQueryBusTest {
         when(mockQueryChannel.query(any())).thenReturn(new StubResultStream<>(new RuntimeException("oops")));
 
         StepVerifier.create(Flux.from(testSubject.streamingQuery(testQuery))
-                                .map(Message::getPayload))
+                                .map(Message::payload))
                     .verifyErrorMatches(t -> t instanceof RuntimeException && "oops".equals(t.getMessage()));
 
         verify(targetContextResolver).resolveContext(testQuery);
@@ -536,7 +536,7 @@ class AxonServerQueryBusTest {
     void dispatchInterceptor() {
         List<Object> results = new LinkedList<>();
         testSubject.registerDispatchInterceptor(messages -> (a, b) -> {
-            results.add(b.getPayload());
+            results.add(b.payload());
             return b;
         });
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
@@ -626,10 +626,10 @@ class AxonServerQueryBusTest {
         queryResult.cancel();
 
         StepVerifier.create(initialResult)
-                    .expectNextMatches(r -> r.getPayload().equals("Hello world"))
+                    .expectNextMatches(r -> r.payload().equals("Hello world"))
                     .verifyComplete();
 
-        StepVerifier.create(updates.map(Message::getPayload))
+        StepVerifier.create(updates.map(Message::payload))
                     .verifyError();
     }
 
@@ -651,10 +651,10 @@ class AxonServerQueryBusTest {
         Flux<SubscriptionQueryUpdateMessage<String>> updates = queryResult.updates();
         queryResult.cancel();
 
-        StepVerifier.create(initialResult.map(Message::getPayload))
+        StepVerifier.create(initialResult.map(Message::payload))
                     .verifyError();
 
-        StepVerifier.create(updates.map(Message::getPayload))
+        StepVerifier.create(updates.map(Message::payload))
                     .expectNextMatches(r -> r.equals("Hello world"))
                     .verifyComplete();
     }
@@ -855,8 +855,8 @@ class AxonServerQueryBusTest {
             QueryMessage<?, ?> message = i.getArgument(0);
             QueryResponseMessage<?> queryResponse = new GenericQueryResponseMessage<>(
                     new MessageType("query"),
-                    message.getPayload(),
-                    MetaData.with("response", message.getPayload().toString())
+                    message.payload(),
+                    MetaData.with("response", message.payload().toString())
             );
             return CompletableFuture.completedFuture(queryResponse);
         });

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessageTest.java
@@ -105,7 +105,7 @@ class GrpcBackedQueryMessageTest {
     }
 
     @Test
-    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
+    void payloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryRequest() {
         TestQuery expectedQuery = TEST_QUERY;
         QueryMessage<TestQuery, String> testQueryMessage =
                 new GenericQueryMessage<>(new MessageType("query"), expectedQuery, RESPONSE_TYPE);
@@ -114,7 +114,7 @@ class GrpcBackedQueryMessageTest {
         GrpcBackedQueryMessage<TestQuery, String> testSubject =
                 new GrpcBackedQueryMessage<>(testQueryRequest, serializer, serializer);
 
-        assertEquals(expectedQuery, testSubject.getPayload());
+        assertEquals(expectedQuery, testSubject.payload());
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessageTest.java
@@ -69,7 +69,7 @@ class GrpcBackedResponseMessageTest {
     }
 
     @Test
-    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
+    void payloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryResponseMessage() {
         TestQueryResponse expectedQuery = TEST_QUERY_RESPONSE;
         QueryResponseMessage<TestQueryResponse> testQueryResponseMessage = asResponseMessage(expectedQuery);
         QueryResponse testQueryResponse =
@@ -77,7 +77,7 @@ class GrpcBackedResponseMessageTest {
         GrpcBackedResponseMessage<TestQueryResponse> testSubject =
                 new GrpcBackedResponseMessage<>(testQueryResponse, serializer);
 
-        assertEquals(expectedQuery, testSubject.getPayload());
+        assertEquals(expectedQuery, testSubject.payload());
     }
 
     @Test
@@ -91,7 +91,7 @@ class GrpcBackedResponseMessageTest {
         GrpcBackedResponseMessage<TestQueryResponse> testSubject =
                 new GrpcBackedResponseMessage<>(testQueryResponse, serializer);
 
-        assertThrows(IllegalPayloadAccessException.class, testSubject::getPayload);
+        assertThrows(IllegalPayloadAccessException.class, testSubject::payload);
     }
 
     @Test
@@ -200,14 +200,14 @@ class GrpcBackedResponseMessageTest {
         } else if (result instanceof ResultMessage) {
             ResultMessage<R> resultMessage = (ResultMessage<R>) result;
             return new GenericQueryResponseMessage<>(
-                    new MessageType(resultMessage.getPayload().getClass()),
-                    resultMessage.getPayload(),
+                    new MessageType(resultMessage.payload().getClass()),
+                    resultMessage.payload(),
                     resultMessage.getMetaData()
             );
         } else if (result instanceof Message) {
             Message<R> message = (Message<R>) result;
-            return new GenericQueryResponseMessage<>(new MessageType(message.getPayload().getClass()),
-                                                     message.getPayload(),
+            return new GenericQueryResponseMessage<>(new MessageType(message.payload().getClass()),
+                                                     message.payload(),
                                                      message.getMetaData());
         } else {
             return new GenericQueryResponseMessage<>(new MessageType(result.getClass()), (R) result);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QueryProcessingTaskIntegrationTest.java
@@ -410,7 +410,7 @@ class QueryProcessingTaskIntegrationTest {
         assertEquals(1, responseHandler.sent().size());
         String payload = querySerializer.deserializeResponse(responseHandler.sent().getFirst(),
                                                              instanceOf(String.class))
-                                        .getPayload();
+                                        .payload();
         assertEquals("value", payload);
         assertTrue(responseHandler.completed());
     }
@@ -441,7 +441,7 @@ class QueryProcessingTaskIntegrationTest {
         assertTrue(responseHandler.completed());
         String firstPayload =
                 querySerializer.deserializeResponse(responseHandler.sent().getFirst(), instanceOf(String.class))
-                               .getPayload();
+                               .payload();
         assertTrue(firstPayload.startsWith("flux-"));
     }
 
@@ -762,13 +762,13 @@ class QueryProcessingTaskIntegrationTest {
         for (int i = 0; i < responses.size(); i++) {
             QueryResponseMessage<String> responseMessage =
                     querySerializer.deserializeResponse(responses.get(i), instanceOf(String.class));
-            assertEquals(i, Integer.parseInt(responseMessage.getPayload()));
+            assertEquals(i, Integer.parseInt(responseMessage.payload()));
         }
     }
 
     private void assertOrder(QueryResponse response) {
         List<String> responses = querySerializer.deserializeResponse(response, multipleInstancesOf(String.class))
-                                                .getPayload();
+                                                .payload();
         for (int i = 0; i < responses.size(); i++) {
             assertEquals(i, Integer.parseInt(responses.get(i)));
         }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/QuerySerializerTest.java
@@ -69,7 +69,7 @@ class QuerySerializerTest {
         assertEquals(message.identifier(), deserialized.identifier());
         assertEquals(message.getMetaData(), deserialized.getMetaData());
         assertTrue(message.getResponseType().matches(deserialized.getResponseType().responseMessagePayloadType()));
-        assertEquals(message.getPayload(), deserialized.getPayload());
+        assertEquals(message.payload(), deserialized.payload());
         assertEquals(message.getPayloadType(), deserialized.getPayloadType());
     }
 
@@ -89,7 +89,7 @@ class QuerySerializerTest {
         assertEquals(message.identifier(), deserialized.identifier());
         assertEquals(message.getMetaData(), deserialized.getMetaData());
         assertEquals(message.getPayloadType(), deserialized.getPayloadType());
-        assertEquals(message.getPayload(), deserialized.getPayload());
+        assertEquals(message.payload(), deserialized.payload());
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryEndToEndTest.java
@@ -237,10 +237,10 @@ class StreamingQueryEndToEndTest {
     private <R> Flux<R> streamingQueryPayloads(StreamingQueryMessage<?, R> query, boolean supportsStreaming) {
         if (supportsStreaming) {
             return Flux.from(senderQueryBus.streamingQuery(query))
-                       .map(Message::getPayload);
+                       .map(Message::payload);
         }
         return Flux.from(nonStreamingSenderQueryBus.streamingQuery(query))
-                   .map(Message::getPayload);
+                   .map(Message::payload);
     }
 
     private <R> R directQueryPayload(QueryMessage<?, R> query,
@@ -250,7 +250,7 @@ class StreamingQueryEndToEndTest {
             response = supportsStreaming
                     ? senderQueryBus.query(query).get()
                     : nonStreamingSenderQueryBus.query(query).get();
-            return response.getPayload();
+            return response.payload();
         } catch (IllegalPayloadAccessException e) {
             if (response != null && response.optionalExceptionResult().isPresent()) {
                 throw response.optionalExceptionResult().get();

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessageTest.java
@@ -71,7 +71,7 @@ class GrpcBackedQueryUpdateMessageTest {
     }
 
     @Test
-    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
+    void payloadReturnsAnIdenticalObjectAsInsertedThroughTheQueryUpdate() {
         TestQueryUpdate expectedQueryUpdate = TEST_QUERY_UPDATE;
         SubscriptionQueryUpdateMessage<Object> testSubscriptionQueryUpdateMessage =
                 asUpdateMessage(expectedQueryUpdate);
@@ -80,7 +80,7 @@ class GrpcBackedQueryUpdateMessageTest {
         GrpcBackedQueryUpdateMessage<TestQueryUpdate> testSubject =
                 new GrpcBackedQueryUpdateMessage<>(testQueryUpdate, serializer);
 
-        assertEquals(expectedQueryUpdate, testSubject.getPayload());
+        assertEquals(expectedQueryUpdate, testSubject.payload());
     }
 
     @Test
@@ -104,7 +104,7 @@ class GrpcBackedQueryUpdateMessageTest {
         GrpcBackedQueryUpdateMessage<TestQueryUpdate> testSubject =
                 new GrpcBackedQueryUpdateMessage<>(testQueryUpdate, serializer);
 
-        assertThrows(IllegalPayloadAccessException.class, testSubject::getPayload);
+        assertThrows(IllegalPayloadAccessException.class, testSubject::payload);
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessageTest.java
@@ -141,7 +141,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
     }
 
     @Test
-    void getPayloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
+    void payloadReturnsAnIdenticalObjectAsInsertedThroughTheSubscriptionQuery() {
         TestQuery expectedQuery = TEST_QUERY;
         SubscriptionQueryMessage<TestQuery, String, String> testQuery = new GenericSubscriptionQueryMessage<>(
                 new MessageType("query"), expectedQuery, RESPONSE_TYPE, RESPONSE_TYPE
@@ -155,7 +155,7 @@ class GrpcBackedSubscriptionQueryMessageTest {
         GrpcBackedSubscriptionQueryMessage<TestQuery, String, String> testSubject =
                 new GrpcBackedSubscriptionQueryMessage<>(testSubscriptionQuery, serializer, serializer);
 
-        assertEquals(expectedQuery, testSubject.getPayload());
+        assertEquals(expectedQuery, testSubject.payload());
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/subscription/SubscriptionMessageSerializerTest.java
@@ -64,7 +64,7 @@ class SubscriptionMessageSerializerTest {
         QueryUpdate result = testSubject.serialize(message);
         SubscriptionQueryUpdateMessage<Object> deserialized = testSubject.deserialize(result);
         assertEquals(message.identifier(), deserialized.identifier());
-        assertEquals(message.getPayload(), deserialized.getPayload());
+        assertEquals(message.payload(), deserialized.payload());
         assertEquals(message.getPayloadType(), deserialized.getPayloadType());
         assertEquals(message.getMetaData(), deserialized.getMetaData());
     }

--- a/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
+++ b/config/src/test/java/org/axonframework/config/DefaultConfigurerTest.java
@@ -138,7 +138,7 @@ class DefaultConfigurerTest {
         config.start();
 
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertNotNull(config.repository(StubAggregate.class));
         assertEquals(LegacyEventSourcingRepository.class, config.repository(StubAggregate.class).getClass());
         assertEquals(2, config.getModules().size());
@@ -272,7 +272,7 @@ class DefaultConfigurerTest {
                                        .configureAggregate(
                                                defaultConfiguration(StubAggregate.class)
                                                        .configureCommandTargetResolver(
-                                                               c -> command -> command.getPayload().toString()
+                                                               c -> command -> command.payload().toString()
                                                        )
                                        )
                                        .registerEventUpcaster(c -> events -> {
@@ -331,7 +331,7 @@ class DefaultConfigurerTest {
 
         config.start();
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertNotNull(config.repository(StubAggregate.class));
         assertEquals(2, config.getModules().size());
         assertExpectedModules(config, AggregateConfiguration.class, AxonIQConsoleModule.class);
@@ -357,7 +357,7 @@ class DefaultConfigurerTest {
 
         config.start();
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertNotNull(config.repository(StubAggregate.class));
         assertTrue(config.getModules().stream().anyMatch(m -> m instanceof AggregateConfiguration));
 
@@ -409,7 +409,7 @@ class DefaultConfigurerTest {
 
         config.start();
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertNotNull(config.repository(StubAggregate.class));
         assertEquals(2, config.getModules().size());
         assertExpectedModules(config, AggregateConfiguration.class, AxonIQConsoleModule.class);
@@ -436,7 +436,7 @@ class DefaultConfigurerTest {
         config.start();
 
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertEquals(1, defaultMonitor.getMessages().size());
         assertEquals(1, commandBusMonitor.getMessages().size());
     }
@@ -480,7 +480,7 @@ class DefaultConfigurerTest {
         config.start();
 
         var result = config.commandBus().dispatch(TEST_COMMAND, null);
-        assertEquals("test", result.get().getPayload());
+        assertEquals("test", result.get().payload());
         assertNotNull(config.repository(StubAggregate.class));
         assertEquals(LegacyCachingEventSourcingRepository.class, config.repository(StubAggregate.class).getClass());
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractAggregateFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AbstractAggregateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public abstract class AbstractAggregateFactory<T> implements AggregateFactory<T>
     @SuppressWarnings("unchecked")
     private Optional<T> fromSnapshot(DomainEventMessage<?> firstEvent) {
         if (aggregateModel.types().anyMatch(firstEvent.getPayloadType()::equals)) {
-            return (Optional<T>) Optional.of(firstEvent.getPayload());
+            return (Optional<T>) Optional.of(firstEvent.payload());
         }
         return Optional.empty();
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnnotationBasedTagResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AnnotationBasedTagResolver.java
@@ -76,7 +76,7 @@ public class AnnotationBasedTagResolver implements TagResolver {
     @Override
     public Set<Tag> resolve(@Nonnull EventMessage<?> event) {
         Objects.requireNonNull(event, "Event cannot be null");
-        var payload = event.getPayload();
+        var payload = event.payload();
         return Stream.concat(resolveFieldTags(payload), resolveMethodTags(payload))
                      .collect(Collectors.toSet());
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/PayloadBasedTagResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/PayloadBasedTagResolver.java
@@ -96,9 +96,9 @@ public class PayloadBasedTagResolver<P> implements TagResolver {
     @Override
     public Set<Tag> resolve(@Nonnull EventMessage<?> event) {
         //noinspection unchecked - suppressing cast warning
-        return payloadType.isAssignableFrom(event.getPayload().getClass())
+        return payloadType.isAssignableFrom(event.payload().getClass())
                 ? resolvers.stream()
-                           .map(resolver -> resolver.apply((P) event.getPayload()))
+                           .map(resolver -> resolver.apply((P) event.payload()))
                            .collect(Collectors.toSet())
                 : Set.of();
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -234,7 +234,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                     nextSequence,
                     event.identifier(),
                     event.type(),
-                    event.getPayload(),
+                    event.payload(),
                     event.getMetaData(),
                     event.getTimestamp()
             );

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/AggregateSnapshotterTest.java
@@ -69,7 +69,7 @@ public class AggregateSnapshotterTest {
         DomainEventMessage<?> snapshot =
                 testSubject.createSnapshot(StubAggregate.class, aggregateIdentifier, eventStream);
         verify(mockAggregateFactory).createAggregateRoot(aggregateIdentifier, firstEvent);
-        assertSame(aggregate, snapshot.getPayload());
+        assertSame(aggregate, snapshot.payload());
     }
 
     @Test
@@ -86,11 +86,11 @@ public class AggregateSnapshotterTest {
         DomainEventStream eventStream = DomainEventStream.of(first, second);
 
         when(mockAggregateFactory.createAggregateRoot(any(), any(DomainEventMessage.class)))
-                .thenAnswer(invocation -> ((DomainEventMessage<?>) invocation.getArguments()[1]).getPayload());
+                .thenAnswer(invocation -> ((DomainEventMessage<?>) invocation.getArguments()[1]).payload());
 
         DomainEventMessage<?> snapshot =
                 testSubject.createSnapshot(StubAggregate.class, aggregateIdentifier.toString(), eventStream);
-        assertSame(aggregate, snapshot.getPayload(), "Snapshotter did not recognize the aggregate snapshot");
+        assertSame(aggregate, snapshot.payload(), "Snapshotter did not recognize the aggregate snapshot");
 
         verify(mockAggregateFactory).createAggregateRoot(any(), any(DomainEventMessage.class));
     }
@@ -141,10 +141,10 @@ public class AggregateSnapshotterTest {
         protected void handle(EventMessage<?> event) {
             identifier = ((DomainEventMessage<?>) event).getAggregateIdentifier();
             // See Issue #
-            if ("Mock contents".equals(event.getPayload().toString())) {
+            if ("Mock contents".equals(event.payload().toString())) {
                 apply("Another");
             }
-            if ("deleted".equals(event.getPayload().toString())) {
+            if ("deleted".equals(event.payload().toString())) {
                 markDeleted();
             }
         }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingRepositoryWithNestedUnitOfWorkTest.java
@@ -293,7 +293,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
                                        e.getPayloadType().getSimpleName(), //
                                        e.getAggregateIdentifier(), //
                                        e.identifier(), //
-                                       e.getPayload());
+                                       e.payload());
             events.add(str);
             return null;
         }
@@ -382,7 +382,7 @@ class CachingRepositoryWithNestedUnitOfWorkTest {
 
         @Override
         public Object handleSync(@Nonnull EventMessage<?> event, @Nonnull ProcessingContext context) {
-            Object payload = event.getPayload();
+            Object payload = event.payload();
 
             if (previousToken == null && payload instanceof AggregateCreatedEvent) {
                 AggregateCreatedEvent created = (AggregateCreatedEvent) payload;

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -66,7 +66,7 @@ class EventSourcingRepositoryTest {
 
         factory = (id, event, ctx) -> {
             if (event != null) {
-                return id + "(" + event.getPayload() + ")";
+                return id + "(" + event.payload() + ")";
             }
             return id + "()";
         };
@@ -76,7 +76,7 @@ class EventSourcingRepositoryTest {
                 eventStore,
                 (id, event, context) -> factory.create(id, event, context),
                 (identifier, ctx) -> TEST_CRITERIA,
-                (entity, event, context) -> entity + "-" + event.getPayload()
+                (entity, event, context) -> entity + "-" + event.payload()
         );
     }
 
@@ -211,7 +211,7 @@ class EventSourcingRepositoryTest {
         ProcessingContext processingContext = new StubProcessingContext();
         factory = (id, event, ctx) -> {
             if (event != null) {
-                return id + "(" + event.getPayload() + ")";
+                return id + "(" + event.payload() + ")";
             }
             return null; // Simulating a null entity creation
         };

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/FilteringEventStorageEngineTest.java
@@ -37,7 +37,7 @@ class FilteringEventStorageEngineTest {
 
     @BeforeEach
     void setUp() {
-        Predicate<EventMessage<?>> filter = m -> m.getPayload().toString().contains("accept");
+        Predicate<EventMessage<?>> filter = m -> m.payload().toString().contains("accept");
         mockStorage = mock(LegacyEventStorageEngine.class);
         testSubject = new LegacyFilteringEventStorageEngine(mockStorage, filter);
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/LegacyEventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/LegacyEventSourcingRepositoryTest.java
@@ -116,7 +116,7 @@ class LegacyEventSourcingRepositoryTest {
 
         verify(mockEventStore, times(1)).publish((EventMessage) any());
         assertEquals(1, aggregate.invoke(TestAggregate::getLiveEvents).size());
-        assertSame(event3, aggregate.invoke(TestAggregate::getLiveEvents).get(0).getPayload());
+        assertSame(event3, aggregate.invoke(TestAggregate::getLiveEvents).get(0).payload());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/SpawningNewAggregateTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/SpawningNewAggregateTest.java
@@ -117,8 +117,8 @@ class SpawningNewAggregateTest {
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
 
         verify(eventStore, times(2)).publish(eventCaptor.capture());
-        assertEquals(new Aggregate2CreatedEvent("aggregate2Id"), eventCaptor.getAllValues().get(0).getPayload());
-        assertEquals(new Aggregate1CreatedEvent("id"), eventCaptor.getAllValues().get(1).getPayload());
+        assertEquals(new Aggregate2CreatedEvent("aggregate2Id"), eventCaptor.getAllValues().get(0).payload());
+        assertEquals(new Aggregate1CreatedEvent("id"), eventCaptor.getAllValues().get(1).payload());
     }
 
     @MockitoSettings(strictness = Strictness.LENIENT)

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AbstractEventStorageEngineTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractEventStorageEngineTest<E extends AbstractLegacyEve
             DomainEventMessage<?> event1 = iterator.next(), event2 = iterator.next();
             assertEquals(event1.getAggregateIdentifier(), event2.getAggregateIdentifier());
             assertEquals(event1.getSequenceNumber(), event2.getSequenceNumber());
-            assertEquals(event1.getPayload(), event2.getPayload());
+            assertEquals(event1.payload(), event2.payload());
             assertEquals(event1.getMetaData(), event2.getMetaData());
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -339,8 +339,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         MessageStream<EventMessage<?>> result = testSubject.source(testCondition);
         // then...
         StepVerifier.create(result.asFlux())
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
                     .assertNext(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
                     .verifyComplete();
         assertEquals(expected, actual);
@@ -372,10 +372,10 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
 
         // then...
         StepVerifier.create(source.asFlux())
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
-                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().getPayload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
+                    .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payload()))
                     .assertNext(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
                     .verifyComplete();
         assertEquals(expected, actual);
@@ -554,7 +554,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     }
 
     private void assertEvent(EventMessage<?> actual, EventMessage<?> expected) {
-        assertEquals(expected.getPayload(), convertPayload(actual).getPayload());
+        assertEquals(expected.payload(), convertPayload(actual).payload());
         assertEquals(expected.identifier(), actual.identifier());
         assertEquals(expected.getTimestamp().toEpochMilli(), actual.getTimestamp().toEpochMilli());
         assertEquals(expected.getMetaData(), actual.getMetaData());
@@ -580,7 +580,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
 
     private @Nonnull Predicate<Entry<EventMessage<?>>> entryWithAggregateEvent(String expectedPayload,
                                                                                int expectedSequence) {
-        return e -> expectedPayload.equals(convertPayload(e.message()).getPayload())
+        return e -> expectedPayload.equals(convertPayload(e.message()).payload())
                 && TEST_AGGREGATE_ID.equals(e.getResource(LegacyResources.AGGREGATE_IDENTIFIER_KEY))
                 && e.getResource(LegacyResources.AGGREGATE_SEQUENCE_NUMBER_KEY) == expectedSequence
                 && TEST_AGGREGATE_TYPE.equals(e.getResource(LegacyResources.AGGREGATE_TYPE_KEY));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConcatenatingDomainEventStreamTest.java
@@ -95,15 +95,15 @@ class ConcatenatingDomainEventStreamTest {
                                                                       DomainEventStream.of(event3, event4));
 
         assertTrue(concat.hasNext());
-        assertSame(event1.getPayload(), concat.next().getPayload());
-        assertSame(event2.getPayload(), concat.next().getPayload());
+        assertSame(event1.payload(), concat.next().payload());
+        assertSame(event2.payload(), concat.next().payload());
 
-        assertSame(event3.getPayload(), concat.peek().getPayload());
+        assertSame(event3.payload(), concat.peek().payload());
 
-        assertSame(event3.getPayload(), concat.next().getPayload());
+        assertSame(event3.payload(), concat.next().payload());
 
-        assertSame(event4.getPayload(), concat.peek().getPayload());
-        assertSame(event4.getPayload(), concat.next().getPayload());
+        assertSame(event4.payload(), concat.peek().payload());
+        assertSame(event4.payload(), concat.next().payload());
         assertFalse(concat.hasNext());
     }
 
@@ -114,11 +114,11 @@ class ConcatenatingDomainEventStreamTest {
                                                                       DomainEventStream.of(event3, event4));
 
         assertTrue(concat.hasNext());
-        assertSame(event1.getPayload(), concat.next().getPayload());
-        assertSame(event1.getPayload(), concat.next().getPayload());
-        assertSame(event2.getPayload(), concat.next().getPayload());
-        assertSame(event3.getPayload(), concat.next().getPayload());
-        assertSame(event4.getPayload(), concat.next().getPayload());
+        assertSame(event1.payload(), concat.next().payload());
+        assertSame(event1.payload(), concat.next().payload());
+        assertSame(event2.payload(), concat.next().payload());
+        assertSame(event3.payload(), concat.next().payload());
+        assertSame(event4.payload(), concat.next().payload());
         assertFalse(concat.hasNext());
     }
 
@@ -132,11 +132,11 @@ class ConcatenatingDomainEventStreamTest {
 
         assertTrue(concat.hasNext());
 
-        assertSame(event1.getPayload(), concat.next().getPayload());
-        assertSame(event2.getPayload(), concat.next().getPayload());
-        assertSame(event3.getPayload(), concat.next().getPayload());
-        assertSame(event4.getPayload(), concat.next().getPayload());
-        assertSame(event5.getPayload(), concat.next().getPayload());
+        assertSame(event1.payload(), concat.next().payload());
+        assertSame(event2.payload(), concat.next().payload());
+        assertSame(event3.payload(), concat.next().payload());
+        assertSame(event4.payload(), concat.next().payload());
+        assertSame(event5.payload(), concat.next().payload());
 
         assertFalse(concat.hasNext());
 
@@ -151,10 +151,10 @@ class ConcatenatingDomainEventStreamTest {
 
         assertTrue(concat.hasNext());
 
-        assertSame(event1.getPayload(), concat.next().getPayload());
-        assertSame(event3.getPayload(), concat.next().getPayload());
-        assertSame(event4.getPayload(), concat.next().getPayload());
-        assertSame(event5.getPayload(), concat.next().getPayload());
+        assertSame(event1.payload(), concat.next().payload());
+        assertSame(event3.payload(), concat.next().payload());
+        assertSame(event4.payload(), concat.next().payload());
+        assertSame(event5.payload(), concat.next().payload());
 
         assertFalse(concat.hasNext());
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -388,7 +388,7 @@ class DefaultEventStoreTransactionTest {
 
     private static void assertEvent(EventMessage<?> actual, EventMessage<?> expected) {
         assertEquals(expected.identifier(), actual.identifier());
-        assertEquals(expected.getPayload(), actual.getPayload());
+        assertEquals(expected.payload(), actual.payload());
         assertEquals(expected.getTimestamp(), actual.getTimestamp());
         assertEquals(expected.getMetaData(), actual.getMetaData());
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EmbeddedEventStoreTest.java
@@ -135,7 +135,7 @@ public abstract class EmbeddedEventStoreTest {
         assertTrue(stream.hasNextAvailable());
         TrackedEventMessage<?> actual = stream.nextAvailable();
         assertEquals(expected.identifier(), actual.identifier());
-        assertEquals(expected.getPayload(), actual.getPayload());
+        assertEquals(expected.payload(), actual.payload());
         assertTrue(actual instanceof DomainEventMessage<?>);
         assertEquals(expected.getAggregateIdentifier(), ((DomainEventMessage<?>) actual).getAggregateIdentifier());
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -92,7 +92,7 @@ public abstract class EventStorageEngineTest {
         Optional<? extends TrackedEventMessage<?>> optionalFirst = testSubject.readEvents(null, false).findFirst();
         assertTrue(optionalFirst.isPresent());
         EventMessage<?> message = optionalFirst.get();
-        assertEquals("application event", message.getPayload());
+        assertEquals("application event", message.payload());
         assertEquals(MetaData.with("key", "value"), message.getMetaData());
     }
 
@@ -105,12 +105,12 @@ public abstract class EventStorageEngineTest {
         DomainEventMessage<?> altered = messageWithMetaData.withMetaData(singletonMap("key2", "value"));
         DomainEventMessage<?> combined = messageWithMetaData.andMetaData(singletonMap("key2", "value"));
         assertTrue(altered.getMetaData().containsKey("key2"));
-        altered.getPayload();
+        altered.payload();
         assertFalse(altered.getMetaData().containsKey("key"));
         assertTrue(altered.getMetaData().containsKey("key2"));
         assertTrue(combined.getMetaData().containsKey("key"));
         assertTrue(combined.getMetaData().containsKey("key2"));
-        assertNotNull(messageWithMetaData.getPayload());
+        assertNotNull(messageWithMetaData.payload());
         assertNotNull(messageWithMetaData.getMetaData());
         assertFalse(messageWithMetaData.getMetaData().isEmpty());
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GenericTaggedEventMessageTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GenericTaggedEventMessageTest.java
@@ -50,7 +50,7 @@ class GenericTaggedEventMessageTest {
     @Test
     void containsExpectedData() {
         assertEquals(TEST_EVENT.identifier(), testSubject.event().identifier());
-        assertEquals(TEST_EVENT.getPayload(), testSubject.event().getPayload());
+        assertEquals(TEST_EVENT.payload(), testSubject.event().payload());
         assertEquals(TEST_META_DATA, testSubject.event().getMetaData());
         assertEquals(TEST_EVENT.getTimestamp(), testSubject.event().getTimestamp());
         assertEquals(TEST_TAGS, testSubject.tags());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SequenceEventStorageEngineTest.java
@@ -311,19 +311,19 @@ class SequenceEventStorageEngineTest {
 
         Stream<? extends TrackedEventMessage<?>> stream = testSubject.readEvents(null, true);
         TrackedEventMessage<?> firstEvent = stream.findFirst().orElseThrow(IllegalStateException::new);
-        assertEquals("test1", firstEvent.getPayload());
+        assertEquals("test1", firstEvent.payload());
 
         Stream<? extends TrackedEventMessage<?>> stream2 = testSubject.readEvents(firstEvent.trackingToken(), true);
         List<TrackedEventMessage<?>> secondBatch = stream2.collect(toList());
         assertEquals(2, secondBatch.size());
-        assertEquals("test2", secondBatch.get(0).getPayload());
-        assertEquals("test3", secondBatch.get(1).getPayload());
+        assertEquals("test2", secondBatch.get(0).payload());
+        assertEquals("test3", secondBatch.get(1).payload());
 
         Stream<? extends TrackedEventMessage<?>> stream3 =
                 testSubject.readEvents(secondBatch.get(0).trackingToken(), true);
         List<TrackedEventMessage<?>> thirdBatch = stream3.collect(toList());
         assertEquals(1, thirdBatch.size());
-        assertEquals("test3", thirdBatch.get(0).getPayload());
+        assertEquals("test3", thirdBatch.get(0).payload());
 
         Stream<? extends TrackedEventMessage<?>> stream4 =
                 testSubject.readEvents(secondBatch.get(1).trackingToken(), true);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
@@ -428,13 +428,13 @@ public abstract class StorageEngineTestSuite<ESE extends EventStorageEngine> {
                 "event-3",
                 stream.next()
                       .map(e -> {
-                          if (e.message().getPayload() instanceof String payload) {
+                          if (e.message().payload() instanceof String payload) {
                               return payload;
-                          } else if (e.message().getPayload() instanceof byte[] payload) {
+                          } else if (e.message().payload() instanceof byte[] payload) {
                               return new String(payload, StandardCharsets.UTF_8);
                           } else {
                               throw new AssertionError(
-                                      "Unexpected payload type: " + e.message().getPayload().getClass()
+                                      "Unexpected payload type: " + e.message().payload().getClass()
                               );
                           }
                       })
@@ -635,12 +635,12 @@ public abstract class StorageEngineTestSuite<ESE extends EventStorageEngine> {
 
     private static void assertEvent(EventMessage<?> actual,
                                     EventMessage<String> expected) {
-        if (actual.getPayload() instanceof byte[] actualPayload) {
-            assertEquals(expected.getPayload(), new String(actualPayload, StandardCharsets.UTF_8));
-        } else if (actual.getPayload() instanceof String actualPayload) {
-            assertEquals(expected.getPayload(), actualPayload);
+        if (actual.payload() instanceof byte[] actualPayload) {
+            assertEquals(expected.payload(), new String(actualPayload, StandardCharsets.UTF_8));
+        } else if (actual.payload() instanceof String actualPayload) {
+            assertEquals(expected.payload(), actualPayload);
         } else {
-            throw new AssertionError("Unexpected payload type: " + actual.getPayload().getClass());
+            throw new AssertionError("Unexpected payload type: " + actual.payload().getClass());
         }
         assertEquals(expected.identifier(), actual.identifier());
         assertEquals(expected.getTimestamp().toEpochMilli(), actual.getTimestamp().toEpochMilli());

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineTest.java
@@ -229,8 +229,8 @@ class JdbcEventStorageEngineTest
                                  createDomainEvent(AGGREGATE, 4, expectedPayloadTwo));
 
         List<String> eventStorageEngineResult = testSubject.readEvents(null, false)
-                                                           .filter(m -> m.getPayload() instanceof String)
-                                                           .map(m -> (String) m.getPayload())
+                                                           .filter(m -> m.payload() instanceof String)
+                                                           .map(m -> (String) m.payload())
                                                            .collect(toList());
         assertEquals(Arrays.asList(expectedPayloadOne, expectedPayloadTwo), eventStorageEngineResult);
 
@@ -238,8 +238,8 @@ class JdbcEventStorageEngineTest
         assertTrue(eventStoreResult.hasNextAvailable());
         assertEquals(UnknownSerializedType.class, eventStoreResult.nextAvailable().getPayloadType());
         assertEquals(UnknownSerializedType.class, eventStoreResult.nextAvailable().getPayloadType());
-        assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().getPayload());
-        assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().getPayload());
+        assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().payload());
+        assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().payload());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaEventStorageEngineTest.java
@@ -241,8 +241,8 @@ class JpaEventStorageEngineTest
         entityManager.clear();
 
         assertFalse(entityManager.createQuery("SELECT e FROM CustomDomainEventEntry e").getResultList().isEmpty());
-        assertEquals("Snapshot1", testSubject.readSnapshot(AGGREGATE).get().getPayload());
-        assertEquals("Payload1", testSubject.readEvents(AGGREGATE).peek().getPayload());
+        assertEquals("Snapshot1", testSubject.readSnapshot(AGGREGATE).get().payload());
+        assertEquals("Payload1", testSubject.readEvents(AGGREGATE).peek().payload());
     }
 
     @Test
@@ -262,8 +262,8 @@ class JpaEventStorageEngineTest
                 createDomainEvent(AGGREGATE, 4, expectedPayloadTwo));
 
         List<String> eventStorageEngineResult = testSubject.readEvents(null, false)
-                .filter(m -> m.getPayload() instanceof String)
-                .map(m -> (String) m.getPayload())
+                .filter(m -> m.payload() instanceof String)
+                .map(m -> (String) m.payload())
                 .collect(toList());
         assertEquals(Arrays.asList(expectedPayloadOne, expectedPayloadTwo), eventStorageEngineResult);
 
@@ -272,8 +272,8 @@ class JpaEventStorageEngineTest
         assertTrue(eventStoreResult.hasNextAvailable());
         assertEquals(UnknownSerializedType.class, eventStoreResult.nextAvailable().getPayloadType());
         assertEquals(UnknownSerializedType.class, eventStoreResult.nextAvailable().getPayloadType());
-        assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().getPayload());
-        assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().getPayload());
+        assertEquals(expectedPayloadOne, eventStoreResult.nextAvailable().payload());
+        assertEquals(expectedPayloadTwo, eventStoreResult.nextAvailable().payload());
         assertFalse(eventStoreResult.hasNextAvailable());
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/MultiStreamableMessageSourceTest.java
@@ -80,7 +80,7 @@ class MultiStreamableMessageSourceTest {
                 testSubject.openStream(testSubject.createTailToken());
 
         assertTrue(singleEventStream.hasNextAvailable());
-        assertEquals(publishedEvent.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(publishedEvent.payload(), singleEventStream.nextAvailable().payload());
 
         singleEventStream.close();
     }
@@ -118,7 +118,7 @@ class MultiStreamableMessageSourceTest {
         assertTrue(singleEventStream.hasNextAvailable());
         TrackedEventMessage<?> actual = singleEventStream.nextAvailable();
 
-        assertEquals(publishedEvent.getPayload(), actual.getPayload());
+        assertEquals(publishedEvent.payload(), actual.payload());
         assertTrue(actual instanceof DomainEventMessage);
 
         singleEventStream.close();
@@ -133,7 +133,7 @@ class MultiStreamableMessageSourceTest {
         eventStoreA.publish(publishedEvent1);
 
         BlockingStream<TrackedEventMessage<?>> stream = testSubject.openStream(null);
-        assertEquals("Event1", stream.peek().map(Message::getPayload).map(Object::toString).orElse("None"));
+        assertEquals("Event1", stream.peek().map(Message::payload).map(Object::toString).orElse("None"));
         assertTrue(stream.hasNextAvailable());
         assertTrue(stream.hasNextAvailable(10, TimeUnit.SECONDS));
     }
@@ -153,7 +153,7 @@ class MultiStreamableMessageSourceTest {
         assertNotNull(actual);
         TrackedEventMessage<?> trackedEventMessage = actual.nextAvailable();
         assertEquals(message.identifier(), trackedEventMessage.identifier());
-        assertEquals(message.getPayload(), trackedEventMessage.getPayload());
+        assertEquals(message.payload(), trackedEventMessage.payload());
     }
 
     @Test
@@ -204,8 +204,8 @@ class MultiStreamableMessageSourceTest {
         assertTrue(singleEventStream.hasNextAvailable());
 
         //order published must be same as order consumed
-        assertEquals(pubToStreamA.getPayload(), singleEventStream.nextAvailable().getPayload());
-        assertEquals(pubToStreamB.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(pubToStreamA.payload(), singleEventStream.nextAvailable().payload());
+        assertEquals(pubToStreamB.payload(), singleEventStream.nextAvailable().payload());
         assertFalse(singleEventStream.hasNextAvailable());
 
         singleEventStream.close();
@@ -221,10 +221,10 @@ class MultiStreamableMessageSourceTest {
                 testSubject.openStream(testSubject.createTokenAt(recentTimeStamp()));
 
         assertTrue(singleEventStream.peek().isPresent());
-        assertEquals(publishedEvent.getPayload(), singleEventStream.peek().get().getPayload());
+        assertEquals(publishedEvent.payload(), singleEventStream.peek().get().payload());
 
         //message is still consumable
-        assertEquals(publishedEvent.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(publishedEvent.payload(), singleEventStream.nextAvailable().payload());
 
         singleEventStream.close();
     }
@@ -245,18 +245,18 @@ class MultiStreamableMessageSourceTest {
         assertTrue(singleEventStream.peek().isPresent());
         TrackedEventMessage<?> peekedMessageA = singleEventStream.peek().get();
         MultiSourceTrackingToken tokenA = (MultiSourceTrackingToken) peekedMessageA.trackingToken();
-        assertEquals(pubToStreamA.getPayload(), peekedMessageA.getPayload());
+        assertEquals(pubToStreamA.payload(), peekedMessageA.payload());
 
         //message is still consumable and consumed message equal to peeked
-        assertEquals(peekedMessageA.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(peekedMessageA.payload(), singleEventStream.nextAvailable().payload());
 
         //peek and consume another
         assertTrue(singleEventStream.peek().isPresent());
         TrackedEventMessage<?> peekedMessageB = singleEventStream.peek().get();
         MultiSourceTrackingToken tokenB = (MultiSourceTrackingToken) peekedMessageB.trackingToken();
-        assertEquals(pubToStreamB.getPayload(), peekedMessageB.getPayload());
+        assertEquals(pubToStreamB.payload(), peekedMessageB.payload());
 
-        assertEquals(peekedMessageB.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(peekedMessageB.payload(), singleEventStream.nextAvailable().payload());
 
         //consuming from second stream doesn't alter token from first stream
         assertEquals(tokenA.getTokenForStream("eventStoreA"), tokenB.getTokenForStream("eventStoreA"));
@@ -392,8 +392,8 @@ class MultiStreamableMessageSourceTest {
         singleEventStream.nextAvailable();
         singleEventStream.nextAvailable();
         singleEventStream.nextAvailable();
-        assertEquals(pubToStreamC.getPayload(), singleEventStream.nextAvailable().getPayload());
-        assertEquals(pubToStreamB.getPayload(), singleEventStream.nextAvailable().getPayload());
+        assertEquals(pubToStreamC.payload(), singleEventStream.nextAvailable().payload());
+        assertEquals(pubToStreamB.payload(), singleEventStream.nextAvailable().payload());
     }
 
     @SuppressWarnings({"unchecked", "resource"})

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/LoopBackWithInterwovenCommandsAndEventsTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/loopbacktest/synchronous/LoopBackWithInterwovenCommandsAndEventsTest.java
@@ -122,7 +122,7 @@ class LoopBackWithInterwovenCommandsAndEventsTest {
         assertEquals(expectedDescriptions(command), configuration.eventStore()
                                                                  .readEvents(aggregateIdentifier)
                                                                  .asStream()
-                                                                 .map(Message::getPayload)
+                                                                 .map(Message::payload)
                                                                  .map(MyEvent.class::cast)
                                                                  .map(MyEvent::getDescription)
                                                                  .collect(Collectors.toList()));

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlerInterceptorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlerInterceptorTest.java
@@ -95,11 +95,11 @@ class CommandHandlerInterceptorTest {
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
 
         verify(eventStore, times(3)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
         assertEquals(new AnyCommandInterceptedEvent(UpdateMyAggregateStateCommand.class.getName()),
-                     eventCaptor.getAllValues().get(1).getPayload());
+                     eventCaptor.getAllValues().get(1).payload());
         assertEquals(new MyAggregateStateUpdatedEvent("id", "state intercepted"),
-                     eventCaptor.getAllValues().get(2).getPayload());
+                     eventCaptor.getAllValues().get(2).payload());
 
         assertEquals("aggregateUpdateResult", result);
     }
@@ -118,10 +118,10 @@ class CommandHandlerInterceptorTest {
 
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
         verify(eventStore, times(3)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
         assertEquals(new AnyCommandInterceptedEvent(ClearMyAggregateStateCommand.class.getName()),
-                     eventCaptor.getAllValues().get(1).getPayload());
-        assertEquals(new MyAggregateStateClearedEvent("id"), eventCaptor.getAllValues().get(2).getPayload());
+                     eventCaptor.getAllValues().get(1).payload());
+        assertEquals(new MyAggregateStateClearedEvent("id"), eventCaptor.getAllValues().get(2).payload());
     }
 
     @SuppressWarnings("unchecked")
@@ -138,8 +138,8 @@ class CommandHandlerInterceptorTest {
 
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
         verify(eventStore, times(2)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
-        assertEquals(new MyAggregateStateNotClearedEvent("id"), eventCaptor.getAllValues().get(1).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
+        assertEquals(new MyAggregateStateNotClearedEvent("id"), eventCaptor.getAllValues().get(1).payload());
     }
 
     @SuppressWarnings("unchecked")
@@ -156,12 +156,12 @@ class CommandHandlerInterceptorTest {
 
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
         verify(eventStore, times(4)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
         assertEquals(new AnyCommandMatchingPatternInterceptedEvent(MyNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(1).getPayload());
+                     eventCaptor.getAllValues().get(1).payload());
         assertEquals(new AnyCommandInterceptedEvent(MyNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(2).getPayload());
-        assertEquals(new MyNestedEvent("id", "state intercepted"), eventCaptor.getAllValues().get(3).getPayload());
+                     eventCaptor.getAllValues().get(2).payload());
+        assertEquals(new MyNestedEvent("id", "state intercepted"), eventCaptor.getAllValues().get(3).payload());
     }
 
     @SuppressWarnings("unchecked")
@@ -178,17 +178,17 @@ class CommandHandlerInterceptorTest {
 
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
         verify(eventStore, times(6)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
         assertEquals(new AnyCommandMatchingPatternInterceptedEvent(MyNestedNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(1).getPayload());
+                     eventCaptor.getAllValues().get(1).payload());
         assertEquals(new AnyCommandInterceptedEvent(MyNestedNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(2).getPayload());
+                     eventCaptor.getAllValues().get(2).payload());
         assertEquals(new AnyCommandInterceptedEvent("StaticNestedNested" + MyNestedNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(3).getPayload());
+                     eventCaptor.getAllValues().get(3).payload());
         assertEquals(new AnyCommandInterceptedEvent("NestedNested" + MyNestedNestedCommand.class.getName()),
-                     eventCaptor.getAllValues().get(4).getPayload());
+                     eventCaptor.getAllValues().get(4).payload());
         assertEquals(new MyNestedNestedEvent("id", "state parent intercepted intercepted"),
-                     eventCaptor.getAllValues().get(5).getPayload());
+                     eventCaptor.getAllValues().get(5).payload());
     }
 
     @Test
@@ -220,7 +220,7 @@ class CommandHandlerInterceptorTest {
         assertThrows(InterceptorException.class, () -> commandGateway.sendAndWait(interceptorCommand));
         ArgumentCaptor<EventMessage<?>> eventCaptor = ArgumentCaptor.forClass(EventMessage.class);
         verify(eventStore, times(1)).publish(eventCaptor.capture());
-        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).getPayload());
+        assertEquals(new MyAggregateCreatedEvent("id"), eventCaptor.getAllValues().get(0).payload());
     }
 
     private record CreateMyAggregateCommand(String id) {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/AbstractPolymorphicAggregateAnnotationCommandHandlerTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/polymorphic/AbstractPolymorphicAggregateAnnotationCommandHandlerTestSuite.java
@@ -236,7 +236,7 @@ public abstract class AbstractPolymorphicAggregateAnnotationCommandHandlerTestSu
             AtomicReference<String> rv = new AtomicReference<>();
             repository.load(aggregateId).execute(a -> rv.set(a.getState()));
             return rv.get();
-        }).getPayload();
+        }).payload();
         assertEquals(expectedState, state);
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
@@ -138,11 +138,11 @@ public abstract class AbstractSubscriptionQueryTestSuite {
                                                                                   "Update12"));
 
 
-        StepVerifier.create(result1.initialResult().map(Message::getPayload))
+        StepVerifier.create(result1.initialResult().map(Message::payload))
                     .expectNext(Arrays.asList("Message1", "Message2", "Message3"))
                     .expectComplete()
                     .verify();
-        StepVerifier.create(result1.updates().map(Message::getPayload))
+        StepVerifier.create(result1.updates().map(Message::payload))
                     .expectNext("Update11")
                     .expectComplete()
                     .verify();
@@ -154,10 +154,10 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         chatQueryHandler.emitter.emit(Integer.class, m -> m == 5, 2);
 
 
-        StepVerifier.create(result2.initialResult().map(Message::getPayload))
+        StepVerifier.create(result2.initialResult().map(Message::payload))
                     .expectNext(0)
                     .verifyComplete();
-        StepVerifier.create(result2.updates().map(Message::getPayload))
+        StepVerifier.create(result2.updates().map(Message::payload))
                     .expectNext(1)
                     .verifyComplete();
     }
@@ -185,7 +185,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         chatQueryHandler.emitter.complete(String.class, TEST_PAYLOAD::equals);
 
         StepVerifier.create(result.updates())
-                    .expectNextMatches(m -> m.getPayload() == null)
+                    .expectNextMatches(m -> m.payload() == null)
                     .verifyComplete();
     }
 
@@ -213,7 +213,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         Flux<SubscriptionQueryUpdateMessage<String>> emittedUpdates = result.updates();
 
         List<String> updateList = new ArrayList<>();
-        emittedUpdates.map(Message::getPayload).subscribe(updateList::add);
+        emittedUpdates.map(Message::payload).subscribe(updateList::add);
         assertTrue(updateList.isEmpty());
 
         // Move the current UnitOfWork to the AFTER_COMMIT phase, triggering the emitter calls
@@ -242,10 +242,10 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         }, 500, TimeUnit.MILLISECONDS);
 
         // then
-        StepVerifier.create(result.initialResult().map(Message::getPayload))
+        StepVerifier.create(result.initialResult().map(Message::payload))
                     .expectNext(Arrays.asList("Message1", "Message2", "Message3"))
                     .verifyComplete();
-        StepVerifier.create(result.updates().map(Message::getPayload))
+        StepVerifier.create(result.updates().map(Message::payload))
                     .expectNext("Update1")
                     .expectErrorMatches(toBeThrown::equals)
                     .verify();
@@ -271,11 +271,11 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         List<String> query1Updates = new ArrayList<>();
         List<String> query2Updates = new ArrayList<>();
-        result1.updates().map(Message::getPayload).subscribe(query1Updates::add, t -> {
+        result1.updates().map(Message::payload).subscribe(query1Updates::add, t -> {
             query1Updates.add("Error1");
             throw (RuntimeException) t;
         });
-        result2.updates().map(Message::getPayload).subscribe(query2Updates::add, t -> query2Updates.add("Error2"));
+        result2.updates().map(Message::payload).subscribe(query2Updates::add, t -> query2Updates.add("Error2"));
 
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
         chatQueryHandler.emitter.completeExceptionally(String.class, TEST_PAYLOAD::equals, new RuntimeException());
@@ -310,7 +310,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         Flux<SubscriptionQueryUpdateMessage<String>> emittedUpdates = result.updates();
         List<String> updateList = new ArrayList<>();
-        emittedUpdates.map(Message::getPayload).subscribe(updateList::add);
+        emittedUpdates.map(Message::payload).subscribe(updateList::add);
         assertTrue(updateList.isEmpty());
 
         // Move the current UnitOfWork to the AFTER_COMMIT phase, triggering the emitter calls
@@ -318,7 +318,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         assertEquals(expectedUpdates, updateList);
         StepVerifier.create(emittedUpdates)
-                    .expectNextMatches(updateMessage -> updateMessage.getPayload().equals(testUpdate))
+                    .expectNextMatches(updateMessage -> updateMessage.payload().equals(testUpdate))
                     .verifyError(RuntimeException.class);
     }
 
@@ -340,10 +340,10 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         }, 500, TimeUnit.MILLISECONDS);
 
         // then
-        StepVerifier.create(result.initialResult().map(Message::getPayload))
+        StepVerifier.create(result.initialResult().map(Message::payload))
                     .expectNext(Arrays.asList("Message1", "Message2", "Message3"))
                     .verifyComplete();
-        StepVerifier.create(result.updates().map(Message::getPayload))
+        StepVerifier.create(result.updates().map(Message::payload))
                     .expectNext("Update1")
                     .verifyComplete();
     }
@@ -371,14 +371,14 @@ public abstract class AbstractSubscriptionQueryTestSuite {
 
         Flux<SubscriptionQueryUpdateMessage<String>> emittedUpdates = result.updates();
         List<String> updateList = new ArrayList<>();
-        emittedUpdates.map(Message::getPayload).subscribe(updateList::add);
+        emittedUpdates.map(Message::payload).subscribe(updateList::add);
         assertTrue(updateList.isEmpty());
 
         // Move the current UnitOfWork to the AFTER_COMMIT phase, triggering the emitter calls
         unitOfWork.commit();
         assertWithin(500, TimeUnit.MILLISECONDS, () -> assertEquals(expectedUpdates, updateList));
         StepVerifier.create(emittedUpdates)
-                    .expectNextMatches(updateMessage -> updateMessage.getPayload().equals(testUpdate))
+                    .expectNextMatches(updateMessage -> updateMessage.payload().equals(testUpdate))
                     .verifyComplete();
     }
 
@@ -395,12 +395,12 @@ public abstract class AbstractSubscriptionQueryTestSuite {
                 .subscriptionQuery(queryMessage);
 
         // then
-        StepVerifier.create(result.initialResult().map(Message::getPayload))
+        StepVerifier.create(result.initialResult().map(Message::payload))
                     .expectNext("Initial")
                     .expectComplete()
                     .verify();
 
-        StepVerifier.create(result.updates().map(Message::getPayload))
+        StepVerifier.create(result.updates().map(Message::payload))
                     .expectNext("Update1", "Update2")
                     .verifyComplete();
     }
@@ -444,15 +444,15 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         List<String> update1 = new ArrayList<>();
         List<String> update2 = new ArrayList<>();
         List<String> update3 = new ArrayList<>();
-        result.initialResult().map(Message::getPayload).subscribe(initial1::addAll);
-        result.initialResult().map(Message::getPayload).subscribe(initial2::addAll);
+        result.initialResult().map(Message::payload).subscribe(initial1::addAll);
+        result.initialResult().map(Message::payload).subscribe(initial2::addAll);
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
-        result.updates().map(Message::getPayload).subscribe(update1::add);
-        result.updates().map(Message::getPayload).subscribe(update2::add);
+        result.updates().map(Message::payload).subscribe(update1::add);
+        result.updates().map(Message::payload).subscribe(update2::add);
         for (int i = 2; i < 10; i++) {
             chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update" + i);
         }
-        result.updates().map(Message::getPayload).subscribe(update3::add);
+        result.updates().map(Message::payload).subscribe(update3::add);
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update10");
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update11");
         chatQueryHandler.emitter.complete(String.class, TEST_PAYLOAD::equals);
@@ -533,10 +533,10 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         LinkedList<SubscriptionQueryUpdateMessage<String>> recordedMessages = new LinkedList<>(elements);
 
         assert recordedMessages.peekFirst() != null;
-        boolean firstIs101 = recordedMessages.peekFirst().getPayload().equals("Update101");
+        boolean firstIs101 = recordedMessages.peekFirst().payload().equals("Update101");
 
         assert recordedMessages.peekLast() != null;
-        boolean lastIs200 = recordedMessages.peekLast().getPayload().equals("Update200");
+        boolean lastIs200 = recordedMessages.peekLast().payload().equals("Update200");
 
         return elements.size() == 100 && firstIs101 && lastIs200;
     }
@@ -582,7 +582,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         result.cancel();
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update2");
 
-        StepVerifier.create(result.updates().map(Message::getPayload))
+        StepVerifier.create(result.updates().map(Message::payload))
                     .expectNext("Update1")
                     .verifyComplete();
     }
@@ -610,7 +610,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
                 queryBus.subscriptionQuery(queryMessage);
 
         // then
-        StepVerifier.create(result.initialResult().map(Message::getPayload))
+        StepVerifier.create(result.initialResult().map(Message::payload))
                     .expectNext(interceptedResponse)
                     .verifyComplete();
     }
@@ -675,11 +675,11 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         List<String> updates = new ArrayList<>();
         CountDownLatch latch = new CountDownLatch(3);
         queryBus.subscriptionQuery(queryMessage).handle(initial -> {
-                                                            initialResult.add(initial.getPayload());
+                                                            initialResult.add(initial.payload());
                                                             latch.countDown();
                                                         },
                                                         update -> {
-                                                            updates.add(update.getPayload());
+                                                            updates.add(update.payload());
                                                             latch.countDown();
                                                         });
 
@@ -703,12 +703,12 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         List<String> updates = new ArrayList<>();
         CountDownLatch latch = new CountDownLatch(3);
         queryBus.subscriptionQuery(queryMessage).handle(initial -> {
-                                                            initialResult.add(initial.getPayload());
+                                                            initialResult.add(initial.payload());
                                                             latch.countDown();
                                                             throw new IllegalStateException("oops");
                                                         },
                                                         update -> {
-                                                            updates.add(update.getPayload());
+                                                            updates.add(update.payload());
                                                             latch.countDown();
                                                         });
 
@@ -730,9 +730,9 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         List<String> initialResult = new ArrayList<>();
         List<String> updates = new ArrayList<>();
         queryBus.subscriptionQuery(queryMessage, 1)
-                .handle(initial -> initialResult.addAll(initial.getPayload()),
+                .handle(initial -> initialResult.addAll(initial.payload()),
                         update -> {
-                            updates.add(update.getPayload());
+                            updates.add(update.payload());
                             throw new IllegalStateException("oops");
                         });
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
@@ -760,10 +760,10 @@ public abstract class AbstractSubscriptionQueryTestSuite {
                 .handle(initial -> {
                             // make sure the update is emitted before subscribing to updates
                             chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
-                            initialResult.addAll(initial.getPayload());
+                            initialResult.addAll(initial.payload());
                         },
                         update -> {
-                            updates.add(update.getPayload());
+                            updates.add(update.payload());
                             throw new IllegalStateException("oops");
                         });
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update2");
@@ -786,8 +786,8 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         // when
         List<String> initialResult = new ArrayList<>();
         List<String> updates = new ArrayList<>();
-        queryBus.subscriptionQuery(queryMessage).handle(initial -> initialResult.add(initial.getPayload()),
-                                                        update -> updates.add(update.getPayload()));
+        queryBus.subscriptionQuery(queryMessage).handle(initial -> initialResult.add(initial.payload()),
+                                                        update -> updates.add(update.payload()));
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update2");
         chatQueryHandler.emitter.complete(String.class, TEST_PAYLOAD::equals);
@@ -809,7 +809,7 @@ public abstract class AbstractSubscriptionQueryTestSuite {
         List<String> initialResult = new ArrayList<>();
         List<String> updates = new ArrayList<>();
         queryBus.subscriptionQuery(queryMessage)
-                .handle(initial -> initialResult.add(initial.getPayload()), update -> updates.add(update.getPayload()));
+                .handle(initial -> initialResult.add(initial.payload()), update -> updates.add(update.payload()));
         chatQueryHandler.emitter.completeExceptionally(String.class, TEST_PAYLOAD::equals, new RuntimeException());
         chatQueryHandler.emitter.emit(String.class, TEST_PAYLOAD::equals, "Update1");
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
@@ -147,7 +147,7 @@ class QueryThreadingIntegrationTest {
                                                                                ResponseTypes.instanceOf(String.class));
             QueryResponseMessage<String> b = queryBus.query(testQuery).get();
             waitingQueries.decrementAndGet();
-            return "a" + b.getPayload();
+            return "a" + b.payload();
         });
 
         CompletableFuture<QueryResponseMessage<String>> query1 = queryBus.query(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/ImmutableBuilderEntityModelAdministrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/ImmutableBuilderEntityModelAdministrationTest.java
@@ -38,7 +38,6 @@ import org.axonframework.integrationtests.testsuite.administration.state.immutab
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutablePerson;
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutableSalaryInformation;
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutableTask;
-import org.axonframework.messaging.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageTypeResolver;
 import org.axonframework.modelling.AnnotationBasedEntityEvolvingComponent;
@@ -49,7 +48,6 @@ import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.entity.child.ChildEntityFieldDefinition;
 import org.axonframework.modelling.entity.child.EntityChildMetamodel;
 import org.axonframework.serialization.Converter;
-import org.axonframework.serialization.PassThroughConverter;
 
 import java.util.Objects;
 
@@ -73,7 +71,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((CompleteTaskCommand) command.getPayload(), eventAppender);
+                                            entity.handle((CompleteTaskCommand) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -86,7 +84,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((GiveRaise) command.getPayload(), eventAppender);
+                                            entity.handle((GiveRaise) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -99,7 +97,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                           ((command, context) -> {
                                               EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                      configuration);
-                                              ImmutableEmployee.handle((CreateEmployee) command.getPayload(),
+                                              ImmutableEmployee.handle((CreateEmployee) command.payload(),
                                                                        eventAppender);
                                               return MessageStream.empty().cast();
                                           }))
@@ -107,7 +105,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                         ((command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((AssignTaskCommand) command.getPayload(), eventAppender);
+                                            entity.handle((AssignTaskCommand) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         }))
                 .addChild(EntityChildMetamodel
@@ -116,7 +114,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                           ImmutableEmployee::getTaskList, ImmutableEmployee::evolveTaskList
                                   ))
                                   .commandTargetResolver((candidates, commandMessage, ctx) -> {
-                                      if (commandMessage.getPayload() instanceof CompleteTaskCommand completeTaskCommand) {
+                                      if (commandMessage.payload() instanceof CompleteTaskCommand completeTaskCommand) {
                                           return candidates.stream()
                                                            .filter(task -> task.getTaskId()
                                                                                .equals(completeTaskCommand.taskId()))
@@ -127,7 +125,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                   })
                                   .eventTargetMatcher((o, eventMessage, ctx) -> {
                                       if(eventMessage.type().name().equals(TaskCompleted.class.getName())) {
-                                          TaskCompleted taskCompleted = converter.convert(eventMessage.getPayload(), TaskCompleted.class);
+                                          TaskCompleted taskCompleted = converter.convert(eventMessage.payload(), TaskCompleted.class);
                                           Objects.requireNonNull(taskCompleted, "TaskCompleted event payload cannot be null");
                                           return o.getTaskId().equals(taskCompleted.taskId());
                                       }
@@ -154,7 +152,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                           ((command, context) -> {
                                               EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                      configuration);
-                                              ImmutableCustomer.handle((CreateCustomer) command.getPayload(),
+                                              ImmutableCustomer.handle((CreateCustomer) command.payload(),
                                                                        eventAppender);
                                               return MessageStream.empty().cast();
                                           }))
@@ -169,7 +167,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((ChangeEmailAddress) command.getPayload(), eventAppender);
+                                            entity.handle((ChangeEmailAddress) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -184,12 +182,12 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                 .entityFactory(c -> EventSourcedEntityFactory.fromEventMessage((identifier, eventMessage) -> {
                     Converter converter = c.getComponent(Converter.class);
                     if(eventMessage.type().name().equals(EmployeeCreated.class.getName())) {
-                        var employeeCreated = converter.convert(eventMessage.getPayload(), EmployeeCreated.class);
+                        var employeeCreated = converter.convert(eventMessage.payload(), EmployeeCreated.class);
                         Objects.requireNonNull(employeeCreated, "EmployeeCreated event payload cannot be null");
                         return new ImmutableEmployee(employeeCreated);
                     }
                     if(eventMessage.type().name().equals(CustomerCreated.class.getName())) {
-                        var customerCreated = converter.convert(eventMessage.getPayload(), CustomerCreated.class);
+                        var customerCreated = converter.convert(eventMessage.payload(), CustomerCreated.class);
                         Objects.requireNonNull(customerCreated, "CustomerCreated event payload cannot be null");
                         return new ImmutableCustomer(customerCreated);
                     }
@@ -198,7 +196,7 @@ public class ImmutableBuilderEntityModelAdministrationTest extends AbstractAdmin
                 }))
                 .criteriaResolver(c -> (s, ctx) -> EventCriteria.havingTags("Person", s.key()))
                 .entityIdResolver(config -> (message, context) -> {
-                    if(message.getPayload() instanceof PersonCommand personCommand) {
+                    if(message.payload() instanceof PersonCommand personCommand) {
                         return personCommand.identifier();
                     }
                     throw new IllegalArgumentException(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/MutableBuilderEntityModelAdministrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/MutableBuilderEntityModelAdministrationTest.java
@@ -71,7 +71,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((CompleteTaskCommand) command.getPayload(), eventAppender);
+                                            entity.handle((CompleteTaskCommand) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -84,7 +84,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((GiveRaise) command.getPayload(), eventAppender);
+                                            entity.handle((GiveRaise) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -97,14 +97,14 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                         ((command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((CreateEmployee) command.getPayload(), eventAppender);
+                                            entity.handle((CreateEmployee) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         }))
                 .instanceCommandHandler(typeResolver.resolveOrThrow(AssignTaskCommand.class).qualifiedName(),
                                         ((command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((AssignTaskCommand) command.getPayload(), eventAppender);
+                                            entity.handle((AssignTaskCommand) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         }))
                 .addChild(EntityChildMetamodel
@@ -113,7 +113,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                           MutableEmployee::getTaskList, MutableEmployee::setTaskList
                                   ))
                                   .commandTargetResolver((candidates, commandMessage, ctx) -> {
-                                      if (commandMessage.getPayload() instanceof CompleteTaskCommand completeTaskCommand) {
+                                      if (commandMessage.payload() instanceof CompleteTaskCommand completeTaskCommand) {
                                           return candidates.stream()
                                                            .filter(task -> task.getTaskId()
                                                                                .equals(completeTaskCommand.taskId()))
@@ -124,7 +124,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                   })
                                   .eventTargetMatcher((o, eventMessage, ctx) -> {
                                      if(eventMessage.type().name().equals(TaskCompleted.class.getName())) {
-                                         TaskCompleted taskCompleted = converter.convert(eventMessage.getPayload(), TaskCompleted.class);
+                                         TaskCompleted taskCompleted = converter.convert(eventMessage.payload(), TaskCompleted.class);
                                          Objects.requireNonNull(taskCompleted, "TaskCompleted event payload cannot be null");
                                          return o.getTaskId().equals(taskCompleted.taskId());
                                       }
@@ -150,7 +150,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                         typeResolver.resolveOrThrow(CreateCustomer.class).qualifiedName(),
                         ((command, entity, context) -> {
                             EventAppender eventAppender = EventAppender.forContext(context, configuration);
-                            entity.handle((CreateCustomer) command.getPayload(), eventAppender);
+                            entity.handle((CreateCustomer) command.payload(), eventAppender);
                             return MessageStream.empty().cast();
                         }))
                 .build();
@@ -165,7 +165,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                                         (command, entity, context) -> {
                                             EventAppender eventAppender = EventAppender.forContext(context,
                                                                                                    configuration);
-                                            entity.handle((ChangeEmailAddress) command.getPayload(), eventAppender);
+                                            entity.handle((ChangeEmailAddress) command.payload(), eventAppender);
                                             return MessageStream.empty().cast();
                                         })
                 .build();
@@ -186,7 +186,7 @@ public class MutableBuilderEntityModelAdministrationTest extends AbstractAdminis
                 }))
                 .criteriaResolver(c -> (s, ctx) -> EventCriteria.havingTags("Person", s.key()))
                 .entityIdResolver(config -> (message, context) -> {
-                    if (message.getPayload() instanceof PersonCommand personCommand) {
+                    if (message.payload() instanceof PersonCommand personCommand) {
                         return personCommand.identifier();
                     }
                     throw new IllegalArgumentException(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/AbstractStudentTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/AbstractStudentTestSuite.java
@@ -177,7 +177,7 @@ public abstract class AbstractStudentTestSuite {
             if(event.type().name().equals(StudentEnrolledEvent.class.getName())) {
                 // Convert the payload to the expected type
                 Converter converter = config.getComponent(Converter.class);
-                StudentEnrolledEvent convert = converter.convert(event.getPayload(), StudentEnrolledEvent.class);
+                StudentEnrolledEvent convert = converter.convert(event.payload(), StudentEnrolledEvent.class);
                 Objects.requireNonNull(convert, "The converted payload must not be null.");
                 course.handle(convert);
             }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/CompoundEntityIdentifierCommandHandlingComponentTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/CompoundEntityIdentifierCommandHandlingComponentTest.java
@@ -60,7 +60,7 @@ class CompoundEntityIdentifierCommandHandlingComponentTest extends AbstractStude
                                                         new QualifiedName(MentorAssignedToStudentEvent.class),
                                                         (entity, event, context) -> {
                                                             Converter converter = c.getComponent(Converter.class);
-                                                            MentorAssignedToStudentEvent payload = converter.convert(event.getPayload(),
+                                                            MentorAssignedToStudentEvent payload = converter.convert(event.payload(),
                                                                                                                      MentorAssignedToStudentEvent.class);
                                                             entity.handle(payload);
                                                             return entity;
@@ -97,7 +97,7 @@ class CompoundEntityIdentifierCommandHandlingComponentTest extends AbstractStude
                 new QualifiedName(AssignMentorCommand.class),
                 c -> (command, state, context) -> {
                     EventAppender eventAppender = EventAppender.forContext(context, c);
-                    AssignMentorCommand payload = (AssignMentorCommand) command.getPayload();
+                    AssignMentorCommand payload = (AssignMentorCommand) command.payload();
                     StudentMentorAssignment assignment = state.loadEntity(
                             StudentMentorAssignment.class, payload.modelIdentifier(), context
                     ).join();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MultiEntityCommandHandlingComponentTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MultiEntityCommandHandlingComponentTest.java
@@ -66,7 +66,7 @@ class MultiEntityCommandHandlingComponentTest extends AbstractStudentTestSuite {
                 new QualifiedName(EnrollStudentToCourseCommand.class),
                 c -> (command, state, context) -> {
                     EventAppender eventAppender = EventAppender.forContext(context, c);
-                    EnrollStudentToCourseCommand payload = (EnrollStudentToCourseCommand) command.getPayload();
+                    EnrollStudentToCourseCommand payload = (EnrollStudentToCourseCommand) command.payload();
                     Student student = state.loadEntity(Student.class, payload.studentId(), context).join();
                     Course course = state.loadEntity(Course.class, payload.courseId(), context).join();
 
@@ -182,7 +182,7 @@ class MultiEntityCommandHandlingComponentTest extends AbstractStudentTestSuite {
             @Nonnull
             public String resolve(@Nonnull Message<?> command, @Nonnull ProcessingContext context) {
                 //noinspection unused
-                if (command.getPayload() instanceof AssignMentorCommand(String studentId, String mentorId)) {
+                if (command.payload() instanceof AssignMentorCommand(String studentId, String mentorId)) {
                     return studentId;
                 }
                 throw new IllegalArgumentException("Can not resolve mentor id from command");

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/SingleEntityCommandHandlingComponentTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/SingleEntityCommandHandlingComponentTest.java
@@ -42,7 +42,7 @@ class SingleEntityCommandHandlingComponentTest extends AbstractStudentTestSuite 
                 new QualifiedName(ChangeStudentNameCommand.class),
                 c -> (command, state, context) -> {
                     EventAppender eventAppender = EventAppender.forContext(context, c);
-                    ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.getPayload();
+                    ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.payload();
                     Student student = state.loadEntity(Student.class, payload.id(), context).join();
                     eventAppender.append(new StudentNameChangedEvent(student.getId(), payload.name()));
                     // Entity through magic of repository automatically updated

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * <p>
  * These messages carry an intention to change application state.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link CommandMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link CommandMessage}.
  * @author Allard Buijze
  * @since 2.0.0
  */

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 /**
  * A {@link ResultMessage} that represents a result from handling a {@link CommandMessage}.
  *
- * @param <R> The type of {@link #getPayload() result} contained in this {@link CommandResultMessage}.
+ * @param <R> The type of {@link #payload() result} contained in this {@link CommandResultMessage}.
  * @author Milan Savic
  * @since 4.0.0
  */

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 /**
  * Generic implementation of the {@link CommandMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link CommandMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link CommandMessage}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 2.0.0
@@ -65,14 +65,14 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
     /**
      * Constructs a {@code GenericCommandMessage} with given {@code delegate}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericCommandMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload},
      *                 {@link Message#type() qualifiedName}, {@link Message#identifier() identifier} and
      *                 {@link Message#getMetaData() metadata} for the {@link CommandMessage} to reconstruct.
      */
@@ -95,7 +95,7 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
         Message<P> delegate = getDelegate();
         Message<C> transformed = new GenericMessage<>(delegate.identifier(),
                                                       delegate.type(),
-                                                      conversion.apply(delegate.getPayload()),
+                                                      conversion.apply(delegate.payload()),
                                                       delegate.getMetaData());
         return new GenericCommandMessage<>(transformed);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 /**
  * Generic implementation of the {@link CommandResultMessage} interface.
  *
- * @param <R> The type of {@link #getPayload() result} contained in this {@link CommandResultMessage}.
+ * @param <R> The type of {@link #payload() result} contained in this {@link CommandResultMessage}.
  * @author Milan Savic
  * @author Steven van Beelen
  * @since 4.0.0
@@ -100,7 +100,7 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload}, {@link Message#type() type},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
      *                 {@link Message#identifier() identifier} and {@link Message#getMetaData() metadata} for the
      *                 {@link QueryResponseMessage} to reconstruct.
      */
@@ -115,7 +115,7 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
      *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                  {@link Message#getMetaData() metadata} for the {@link QueryResponseMessage} to reconstruct.
      * @param exception The {@link Throwable} describing the error representing the response of this
@@ -144,7 +144,7 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
         Message<R> delegate = getDelegate();
         Message<T> transformed = new GenericMessage<>(delegate.identifier(),
                                                       delegate.type(),
-                                                      conversion.apply(delegate.getPayload()),
+                                                      conversion.apply(delegate.payload()),
                                                       delegate.getMetaData());
         return new GenericCommandResultMessage<>(transformed, exception);
     }

--- a/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/distributed/AnnotationRoutingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class AnnotationRoutingStrategy implements RoutingStrategy {
     @Override
     public String getRoutingKey(@Nonnull CommandMessage<?> command) {
         try {
-            Object payload = command.getPayload();
+            Object payload = command.payload();
             return payload == null ? null : findIdentifier(payload);
         } catch (InvocationTargetException e) {
             throw new AxonConfigurationException(

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -131,7 +131,7 @@ public interface CommandGateway {
     default Object sendAndWait(@Nonnull Object command) {
         try {
             return send(command, null).getResultMessage()
-                                      .thenApply(Message::getPayload)
+                                      .thenApply(Message::payload)
                                       .get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandResult.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandResult.java
@@ -49,7 +49,7 @@ public interface CommandResult {
      */
     default <R> CompletableFuture<R> resultAs(@Nonnull Class<R> type) {
         requireNonNull(type, "The result type must not be null");
-        return getResultMessage().thenApply(Message::getPayload)
+        return getResultMessage().thenApply(Message::payload)
                                  .thenApply(type::cast);
     }
 
@@ -92,7 +92,7 @@ public interface CommandResult {
         requireNonNull(successHandler, "The success handler must not be null.");
         getResultMessage().whenComplete((r, e) -> {
             if (e == null) {
-                successHandler.accept(resultType.cast(r.getPayload()), r);
+                successHandler.accept(resultType.cast(r.payload()), r);
             }
         });
         return this;

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -89,14 +89,14 @@ public class DefaultCommandGateway implements CommandGateway {
     /**
      * Returns the given command as a {@link CommandMessage}. If {@code command} already implements
      * {@code CommandMessage}, it is returned as-is. When the {@code command} is another implementation of
-     * {@link Message}, the {@link Message#getPayload()} and {@link Message#getMetaData()} are used as input for a new
+     * {@link Message}, the {@link Message#payload()} and {@link Message#getMetaData()} are used as input for a new
      * {@link GenericCommandMessage}. Otherwise, the given {@code command} is wrapped into a
      * {@code GenericCommandMessage} as its payload.
      *
      * @param command The command to wrap as {@link CommandMessage}.
      * @return A {@link CommandMessage} containing given {@code command} as payload, a {@code command} if it already
      * implements {@code CommandMessage}, or a {@code CommandMessage} based on the result of
-     * {@link Message#getPayload()} and {@link Message#getMetaData()} for other {@link Message} implementations.
+     * {@link Message#payload()} and {@link Message#getMetaData()} for other {@link Message} implementations.
      */
     @SuppressWarnings("unchecked")
     private <C> CommandMessage<C> asCommandMessage(Object command, MetaData metaData) {
@@ -107,7 +107,7 @@ public class DefaultCommandGateway implements CommandGateway {
         if (command instanceof Message<?> message) {
             return new GenericCommandMessage<>(
                     message.type(),
-                    (C) message.getPayload(),
+                    (C) message.payload(),
                     message.getMetaData()
             );
         }

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGateway.java
@@ -75,7 +75,7 @@ public class ResultDeserializingCommandGateway implements CommandGateway {
         @Override
         public <R> CompletableFuture<R> resultAs(@Nonnull Class<R> type) {
             return delegate.getResultMessage()
-                           .thenApply(Message::getPayload)
+                           .thenApply(Message::payload)
                            .thenApply(payload -> serializer.convert(payload, type));
         }
 
@@ -86,7 +86,7 @@ public class ResultDeserializingCommandGateway implements CommandGateway {
             delegate.getResultMessage()
                     .whenComplete((message, e) -> {
                         if (e == null) {
-                            successHandler.accept(serializer.convert(message.getPayload(), resultType), message);
+                            successHandler.accept(serializer.convert(message.payload(), resultType), message);
                         }
                     });
             return this;

--- a/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * Implementations of the {@link DeadlineMessage} represent a fact (it's a specialization of {@code EventMessage}) that
  * some deadline was reached. The optional payload contains relevant data of the scheduled deadline.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
+ * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
  *            if no payload was provided.
  * @author Milan Savic
  * @author Steven van Beelen

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 /**
  * Generic implementation of the {@link DeadlineMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
+ * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
  *            if no payload was provided.
  * @author Milan Savic
  * @author Steven van Beelen
@@ -43,7 +43,7 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
     /**
      * Constructs a {@code GenericDeadlineMessage} for the given {@code type} and {@code deadlineName}.
      * <p>
-     * The {@link #getPayload()} defaults to {@code null} and the {@link MetaData} defaults to an empty instance.
+     * The {@link #payload()} defaults to {@code null} and the {@link MetaData} defaults to an empty instance.
      *
      * @param type         The {@link MessageType type} for this {@link DeadlineMessage}.
      * @param deadlineName The type for this {@link DeadlineMessage}.
@@ -118,7 +118,7 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
      * of Work.
      *
      * @param deadlineName      The name for this {@link DeadlineMessage}.
-     * @param delegate          The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate          The {@link Message} containing {@link Message#payload() payload},
      *                          {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                          {@link Message#getMetaData() metadata} for the {@link DeadlineMessage} to reconstruct.
      * @param timestampSupplier {@link Supplier} for the {@link Instant timestamp} of the

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetails.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetails.java
@@ -107,7 +107,7 @@ public class DbSchedulerBinaryDeadlineDetails implements Serializable {
                                                        @Nonnull DeadlineMessage message,
                                                        @Nonnull Serializer serializer) {
         SerializedObject<byte[]> serializedDescriptor = serializer.serialize(descriptor, byte[].class);
-        SerializedObject<byte[]> serializedPayload = serializer.serialize(message.getPayload(), byte[].class);
+        SerializedObject<byte[]> serializedPayload = serializer.serialize(message.payload(), byte[].class);
         SerializedObject<byte[]> serializedMetaData = serializer.serialize(message.getMetaData(), byte[].class);
 
         return new DbSchedulerBinaryDeadlineDetails(deadlineName,

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerHumanReadableDeadlineDetails.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerHumanReadableDeadlineDetails.java
@@ -107,7 +107,7 @@ public class DbSchedulerHumanReadableDeadlineDetails implements Serializable {
                                                               @Nonnull DeadlineMessage message,
                                                               @Nonnull Serializer serializer) {
         SerializedObject<String> serializedDescriptor = serializer.serialize(descriptor, String.class);
-        SerializedObject<String> serializedPayload = serializer.serialize(message.getPayload(), String.class);
+        SerializedObject<String> serializedPayload = serializer.serialize(message.payload(), String.class);
         SerializedObject<String> serializedMetaData = serializer.serialize(message.getMetaData(), String.class);
 
         return new DbSchedulerHumanReadableDeadlineDetails(deadlineName,

--- a/messaging/src/main/java/org/axonframework/deadline/jobrunr/DeadlineDetails.java
+++ b/messaging/src/main/java/org/axonframework/deadline/jobrunr/DeadlineDetails.java
@@ -102,7 +102,7 @@ public class DeadlineDetails {
                              @Nonnull DeadlineMessage message,
                              @Nonnull Serializer serializer) {
         SerializedObject<String> serializedDescriptor = serializer.serialize(descriptor, String.class);
-        SerializedObject<String> serializedPayload = serializer.serialize(message.getPayload(), String.class);
+        SerializedObject<String> serializedPayload = serializer.serialize(message.payload(), String.class);
         SerializedObject<String> serializedMetaData = serializer.serialize(message.getMetaData(), String.class);
         DeadlineDetails deadlineDetails = new DeadlineDetails(deadlineName,
                                                               message.type().toString(),

--- a/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
+++ b/messaging/src/main/java/org/axonframework/deadline/quartz/DeadlineJob.java
@@ -246,7 +246,7 @@ public class DeadlineJob implements Job {
             jobData.put(MESSAGE_TIMESTAMP, deadlineMessage.getTimestamp().toString());
 
             SerializedObject<byte[]> serializedDeadlinePayload =
-                    serializer.serialize(deadlineMessage.getPayload(), byte[].class);
+                    serializer.serialize(deadlineMessage.payload(), byte[].class);
             jobData.put(SERIALIZED_MESSAGE_PAYLOAD, serializedDeadlinePayload.getData());
             jobData.put(MESSAGE_TYPE, serializedDeadlinePayload.getType().getName());
             jobData.put(MESSAGE_REVISION, serializedDeadlinePayload.getType().getRevision());

--- a/messaging/src/main/java/org/axonframework/eventhandling/DomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/DomainEventMessage.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * that reported it. The {@code DomainEventMessage's} sequence number allows messages to be placed in their order of
  * generation.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link DomainEventMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link DomainEventMessage}.
  * @author Allard Buijze
  * @since 2.0.0
  */

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
@@ -25,13 +25,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * A {@link Message} wrapping an event, which is represented by its {@link #getPayload() payload}.
+ * A {@link Message} wrapping an event, which is represented by its {@link #payload() payload}.
  * <p>
  * An event is a representation of an occurrence of an event (i.e. anything that happened any might be of importance to
  * any other component) in the application. It contains the data relevant for components that need to act based on that
  * event.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link EventMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link EventMessage}.
  * @author Allard Buijze
  * @see DomainEventMessage
  * @since 2.0.0
@@ -42,7 +42,7 @@ public interface EventMessage<P> extends Message<P> {
      * Returns the identifier of this {@link EventMessage event}.
      * <p>
      * The identifier is used to define the uniqueness of an event. Two events may contain similar (or equal)
-     * {@link #getPayload() payloads} and {@link #getTimestamp() timestamp}, if the event identifiers are different,
+     * {@link #payload() payloads} and {@link #getTimestamp() timestamp}, if the event identifiers are different,
      * they both represent a different occurrence of an Event.
      * <p>
      * If two messages have the same identifier, they both represent the same unique occurrence of an event, even though
@@ -82,7 +82,7 @@ public interface EventMessage<P> extends Message<P> {
      * @return a copy of this message with the payload converted
      */
     default <C> EventMessage<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        P payload = getPayload();
+        P payload = payload();
         if (Objects.equals(payload, conversion.apply(payload))) {
             //noinspection unchecked
             return (EventMessage<C>) this;

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
@@ -29,7 +29,7 @@ import java.util.function.Supplier;
 /**
  * Generic implementation of the {@link DomainEventMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link EventMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link EventMessage}.
  * @author Allard Buijze
  * @author Rene de Waele
  * @author Steven van Beelen
@@ -130,7 +130,7 @@ public class GenericDomainEventMessage<P> extends GenericEventMessage<P> impleme
      * @param aggregateType       The domain type generating this {@link DomainEventMessage}.
      * @param aggregateIdentifier The identifier of the aggregate generating this {@link DomainEventMessage}.
      * @param sequenceNumber      The {@link DomainEventMessage DomainEventMessage's} sequence number.
-     * @param delegate            The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate            The {@link Message} containing {@link Message#payload() payload},
      *                            {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                            {@link Message#getMetaData() metadata} for the {@link DomainEventMessage} to
      *                            reconstruct.
@@ -153,7 +153,7 @@ public class GenericDomainEventMessage<P> extends GenericEventMessage<P> impleme
      * with the given {@code aggregateIdentifier}, {@code sequenceNumber}, {@code delegate}, and {@code timestamp},
      * intended to reconstruct another {@link DomainEventMessage}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericEventMessage}.
      * <p>
@@ -163,7 +163,7 @@ public class GenericDomainEventMessage<P> extends GenericEventMessage<P> impleme
      * @param aggregateType       The domain type generating this {@link DomainEventMessage}.
      * @param aggregateIdentifier The identifier of the aggregate generating this {@link DomainEventMessage}.
      * @param sequenceNumber      The {@link DomainEventMessage DomainEventMessage's} sequence number.
-     * @param delegate            The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate            The {@link Message} containing {@link Message#payload() payload},
      *                            {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                            {@link Message#getMetaData() metadata} for the {@link DomainEventMessage} to
      *                            reconstruct.

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 /**
  * Generic implementation of the {@link EventMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link EventMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link EventMessage}.
  * @author Allard Buijze
  * @author Rene de Waele
  * @author Steven van Beelen
@@ -107,7 +107,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate          The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate          The {@link Message} containing {@link Message#payload() payload},
      *                          {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                          {@link Message#getMetaData() metadata} for the {@link EventMessage} to reconstruct.
      * @param timestampSupplier {@link Supplier} for the {@link Instant timestamp} of the
@@ -122,14 +122,14 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
     /**
      * Constructs a {@code GenericEventMessage} with given {@code delegate} and {@code timestamp}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericEventMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
      *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                  {@link Message#getMetaData() metadata} for the {@link EventMessage} to reconstruct.
      * @param timestamp The {@link Instant timestamp} of this {@link EventMessage GenericEventMessage's} creation.
@@ -176,7 +176,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
 
     @Override
     public <C> EventMessage<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        P payload = getPayload();
+        P payload = payload();
         C converted = conversion.apply(payload);
         if (Objects.equals(converted, payload)) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/eventhandling/TerminalEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TerminalEventMessage.java
@@ -20,7 +20,7 @@ import org.axonframework.common.annotation.Internal;
 import org.axonframework.messaging.MessageType;
 
 /**
- * Empty {@link EventMessage} implementation without any {@link EventMessage#getPayload() payload}, used as the
+ * Empty {@link EventMessage} implementation without any {@link EventMessage#payload() payload}, used as the
  * <b>terminal</b> message of a {@link org.axonframework.messaging.MessageStream}. This thus signals the end of the
  * {@code MessageStream}.
  * <p>

--- a/messaging/src/main/java/org/axonframework/eventhandling/async/PropertySequencingPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/PropertySequencingPolicy.java
@@ -63,7 +63,7 @@ public class PropertySequencingPolicy<T, K> implements SequencingPolicy {
     @Override
     public Optional<Object> getSequenceIdentifierFor(@Nonnull final EventMessage<?> eventMessage) {
         if (payloadClass.isAssignableFrom(eventMessage.getPayloadType())) {
-            @SuppressWarnings("unchecked") final T castedPayload = (T) eventMessage.getPayload();
+            @SuppressWarnings("unchecked") final T castedPayload = (T) eventMessage.payload();
             return Optional.ofNullable(propertyExtractor.apply(castedPayload));
         }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
@@ -237,7 +237,7 @@ public class DeadLetteringEventHandlerInvoker
                                                     transactionManager);
         LegacyUnitOfWork<?> uow = new LegacyDefaultUnitOfWork<>(null);
         uow.attachTransaction(transactionManager);
-        return uow.executeWithResult((ctx) -> queue.process(sequenceFilter, processingTask::process)).getPayload();
+        return uow.executeWithResult((ctx) -> queue.process(sequenceFilter, processingTask::process)).payload();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterJdbcConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterJdbcConverter.java
@@ -51,7 +51,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * This converter expects a {@link DeadLetterSchema} to define the column names / labels used to retrieve the fields
  * from the {@link ResultSet}. Furthermore, it uses the configurable {@code genericSerializer} to deserialize
  * {@link TrackingToken TrackingTokens} for {@link TrackedEventMessage} instances. Lastly, this factory uses the
- * {@code eventSerializer} to deserialize the {@link EventMessage#getPayload() event payload},
+ * {@code eventSerializer} to deserialize the {@link EventMessage#payload() event payload},
  * {@link EventMessage#getMetaData() MetaData}, and {@link DeadLetter#diagnostics() diagnostics} for the
  * {@code JdbcDeadLetter} to return.
  *
@@ -125,7 +125,7 @@ public class DefaultDeadLetterJdbcConverter<E extends EventMessage<?>>
                                                            resultSet.getLong(schema.sequenceNumberColumn()),
                                                            serializedMessage.identifier(),
                                                            MessageType.fromString(resultSet.getString(schema.typeColumn())),
-                                                           serializedMessage.getPayload(),
+                                                           serializedMessage.payload(),
                                                            serializedMessage.getMetaData(),
                                                            timestampSupplier.get());
         } else {
@@ -240,11 +240,11 @@ public class DefaultDeadLetterJdbcConverter<E extends EventMessage<?>>
         }
 
         /**
-         * Sets the {@link Serializer} to deserialize {@link EventMessage#getPayload() event payloads},
+         * Sets the {@link Serializer} to deserialize {@link EventMessage#payload() event payloads},
          * {@link EventMessage#getMetaData() MetaData} instances, and {@link DeadLetter#diagnostics() diagnostics}
          * with.
          *
-         * @param eventSerializer The serializer used to deserialize {@link EventMessage#getPayload() event payloads},
+         * @param eventSerializer The serializer used to deserialize {@link EventMessage#payload() event payloads},
          *                        {@link EventMessage#getMetaData() MetaData} instances, and
          *                        {@link DeadLetter#diagnostics() diagnostics} with.
          * @return The current Builder, for fluent interfacing.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -48,7 +48,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * This factory expects a {@link DeadLetterSchema} to base the table and columns names used for <b>all</b>
  * {@code PreparedStatements}. Furthermore, it uses the configurable {@code genericSerializer} to serialize
  * {@link TrackingToken TrackingTokens} in {@link TrackedEventMessage} instances. Lastly, this factory uses the
- * {@code eventSerializer} to serialize the {@link EventMessage#getPayload() event payload},
+ * {@code eventSerializer} to serialize the {@link EventMessage#payload() event payload},
  * {@link EventMessage#getMetaData() MetaData}, and {@link DeadLetter#diagnostics() diagnostics} of any
  * {@code DeadLetter}.
  * <p>
@@ -465,11 +465,11 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
         }
 
         /**
-         * Sets the {@link Serializer} to serialize the {@link EventMessage#getPayload() event payload},
+         * Sets the {@link Serializer} to serialize the {@link EventMessage#payload() event payload},
          * {@link EventMessage#getMetaData() MetaData}, and {@link DeadLetter#diagnostics() diagnostics} of the
          * {@link DeadLetter} when storing it to a database.
          *
-         * @param eventSerializer The serializer to use for {@link EventMessage#getPayload() event payload}s,
+         * @param eventSerializer The serializer to use for {@link EventMessage#payload() event payload}s,
          *                        {@link EventMessage#getMetaData() MetaData} instances, and
          *                        {@link DeadLetter#diagnostics() diagnostics}.
          * @return The current Builder, for fluent interfacing.

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
@@ -112,7 +112,7 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
                                                    entry.getSequenceNumber(),
                                                    serializedMessage.identifier(),
                                                    MessageType.fromString(entry.getType()),
-                                                   serializedMessage.getPayload(),
+                                                   serializedMessage.payload(),
                                                    serializedMessage.getMetaData(),
                                                    timestampSupplier.get());
         } else {

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Generic implementation of the {@link ResetContext} interface.
  *
- * @param <P> The type of {@link #getPayload()} contained in this {@link GenericResetContext}.
+ * @param <P> The type of {@link #payload()} contained in this {@link GenericResetContext}.
  * @author Steven van Beelen
  * @since 4.4.0
  */
@@ -69,7 +69,7 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload}, {@link Message#type() type},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
      *                 {@link Message#identifier() identifier} and {@link Message#getMetaData() metadata} for the
      *                 {@link EventMessage} to reconstruct.
      */

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Nonnull;
  * <p>
  * A payload of {@code P} can be provided to support the reset operation handling this message.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link Message}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link Message}.
  * @author Steven van Beelen
  * @since 4.4.0
  */

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
@@ -26,14 +26,12 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
-import org.axonframework.configuration.LifecycleRegistry;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.scheduling.EventScheduler;
 import org.axonframework.eventhandling.scheduling.ScheduleToken;
 import org.axonframework.eventhandling.scheduling.SchedulingException;
-import org.axonframework.lifecycle.Phase;
 import org.axonframework.messaging.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTypeResolver;
@@ -201,7 +199,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
     }
 
     private DbSchedulerBinaryEventData binaryDataFromEvent(EventMessage<?> eventMessage) {
-        SerializedObject<byte[]> serialized = serializer.serialize(eventMessage.getPayload(), byte[].class);
+        SerializedObject<byte[]> serialized = serializer.serialize(eventMessage.payload(), byte[].class);
         byte[] serializedPayload = serialized.getData();
         String payloadClass = serialized.getType().getName();
         String revision = serialized.getType().getRevision();
@@ -228,7 +226,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
     }
 
     private DbSchedulerHumanReadableEventData humanReadableDataFromEvent(EventMessage<?> eventMessage) {
-        SerializedObject<String> serialized = serializer.serialize(eventMessage.getPayload(), String.class);
+        SerializedObject<String> serialized = serializer.serialize(eventMessage.payload(), String.class);
         String serializedPayload = serialized.getData();
         String payloadClass = serialized.getType().getName();
         String revision = serialized.getType().getRevision();

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/java/SimpleEventScheduler.java
@@ -250,7 +250,7 @@ public class SimpleEventScheduler implements EventScheduler {
         private EventMessage<?> createMessage() {
             return event instanceof EventMessage
                     ? new GenericEventMessage<>(((EventMessage<?>) event).type(),
-                                                ((EventMessage<?>) event).getPayload(),
+                                                ((EventMessage<?>) event).payload(),
                                                 ((EventMessage<?>) event).getMetaData())
                     : new GenericEventMessage<>(messageTypeResolver.resolveOrThrow(event), event);
         }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
@@ -137,7 +137,7 @@ public class JobRunrEventScheduler implements EventScheduler {
 
     @SuppressWarnings("rawtypes")
     private void addDetailsFromEvent(JobBuilder job, EventMessage eventMessage) {
-        SerializedObject<String> serialized = serializer.serialize(eventMessage.getPayload(), String.class);
+        SerializedObject<String> serialized = serializer.serialize(eventMessage.payload(), String.class);
         String serializedPayload = serialized.getData();
         String payloadClass = serialized.getType().getName();
         String revision = serialized.getType().getRevision();

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/FireEventJob.java
@@ -112,7 +112,7 @@ public class FireEventJob implements Job {
     private EventMessage<?> createMessage(Object event, MessageTypeResolver messageTypeResolver) {
         return event instanceof EventMessage
                 ? new GenericEventMessage<>(((EventMessage<?>) event).type(),
-                                            ((EventMessage<?>) event).getPayload(),
+                                            ((EventMessage<?>) event).payload(),
                                             ((EventMessage<?>) event).getMetaData())
                 : new GenericEventMessage<>(messageTypeResolver.resolveOrThrow(event), event);
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -276,7 +276,7 @@ public class QuartzEventScheduler implements EventScheduler {
             jobData.put(MESSAGE_TIMESTAMP, eventMessage.getTimestamp().toString());
 
             SerializedObject<byte[]> serializedPayload =
-                    serializer.serialize(eventMessage.getPayload(), byte[].class);
+                    serializer.serialize(eventMessage.payload(), byte[].class);
             jobData.put(SERIALIZED_MESSAGE_PAYLOAD, serializedPayload.getData());
             jobData.put(MESSAGE_TYPE, serializedPayload.getType().getName());
             jobData.put(MESSAGE_REVISION, serializedPayload.getType().getRevision());

--- a/messaging/src/main/java/org/axonframework/messaging/AbstractMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/AbstractMessage.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Abstract base class for {@link Message Messages}.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link AbstractMessage}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link AbstractMessage}.
  * @author Rene de Waele
  * @author Steven van Beelen
  * @since 3.0.0

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -32,13 +32,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 /**
- * Generic implementation of the {@link Message} interface containing the {@link #getPayload() payload} and
+ * Generic implementation of the {@link Message} interface containing the {@link #payload() payload} and
  * {@link #getMetaData() metadata} in deserialized form.
  * <p>
  * If a {@link GenericMessage} is created while a {@link LegacyUnitOfWork} is active it copies over the correlation data
  * of the {@code UnitOfWork} to the created message.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link Message}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link Message}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 2.0.0
@@ -155,7 +155,7 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     private GenericMessage(@Nonnull GenericMessage<P> original,
                            @Nonnull MetaData metaData) {
         super(original.identifier(), original.type());
-        this.payload = original.getPayload();
+        this.payload = original.payload();
         this.metaData = metaData;
         this.payloadType = original.getPayloadType();
     }
@@ -178,7 +178,7 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     /**
      * Construct an empty message.
      *
-     * @return A message with {@code null} {@link Message#getPayload()}, no {@link MetaData}, and a
+     * @return A message with {@code null} {@link Message#payload()}, no {@link MetaData}, and a
      * {@link Message#type()} of {@code "empty"}.
      */
     public static Message<Void> emptyMessage() {
@@ -191,7 +191,7 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     }
 
     @Override
-    public P getPayload() {
+    public P payload() {
         return this.payload;
     }
 
@@ -199,10 +199,10 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     public <T> T payloadAs(@Nonnull Type type, @Nullable Converter converter) {
         //noinspection unchecked,rawtypes
         return type instanceof Class clazz && getPayloadType().isAssignableFrom(clazz)
-                ? (T) getPayload()
+                ? (T) payload()
                 : Objects.requireNonNull(converter,
                                          "Cannot convert payload to [" + type.getTypeName() + "] with null Converter.")
-                         .convert(getPayload(), type);
+                         .convert(payload(), type);
     }
 
     @Override
@@ -234,7 +234,7 @@ public class GenericMessage<P> extends AbstractMessage<P> {
 
     @Override
     public <C> Message<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        C convertedPayload = conversion.apply(getPayload());
+        C convertedPayload = conversion.apply(payload());
         return new GenericMessage<>(type(),  convertedPayload, MetaData.from(metaData));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * Generic implementation of {@link ResultMessage} interface.
  *
- * @param <R> The type of {@link #getPayload() result} contained in this {@link ResultMessage}.
+ * @param <R> The type of {@link #payload() result} contained in this {@link ResultMessage}.
  * @author Milan Savic
  * @author Steven van Beelen
  * @since 4.0.0
@@ -98,7 +98,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload}, {@link Message#type() type},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
      *                 {@link Message#identifier() identifier} and {@link Message#getMetaData() metadata} for the
      *                 {@link QueryResponseMessage} to reconstruct.
      */
@@ -113,7 +113,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
      *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                  {@link Message#getMetaData() metadata} for the {@link QueryResponseMessage} to reconstruct.
      * @param exception The {@link Throwable} describing the error representing the response of this
@@ -204,7 +204,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
     @Override
     protected void describeTo(StringBuilder stringBuilder) {
         stringBuilder.append("payload={")
-                     .append(isExceptional() ? null : getPayload())
+                     .append(isExceptional() ? null : payload())
                      .append('}')
                      .append(", metadata={")
                      .append(getMetaData())
@@ -223,7 +223,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
     }
 
     @Override
-    public R getPayload() {
+    public R payload() {
         if (isExceptional()) {
             throw new IllegalPayloadAccessException(
                     "This result completed exceptionally, payload is not available. "
@@ -231,6 +231,6 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
                     exception
             );
         }
-        return super.getPayload();
+        return super.payload();
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
  * Instead of implementing {@code Message} directly, consider implementing {@code CommandMessage}, {@code EventMessage}
  * or {@code QueryMessage} instead.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@code Message}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@code Message}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @see org.axonframework.commandhandling.CommandMessage
@@ -91,7 +91,7 @@ public interface Message<P> {
      * <p>
      * Two messages with the same identifiers should be interpreted as different representations of the same conceptual
      * message. In such case, the {@link Message#getMetaData() metadata} may be different for both representations. The
-     * {@link Message#getPayload() payload} <em>may</em> be identical.
+     * {@link Message#payload() payload} <em>may</em> be identical.
      *
      * @return The unique identifier of this {@code Message}.
      */
@@ -122,13 +122,13 @@ public interface Message<P> {
      *
      * @return The payload of this {@code Message} of generic type {@code P}.
      */
-    P getPayload();
+    P payload();
 
     /**
      * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
      * <p>
      * If {@link #getPayloadType()} is {@link Class#isAssignableFrom(Class) assignable from} the given {@code type},
-     * {@link #getPayload()} may be invoked instead of using the given {@code converter}.
+     * {@link #payload()} may be invoked instead of using the given {@code converter}.
      * <p>
      * Implementers of this operation may optimize by storing the converted payloads, thus saving a
      * {@link Converter#convert(Object, Class)} invocation in the process. Only when this optimization is in place will
@@ -142,14 +142,14 @@ public interface Message<P> {
      *                              {@code converter} is given.
      */
     default <T> T payloadAs(@Nonnull Class<T> type, @Nullable Converter converter) {
-        return getPayloadType().isAssignableFrom(type) ? type.cast(getPayload()) : payloadAs((Type) type, converter);
+        return getPayloadType().isAssignableFrom(type) ? type.cast(payload()) : payloadAs((Type) type, converter);
     }
 
     /**
      * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
      * <p>
      * If {@link #getPayloadType()} is {@link Class#isAssignableFrom(Class) assignable from} the given
-     * {@link TypeReference#getType()}, {@link #getPayload()} may be invoked instead of using the given
+     * {@link TypeReference#getType()}, {@link #payload()} may be invoked instead of using the given
      * {@code converter}.
      * <p>
      * Implementers of this operation may optimize by storing the converted payloads, thus saving a
@@ -171,7 +171,7 @@ public interface Message<P> {
      * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
      * <p>
      * If the given {@code type} is an instance of {@link Class} and {@link #getPayloadType()} is
-     * {@link Class#isAssignableFrom(Class) assignable from} that {@code Class}, {@link #getPayload()} may be invoked
+     * {@link Class#isAssignableFrom(Class) assignable from} that {@code Class}, {@link #payload()} may be invoked
      * instead of using the given {@code converter}.
      * <p>
      * Implementers of this operation may optimize by storing the converted payloads, thus saving a
@@ -203,7 +203,7 @@ public interface Message<P> {
     /**
      * Returns a copy of this {@code Message} (implementation) with the given {@code metaData}.
      * <p>
-     * All others fields, like for example the {@link #getPayload()}, remain unchanged.
+     * All others fields, like for example the {@link #payload()}, remain unchanged.
      * <p/>
      * While the implementation returned may be different from the implementation of {@code this}, implementations must
      * take special care in returning the same type of {@code Message} to prevent errors further downstream.
@@ -217,7 +217,7 @@ public interface Message<P> {
      * Returns a copy of this {@code Message} (implementation) with its {@link Message#getMetaData() metadata} merged
      * with the given {@code metaData}.
      * <p>
-     * All others fields, like for example the {@link #getPayload()}, remain unchanged.
+     * All others fields, like for example the {@link #payload()}, remain unchanged.
      *
      * @param metaData The metadata to merge with.
      * @return A copy of {@code this Message (implementation)} with the given {@code metaData}.
@@ -238,7 +238,7 @@ public interface Message<P> {
      */
     @Deprecated
     default <R> SerializedObject<R> serializePayload(Serializer serializer, Class<R> expectedRepresentation) {
-        return serializer.serialize(getPayload(), expectedRepresentation);
+        return serializer.serialize(payload(), expectedRepresentation);
     }
 
     /**
@@ -270,7 +270,7 @@ public interface Message<P> {
      * @return a message with the converted payload
      */
     default <C> Message<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        if (Objects.equals(getPayload(), conversion.apply(getPayload()))) {
+        if (Objects.equals(payload(), conversion.apply(payload()))) {
             //noinspection unchecked
             return (Message<C>) this;
         }

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Type;
  * <p>
  * Extend this decorator class to extend the message with additional features.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link MessageDecorator}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link MessageDecorator}.
  * @author Steven van Beelen
  * @author Rene de Waele
  * @since 3.0.0
@@ -42,7 +42,7 @@ public abstract class MessageDecorator<P> implements Message<P> {
      * Initializes a new decorator with given {@code delegate} {@link Message}.
      * <p>
      * The decorator delegates to the delegate for the message's {@link #identifier() identifier},
-     * {@link Message#type() type}, {@link #getPayload() payload}, and {@link #getMetaData() metadata}.
+     * {@link Message#type() type}, {@link #payload() payload}, and {@link #getMetaData() metadata}.
      *
      * @param delegate The {@link Message} delegate.
      */
@@ -67,8 +67,8 @@ public abstract class MessageDecorator<P> implements Message<P> {
     }
 
     @Override
-    public P getPayload() {
-        return delegate.getPayload();
+    public P payload() {
+        return delegate.payload();
     }
 
     @Override
@@ -125,7 +125,7 @@ public abstract class MessageDecorator<P> implements Message<P> {
                      .append(type())
                      .append('}')
                      .append(", payload={")
-                     .append(getPayload())
+                     .append(payload())
                      .append('}')
                      .append(", metadata={")
                      .append(getMetaData())

--- a/messaging/src/main/java/org/axonframework/messaging/MessageTypeResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageTypeResolver.java
@@ -22,7 +22,7 @@ import org.axonframework.common.ObjectUtils;
 import java.util.Optional;
 
 /**
- * Functional interface describing a resolver from {@link Message#getPayload() Message payload} to it's
+ * Functional interface describing a resolver from {@link Message#payload() Message payload} to it's
  * {@link MessageType type}. Used to set the {@link Message#type() type} when putting the given payload on its
  * respective bus.
  *
@@ -38,7 +38,7 @@ public interface MessageTypeResolver {
      * Resolves a {@link MessageType type} for the given {@code payload}. If the given {@code payload} is already a
      * {@link Message} implementation, the {@link Message#type() Message Type} is returned.
      *
-     * @param payload The {@link Message#getPayload() Message payload} to resolve a {@link MessageType type} for.
+     * @param payload The {@link Message#payload() Message payload} to resolve a {@link MessageType type} for.
      * @return The {@link MessageType type} for the given {@code payload}.
      * @throws MessageTypeNotResolvedException if the {@link MessageType type} could not be resolved.
      */
@@ -52,7 +52,7 @@ public interface MessageTypeResolver {
     /**
      * Resolves a {@link MessageType type} for the given {@code payloadType}.
      *
-     * @param payloadType The {@link Class type} of the {@link Message#getPayload() Message payload} to resolve a
+     * @param payloadType The {@link Class type} of the {@link Message#payload() Message payload} to resolve a
      *                    {@link MessageType type} for.
      * @return The {@link MessageType type} for the given {@code payloadType}.
      * @throws MessageTypeNotResolvedException if the {@link MessageType type} could not be resolved.
@@ -69,7 +69,7 @@ public interface MessageTypeResolver {
      * This method returns an {@link Optional} that will be empty if the
      * {@link MessageType type} could not be resolved.
      *
-     * @param payload The {@link Message#getPayload() Message payload} to resolve a {@link MessageType type} for.
+     * @param payload The {@link Message#payload() Message payload} to resolve a {@link MessageType type} for.
      * @return An {@link Optional} containing the {@link MessageType type} for the given {@code payload},
      *         or empty if the type could not be resolved.
      */
@@ -86,7 +86,7 @@ public interface MessageTypeResolver {
      * This method returns an {@link Optional} that will be empty if the
      * {@link MessageType type} could not be resolved.
      *
-     * @param payloadType The {@link Class type} of the {@link Message#getPayload() Message payload} to resolve a
+     * @param payloadType The {@link Class type} of the {@link Message#payload() Message payload} to resolve a
      *                    {@link MessageType type} for.
      * @return An {@link Optional} containing the {@link MessageType type} for the given {@code payloadType},
      *         or empty if the type could not be resolved.

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -27,7 +27,7 @@ import jakarta.annotation.Nonnull;
 /**
  * A {@link Message} that represents a result of handling some form of request message.
  *
- * @param <R> The type of {@link #getPayload() result} contained in this {@link ResultMessage}.
+ * @param <R> The type of {@link #payload() result} contained in this {@link ResultMessage}.
  * @author Milan Savic
  * @since 4.0.0
  */
@@ -84,7 +84,7 @@ public interface ResultMessage<R> extends Message<R> {
         if (isExceptional()) {
             return serializer.serialize(exceptionDetails().orElse(null), expectedRepresentation);
         }
-        return serializer.serialize(getPayload(), expectedRepresentation);
+        return serializer.serialize(payload(), expectedRepresentation);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/MethodInvokingMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/MethodInvokingMessageHandlingMember.java
@@ -149,10 +149,15 @@ public class MethodInvokingMessageHandlingMember<T> implements MessageHandlingMe
     }
 
     @Override
-    public Object handleSync(@Nonnull Message<?> message, @Nonnull ProcessingContext context, T target) throws Exception {
+    public Object handleSync(@Nonnull Message<?> message,
+                             @Nonnull ProcessingContext context,
+                             T target) throws Exception {
         try {
-            return handle(message, context, target).first().asCompletableFuture().get()
-                                                                  .message().getPayload();
+            return handle(message, context, target).first()
+                                                   .asCompletableFuture()
+                                                   .get()
+                                                   .message()
+                                                   .payload();
         } catch (ExecutionException e) {
             if (e.getCause() instanceof Exception ex) {
                 throw ex;

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/PayloadParameterResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/PayloadParameterResolver.java
@@ -42,7 +42,7 @@ public class PayloadParameterResolver implements ParameterResolver<Object> {
 
     @Override
     public Object resolveParameterValue(@Nonnull ProcessingContext context) {
-        return Message.fromContext(context).getPayload();
+        return Message.fromContext(context).payload();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/BeanValidationInterceptor.java
@@ -92,7 +92,7 @@ public class BeanValidationInterceptor<T extends Message<?>>
 
     private Set<ConstraintViolation<Object>> validate(Message<?> message) {
         Validator validator = validatorFactory.getValidator();
-        return validateMessage(message.getPayload(), validator);
+        return validateMessage(message.payload(), validator);
     }
 
     @Deprecated
@@ -109,7 +109,7 @@ public class BeanValidationInterceptor<T extends Message<?>>
     public BiFunction<Integer, T, T> handle(@Nonnull List<? extends T> messages) {
         return (index, message) -> {
             Validator validator = validatorFactory.getValidator();
-            Set<ConstraintViolation<Object>> violations = validateMessage(message.getPayload(), validator);
+            Set<ConstraintViolation<Object>> violations = validateMessage(message.payload(), validator);
             if (violations != null && !violations.isEmpty()) {
                 throw new JSR303ViolationException(violations);
             }

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  * The conversion is generally used to accommodate response types that aren't compatible with serialization, such as
  * {@link OptionalResponseType}.
  *
- * @param <R> The type of {@link #getPayload() payload} contained in this {@link QueryResponseMessage}.
+ * @param <R> The type of {@link #payload() payload} contained in this {@link QueryResponseMessage}.
  * @author Allard Buijze
  * @since 4.3.0
  */
@@ -101,7 +101,7 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
     }
 
     @Override
-    public R getPayload() {
+    public R payload() {
         if (isExceptional()) {
             throw new IllegalPayloadAccessException(
                     "This result completed exceptionally, payload is not available. "
@@ -109,7 +109,7 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
                     optionalExceptionResult().orElse(null)
             );
         }
-        return expectedResponseType.convert(responseMessage.getPayload());
+        return expectedResponseType.convert(responseMessage.payload());
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/DefaultQueryGateway.java
@@ -97,7 +97,7 @@ public class DefaultQueryGateway implements QueryGateway {
                              if (queryResponseMessage.isExceptional()) {
                                  result.completeExceptionally(queryResponseMessage.exceptionResult());
                              } else {
-                                 result.complete(queryResponseMessage.getPayload());
+                                 result.complete(queryResponseMessage.payload());
                              }
                          } catch (Exception e) {
                              result.completeExceptionally(e);
@@ -127,7 +127,7 @@ public class DefaultQueryGateway implements QueryGateway {
     public <R, Q> Publisher<R> streamingQuery(Q query, Class<R> responseType) {
         return Mono.fromSupplier(() -> asStreamingQueryMessage(query, responseType))
                    .flatMapMany(queryMessage -> queryBus.streamingQuery(processInterceptors(queryMessage)))
-                   .map(Message::getPayload);
+                   .map(Message::payload);
     }
 
     private <R, Q> StreamingQueryMessage<Q, R> asStreamingQueryMessage(Q query,
@@ -148,7 +148,7 @@ public class DefaultQueryGateway implements QueryGateway {
                                           @Nonnull TimeUnit timeUnit) {
         QueryMessage<Q, R> queryMessage = asQueryMessage(query, responseType);
         return queryBus.scatterGather(processInterceptors(queryMessage), timeout, timeUnit)
-                       .map(QueryResponseMessage::getPayload);
+                       .map(QueryResponseMessage::payload);
     }
 
     private <R, Q> QueryMessage<Q, R> asQueryMessage(Q query,
@@ -197,12 +197,12 @@ public class DefaultQueryGateway implements QueryGateway {
             SubscriptionQueryResult<QueryResponseMessage<I>, SubscriptionQueryUpdateMessage<U>> result) {
         return new DefaultSubscriptionQueryResult<>(
                 result.initialResult()
-                      .filter(initialResult -> Objects.nonNull(initialResult.getPayload()))
-                      .map(Message::getPayload)
+                      .filter(initialResult -> Objects.nonNull(initialResult.payload()))
+                      .map(Message::payload)
                       .onErrorMap(e -> e instanceof IllegalPayloadAccessException ? e.getCause() : e),
                 result.updates()
-                      .filter(update -> Objects.nonNull(update.getPayload()))
-                      .map(SubscriptionQueryUpdateMessage::getPayload),
+                      .filter(update -> Objects.nonNull(update.payload()))
+                      .map(SubscriptionQueryUpdateMessage::payload),
                 result
         );
     }

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * Generic implementation of the {@link QueryMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link QueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link QueryMessage}.
  * @param <R> The type of {@link #getResponseType() response} expected from this {@link QueryMessage}.
  * @author Marc Gathier
  * @author Steven van Beelen
@@ -60,14 +60,14 @@ public class GenericQueryMessage<P, R> extends MessageDecorator<P> implements Qu
     /**
      * Constructs a {@code GenericQueryMessage} with given {@code delegate} and {@code responseType}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericQueryMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate     The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate     The {@link Message} containing {@link Message#payload() payload},
      *                     {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                     {@link Message#getMetaData() metadata} for the {@link QueryMessage} to reconstruct.
      * @param responseType The expected {@link ResponseType response type} for this {@link QueryMessage}.

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * Generic implementation of the {@link QueryResponseMessage} interface.
  *
- * @param <R> The type of {@link #getPayload() response} contained in this {@link QueryResponseMessage}.
+ * @param <R> The type of {@link #payload() response} contained in this {@link QueryResponseMessage}.
  * @author Allard Buijze
  * @author Steven van Beelen
  * @since 3.2.0
@@ -143,7 +143,7 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload}, {@link Message#type() type},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
      *                 {@link Message#identifier() identifier} and {@link Message#getMetaData() metadata} for the
      *                 {@link QueryResponseMessage} to reconstruct.
      */
@@ -158,7 +158,7 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
      *                  {@link Message#type() type, {@link Message#identifier() identifier} and {@link
      *                  Message#getMetaData() metadata} for the {@link QueryResponseMessage} to reconstruct.
      * @param exception The {@link Throwable} describing the error representing the response of this

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Generic implementation of the {@link StreamingQueryMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link StreamingQueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link StreamingQueryMessage}.
  * @param <R> The type of {@link #getResponseType() response} expected from this {@link StreamingQueryMessage} streamed
  *            via {@link Publisher}.
  * @author Milan Savic
@@ -79,14 +79,14 @@ public class GenericStreamingQueryMessage<P, R>
      * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and
      * {@code responseType}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericQueryMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate     The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate     The {@link Message} containing {@link Message#payload() payload},
      *                     {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                     {@link Message#getMetaData() metadata} for the {@link SubscriptionQueryMessage} to
      *                     reconstruct.
@@ -101,14 +101,14 @@ public class GenericStreamingQueryMessage<P, R>
      * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and
      * {@code responseType}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericQueryMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate     The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate     The {@link Message} containing {@link Message#payload() payload},
      *                     {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                     {@link Message#getMetaData() metadata} for the {@link SubscriptionQueryMessage} to
      *                     reconstruct.

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * Generic implementation of the {@link SubscriptionQueryMessage} interface.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link SubscriptionQueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link SubscriptionQueryMessage}.
  * @param <I> The type of {@link #getResponseType() initial response} expected from this
  *            {@link SubscriptionQueryMessage}.
  * @param <U> The type of {@link #getUpdateResponseType() incremental updates} expected from this
@@ -68,14 +68,14 @@ public class GenericSubscriptionQueryMessage<P, I, U>
      * Constructs a {@code GenericSubscriptionQueryMessage} with given {@code delegate},
      * {@code responseType}, and {@code updateResponseType}.
      * <p>
-     * The {@code delegate} will be used supply the {@link Message#getPayload() payload}, {@link Message#type() type},
+     * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#getMetaData() metadata} and {@link Message#identifier() identifier} of the resulting
      * {@code GenericQueryMessage}.
      * <p>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate           The {@link Message} containing {@link Message#getPayload() payload},
+     * @param delegate           The {@link Message} containing {@link Message#payload() payload},
      *                           {@link Message#type() type}, {@link Message#identifier() identifier} and
      *                           {@link Message#getMetaData() metadata} for the {@link SubscriptionQueryMessage} to
      *                           reconstruct.

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * Generic implementation of the {@link SubscriptionQueryUpdateMessage} interface holding incremental updates of a
  * subscription query.
  *
- * @param <U> The type of {@link #getPayload() update} contained in this {@link SubscriptionQueryUpdateMessage}.
+ * @param <U> The type of {@link #payload() update} contained in this {@link SubscriptionQueryUpdateMessage}.
  * @author Milan Savic
  * @author Steven van Beelen
  * @since 3.3.0
@@ -116,7 +116,7 @@ public class GenericSubscriptionQueryUpdateMessage<U>
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate The {@link Message} containing {@link Message#getPayload() payload}, {@link Message#type() type},
+     * @param delegate The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
      *                 {@link Message#identifier() identifier} and {@link Message#getMetaData() metadata} for the
      *                 {@link QueryResponseMessage} to reconstruct.
      */

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
@@ -24,12 +24,12 @@ import java.util.Map;
 /**
  * A {@link Message} type that carries a Query: a request for information.
  * <p>
- * Besides a {@link #getPayload() payload}, {@link QueryMessage QueryMessages} also carry the expected
+ * Besides a {@link #payload() payload}, {@link QueryMessage QueryMessages} also carry the expected
  * {@link #getResponseType() response type}. This is the type of result expected by the caller.
  * <p>
  * Handlers should only answer a query if they can respond with the appropriate response type.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link QueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link QueryMessage}.
  * @param <R> The type of {@link #getResponseType() response} expected from this {@link QueryMessage}.
  * @author Marc Gathier
  * @since 3.1.0

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A {@link ResultMessage} implementation that contains the result of query handling.
  *
- * @param <R> The type of {@link #getPayload() payload} contained in this {@link QueryResponseMessage}.
+ * @param <R> The type of {@link #payload() payload} contained in this {@link QueryResponseMessage}.
  * @author Allard Buijze
  * @since 3.2.0
  */

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryUpdateEmitter.java
@@ -122,7 +122,7 @@ public interface QueryUpdateEmitter extends MessageDispatchInterceptorSupport<Su
                              @Nonnull Predicate<? super Q> filter,
                              @Nonnull SubscriptionQueryUpdateMessage<U> update) {
         Predicate<SubscriptionQueryMessage<?, ?, U>> sqmFilter =
-                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.getPayload());
+                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.payload());
         emit(sqmFilter, update);
     }
 
@@ -160,7 +160,7 @@ public interface QueryUpdateEmitter extends MessageDispatchInterceptorSupport<Su
     @SuppressWarnings("unchecked")
     default <Q> void complete(@Nonnull Class<Q> queryType, @Nonnull Predicate<? super Q> filter) {
         Predicate<SubscriptionQueryMessage<?, ?, ?>> sqmFilter =
-                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.getPayload());
+                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.payload());
         complete(sqmFilter);
     }
 
@@ -184,7 +184,7 @@ public interface QueryUpdateEmitter extends MessageDispatchInterceptorSupport<Su
     default <Q> void completeExceptionally(@Nonnull Class<Q> queryType, @Nonnull Predicate<? super Q> filter,
                                            @Nonnull Throwable cause) {
         Predicate<SubscriptionQueryMessage<?, ?, ?>> sqmFilter =
-                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.getPayload());
+                m -> queryType.isAssignableFrom(m.getPayloadType()) && filter.test((Q) m.payload());
         completeExceptionally(sqmFilter, cause);
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -225,7 +225,7 @@ public class SimpleQueryBus implements QueryBus {
                         return result;
                     }
                 } else {
-                    result = resultMessage.getPayload();
+                    result = resultMessage.payload();
                     invocationSuccess = true;
                 }
             }
@@ -255,7 +255,7 @@ public class SimpleQueryBus implements QueryBus {
                                .doOnEach(new ErrorIfComplete(lastError, interceptedQuery))
                                .next()
                                .doOnEach(new SuccessReporter())
-                               .flatMapMany(Message::getPayload)
+                               .flatMapMany(Message::payload)
                        ).contextWrite(new MonitorCallbackContextWriter(messageMonitor, query))
                        .doOnTerminate(span::end);
         }
@@ -453,8 +453,8 @@ public class SimpleQueryBus implements QueryBus {
             errorHandler.onError(resultMessage.exceptionResult(), interceptedQuery, handler);
         } else {
             try {
-                response = resultMessage.getPayload().get(leftTimeout,
-                                                          TimeUnit.MILLISECONDS);
+                response = resultMessage.payload().get(leftTimeout,
+                                                       TimeUnit.MILLISECONDS);
                 monitorCallback.reportSuccess();
             } catch (Exception e) {
                 span.recordException(e);
@@ -565,15 +565,15 @@ public class SimpleQueryBus implements QueryBus {
                                                          declaredType);
             }
             return new GenericQueryResponseMessage<>(
-                    messageTypeResolver.resolveOrThrow(resultMessage.getPayload()),
-                    resultMessage.getPayload(),
+                    messageTypeResolver.resolveOrThrow(resultMessage.payload()),
+                    resultMessage.payload(),
                     resultMessage.getMetaData()
             );
         } else if (result instanceof Message) {
             //noinspection unchecked
             Message<R> message = (Message<R>) result;
-            return new GenericQueryResponseMessage<>(messageTypeResolver.resolveOrThrow(message.getPayload()),
-                                                     message.getPayload(),
+            return new GenericQueryResponseMessage<>(messageTypeResolver.resolveOrThrow(message.payload()),
+                                                     message.payload(),
                                                      message.getMetaData());
         } else {
             MessageType type = messageTypeResolver.resolveOrThrow(ObjectUtils.nullSafeTypeOf(result));
@@ -615,14 +615,14 @@ public class SimpleQueryBus implements QueryBus {
         } else if (result instanceof ResultMessage) {
             ResultMessage<R> resultMessage = (ResultMessage<R>) result;
             return new GenericQueryResponseMessage<>(
-                    messageTypeResolver.resolveOrThrow(resultMessage.getPayload()),
-                    resultMessage.getPayload(),
+                    messageTypeResolver.resolveOrThrow(resultMessage.payload()),
+                    resultMessage.payload(),
                     resultMessage.getMetaData()
             );
         } else if (result instanceof Message) {
             Message<R> message = (Message<R>) result;
-            return new GenericQueryResponseMessage<>(messageTypeResolver.resolveOrThrow(message.getPayload()),
-                                                     message.getPayload(),
+            return new GenericQueryResponseMessage<>(messageTypeResolver.resolveOrThrow(message.payload()),
+                                                     message.payload(),
                                                      message.getMetaData());
         } else {
             return new GenericQueryResponseMessage<>(messageTypeResolver.resolveOrThrow(result), (R) result);

--- a/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>
  * It hard codes the {@link #getResponseType() response type} to an {@link PublisherResponseType} implementation.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link StreamingQueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link StreamingQueryMessage}.
  * @param <R> The type of {@link #getResponseType() response} expected from this {@link StreamingQueryMessage} streamed
  *            via {@link Publisher}.
  * @author Milan Savic

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryMessage.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * <p>
  * Handlers should only answer a query if they can respond with the appropriate response type and update type.
  *
- * @param <P> The type of {@link #getPayload() payload} expressing the query in this {@link SubscriptionQueryMessage}.
+ * @param <P> The type of {@link #payload() payload} expressing the query in this {@link SubscriptionQueryMessage}.
  * @param <I> The type of {@link #getResponseType() initial response} expected from this
  *            {@link SubscriptionQueryMessage}.
  * @param <U> The type of {@link #getUpdateResponseType() incremental updates} expected from this

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * A {@link ResultMessage} implementation that holds incremental updates of a subscription query.
  *
- * @param <U> The type of {@link #getPayload() update} contained in this {@link SubscriptionQueryUpdateMessage}.
+ * @param <U> The type of {@link #payload() update} contained in this {@link SubscriptionQueryUpdateMessage}.
  * @author Milan Savic
  * @since 3.3.0
  */

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
@@ -26,15 +26,15 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
- * A message containing serialized {@link #getPayload() payload data} and {@link #getMetaData() metadata}.
+ * A message containing serialized {@link #payload() payload data} and {@link #getMetaData() metadata}.
  * <p>
- * A {@link SerializedMessage} will deserialize the payload or metadata on demand when {@link #getPayload()} or
+ * A {@link SerializedMessage} will deserialize the payload or metadata on demand when {@link #payload()} or
  * {@link #getMetaData()} is called.
  * <p>
  * The {@code SerializedMessage} guarantees that the payload and metadata will not be deserialized more than once.
  * Messages of this type  will not be serialized more than once by the same serializer.
  *
- * @param <P> The type of {@link #getPayload() payload} contained in this {@link org.axonframework.messaging.Message}.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link org.axonframework.messaging.Message}.
  * @author Rene de Waele
  * @author Steven van Beelen
  * @since 3.0.0
@@ -93,7 +93,7 @@ public class SerializedMessage<P> extends AbstractMessage<P> {
     }
 
     @Override
-    public P getPayload() {
+    public P payload() {
         try {
             return payload.getObject();
         } catch (SerializationException e) {

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedObjectHolder.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedObjectHolder.java
@@ -56,8 +56,8 @@ public class SerializedObjectHolder {
         synchronized (payloadGuard) {
             SerializedObject existingForm = serializedPayload.get(serializer);
             if (existingForm == null) {
-                SerializedObject<T> serialized = serializer.serialize(message.getPayload(), expectedRepresentation);
-                if (message.getPayload() == null) {
+                SerializedObject<T> serialized = serializer.serialize(message.payload(), expectedRepresentation);
+                if (message.payload() == null) {
                     // make sure the payload type is maintained
                     serialized = new SimpleSerializedObject<>(serialized.getData(),
                                                               serialized.getContentType(),

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -53,16 +53,16 @@ class GenericCommandMessageTest extends MessageTestSuite {
 
         assertSame(MetaData.emptyInstance(), message1.getMetaData());
         assertEquals(TEST_TYPE, message1.type());
-        assertEquals(Object.class, message1.getPayload().getClass());
+        assertEquals(Object.class, message1.payload().getClass());
 
         assertEquals(TEST_TYPE, message3.type());
         assertSame(testMetaData, message3.getMetaData());
-        assertEquals(Object.class, message3.getPayload().getClass());
+        assertEquals(Object.class, message3.payload().getClass());
 
         assertEquals(TEST_TYPE, message2.type());
         assertNotSame(testMetaDataMap, message2.getMetaData());
         assertEquals(testMetaDataMap, message2.getMetaData());
-        assertEquals(Object.class, message2.getPayload().getClass());
+        assertEquals(Object.class, message2.payload().getClass());
 
         assertNotEquals(message1.identifier(), message3.identifier());
         assertNotEquals(message1.identifier(), message2.identifier());

--- a/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/SimpleCommandBusTest.java
@@ -67,7 +67,7 @@ class SimpleCommandBusTest {
 
         CompletableFuture<? extends Message<?>> actual = testSubject.dispatch(TEST_COMMAND, StubProcessingContext.forMessage(TEST_COMMAND));
 
-        assertEquals("Hi!", actual.get().getPayload());
+        assertEquals("Hi!", actual.get().payload());
     }
 
     @Test
@@ -91,7 +91,7 @@ class SimpleCommandBusTest {
         assertTrue(actual.isDone());
         assertFalse(actual.isCompletedExceptionally());
         Message<?> actualResult = actual.join();
-        assertEquals(PAYLOAD, actualResult.getPayload());
+        assertEquals(PAYLOAD, actualResult.payload());
         assertNotNull(contextRef.get());
     }
 
@@ -297,7 +297,7 @@ class SimpleCommandBusTest {
     }
 
     private static GenericCommandResultMessage<?> asCommandResultMessage(CommandMessage<?> message) {
-        var payload = message.getPayload();
+        var payload = message.payload();
         return new GenericCommandResultMessage<>(new MessageType(payload.getClass()), payload);
     }
 }

--- a/messaging/src/test/java/org/axonframework/commandhandling/annotation/AnnotatedCommandHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/annotation/AnnotatedCommandHandlingComponentTest.java
@@ -77,7 +77,7 @@ class AnnotatedCommandHandlingComponentTest {
                                    .asCompletableFuture()
                                    .join()
                                    .message()
-                                   .getPayload();
+                                   .payload();
 
         assertNull(result);
         assertEquals(1, annotatedCommandHandler.voidHandlerInvoked);
@@ -93,7 +93,7 @@ class AnnotatedCommandHandlingComponentTest {
                                    .asCompletableFuture()
                                    .join()
                                    .message()
-                                   .getPayload();
+                                   .payload();
 
         assertEquals(1L, result);
         assertEquals(0, annotatedCommandHandler.voidHandlerInvoked);
@@ -110,7 +110,7 @@ class AnnotatedCommandHandlingComponentTest {
                                    .asCompletableFuture()
                                    .join()
                                    .message()
-                                   .getPayload();
+                                   .payload();
 
         assertEquals(1L, result);
         assertEquals(0, annotatedCommandHandler.voidHandlerInvoked);
@@ -161,7 +161,7 @@ class AnnotatedCommandHandlingComponentTest {
                                    .asCompletableFuture()
                                    .join()
                                    .message()
-                                   .getPayload();
+                                   .payload();
 
         assertNull(result);
         // TODO The interceptor chain is not yet implemented fully through the MessageStream.

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
@@ -56,8 +56,8 @@ class DefaultCommandGatewayTest {
         ));
         TestPayload payload = new TestPayload();
         CommandResult result = testSubject.send(payload, null);
-        verify(mockCommandBus).dispatch(argThat(m -> m.getPayload().equals(payload)), isNull());
-        assertEquals("OK", result.getResultMessage().get().getPayload());
+        verify(mockCommandBus).dispatch(argThat(m -> m.payload().equals(payload)), isNull());
+        assertEquals("OK", result.getResultMessage().get().payload());
     }
 
     @Test
@@ -66,7 +66,7 @@ class DefaultCommandGatewayTest {
                                      any())).thenAnswer(i -> CompletableFuture.failedFuture(new MockException()));
         TestPayload payload = new TestPayload();
         CommandResult result = testSubject.send(payload, null);
-        verify(mockCommandBus).dispatch(argThat(m -> m.getPayload().equals(payload)), isNull());
+        verify(mockCommandBus).dispatch(argThat(m -> m.payload().equals(payload)), isNull());
         assertTrue(result.getResultMessage().isCompletedExceptionally());
     }
 
@@ -77,7 +77,7 @@ class DefaultCommandGatewayTest {
         ));
         TestPayload payload = new TestPayload();
         CommandResult result = testSubject.send(payload, null);
-        verify(mockCommandBus).dispatch(argThat(m -> m.getPayload().equals(payload)), isNull());
+        verify(mockCommandBus).dispatch(argThat(m -> m.payload().equals(payload)), isNull());
         assertTrue(result.getResultMessage().isCompletedExceptionally());
     }
 
@@ -95,7 +95,7 @@ class DefaultCommandGatewayTest {
         // then
         var expectedMessageType = new MessageType("TestPayload");
         verify(mockCommandBus).dispatch(argThat(m -> m.type().equals(expectedMessageType)), isNull());
-        assertEquals("OK", result.getResultMessage().get().getPayload());
+        assertEquals("OK", result.getResultMessage().get().payload());
     }
 
     @Test
@@ -113,7 +113,7 @@ class DefaultCommandGatewayTest {
 
         // then
         verify(mockCommandBus).dispatch(argThat(m -> m.equals(testCommand)), isNull());
-        assertEquals("OK", result.getResultMessage().get().getPayload());
+        assertEquals("OK", result.getResultMessage().get().payload());
     }
 
     private static class TestPayload {

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/ResultDeserializingCommandGatewayTest.java
@@ -88,7 +88,7 @@ class ResultDeserializingCommandGatewayTest {
         CompletableFuture<byte[]> actual = commandResult.resultAs(byte[].class);
         assertTrue(actual.isDone());
         assertArrayEquals(HELLO_BYTES, actual.get());
-        assertEquals(HELLO_MESSAGE, commandResult.getResultMessage().get().getPayload());
+        assertEquals(HELLO_MESSAGE, commandResult.getResultMessage().get().payload());
     }
 
     @Test
@@ -107,7 +107,7 @@ class ResultDeserializingCommandGatewayTest {
 
         commandResult.onSuccess(byte[].class, (p, m) -> {
             assertArrayEquals(HELLO_BYTES, p);
-            assertEquals(HELLO_MESSAGE, m.getPayload());
+            assertEquals(HELLO_MESSAGE, m.payload());
             invoked.set(true);
         });
 

--- a/messaging/src/test/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetailsTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/dbscheduler/DbSchedulerBinaryDeadlineDetailsTest.java
@@ -77,7 +77,7 @@ class DbSchedulerBinaryDeadlineDetailsTest {
         assertEquals(descriptor, result.getDeserializedScopeDescriptor(serializer));
         DeadlineMessage<?> resultMessage = result.asDeadLineMessage(serializer);
         assertNotNull(resultMessage);
-        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.getPayload());
+        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.payload());
         assertEquals(META_DATA, resultMessage.getMetaData());
     }
 

--- a/messaging/src/test/java/org/axonframework/deadline/dbscheduler/DbSchedulerHumanReadableDeadlineDetailsTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/dbscheduler/DbSchedulerHumanReadableDeadlineDetailsTest.java
@@ -81,7 +81,7 @@ class DbSchedulerHumanReadableDeadlineDetailsTest {
         DeadlineMessage<?> resultMessage = result.asDeadLineMessage(serializer);
 
         assertNotNull(resultMessage);
-        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.getPayload());
+        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.payload());
         assertEquals(META_DATA, resultMessage.getMetaData());
     }
 

--- a/messaging/src/test/java/org/axonframework/deadline/jobrunr/DeadlineDetailsSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/jobrunr/DeadlineDetailsSerializationTest.java
@@ -84,7 +84,7 @@ class DeadlineDetailsSerializationTest {
         DeadlineMessage resultMessage = result.asDeadLineMessage(serializer);
 
         assertNotNull(resultMessage);
-        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.getPayload());
+        assertEquals(TEST_DEADLINE_PAYLOAD, resultMessage.payload());
         assertEquals(metaData, resultMessage.getMetaData());
     }
 }

--- a/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/quartz/DeadlineJobDataBinderTest.java
@@ -121,7 +121,7 @@ class DeadlineJobDataBinderTest {
         assertEquals(testDeadlineMessage.getDeadlineName(), result.getDeadlineName());
         assertEquals(testDeadlineMessage.identifier(), result.identifier());
         assertEquals(testDeadlineMessage.getTimestamp(), result.getTimestamp());
-        assertEquals(testDeadlineMessage.getPayload(), result.getPayload());
+        assertEquals(testDeadlineMessage.payload(), result.payload());
         assertEquals(testDeadlineMessage.getPayloadType(), result.getPayloadType());
         assertEquals(testDeadlineMessage.getMetaData(), result.getMetaData());
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/AbstractEventBusTest.java
@@ -244,7 +244,7 @@ class AbstractEventBusTest {
 
         private void onEvents(List<? extends EventMessage<?>> events) {
             //if the event payload is a number > 0, a new number is published that is 1 smaller than the first number
-            Object payload = events.get(0).getPayload();
+            Object payload = events.get(0).payload();
             if (payload instanceof Integer) {
                 int number = (int) payload;
                 if (number > 0) {
@@ -315,17 +315,17 @@ class AbstractEventBusTest {
                 return false;
             }
             StubNumberedEvent that = (StubNumberedEvent) o;
-            return Objects.equals(getPayload(), that.getPayload());
+            return Objects.equals(payload(), that.payload());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getPayload());
+            return Objects.hash(payload());
         }
 
         @Override
         public String toString() {
-            return "StubNumberedEvent{" + getPayload() + "}";
+            return "StubNumberedEvent{" + payload() + "}";
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/EventTestUtils.java
@@ -46,7 +46,7 @@ public abstract class EventTestUtils {
     /**
      * Constructs a {@link List} of {@link EventMessage EventMessages} with a size equalling the given {@code number}.
      * <p>
-     * The {@link EventMessage#getPayload() payload} of the events equals it's position within the sequence.
+     * The {@link EventMessage#payload() payload} of the events equals it's position within the sequence.
      *
      * @param number The number of events to construct.
      * @param <P>   The generic type of the expected payload of the resulting object.
@@ -59,11 +59,11 @@ public abstract class EventTestUtils {
     }
 
     /**
-     * Constructs an {@link EventMessage} with the given {@code seq} as the {@link EventMessage#getPayload() payload}.
+     * Constructs an {@link EventMessage} with the given {@code seq} as the {@link EventMessage#payload() payload}.
      *
      * @param seq The payload for the message to construct.
      * @param <P> The generic type of the expected payload of the resulting object.
-     * @return An {@link EventMessage} with the given {@code seq} as the {@link EventMessage#getPayload() payload}.
+     * @return An {@link EventMessage} with the given {@code seq} as the {@link EventMessage#payload() payload}.
      */
     public static <P> EventMessage<P> createEvent(int seq) {
         return EventTestUtils.asEventMessage(seq);

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericDomainEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericDomainEventMessageTest.java
@@ -53,20 +53,20 @@ class GenericDomainEventMessageTest {
         assertSame(id, message1.getAggregateIdentifier());
         assertEquals(seqNo, message1.getSequenceNumber());
         assertSame(MetaData.emptyInstance(), message1.getMetaData());
-        assertEquals(Object.class, message1.getPayload().getClass());
+        assertEquals(Object.class, message1.payload().getClass());
         assertEquals(Object.class, message1.getPayloadType());
 
         assertSame(id, message2.getAggregateIdentifier());
         assertEquals(seqNo, message2.getSequenceNumber());
         assertSame(metaData, message2.getMetaData());
-        assertEquals(Object.class, message2.getPayload().getClass());
+        assertEquals(Object.class, message2.payload().getClass());
         assertEquals(Object.class, message2.getPayloadType());
 
         assertSame(id, message3.getAggregateIdentifier());
         assertEquals(seqNo, message3.getSequenceNumber());
         assertNotSame(metaDataMap, message3.getMetaData());
         assertEquals(metaDataMap, message3.getMetaData());
-        assertEquals(Object.class, message3.getPayload().getClass());
+        assertEquals(Object.class, message3.payload().getClass());
         assertEquals(Object.class, message3.getPayloadType());
 
         assertNotEquals(message1.identifier(), message2.identifier());

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -52,16 +52,16 @@ class GenericEventMessageTest extends MessageTestSuite {
                 new GenericEventMessage<>(new MessageType("event"), payload, metaDataMap);
 
         assertSame(MetaData.emptyInstance(), message1.getMetaData());
-        assertEquals(Object.class, message1.getPayload().getClass());
+        assertEquals(Object.class, message1.payload().getClass());
         assertEquals(Object.class, message1.getPayloadType());
 
         assertEquals(metaData, message2.getMetaData());
-        assertEquals(Object.class, message2.getPayload().getClass());
+        assertEquals(Object.class, message2.payload().getClass());
         assertEquals(Object.class, message2.getPayloadType());
 
         assertNotSame(metaDataMap, message3.getMetaData());
         assertEquals(metaDataMap, message3.getMetaData());
-        assertEquals(Object.class, message3.getPayload().getClass());
+        assertEquals(Object.class, message3.payload().getClass());
         assertEquals(Object.class, message3.getPayloadType());
 
         assertNotEquals(message1.identifier(), message2.identifier());

--- a/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/async/AsynchronousEventProcessorConcurrencyTest.java
@@ -42,7 +42,7 @@ class AsynchronousEventProcessorConcurrencyTest {
     @BeforeEach
     void setUp() {
         executor = Executors.newCachedThreadPool();
-        testSubject = new AsynchronousEventProcessingStrategy(executor, e -> Optional.of(e.getPayload()));
+        testSubject = new AsynchronousEventProcessingStrategy(executor, e -> Optional.of(e.payload()));
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventIntegrationTest.java
@@ -173,7 +173,7 @@ public abstract class DeadLetteringEventIntegrationTest {
         DeadLetteringEventHandlerInvoker.Builder invokerBuilder = DeadLetteringEventHandlerInvoker
                 .builder()
                 .eventHandlers(eventHandlingComponent)
-                .sequencingPolicy(event -> Optional.of(((DeadLetterableEvent) event.getPayload()).getAggregateIdentifier()))
+                .sequencingPolicy(event -> Optional.of(((DeadLetterableEvent) event.payload()).getAggregateIdentifier()))
                 .enqueuePolicy(enqueuePolicy)
                 .queue(deadLetterQueue)
                 .transactionManager(transactionManager);
@@ -265,7 +265,7 @@ public abstract class DeadLetteringEventIntegrationTest {
         Iterator<DeadLetter<? extends EventMessage<?>>> sequence = deadLetterQueue.deadLetterSequence("failure")
                                                                                   .iterator();
         assertTrue(sequence.hasNext());
-        assertEquals(failedEvent.getPayload(), sequence.next().message().getPayload());
+        assertEquals(failedEvent.payload(), sequence.next().message().payload());
         assertFalse(sequence.hasNext());
     }
 
@@ -305,11 +305,11 @@ public abstract class DeadLetteringEventIntegrationTest {
             Iterator<DeadLetter<? extends EventMessage<?>>> sequence = deadLetterQueue.deadLetterSequence(aggregateId)
                                                                                       .iterator();
             assertTrue(sequence.hasNext());
-            assertEquals(firstDeadLetter, sequence.next().message().getPayload());
+            assertEquals(firstDeadLetter, sequence.next().message().payload());
             assertTrue(sequence.hasNext());
-            assertEquals(secondDeadLetter, sequence.next().message().getPayload());
+            assertEquals(secondDeadLetter, sequence.next().message().payload());
             assertTrue(sequence.hasNext());
-            assertEquals(thirdDeadLetter, sequence.next().message().getPayload());
+            assertEquals(thirdDeadLetter, sequence.next().message().payload());
             assertFalse(sequence.hasNext());
         });
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcDeadLetteringEventIntegrationTest.java
@@ -172,7 +172,7 @@ class JdbcDeadLetteringEventIntegrationTest extends DeadLetteringEventIntegratio
             JdbcDeadLetter<? extends EventMessage<?>> actual = ((JdbcDeadLetter<? extends EventMessage<?>>) result);
 
             assertEquals(expected.getSequenceIdentifier(), actual.getSequenceIdentifier(), assertMessageSupplier);
-            assertEquals(expected.message().getPayload(), actual.message().getPayload(), assertMessageSupplier);
+            assertEquals(expected.message().payload(), actual.message().payload(), assertMessageSupplier);
             assertFalse(result.cause().isPresent(), assertMessageSupplier);
             assertEquals(expected.diagnostics(), actual.diagnostics(), assertMessageSupplier);
             assertEquals(sequenceIndex.longValue(), actual.getSequenceIndex(), assertMessageSupplier);

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueueTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/JdbcSequencedDeadLetterQueueTest.java
@@ -178,7 +178,7 @@ class JdbcSequencedDeadLetterQueueTest extends SequencedDeadLetterQueueTest<Even
                                 DeadLetter<? extends EventMessage<?>> actual) {
         EventMessage<?> expectedMessage = expected.message();
         EventMessage<?> actualMessage = actual.message();
-        assertEquals(expectedMessage.getPayload(), actualMessage.getPayload());
+        assertEquals(expectedMessage.payload(), actualMessage.payload());
         assertEquals(expectedMessage.getPayloadType(), actualMessage.getPayloadType());
         assertEquals(expectedMessage.getMetaData(), actualMessage.getMetaData());
         assertEquals(expectedMessage.identifier(), actualMessage.identifier());

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverterTest.java
@@ -145,7 +145,7 @@ class EventMessageDeadLetterJpaConverterTest {
     private void assertCorrectlyRestored(EventMessage<?> expected, EventMessage<?> actual) {
         assertEquals(expected.identifier(), actual.identifier());
         assertEquals(expected.getTimestamp(), actual.getTimestamp());
-        assertEquals(expected.getPayload(), actual.getPayload());
+        assertEquals(expected.payload(), actual.payload());
         assertEquals(expected.getPayloadType(), actual.getPayloadType());
         assertEquals(expected.getMetaData(), actual.getMetaData());
 
@@ -167,7 +167,7 @@ class EventMessageDeadLetterJpaConverterTest {
     private void assertCorrectlyMapped(EventMessage<?> eventMessage, DeadLetterEventEntry deadLetterEventEntry) {
         assertEquals(eventMessage.identifier(), deadLetterEventEntry.getEventIdentifier());
         assertEquals(eventMessage.getTimestamp().toString(), deadLetterEventEntry.getTimeStamp());
-        assertEquals(eventMessage.getPayload().getClass().getName(),
+        assertEquals(eventMessage.payload().getClass().getName(),
                      deadLetterEventEntry.getPayload().getType().getName());
         assertEquals(PAYLOAD_REVISION, deadLetterEventEntry.getPayload().getType().getRevision());
         assertEquals(eventSerializer.serialize(event, String.class).getData(),

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueueTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jpa/JpaSequencedDeadLetterQueueTest.java
@@ -120,7 +120,7 @@ class JpaSequencedDeadLetterQueueTest extends SequencedDeadLetterQueueTest<Event
     protected void assertLetter(DeadLetter<? extends EventMessage<?>> expected,
                                 DeadLetter<? extends EventMessage<?>> actual) {
 
-        assertEquals(expected.message().getPayload(), actual.message().getPayload());
+        assertEquals(expected.message().payload(), actual.message().payload());
         assertEquals(expected.message().getPayloadType(), actual.message().getPayloadType());
         assertEquals(expected.message().getMetaData(), actual.message().getMetaData());
         assertEquals(expected.message().identifier(), actual.message().identifier());

--- a/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
@@ -66,7 +66,7 @@ class DefaultEventGatewayTest {
         // Then
         verify(mockEventSink).publish(contextCaptor.capture(), eventCaptor.capture());
         List<EventMessage<?>> result = eventCaptor.getValue();
-        assertEquals("Event1", result.getFirst().getPayload());
+        assertEquals("Event1", result.getFirst().payload());
         assertEquals("java.lang.String", result.getFirst().type().qualifiedName().name());
         assertNull(contextCaptor.getValue());
     }
@@ -85,7 +85,7 @@ class DefaultEventGatewayTest {
         // Then
         verify(mockEventSink).publish(contextCaptor.capture(), eventCaptor.capture());
         List<EventMessage<?>> result = eventCaptor.getValue();
-        assertEquals("Event1", result.getFirst().getPayload());
+        assertEquals("Event1", result.getFirst().payload());
         assertEquals("java.lang.String", result.getFirst().type().qualifiedName().name());
         assertEquals(testContext, contextCaptor.getValue());
     }
@@ -103,9 +103,9 @@ class DefaultEventGatewayTest {
         verify(mockEventSink).publish(isNull(), eventsCaptor.capture());
         List<EventMessage<?>> result = eventsCaptor.getValue();
         assertEquals(2, result.size());
-        assertEquals("Event2", result.get(0).getPayload());
+        assertEquals("Event2", result.get(0).payload());
         assertEquals("java.lang.String", result.getFirst().type().qualifiedName().name());
-        assertEquals("Event3", result.get(1).getPayload());
+        assertEquals("Event3", result.get(1).payload());
         assertEquals("java.lang.String", result.get(1).type().qualifiedName().name());
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/gateway/ProcessingContextEventAppenderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/gateway/ProcessingContextEventAppenderTest.java
@@ -60,8 +60,8 @@ class ProcessingContextEventAppenderTest {
         assertEquals(2, publishedEvents.size());
         EventMessage<?> publishedEvent1 = publishedEvents.get(0);
         EventMessage<?> publishedEvent2 = publishedEvents.get(1);
-        assertEquals(payload1, publishedEvent1.getPayload());
-        assertEquals(payload2, publishedEvent2.getPayload());
+        assertEquals(payload1, publishedEvent1.payload());
+        assertEquals(payload2, publishedEvent2.payload());
         assertEquals(
                 messageTypeResolver.resolveOrThrow(payload1).qualifiedName(),
                 publishedEvent1.type().qualifiedName()

--- a/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/pooled/PooledStreamingEventProcessorTest.java
@@ -497,7 +497,7 @@ class PooledStreamingEventProcessorTest {
 
         // then - Verify the event was tracked as ignored (even though filtered at stream level)
         assertThat(stubMessageSource.getIgnoredEvents()).hasSize(1);
-        assertThat(stubMessageSource.getIgnoredEvents().getFirst().getPayload()).isEqualTo(1337);
+        assertThat(stubMessageSource.getIgnoredEvents().getFirst().payload()).isEqualTo(1337);
     }
 
     @Test
@@ -525,19 +525,19 @@ class PooledStreamingEventProcessorTest {
         EventMessage<Integer> eventToIgnoreTwo = EventTestUtils.asEventMessage(42);
         EventMessage<Integer> eventToIgnoreThree = EventTestUtils.asEventMessage(9001);
         List<Integer> eventsToIgnore = new ArrayList<>();
-        eventsToIgnore.add(eventToIgnoreOne.getPayload());
-        eventsToIgnore.add(eventToIgnoreTwo.getPayload());
-        eventsToIgnore.add(eventToIgnoreThree.getPayload());
+        eventsToIgnore.add(eventToIgnoreOne.payload());
+        eventsToIgnore.add(eventToIgnoreTwo.payload());
+        eventsToIgnore.add(eventToIgnoreThree.payload());
 
         EventMessage<String> eventToHandleOne = EventTestUtils.asEventMessage("some-text");
         EventMessage<String> eventToHandleTwo = EventTestUtils.asEventMessage("some-other-text");
         List<String> eventsToHandle = new ArrayList<>();
-        eventsToHandle.add(eventToHandleOne.getPayload());
-        eventsToHandle.add(eventToHandleTwo.getPayload());
+        eventsToHandle.add(eventToHandleOne.payload());
+        eventsToHandle.add(eventToHandleTwo.payload());
 
         List<Object> eventsToValidate = new ArrayList<>();
-        eventsToValidate.add(eventToHandleOne.getPayload());
-        eventsToValidate.add(eventToHandleTwo.getPayload());
+        eventsToValidate.add(eventToHandleOne.payload());
+        eventsToValidate.add(eventToHandleTwo.payload());
 
         // when
         stubMessageSource.publishMessage(eventToIgnoreOne);
@@ -561,7 +561,7 @@ class PooledStreamingEventProcessorTest {
         assertThat(handledEvents).hasSize(2);
 
         List<Object> handledPayloads = handledEvents.stream()
-                                                    .map(EventMessage::getPayload)
+                                                    .map(EventMessage::payload)
                                                     .collect(Collectors.toList());
         assertThat(handledPayloads).containsExactlyInAnyOrderElementsOf(eventsToHandle);
 
@@ -570,7 +570,7 @@ class PooledStreamingEventProcessorTest {
         assertThat(ignoredEvents).hasSize(3);
 
         List<Object> ignoredPayloads = ignoredEvents.stream()
-                                                    .map(EventMessage::getPayload)
+                                                    .map(EventMessage::payload)
                                                     .collect(Collectors.toList());
         assertThat(ignoredPayloads).containsExactlyInAnyOrderElementsOf(eventsToIgnore);
     }

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
@@ -52,16 +52,16 @@ class GenericResetContextTest extends MessageTestSuite {
         ResetContext<Object> messageThree = new GenericResetContext<>(TEST_TYPE, TEST_PAYLOAD, metaData);
 
         assertSame(MetaData.emptyInstance(), messageOne.getMetaData());
-        assertEquals(Object.class, messageOne.getPayload().getClass());
+        assertEquals(Object.class, messageOne.payload().getClass());
         assertEquals(Object.class, messageOne.getPayloadType());
 
         assertNotSame(metaDataMap, messageTwo.getMetaData());
         assertEquals(metaDataMap, messageTwo.getMetaData());
-        assertEquals(Object.class, messageTwo.getPayload().getClass());
+        assertEquals(Object.class, messageTwo.payload().getClass());
         assertEquals(Object.class, messageTwo.getPayloadType());
 
         assertSame(metaData, messageThree.getMetaData());
-        assertEquals(Object.class, messageThree.getPayload().getClass());
+        assertEquals(Object.class, messageThree.payload().getClass());
         assertEquals(Object.class, messageThree.getPayloadType());
 
         assertNotEquals(messageOne.identifier(), messageTwo.identifier());

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
@@ -106,7 +106,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(1, publishedMessage.getPayload());
+        assertEquals(1, publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertTrue(publishedMessage.getMetaData().isEmpty());
     }
@@ -120,7 +120,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(1, publishedMessage.getPayload());
+        assertEquals(1, publishedMessage.payload());
     }
 
     @Test
@@ -137,7 +137,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(2, publishedMessage.getPayload());
+        assertEquals(2, publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertEquals(metadata, publishedMessage.getMetaData());
     }
@@ -152,7 +152,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(new PayloadWithRevision(), publishedMessage.getPayload());
+        assertEquals(new PayloadWithRevision(), publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertTrue(publishedMessage.getMetaData().isEmpty());
     }
@@ -172,7 +172,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(new PayloadWithRevision(), publishedMessage.getPayload());
+        assertEquals(new PayloadWithRevision(), publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertEquals(metadata, publishedMessage.getMetaData());
     }
@@ -186,7 +186,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
         assertEquals(1, publishedMessages.size());
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
-        assertEquals(4, publishedMessage.getPayload());
+        assertEquals(4, publishedMessage.payload());
     }
 
     @Test
@@ -198,7 +198,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
         assertEquals(1, publishedMessages.size());
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
-        assertEquals(6, publishedMessage.getPayload());
+        assertEquals(6, publishedMessage.payload());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/java/SimpleEventSchedulerTest.java
@@ -26,11 +26,6 @@ import org.junit.jupiter.api.extension.*;
 import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -98,7 +93,7 @@ class SimpleEventSchedulerTest {
         latch.await(1, TimeUnit.SECONDS);
         verify(eventBus, never()).publish(event1);
         verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<Object>>) item -> (item != null)
-                && event2.getPayload().equals(item.getPayload())
+                && event2.payload().equals(item.payload())
                 && event2.getMetaData().equals(item.getMetaData())));
         scheduledExecutorService.shutdown();
         assertTrue(scheduledExecutorService.awaitTermination(1, TimeUnit.SECONDS),

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
@@ -100,7 +100,7 @@ class JobRunrEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(1, publishedMessage.getPayload());
+        assertEquals(1, publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertTrue(publishedMessage.getMetaData().isEmpty());
     }
@@ -114,7 +114,7 @@ class JobRunrEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(1, publishedMessage.getPayload());
+        assertEquals(1, publishedMessage.payload());
     }
 
     @Test
@@ -131,7 +131,7 @@ class JobRunrEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(2, publishedMessage.getPayload());
+        assertEquals(2, publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertEquals(metadata, publishedMessage.getMetaData());
     }
@@ -146,7 +146,7 @@ class JobRunrEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(new PayloadWithRevision(), publishedMessage.getPayload());
+        assertEquals(new PayloadWithRevision(), publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertTrue(publishedMessage.getMetaData().isEmpty());
     }
@@ -166,7 +166,7 @@ class JobRunrEventSchedulerTest {
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
 
-        assertEquals(new PayloadWithRevision(), publishedMessage.getPayload());
+        assertEquals(new PayloadWithRevision(), publishedMessage.payload());
         assertTrue(rightAfterSchedule.isBefore(publishedMessage.getTimestamp()));
         assertEquals(metadata, publishedMessage.getMetaData());
     }
@@ -180,7 +180,7 @@ class JobRunrEventSchedulerTest {
         assertEquals(1, publishedMessages.size());
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
-        assertEquals(4, publishedMessage.getPayload());
+        assertEquals(4, publishedMessage.payload());
     }
 
     @Test
@@ -192,7 +192,7 @@ class JobRunrEventSchedulerTest {
         assertEquals(1, publishedMessages.size());
 
         EventMessage<?> publishedMessage = publishedMessages.getFirst();
-        assertEquals(6, publishedMessage.getPayload());
+        assertEquals(6, publishedMessage.payload());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/scheduling/quartz/DirectEventJobDataBinderTest.java
@@ -111,7 +111,7 @@ class DirectEventJobDataBinderTest {
 
         assertEquals(testEventMessage.identifier(), resultEventMessage.identifier());
         assertEquals(testEventMessage.getTimestamp(), resultEventMessage.getTimestamp());
-        assertEquals(testEventMessage.getPayload(), resultEventMessage.getPayload());
+        assertEquals(testEventMessage.payload(), resultEventMessage.payload());
         assertEquals(testEventMessage.getPayloadType(), resultEventMessage.getPayloadType());
         assertEquals(testEventMessage.getMetaData(), resultEventMessage.getMetaData());
 

--- a/messaging/src/test/java/org/axonframework/eventstreaming/LegacyStreamableEventSourceTest.java
+++ b/messaging/src/test/java/org/axonframework/eventstreaming/LegacyStreamableEventSourceTest.java
@@ -216,7 +216,7 @@ class LegacyStreamableEventSourceTest {
 
         private static void assertEvent(EventMessage<?> actual, EventMessage<?> expected) {
             assertEquals(expected.identifier(), actual.identifier());
-            assertEquals(expected.getPayload(), actual.getPayload());
+            assertEquals(expected.payload(), actual.payload());
             assertEquals(expected.getTimestamp(), actual.getTimestamp());
             assertEquals(expected.getMetaData(), actual.getMetaData());
         }

--- a/messaging/src/test/java/org/axonframework/messaging/DefaultInterceptorChainTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DefaultInterceptorChainTest.java
@@ -65,6 +65,6 @@ class DefaultInterceptorChainTest {
         String actual = (String) testSubject.proceedSync(StubProcessingContext.forUnitOfWork(unitOfWork));
 
         assertSame("Result", actual);
-        verify(mockHandler).handleSync(argThat(x -> (x != null) && x.getPayload().equals("testing")), any());
+        verify(mockHandler).handleSync(argThat(x -> (x != null) && x.payload().equals("testing")), any());
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
@@ -130,7 +130,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message<String>> {
         @Test
         void reduceResultBecomesVisibleWhenFutureCompletes() {
             Message<String> randomMessage = createRandomMessage();
-            String expected = randomMessage.getPayload() + randomMessage.getPayload();
+            String expected = randomMessage.payload() + randomMessage.payload();
             MessageStream<Message<String>> futureStream = completedTestSubject(List.of(randomMessage, randomMessage));
             CompletableFuture<MessageStream<Message<String>>> testFuture = new CompletableFuture<>();
 
@@ -138,7 +138,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message<String>> {
 
             CompletableFuture<String> result = testSubject.reduce(
                     "",
-                    (base, entry) -> base + entry.message().getPayload()
+                    (base, entry) -> base + entry.message().payload()
             );
             assertFalse(result.isDone());
 
@@ -288,7 +288,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message<String>> {
         @Test
         void reduceResultBecomesVisibleWhenFutureCompletes() {
             Message<String> randomMessage = createRandomMessage();
-            String expected = randomMessage.getPayload();
+            String expected = randomMessage.payload();
             MessageStream.Single<Message<String>> futureStream = completedSingleStreamTestSubject(randomMessage);
             CompletableFuture<MessageStream.Single<Message<String>>> testFuture = new CompletableFuture<>();
 
@@ -296,7 +296,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message<String>> {
 
             CompletableFuture<String> result = testSubject.reduce(
                     "",
-                    (base, entry) -> base + entry.message().getPayload()
+                    (base, entry) -> base + entry.message().payload()
             );
             assertFalse(result.isDone());
 

--- a/messaging/src/test/java/org/axonframework/messaging/FilteringMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FilteringMessageStreamTest.java
@@ -69,7 +69,7 @@ class FilteringMessageStreamTest extends MessageStreamTest<Message<String>> {
             MessageStream<Message<String>> delegate = MessageStream.fromIterable(List.of(first, second));
             FilteringMessageStream<Message<String>> stream = new FilteringMessageStream<>(delegate,
                                                                                           entry -> entry.message()
-                                                                                                        .getPayload()
+                                                                                                        .payload()
                                                                                                         .equals("keep"));
 
             Optional<Entry<Message<String>>> peeked = stream.peek();
@@ -77,9 +77,9 @@ class FilteringMessageStreamTest extends MessageStreamTest<Message<String>> {
             Optional<Entry<Message<String>>> after = stream.next();
 
             assertThat(peeked).isPresent();
-            assertThat(peeked.get().message().getPayload()).isEqualTo("keep");
+            assertThat(peeked.get().message().payload()).isEqualTo("keep");
             assertThat(next).isPresent();
-            assertThat(next.get().message().getPayload()).isEqualTo("keep");
+            assertThat(next.get().message().payload()).isEqualTo("keep");
             assertThat(after).isNotPresent();
         }
 
@@ -90,7 +90,7 @@ class FilteringMessageStreamTest extends MessageStreamTest<Message<String>> {
             MessageStream<Message<String>> delegate = MessageStream.fromIterable(List.of(first, second));
             FilteringMessageStream<Message<String>> stream = new FilteringMessageStream<>(delegate,
                                                                                           entry -> entry.message()
-                                                                                                        .getPayload()
+                                                                                                        .payload()
                                                                                                         .startsWith(
                                                                                                                 "keep"));
 
@@ -117,17 +117,17 @@ class FilteringMessageStreamTest extends MessageStreamTest<Message<String>> {
             MessageStream<Message<String>> delegate = MessageStream.fromIterable(List.of(first, second, third, fourth));
             FilteringMessageStream<Message<String>> stream = new FilteringMessageStream<>(delegate,
                                                                                           entry -> entry.message()
-                                                                                                        .getPayload()
+                                                                                                        .payload()
                                                                                                         .startsWith(
                                                                                                                 "keep"));
 
             Optional<Entry<Message<String>>> firstMatch = stream.next();
             assertThat(firstMatch).isPresent();
-            assertThat(firstMatch.get().message().getPayload()).isEqualTo("keep1");
+            assertThat(firstMatch.get().message().payload()).isEqualTo("keep1");
 
             Optional<Entry<Message<String>>> secondMatch = stream.next();
             assertThat(secondMatch).isPresent();
-            assertThat(secondMatch.get().message().getPayload()).isEqualTo("keep2");
+            assertThat(secondMatch.get().message().payload()).isEqualTo("keep2");
 
             Optional<Entry<Message<String>>> after = stream.next();
             assertThat(after).isNotPresent();
@@ -140,7 +140,7 @@ class FilteringMessageStreamTest extends MessageStreamTest<Message<String>> {
             MessageStream<Message<String>> delegate = MessageStream.fromIterable(List.of(first, second));
             FilteringMessageStream<Message<String>> stream = new FilteringMessageStream<>(delegate,
                                                                                           entry -> entry.message()
-                                                                                                        .getPayload()
+                                                                                                        .payload()
                                                                                                         .startsWith(
                                                                                                                 "keep"));
 

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -77,7 +77,7 @@ class GenericMessageTest extends MessageTestSuite {
 
         assertEquals(testIdentifier, testSubject.identifier());
         assertEquals(testType, testSubject.type());
-        assertEquals(testPayload, testSubject.getPayload());
+        assertEquals(testPayload, testSubject.payload());
         assertEquals(testMetaData, testSubject.getMetaData());
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class GenericResultMessageTest {
         Throwable t = new Throwable("oops");
         ResultMessage<?> resultMessage = asResultMessage(t);
         try {
-            resultMessage.getPayload();
+            resultMessage.payload();
         } catch (IllegalPayloadAccessException ipae) {
             assertEquals(t, ipae.getCause());
         }

--- a/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
@@ -656,13 +656,13 @@ public abstract class MessageStreamTest<M extends Message<?>> {
     @Test
     void shouldReduceToExpectedResult() {
         M randomMessage = createRandomMessage();
-        String expected = randomMessage.getPayload().toString() + randomMessage.getPayload().toString();
+        String expected = randomMessage.payload().toString() + randomMessage.payload().toString();
 
         MessageStream<M> testSubject = completedTestSubject(List.of(randomMessage, randomMessage));
 
         CompletableFuture<String> result = testSubject.reduce(
                 "",
-                (base, entry) -> entry.message().getPayload().toString() + entry.message().getPayload().toString()
+                (base, entry) -> entry.message().payload().toString() + entry.message().payload().toString()
         );
 
         assertTrue(result.isDone());
@@ -700,7 +700,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                 expected,
                 (base, entry) -> {
                     invoked.set(true);
-                    return entry.message().getPayload().toString() + entry.message().getPayload().toString();
+                    return entry.message().payload().toString() + entry.message().payload().toString();
                 }
         );
 
@@ -720,7 +720,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                 "",
                 (base, entry) -> {
                     invoked.set(true);
-                    return entry.message().getPayload().toString() + entry.message().getPayload().toString();
+                    return entry.message().payload().toString() + entry.message().payload().toString();
                 }
         );
 
@@ -741,7 +741,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
                 "",
                 (base, entry) -> {
                     invoked.set(true);
-                    return entry.message().getPayload().toString() + entry.message().getPayload().toString();
+                    return entry.message().payload().toString() + entry.message().payload().toString();
                 }
         );
 
@@ -1042,9 +1042,9 @@ public abstract class MessageStreamTest<M extends Message<?>> {
 
             //then
             assertTrue(peeked.isPresent());
-            assertEquals(message.getPayload(), peeked.get().message().getPayload());
+            assertEquals(message.payload(), peeked.get().message().payload());
             assertTrue(peekedAgain.isPresent());
-            assertEquals(message.getPayload(), peekedAgain.get().message().getPayload());
+            assertEquals(message.payload(), peekedAgain.get().message().payload());
         }
 
         @Test
@@ -1071,9 +1071,9 @@ public abstract class MessageStreamTest<M extends Message<?>> {
 
             //then
             assertTrue(peeked.isPresent());
-            assertEquals(messages.getFirst().getPayload(), peeked.get().message().getPayload());
+            assertEquals(messages.getFirst().payload(), peeked.get().message().payload());
             assertTrue(next.isPresent());
-            assertEquals(messages.getFirst().getPayload(), next.get().message().getPayload());
+            assertEquals(messages.getFirst().payload(), next.get().message().payload());
         }
 
         @Test
@@ -1089,7 +1089,7 @@ public abstract class MessageStreamTest<M extends Message<?>> {
             //then
             assertTrue(peeked.isPresent());
             assertTrue(next.isPresent());
-            assertEquals(peeked.get().message().getPayload(), next.get().message().getPayload());
+            assertEquals(peeked.get().message().payload(), next.get().message().payload());
         }
 
         @Test
@@ -1143,9 +1143,9 @@ public abstract class MessageStreamTest<M extends Message<?>> {
 
             //then
             assertTrue(peeked.isPresent());
-            assertEquals(message.getPayload(), peeked.get().message().getPayload());
+            assertEquals(message.payload(), peeked.get().message().payload());
             assertTrue(peekedAgain.isPresent());
-            assertEquals(message.getPayload(), peekedAgain.get().message().getPayload());
+            assertEquals(message.payload(), peekedAgain.get().message().payload());
         }
 
         @Test

--- a/messaging/src/test/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueueTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/deadletter/SequencedDeadLetterQueueTest.java
@@ -741,8 +741,8 @@ public abstract class SequencedDeadLetterQueueTest<M extends Message<?>> {
         // Add non-matching-id letter
         testSubject.enqueue(nonMatchingId, generateInitialLetter());
 
-        boolean result = testSubject.process(letter -> letter.message().getPayload()
-                                                             .equals(testLetter.message().getPayload()), testTask);
+        boolean result = testSubject.process(letter -> letter.message().payload()
+                                                             .equals(testLetter.message().payload()), testTask);
         assertTrue(result);
         assertLetter(testLetter, resultLetter.get());
 

--- a/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessageTest.java
@@ -39,7 +39,7 @@ class ConvertingResponseMessageTest {
                 new ConvertingResponseMessage<>(ResponseTypes.multipleInstancesOf(String.class), msg);
 
         assertEquals(List.class, wrapped.getPayloadType());
-        assertEquals(singletonList("Some string result"), wrapped.getPayload());
+        assertEquals(singletonList("Some string result"), wrapped.payload());
         assertEquals("value", wrapped.getMetaData().get("test"));
     }
 
@@ -50,7 +50,7 @@ class ConvertingResponseMessageTest {
                 new ConvertingResponseMessage<>(ResponseTypes.multipleInstancesOf(String.class), msg);
 
         assertEquals(List.class, wrapped.getPayloadType());
-        assertThrows(IllegalPayloadAccessException.class, wrapped::getPayload);
+        assertThrows(IllegalPayloadAccessException.class, wrapped::payload);
     }
 
     private static <R> QueryResponseMessage<R> asResponseMessage(Class<R> declaredType, Throwable exception) {

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/AbstractUnitOfWorkTest.java
@@ -140,9 +140,9 @@ class AbstractUnitOfWorkTest {
         inOrder.verify(task).call(any());
         inOrder.verify(subject).commit();
         assertFalse(subject.isActive());
-        assertSame(taskResult, result.getPayload());
+        assertSame(taskResult, result.payload());
         assertNotNull(subject.getExecutionResult());
-        assertSame(taskResult, subject.getExecutionResult().getResult().getPayload());
+        assertSame(taskResult, subject.getExecutionResult().getResult().payload());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
@@ -76,7 +76,7 @@ class BatchingUnitOfWorkTest {
         try {
             subject.executeWithResult((ctx) -> {
                 registerListeners(subject);
-                if (subject.getMessage().getPayload().equals(1)) {
+                if (subject.getMessage().payload().equals(1)) {
                     throw e;
                 }
                 return resultFor(subject.getMessage());
@@ -106,7 +106,7 @@ class BatchingUnitOfWorkTest {
         try {
             subject.executeWithResult((ctx) -> {
                 registerListeners(subject);
-                if (subject.getMessage().getPayload().equals(2)) {
+                if (subject.getMessage().payload().equals(2)) {
                     subject.addHandler(PREPARE_COMMIT, u -> {
                         throw commitException;
                     });
@@ -139,7 +139,7 @@ class BatchingUnitOfWorkTest {
     }
 
     public static Object resultFor(Message<?> message) {
-        return "Result for: " + message.getPayload();
+        return "Result for: " + message.payload();
     }
 
     private void validatePhaseTransitions(List<LegacyUnitOfWork.Phase> phases, List<Message<?>> messages) {
@@ -170,11 +170,11 @@ class BatchingUnitOfWorkTest {
                                                       .collect(Collectors.toList());
         List<?> expectedPayloads = expectedMessages.stream()
                                                    .filter(crm -> !crm.isExceptional())
-                                                   .map(Message::getPayload)
+                                                   .map(Message::payload)
                                                    .collect(Collectors.toList());
         List<?> actualPayloads = actualMessages.stream()
                                                .filter(crm -> !crm.isExceptional())
-                                               .map(Message::getPayload)
+                                               .map(Message::payload)
                                                .collect(Collectors.toList());
         List<Throwable> expectedExceptions = expectedMessages.stream()
                                                              .filter(ResultMessage::isExceptional)
@@ -224,7 +224,7 @@ class BatchingUnitOfWorkTest {
 
         @Override
         public String toString() {
-            return phase + " -> " + message.getPayload();
+            return phase + " -> " + message.payload();
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/DefaultQueryGatewayTest.java
@@ -78,7 +78,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).query(queryMessageCaptor.capture());
 
         QueryMessage<String, String> result = queryMessageCaptor.getValue();
-        assertEquals("query", result.getPayload());
+        assertEquals("query", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -107,7 +107,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).query(queryMessageCaptor.capture());
 
         QueryMessage<String, String> result = queryMessageCaptor.getValue();
-        assertEquals("query", result.getPayload());
+        assertEquals("query", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -180,7 +180,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).scatterGather(queryMessageCaptor.capture(), eq(expectedTimeout), eq(expectedTimeUnit));
 
         QueryMessage<String, String> result = queryMessageCaptor.getValue();
-        assertEquals("scatterGather", result.getPayload());
+        assertEquals("scatterGather", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -214,7 +214,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).scatterGather(queryMessageCaptor.capture(), eq(expectedTimeout), eq(expectedTimeUnit));
 
         QueryMessage<String, String> result = queryMessageCaptor.getValue();
-        assertEquals("scatterGather", result.getPayload());
+        assertEquals("scatterGather", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -237,7 +237,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).subscriptionQuery(queryMessageCaptor.capture(), anyInt());
 
         SubscriptionQueryMessage<String, String, String> result = queryMessageCaptor.getValue();
-        assertEquals("subscription", result.getPayload());
+        assertEquals("subscription", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -268,7 +268,7 @@ class DefaultQueryGatewayTest {
         verify(mockBus).subscriptionQuery(queryMessageCaptor.capture(), anyInt());
 
         SubscriptionQueryMessage<String, String, String> result = queryMessageCaptor.getValue();
-        assertEquals("subscription", result.getPayload());
+        assertEquals("subscription", result.payload());
         assertEquals(String.class, result.getPayloadType());
         assertTrue(InstanceResponseType.class.isAssignableFrom(result.getResponseType().getClass()));
         assertEquals(String.class, result.getResponseType().getExpectedResponseType());
@@ -284,13 +284,13 @@ class DefaultQueryGatewayTest {
         when(mockBus.query(anyMessage(String.class, String.class))).thenReturn(completedFuture(answer));
         testSubject.registerDispatchInterceptor(messages -> (integer, queryMessage) -> new GenericQueryMessage<>(
                 new MessageType(queryMessage.type().name()),
-                "dispatch-" + queryMessage.getPayload(), queryMessage.getResponseType())
+                "dispatch-" + queryMessage.payload(), queryMessage.getResponseType())
         );
 
         testSubject.query("query", String.class).join();
 
         verify(mockBus).query(
-                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "dispatch-query".equals(x.getPayload()))
+                argThat((ArgumentMatcher<QueryMessage<String, String>>) x -> "dispatch-query".equals(x.payload()))
         );
     }
 
@@ -359,7 +359,7 @@ class DefaultQueryGatewayTest {
                         new MessageType("query"), "test"
                 ) {
                     @Override
-                    public String getPayload() {
+                    public String payload() {
                         throw new MockException("Faking serialization problem");
                     }
                 }));

--- a/messaging/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -66,7 +66,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
                 multipleInstancesOf(String.class)
         );
 
-        List<String> response = queryBus.query(testQuery).get().getPayload();
+        List<String> response = queryBus.query(testQuery).get().payload();
 
         assertEquals(asList("Response1", "Response2"), response);
     }
@@ -78,7 +78,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
                 instanceOf(String.class)
         );
 
-        String response = queryBus.query(testQuery).get().getPayload();
+        String response = queryBus.query(testQuery).get().payload();
 
         assertEquals("Response", response);
     }
@@ -92,7 +92,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         List<String> response =
                 queryBus.scatterGather(testQuery, FUTURE_RESOLVING_TIMEOUT * 2, TimeUnit.MILLISECONDS)
-                        .map(Message::getPayload)
+                        .map(Message::payload)
                         .flatMap(Collection::stream)
                         .collect(Collectors.toList());
 
@@ -108,7 +108,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         String response =
                 queryBus.scatterGather(testQuery, FUTURE_RESOLVING_TIMEOUT + 100, TimeUnit.MILLISECONDS)
-                        .map(Message::getPayload)
+                        .map(Message::payload)
                         .findFirst()
                         .orElse(null);
 
@@ -124,7 +124,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         Mono<List<String>> response = queryBus.subscriptionQuery(testQuery)
                                               .initialResult()
-                                              .map(Message::getPayload);
+                                              .map(Message::payload);
 
         StepVerifier.create(response)
                     .expectNext(asList("Response1", "Response2"))
@@ -140,7 +140,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         Mono<String> response = queryBus.subscriptionQuery(testQuery)
                                         .initialResult()
-                                        .map(Message::getPayload);
+                                        .map(Message::payload);
 
         StepVerifier.create(response)
                     .expectNext("Response")
@@ -156,7 +156,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         List<String> result = queryBus.query(testQuery)
                                       .get()
-                                      .getPayload();
+                                      .payload();
 
         assertEquals(asList("Response1", "Response2"), result);
     }
@@ -170,7 +170,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         List<String> result =
                 queryBus.scatterGather(testQuery, FUTURE_RESOLVING_TIMEOUT + 100, TimeUnit.MILLISECONDS)
-                        .map(Message::getPayload)
+                        .map(Message::payload)
                         .findFirst()
                         .orElse(null);
 
@@ -186,7 +186,7 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         Mono<List<String>> response = queryBus.subscriptionQuery(testQuery)
                                               .initialResult()
-                                              .map(Message::getPayload);
+                                              .map(Message::payload);
 
         StepVerifier.create(response)
                     .expectNext(asList("Response1", "Response2"))

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
@@ -49,7 +49,7 @@ class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
                 new MessageType("query"), payload, String.class
         );
 
-        assertEquals(payload, result.getPayload());
+        assertEquals(payload, result.payload());
     }
 
     @Test
@@ -60,7 +60,7 @@ class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
                 new MessageType("query"), payload, String.class
         );
 
-        assertNull(result.getPayload());
+        assertNull(result.payload());
     }
 
     @Test
@@ -73,7 +73,7 @@ class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
         Map<String, String> newMetaData = Collections.singletonMap("k2", "v3");
         SubscriptionQueryUpdateMessage<Object> result = original.andMetaData(newMetaData);
 
-        assertEquals(original.getPayload(), result.getPayload());
+        assertEquals(original.payload(), result.payload());
         MetaData expectedMetaData = MetaData.from(metaData)
                                             .mergedWith(newMetaData);
         assertEquals(expectedMetaData, result.getMetaData());
@@ -89,7 +89,7 @@ class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
         Map<String, String> newMetaData = Collections.singletonMap("k2", "v3");
         SubscriptionQueryUpdateMessage<Object> result = original.withMetaData(newMetaData);
 
-        assertEquals(original.getPayload(), result.getPayload());
+        assertEquals(original.payload(), result.payload());
         assertEquals(newMetaData, result.getMetaData());
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/PrimitiveQueryHandlerResponseTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/PrimitiveQueryHandlerResponseTypeTest.java
@@ -98,8 +98,8 @@ class PrimitiveQueryHandlerResponseTypeTest {
         );
 
 
-        final T responseBoxed = queryBus.query(queryBoxed).join().getPayload();
-        final T responsePrimitive = queryBus.query(queryPrimitive).join().getPayload();
+        final T responseBoxed = queryBus.query(queryBoxed).join().payload();
+        final T responsePrimitive = queryBus.query(queryPrimitive).join().payload();
 
         assertEquals(value, responseBoxed);
         assertEquals(value, responsePrimitive);

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryBusTest.java
@@ -114,7 +114,7 @@ class SimpleQueryBusTest {
 
     @Test
     public void handlerInterceptorThrowsException() throws ExecutionException, InterruptedException {
-        testSubject.subscribe("test", String.class, (q, ctx) -> q.getPayload().toString());
+        testSubject.subscribe("test", String.class, (q, ctx) -> q.payload().toString());
         testSubject.registerHandlerInterceptor((unitOfWork, context, interceptorChain) -> {
             throw new RuntimeException("Faking");
         });
@@ -130,17 +130,17 @@ class SimpleQueryBusTest {
 
     @Test
     void subscribe() {
-        testSubject.subscribe("test", String.class, (m, ctx) -> m.getPayload());
+        testSubject.subscribe("test", String.class, (m, ctx) -> m.payload());
 
         assertEquals(1, testSubject.getSubscriptions().size());
         assertEquals(1, testSubject.getSubscriptions().values().iterator().next().size());
 
-        testSubject.subscribe("test", String.class, (q, c) -> "aa" + q.getPayload());
+        testSubject.subscribe("test", String.class, (q, c) -> "aa" + q.payload());
 
         assertEquals(1, testSubject.getSubscriptions().size());
         assertEquals(2, testSubject.getSubscriptions().values().iterator().next().size());
 
-        testSubject.subscribe("test2", String.class, (q, c) -> "aa" + q.getPayload());
+        testSubject.subscribe("test2", String.class, (q, c) -> "aa" + q.payload());
 
         assertEquals(2, testSubject.getSubscriptions().size());
     }
@@ -158,7 +158,7 @@ class SimpleQueryBusTest {
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType("test"), "request", singleStringResponse
         );
-        String result = testSubject.query(testQuery).thenApply(QueryResponseMessage::getPayload).get();
+        String result = testSubject.query(testQuery).thenApply(QueryResponseMessage::payload).get();
 
         assertEquals("reply", result);
         assertEquals(1, invocationCount.get());
@@ -188,7 +188,7 @@ class SimpleQueryBusTest {
      */
     @Test
     void queryResultContainsCorrelationData() throws Exception {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
 
         QueryMessage<String, String> testQuery =
                 new GenericQueryMessage<>(new MessageType(String.class), "hello", singleStringResponse)
@@ -196,7 +196,7 @@ class SimpleQueryBusTest {
         CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQuery);
 
         assertTrue(result.isDone(), "SimpleQueryBus should resolve CompletableFutures directly");
-        assertEquals("hello1234", result.get().getPayload());
+        assertEquals("hello1234", result.get().payload());
         assertEquals(
                 MetaData.with(CORRELATION_ID, testQuery.identifier()).and(TRACE_ID, "fakeTraceId"),
                 result.get().getMetaData()
@@ -212,7 +212,7 @@ class SimpleQueryBusTest {
         CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQuery);
 
         assertTrue(result.isDone(), "SimpleQueryBus should resolve CompletableFutures directly");
-        assertNull(result.get().getPayload());
+        assertNull(result.get().payload());
         assertEquals(String.class, result.get().getPayloadType());
         assertEquals(
                 MetaData.with(CORRELATION_ID, testQuery.identifier()).and(TRACE_ID, "fakeTraceId"),
@@ -231,13 +231,13 @@ class SimpleQueryBusTest {
 
         testSubject.subscribe(String.class.getName(),
                               methodOf(this.getClass(), "stringListQueryHandler").getGenericReturnType(),
-                              (q, ctx) -> asList(q.getPayload() + "1234", q.getPayload() + "567"));
+                              (q, ctx) -> asList(q.payload() + "1234", q.payload() + "567"));
 
         QueryMessage<String, List<String>> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", multipleInstancesOf(String.class)
         );
         CompletableFuture<List<String>> result = testSubject.query(testQuery)
-                                                            .thenApply(QueryResponseMessage::getPayload);
+                                                            .thenApply(QueryResponseMessage::payload);
 
         assertTrue(result.isDone());
         List<String> completedResult = result.get();
@@ -261,13 +261,13 @@ class SimpleQueryBusTest {
                                     .transactionManager(mockTxManager)
                                     .build();
 
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", singleStringResponse
         );
         CompletableFuture<String> result = testSubject.query(testQuery)
-                                                      .thenApply(QueryResponseMessage::getPayload);
+                                                      .thenApply(QueryResponseMessage::payload);
 
         assertEquals("hello1234", result.get());
         verify(mockTxManager).startTransaction();
@@ -281,7 +281,7 @@ class SimpleQueryBusTest {
         );
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> {
             spanFactory.verifySpanActive("QueryBus.query", testQuery);
-            return q.getPayload() + "1234";
+            return q.payload() + "1234";
         });
 
         testSubject.query(testQuery).get();
@@ -298,12 +298,12 @@ class SimpleQueryBusTest {
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> {
             spanFactory.verifySpanActive("QueryBus.scatterGatherQuery", testQuery);
             spanFactory.verifySpanActive("QueryBus.scatterGatherQuery-0");
-            return q.getPayload() + "1234";
+            return q.payload() + "1234";
         });
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> {
             spanFactory.verifySpanActive("QueryBus.scatterGatherQuery", testQuery);
             spanFactory.verifySpanActive("QueryBus.scatterGatherQuery-1");
-            return q.getPayload() + "12345678";
+            return q.payload() + "12345678";
         });
 
         //noinspection ResultOfMethodCallIgnored
@@ -317,13 +317,13 @@ class SimpleQueryBusTest {
 
     @Test
     void queryListWithSingleHandlerReturnsSingleAsList() throws Exception {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
 
         QueryMessage<String, List<String>> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", multipleStringResponse
         );
         CompletableFuture<List<String>> result = testSubject.query(testQuery)
-                                                            .thenApply(QueryResponseMessage::getPayload);
+                                                            .thenApply(QueryResponseMessage::payload);
 
         assertEquals(1, result.get().size());
         assertEquals("hello1234", result.get().getFirst());
@@ -332,16 +332,16 @@ class SimpleQueryBusTest {
 
     @Test
     void queryListWithBothSingleHandlerAndListHandlerReturnsListResult() throws Exception {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
         testSubject.subscribe(String.class.getName(), String[].class, (q, c) -> Arrays.asList(
-                q.getPayload() + "1234", q.getPayload() + "5678"
+                q.payload() + "1234", q.payload() + "5678"
         ));
 
         QueryMessage<String, List<String>> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", multipleStringResponse
         );
         CompletableFuture<List<String>> result = testSubject.query(testQuery)
-                                                            .thenApply(QueryResponseMessage::getPayload);
+                                                            .thenApply(QueryResponseMessage::payload);
 
         assertEquals(2, result.get().size());
         assertEquals("hello1234", result.get().get(0));
@@ -368,7 +368,7 @@ class SimpleQueryBusTest {
                 new MessageType("query"), "query", singleStringResponse
         );
         CompletableFuture<String> result = testSubject.query(testQuery)
-                                                      .thenApply(QueryResponseMessage::getPayload);
+                                                      .thenApply(QueryResponseMessage::payload);
 
         assertTrue(result.isDone());
         assertEquals("reply", result.get());
@@ -388,7 +388,7 @@ class SimpleQueryBusTest {
 
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
-        assertEquals("NoHandlerForQueryException", result.thenApply(QueryResponseMessage::getPayload)
+        assertEquals("NoHandlerForQueryException", result.thenApply(QueryResponseMessage::payload)
                                                          .exceptionally(e -> e.getCause().getClass().getSimpleName())
                                                          .get());
     }
@@ -418,7 +418,7 @@ class SimpleQueryBusTest {
 
         assertTrue(result.isDone());
         assertTrue(result.isCompletedExceptionally());
-        assertEquals("NoHandlerForQueryException", result.thenApply(QueryResponseMessage::getPayload)
+        assertEquals("NoHandlerForQueryException", result.thenApply(QueryResponseMessage::payload)
                                                          .exceptionally(e -> e.getCause().getClass().getSimpleName())
                                                          .get());
     }
@@ -453,13 +453,13 @@ class SimpleQueryBusTest {
             }
             return interceptorChain.proceedSync(context);
         });
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", singleStringResponse
         );
         CompletableFuture<String> result = testSubject.query(testQuery)
-                                                      .thenApply(QueryResponseMessage::getPayload);
+                                                      .thenApply(QueryResponseMessage::payload);
 
         assertEquals("fakeReply", result.get());
     }
@@ -467,13 +467,13 @@ class SimpleQueryBusTest {
     @Test
     void queryDoesNotArriveAtUnsubscribedHandler() throws Exception {
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> "1234");
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + " is not here!").cancel();
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + " is not here!").cancel();
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", singleStringResponse
         );
         CompletableFuture<String> result = testSubject.query(testQuery)
-                                                      .thenApply(QueryResponseMessage::getPayload);
+                                                      .thenApply(QueryResponseMessage::payload);
 
         assertEquals("1234", result.get());
     }
@@ -515,8 +515,8 @@ class SimpleQueryBusTest {
 
     @Test
     void queryUnsubscribedHandlers() throws Exception {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + " is not here!").cancel();
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + " is not here!").cancel();
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + " is not here!").cancel();
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + " is not here!").cancel();
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "hello", singleStringResponse
@@ -537,9 +537,9 @@ class SimpleQueryBusTest {
     void scatterGather() {
         int expectedResults = 3;
 
-        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.getPayload() + "1234");
-        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.getPayload() + "5678");
-        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.getPayload() + "90");
+        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.payload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.payload() + "5678");
+        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.payload() + "90");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", singleStringResponse
@@ -548,7 +548,7 @@ class SimpleQueryBusTest {
                                                                .collect(toSet());
 
         assertEquals(expectedResults, results.size());
-        Set<String> resultSet = results.stream().map(Message::getPayload).collect(toSet());
+        Set<String> resultSet = results.stream().map(Message::payload).collect(toSet());
         assertEquals(expectedResults, resultSet.size());
         verify(messageMonitor, times(1)).onMessageIngested(any());
         verify(monitorCallback, times(3)).reportSuccess();
@@ -561,13 +561,13 @@ class SimpleQueryBusTest {
 
         testSubject.subscribe(String.class.getName(),
                               methodOf(getClass(), "stringArrayQueryHandler").getGenericReturnType(),
-                              (q, ctx) -> new String[]{q.getPayload() + "12", q.getPayload() + "34"});
+                              (q, ctx) -> new String[]{q.payload() + "12", q.payload() + "34"});
         testSubject.subscribe(String.class.getName(),
                               methodOf(getClass(), "stringArrayQueryHandler").getGenericReturnType(),
-                              (q, ctx) -> new String[]{q.getPayload() + "56", q.getPayload() + "78"});
+                              (q, ctx) -> new String[]{q.payload() + "56", q.payload() + "78"});
         testSubject.subscribe(String.class.getName(),
                               methodOf(getClass(), "stringArrayQueryHandler").getGenericReturnType(),
-                              (q, ctx) -> new String[]{q.getPayload() + "9", q.getPayload() + "0"});
+                              (q, ctx) -> new String[]{q.payload() + "9", q.payload() + "0"});
 
         QueryMessage<String, List<String>> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", multipleInstancesOf(String.class)
@@ -578,7 +578,7 @@ class SimpleQueryBusTest {
 
         assertEquals(expectedQueryResponses, results.size());
         Set<String> resultSet = results.stream()
-                                       .map(Message::getPayload)
+                                       .map(Message::payload)
                                        .flatMap(Collection::stream)
                                        .collect(toSet());
         assertEquals(expectedResults, resultSet.size());
@@ -603,8 +603,8 @@ class SimpleQueryBusTest {
                                     .duplicateQueryHandlerResolver(silentlyAdd())
                                     .build();
 
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "567");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "567");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", singleStringResponse
@@ -630,7 +630,7 @@ class SimpleQueryBusTest {
                                     .duplicateQueryHandlerResolver(silentlyAdd())
                                     .build();
 
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> {
             throw new MockException();
         });
@@ -661,8 +661,8 @@ class SimpleQueryBusTest {
                                     .duplicateQueryHandlerResolver(silentlyAdd())
                                     .build();
 
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "567");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "567");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", singleStringResponse
@@ -688,14 +688,14 @@ class SimpleQueryBusTest {
             }
             return interceptorChain.proceedSync(context);
         });
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "567");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "567");
 
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", singleStringResponse
         );
         List<String> results = testSubject.scatterGather(testQuery, 0, TimeUnit.SECONDS)
-                                          .map(Message::getPayload)
+                                          .map(Message::payload)
                                           .collect(Collectors.toList());
 
         assertEquals(2, results.size());
@@ -718,7 +718,7 @@ class SimpleQueryBusTest {
 
     @Test
     void scatterGatherReportsExceptionsWithErrorHandler() {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
         testSubject.subscribe(String.class.getName(), String.class, (q, c) -> {
             throw new MockException();
         });
@@ -737,7 +737,7 @@ class SimpleQueryBusTest {
 
     @Test
     void queryResponseMessageCorrelationData() throws ExecutionException, InterruptedException {
-        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, c) -> q.payload() + "1234");
         testSubject.registerHandlerInterceptor(new CorrelationDataInterceptor<>(new MessageOriginProvider()));
         QueryMessage<String, String> testQuery = new GenericQueryMessage<>(
                 new MessageType(String.class), "Hello, World", singleStringResponse
@@ -745,7 +745,7 @@ class SimpleQueryBusTest {
         QueryResponseMessage<String> queryResponseMessage = testSubject.query(testQuery).get();
         assertEquals(testQuery.identifier(), queryResponseMessage.getMetaData().get("traceId"));
         assertEquals(testQuery.identifier(), queryResponseMessage.getMetaData().get("correlationId"));
-        assertEquals("Hello, World1234", queryResponseMessage.getPayload());
+        assertEquals("Hello, World1234", queryResponseMessage.payload());
     }
 
     @Test
@@ -801,11 +801,11 @@ class SimpleQueryBusTest {
                 testSubject.subscriptionQuery(testQuery);
         Mono<QueryResponseMessage<Long>> initialResult = result.initialResult();
         ten.await();
-        Long firstInitialResult = Objects.requireNonNull(initialResult.block()).getPayload();
+        Long firstInitialResult = Objects.requireNonNull(initialResult.block()).payload();
         hundred.await();
-        Long fistUpdate = Objects.requireNonNull(result.updates().next().block()).getPayload();
+        Long fistUpdate = Objects.requireNonNull(result.updates().next().block()).payload();
         thousand.await();
-        Long anotherInitialResult = Objects.requireNonNull(initialResult.block()).getPayload();
+        Long anotherInitialResult = Objects.requireNonNull(initialResult.block()).payload();
         assertTrue(fistUpdate <= firstInitialResult + 1);
         assertTrue(firstInitialResult <= anotherInitialResult);
         disposable.dispose();
@@ -834,10 +834,10 @@ class SimpleQueryBusTest {
             SubscriptionQueryResult<QueryResponseMessage<Long>, SubscriptionQueryUpdateMessage<Long>> result =
                     testSubject.subscriptionQuery(testQuery);
             Mono<QueryResponseMessage<Long>> initialResult = result.initialResult();
-            Objects.requireNonNull(initialResult.block()).getPayload();
+            Objects.requireNonNull(initialResult.block()).payload();
             spanFactory.verifySpanCompleted("QueryBus.query");
             updatedLatch.await();
-            Objects.requireNonNull(result.updates().next().block()).getPayload();
+            Objects.requireNonNull(result.updates().next().block()).payload();
             spanFactory.verifySpanCompleted("QueryUpdateEmitter.emitQueryUpdateMessage");
         } finally {
             disposable.dispose();
@@ -863,14 +863,14 @@ class SimpleQueryBusTest {
         Type responseType = ReflectionUtils.methodOf(getClass(), "futureMethod").getGenericReturnType();
         testSubject.subscribe(String.class.getName(),
                               responseType,
-                              (q, c) -> CompletableFuture.completedFuture(q.getPayload() + "1234"));
+                              (q, c) -> CompletableFuture.completedFuture(q.payload() + "1234"));
 
         QueryMessage<String, String> testQuery =
                 new GenericQueryMessage<>(new MessageType(String.class), "hello", singleStringResponse);
         CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQuery);
 
         assertTrue(result.isDone(), "SimpleQueryBus should resolve CompletableFutures directly");
-        assertEquals("hello1234", result.get().getPayload());
+        assertEquals("hello1234", result.get().payload());
     }
 
     @Test
@@ -878,19 +878,19 @@ class SimpleQueryBusTest {
         Type responseType = ReflectionUtils.methodOf(getClass(), "completableFutureMethod").getGenericReturnType();
         testSubject.subscribe(String.class.getName(),
                               responseType,
-                              (q, c) -> CompletableFuture.completedFuture(q.getPayload() + "1234"));
+                              (q, c) -> CompletableFuture.completedFuture(q.payload() + "1234"));
 
         QueryMessage<String, String> testQuery =
                 new GenericQueryMessage<>(new MessageType(String.class), "hello", singleStringResponse);
         CompletableFuture<QueryResponseMessage<String>> result = testSubject.query(testQuery);
 
         assertTrue(result.isDone(), "SimpleQueryBus should resolve CompletableFutures directly");
-        assertEquals("hello1234", result.get().getPayload());
+        assertEquals("hello1234", result.get().payload());
     }
 
     @Test
     void onSubscriptionQueryCancelTheActiveSubscriptionIsRemovedFromTheEmitterIfFluxIsNotSubscribed() {
-        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.getPayload() + "1234");
+        testSubject.subscribe(String.class.getName(), String.class, (q, ctx) -> q.payload() + "1234");
 
         SubscriptionQueryMessage<String, String, String> testQuery = new GenericSubscriptionQueryMessage<>(
                 new MessageType(String.class), "test", instanceOf(String.class), instanceOf(String.class)

--- a/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -65,7 +65,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext("some-awesome-text")
                     .verifyComplete();
     }
@@ -122,7 +122,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.getRegistration().cancel();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext("some-awesome-text")
                     .verifyTimeout(Duration.ofMillis(500));
     }
@@ -143,7 +143,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext("some-awesome-text")
                     .verifyComplete();
     }
@@ -189,7 +189,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, 1234);
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext(1234)
                     .verifyComplete();
     }
@@ -217,7 +217,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, Mono.just("mono-item"));
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNextMatches(actual -> equalTo(new String[]{"array-item-1", "array-item-2"}).matches(actual))
                     .expectNextMatches(actual -> equalTo(Arrays.asList("list-item-1", "list-item-2")).matches(actual))
                     .verifyComplete();
@@ -246,7 +246,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, Mono.just("mono-item"));
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext(Optional.of("optional-payload"), Optional.empty())
                     .verifyComplete();
     }
@@ -276,7 +276,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, Mono.empty());
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNextMatches(publisher -> {
                         try {
                             StepVerifier.create((Publisher<String>) publisher)
@@ -325,7 +325,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, Arrays.asList("text3", "text4"));
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext(Arrays.asList("text1", "text2"), Arrays.asList("text3", "text4"))
                     .verifyComplete();
     }
@@ -347,7 +347,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, Optional.of("text2"));
         result.complete();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext(Optional.of("text1"), Optional.of("text2"))
                     .verifyComplete();
     }
@@ -368,7 +368,7 @@ class SimpleQueryUpdateEmitterTest {
         testSubject.emit(any -> true, "some-awesome-text");
         result.getRegistration().cancel();
 
-        StepVerifier.create(result.getUpdates().map(Message::getPayload))
+        StepVerifier.create(result.getUpdates().map(Message::payload))
                     .expectNext("some-awesome-text")
                     .verifyTimeout(Duration.ofMillis(500));
     }

--- a/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
@@ -71,7 +71,7 @@ class StreamingQueryTest {
     }
 
     private <Q, R> Flux<R> streamingQueryPayloads(StreamingQueryMessage<Q, R> testQuery) {
-        return streamingQuery(testQuery).map(Message::getPayload);
+        return streamingQuery(testQuery).map(Message::payload);
     }
 
     private <Q, R> Flux<QueryResponseMessage<R>> streamingQuery(StreamingQueryMessage<Q, R> testQuery) {

--- a/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
@@ -58,7 +58,7 @@ class SerializedMessageTest {
 
         assertEquals(Object.class, testSubject.getPayloadType());
         assertFalse(testSubject.isPayloadDeserialized());
-        assertEquals(Object.class, testSubject.getPayload().getClass());
+        assertEquals(Object.class, testSubject.payload().getClass());
         assertTrue(testSubject.isPayloadDeserialized());
         assertFalse(testSubject.isMetaDataDeserialized());
         assertSame(MetaData.emptyInstance(), testSubject.getMetaData());
@@ -136,7 +136,7 @@ class SerializedMessageTest {
         SerializedMessage<Object> testSubject =
                 new SerializedMessage<>(eventId, serializedPayload, serializedMetaData, serializer);
 
-        SerializationException result = assertThrows(SerializationException.class, testSubject::getPayload);
+        SerializationException result = assertThrows(SerializationException.class, testSubject::payload);
         assertEquals("Error while deserializing payload of message " + eventId, result.getMessage());
         assertSame(serializationException, result.getCause());
     }

--- a/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSource.java
@@ -75,7 +75,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class AsyncInMemoryStreamableEventSource implements StreamableEventSource<EventMessage<?>> {
 
     /**
-     * An {@link EventMessage#getPayload()} representing a failed event.
+     * An {@link EventMessage#payload()} representing a failed event.
      */
     private static final String FAIL_PAYLOAD = "FAIL";
 
@@ -241,7 +241,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                 context = TrackingToken.addToContext(context, new GlobalSequenceTrackingToken(position + 1));
                 context = Tag.addToContext(context, Collections.emptySet());
 
-                if (FAIL_PAYLOAD.equals(event.getPayload())) {
+                if (FAIL_PAYLOAD.equals(event.payload())) {
                     throw new IllegalStateException("Cannot retrieve event at position [" + position + "].");
                 }
 
@@ -270,7 +270,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
             context = TrackingToken.addToContext(context, new GlobalSequenceTrackingToken(position + 1));
             context = Tag.addToContext(context, Collections.emptySet());
 
-            if (FAIL_PAYLOAD.equals(event.getPayload())) {
+            if (FAIL_PAYLOAD.equals(event.payload())) {
                 throw new IllegalStateException("Cannot retrieve event at position [" + position + "].");
             }
 
@@ -285,7 +285,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                     if (nextEvent == null) {
                         return Optional.empty();
                     }
-                    if (FAIL_PAYLOAD.equals(nextEvent.getPayload())) {
+                    if (FAIL_PAYLOAD.equals(nextEvent.payload())) {
                         throw new IllegalStateException("Cannot retrieve event at position [" + nextPos + "].");
                     }
                     if (matches(nextEvent, condition)) {
@@ -370,7 +370,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
         }
 
         // Always let FAIL_EVENT through to trigger the exception
-        if (FAIL_PAYLOAD.equals(event.getPayload())) {
+        if (FAIL_PAYLOAD.equals(event.payload())) {
             return true;
         }
 

--- a/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSourceTest.java
+++ b/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSourceTest.java
@@ -74,7 +74,7 @@ class AsyncInMemoryStreamableEventSourceTest {
             var asyncEntry1 = asyncStream.next().orElseThrow();
             TrackedEventMessage<?> legacyEvent1 = legacyStream.nextAvailable();
 
-            assertEquals(legacyEvent1.getPayload(), asyncEntry1.message().getPayload());
+            assertEquals(legacyEvent1.payload(), asyncEntry1.message().payload());
             assertEquals(legacyEvent1.trackingToken().position(),
                          TrackingToken.fromContext(asyncEntry1).orElseThrow().position());
 
@@ -82,7 +82,7 @@ class AsyncInMemoryStreamableEventSourceTest {
             var asyncEntry2 = asyncStream.next().orElseThrow();
             TrackedEventMessage<?> legacyEvent2 = legacyStream.nextAvailable();
 
-            assertEquals(legacyEvent2.getPayload(), asyncEntry2.message().getPayload());
+            assertEquals(legacyEvent2.payload(), asyncEntry2.message().payload());
             assertEquals(legacyEvent2.trackingToken().position(),
                          TrackingToken.fromContext(asyncEntry2).orElseThrow().position());
 
@@ -179,12 +179,12 @@ class AsyncInMemoryStreamableEventSourceTest {
             MessageStream<EventMessage<?>> stream = eventSource.open(condition);
             Optional<MessageStream.Entry<EventMessage<?>>> entry1 = stream.next();
             assertTrue(entry1.isPresent());
-            assertEquals("Event 1", entry1.get().message().getPayload());
+            assertEquals("Event 1", entry1.get().message().payload());
             assertEquals(1, TrackingToken.fromContext(entry1.get()).orElseThrow().position().orElse(-1));
 
             Optional<MessageStream.Entry<EventMessage<?>>> entry2 = stream.next();
             assertTrue(entry2.isPresent());
-            assertEquals("Event 2", entry2.get().message().getPayload());
+            assertEquals("Event 2", entry2.get().message().payload());
             assertEquals(2, TrackingToken.fromContext(entry2.get()).orElseThrow().position().orElse(-1));
         }
 

--- a/messaging/src/test/java/org/axonframework/utils/InMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/utils/InMemoryStreamableEventSource.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class InMemoryStreamableEventSource implements StreamableMessageSource<TrackedEventMessage<?>> {
 
     /**
-     * An {@link EventMessage#getPayload()} representing a failed event.
+     * An {@link EventMessage#payload()} representing a failed event.
      */
     private static final String FAIL_PAYLOAD = "FAIL";
     /**
@@ -104,7 +104,7 @@ public class InMemoryStreamableEventSource implements StreamableMessageSource<Tr
                                            .position()
                                            .orElseThrow(() -> new UnsupportedOperationException("Not supported"));
 
-                if (next.getPayload().equals(FAIL_PAYLOAD)) {
+                if (next.payload().equals(FAIL_PAYLOAD)) {
                     throw new IllegalStateException("Cannot retrieve event at position [" + lastToken + "].");
                 }
 

--- a/modelling/src/main/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponent.java
@@ -126,7 +126,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
 
     private E entityFromStreamResultOrUpdatedExisting(MessageStream.Entry<?> potentialEntityFromStream, E existing) {
         if (potentialEntityFromStream != null) {
-            var resultPayload = potentialEntityFromStream.message().getPayload();
+            var resultPayload = potentialEntityFromStream.message().payload();
             if (resultPayload != null && existing.getClass().isAssignableFrom(resultPayload.getClass())) {
                 //noinspection unchecked
                 return (E) existing.getClass().cast(resultPayload);

--- a/modelling/src/main/java/org/axonframework/modelling/PayloadBasedEntityEvolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/PayloadBasedEntityEvolver.java
@@ -25,7 +25,7 @@ import java.util.function.BiFunction;
 import static java.util.Objects.requireNonNull;
 
 /**
- * An {@link EntityEvolver} implementation that converts the {@link EventMessage#getPayload()} to the given
+ * An {@link EntityEvolver} implementation that converts the {@link EventMessage#payload()} to the given
  * {@code payloadType} to evolve an entity with.
  * <p>
  * Will throw a {@link ClassCastException} if the {@code payloadType} does not match.
@@ -41,10 +41,10 @@ public class PayloadBasedEntityEvolver<P, E> implements EntityEvolver<E> {
     private final BiFunction<E, P, E> evolver;
 
     /**
-     * Constructs a {@code PayloadConvertingEntityEvolver}, converting the {@link EventMessage#getPayload()} to the
+     * Constructs a {@code PayloadConvertingEntityEvolver}, converting the {@link EventMessage#payload()} to the
      * given {@code payloadType}, after which it invokes the given {@code evolver}.
      * <p>
-     * If the {@link EventMessage#getPayload()} cannot be converted to the requested {@code payloadType}, a
+     * If the {@link EventMessage#payload()} cannot be converted to the requested {@code payloadType}, a
      * {@link ClassCastException} is thrown.
      *
      * @param payloadType The payload type to check against.
@@ -60,7 +60,7 @@ public class PayloadBasedEntityEvolver<P, E> implements EntityEvolver<E> {
     public E evolve(@Nonnull E entity,
                     @Nonnull EventMessage<?> event,
                     @Nonnull ProcessingContext context) {
-        P payload = payloadType.cast(requireNonNull(event, "The event must not be null.").getPayload());
+        P payload = payloadType.cast(requireNonNull(event, "The event must not be null.").payload());
         return evolver.apply(requireNonNull(entity, "The entity must not be null."), payload);
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolver.java
@@ -55,7 +55,7 @@ public class AnnotationBasedEntityIdResolver<T> implements EntityIdResolver<T> {
     @Nonnull
     @Override
     public T resolve(@Nonnull Message<?> message, @Nonnull ProcessingContext context) {
-        Object payload = message.getPayload();
+        Object payload = message.payload();
         List<Object> identifiers = getIdentifiers(payload)
                 .stream()
                 .filter(Objects::nonNull)

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolver.java
@@ -77,7 +77,7 @@ class InjectEntityParameterResolver implements ParameterResolver<Object> {
         Object resolvedId = identifierResolver.resolve(message, context);
         //noinspection ConstantValue Users can still make the mistake to return null.
         if (resolvedId == null) {
-            throw new NullEntityIdInPayloadException(message.getPayload().getClass());
+            throw new NullEntityIdInPayloadException(message.payload().getClass());
         }
         StateManager stateManager = configuration.getComponent(StateManager.class);
         if (managedEntity) {

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/PropertyBasedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/PropertyBasedEntityIdResolver.java
@@ -56,7 +56,7 @@ public class PropertyBasedEntityIdResolver implements EntityIdResolver<Object> {
     @Nonnull
     @Override
     public Object resolve(@Nonnull Message<?> message, @Nonnull ProcessingContext context) {
-        Object payload = message.getPayload();
+        Object payload = message.payload();
         Class<?> payloadClass = payload.getClass();
         var property = propertyCache.computeIfAbsent(payloadClass, this::getObjectProperty);
         Object value = property.getValue(payload);

--- a/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/AnnotationCommandTargetResolver.java
@@ -101,12 +101,12 @@ public class AnnotationCommandTargetResolver implements CommandTargetResolver {
         for (Method m : methodsOf(command.getPayloadType())) {
             if (AnnotationUtils.isAnnotationPresent(m, annotation)) {
                 ensureAccessible(m);
-                return m.invoke(command.getPayload());
+                return m.invoke(command.payload());
             }
         }
         for (Field f : fieldsOf(command.getPayloadType())) {
             if (AnnotationUtils.isAnnotationPresent(f, annotation)) {
-                return getFieldValue(f, command.getPayload());
+                return getFieldValue(f, command.payload());
             }
         }
         return null;

--- a/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/ForwardMatchingInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class ForwardMatchingInstances<T extends Message<?>> implements Forwardin
             return Stream.empty();
         }
 
-        Object routingValue = routingProperty.getValue(message.getPayload());
+        Object routingValue = routingProperty.getValue(message.payload());
         return candidates.filter(candidate -> matchesInstance(candidate, routingValue));
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class AggregateMemberAnnotatedChildEntityCollectionDefinition extends Abs
                 extractCommandHandlerRoutingKeys(member, childEntityModel);
 
         Object routingValue = commandHandlerRoutingKeys.get(msg.type().name())
-                                                       .getValue(msg.getPayload());
+                                                       .getValue(msg.payload());
         Iterable<?> memberValue = ReflectionUtils.getMemberValue(member, parent);
 
         return StreamSupport.stream(memberValue.spliterator(), false)

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class AggregateMemberAnnotatedChildEntityMapDefinition extends AbstractCh
                 extractCommandHandlerRoutingKeys(member, childEntityModel);
 
         Object routingValue = commandHandlerRoutingKeys.get(msg.type().name())
-                                                       .getValue(msg.getPayload());
+                                                       .getValue(msg.payload());
         Map<?, ?> fieldValue = ReflectionUtils.getMemberValue(member, parent);
 
         return fieldValue == null ? null : fieldValue.get(routingValue);

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregate.java
@@ -543,7 +543,7 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
      */
     protected void applyMessageOrPayload(Object payloadOrMessage) {
         if (payloadOrMessage instanceof Message<?> message) {
-            apply(message.getPayload(), message.getMetaData());
+            apply(message.payload(), message.getMetaData());
         } else if (payloadOrMessage != null) {
             apply(payloadOrMessage, MetaData.emptyInstance());
         }
@@ -570,12 +570,12 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
             if (identifier != null) {
                 return new GenericDomainEventMessage<>(
                         getType(), getAggregateIdentifier(), getSequenceNumber(),
-                        identifier(), type(), getPayload(), getMetaData(), getTimestamp()
+                        identifier(), type(), payload(), getMetaData(), getTimestamp()
                 );
             } else {
                 return new LazyIdentifierDomainEventMessage<>(
                         getType(), getSequenceNumber(),
-                        type(), getPayload(), MetaData.from(newMetaData)
+                        type(), payload(), MetaData.from(newMetaData)
                 );
             }
         }
@@ -586,12 +586,12 @@ public class AnnotatedAggregate<T> extends AggregateLifecycle implements Aggrega
             if (identifier != null) {
                 return new GenericDomainEventMessage<>(
                         getType(), getAggregateIdentifier(), getSequenceNumber(),
-                        identifier(), type(), getPayload(), getMetaData(), getTimestamp()
+                        identifier(), type(), payload(), getMetaData(), getTimestamp()
                 ).andMetaData(additionalMetaData);
             } else {
                 return new LazyIdentifierDomainEventMessage<>(
                         getType(), getSequenceNumber(),
-                        type(), getPayload(), getMetaData().mergedWith(additionalMetaData)
+                        type(), payload(), getMetaData().mergedWith(additionalMetaData)
                 );
             }
         }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityModelRoutingKeyMatcher.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityModelRoutingKeyMatcher.java
@@ -21,7 +21,6 @@ import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.property.Property;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageType;
-import org.axonframework.serialization.Converter;
 
 import java.util.Map;
 import java.util.Objects;
@@ -99,7 +98,7 @@ public class AnnotatedEntityModelRoutingKeyMatcher<E> {
                     messageRoutingProperty,
                     metamodel.entityType()));
         }
-        Object convertedPayload = metamodel.converter().convert(message.getPayload(), payloadType);
+        Object convertedPayload = metamodel.converter().convert(message.payload(), payloadType);
 
         Object routingValue = routingProperty.getValue(convertedPayload);
         return matchesInstance(entity, routingValue);

--- a/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/saga/PayloadAssociationResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class PayloadAssociationResolver implements AssociationResolver {
     @SuppressWarnings("unchecked")
     public <T> Object resolve(@Nonnull String associationPropertyName, @Nonnull EventMessage<?> message,
                               @Nonnull MessageHandlingMember<T> handler) {
-        return getProperty(associationPropertyName, handler).getValue(message.getPayload());
+        return getProperty(associationPropertyName, handler).getValue(message.payload());
     }
 
     private <T> Property getProperty(String associationPropertyName, MessageHandlingMember<T> handler) {

--- a/modelling/src/test/java/org/axonframework/modelling/SimpleEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/SimpleEntityEvolvingComponentTest.java
@@ -57,11 +57,11 @@ class SimpleEntityEvolvingComponentTest {
 
         EntityEvolver<String> stringBasedEntityEvolver = (entity, event, context) -> {
             stringEvolverInvoked.set(true);
-            return entity + "-" + event.getPayload();
+            return entity + "-" + event.payload();
         };
         EntityEvolver<String> integerBasedEntityEvolver = (entity, event, context) -> {
             integerEvolverInvoked.set(true);
-            return entity + "-" + event.getPayload();
+            return entity + "-" + event.payload();
         };
 
         Map<QualifiedName, EntityEvolver<String>> evolvers = new HashMap<>();

--- a/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/AnnotatedAggregateTest.java
@@ -73,14 +73,14 @@ public class AnnotatedAggregateTest {
                        root.handle(testPayload);
                        return root;
                    }))
-                   .getPayload();
+                   .payload();
         assertNotNull(aggregate);
 
         InOrder inOrder = inOrder(eventBus);
         inOrder.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_1.class
-                .equals(x.getPayloadType()) && ((Event_1) x.getPayload()).value == 1));
+                .equals(x.getPayloadType()) && ((Event_1) x.payload()).value == 1));
         inOrder.verify(eventBus).publish(argThat((ArgumentMatcher<EventMessage<?>>) x -> Event_1.class
-                .equals(x.getPayloadType()) && ((Event_1) x.getPayload()).value == 2));
+                .equals(x.getPayloadType()) && ((Event_1) x.payload()).value == 2));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class AnnotatedAggregateTest {
                        root.handle(testPayload);
                        return root;
                    }))
-                   .getPayload();
+                   .payload();
         assertNotNull(aggregate);
 
         InOrder inOrder = inOrder(eventBus);
@@ -114,7 +114,7 @@ public class AnnotatedAggregateTest {
 
         AnnotatedAggregate<AggregateRoot> testSubject =
                 (AnnotatedAggregate<AggregateRoot>) uow.executeWithResult(
-                        (ctx) -> repository.newInstance(AggregateRoot::new)).getPayload();
+                        (ctx) -> repository.newInstance(AggregateRoot::new)).payload();
 
         assertNull(testSubject.lastSequence());
     }
@@ -132,7 +132,7 @@ public class AnnotatedAggregateTest {
                        root.handle(testPayload, sideEffect);
                        return root;
                    }))
-                   .getPayload();
+                   .payload();
         assertNotNull(aggregate);
 
         InOrder inOrderEvents = inOrder(eventBus);

--- a/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -158,21 +158,21 @@ class GenericJpaRepositoryTest {
         EventMessage<?> eventOne = publishedEvents.get(0);
         assertTrue(eventOne instanceof DomainEventMessage);
         DomainEventMessage<?> domainEventOne = (DomainEventMessage<?>) eventOne;
-        assertEquals("test1", domainEventOne.getPayload());
+        assertEquals("test1", domainEventOne.payload());
         assertEquals(0, domainEventOne.getSequenceNumber());
         assertEquals("id", domainEventOne.getAggregateIdentifier());
 
         EventMessage<?> eventTwo = publishedEvents.get(1);
         assertTrue(eventTwo instanceof DomainEventMessage);
         DomainEventMessage<?> domainEventTwo = (DomainEventMessage<?>) eventTwo;
-        assertEquals("test2", domainEventTwo.getPayload());
+        assertEquals("test2", domainEventTwo.payload());
         assertEquals(1, domainEventTwo.getSequenceNumber());
         assertEquals("id", domainEventTwo.getAggregateIdentifier());
 
         EventMessage<?> eventThree = publishedEvents.get(2);
         assertTrue(eventThree instanceof DomainEventMessage);
         DomainEventMessage<?> domainEventThree = (DomainEventMessage<?>) eventThree;
-        assertEquals("test3", domainEventThree.getPayload());
+        assertEquals("test3", domainEventThree.payload());
         assertEquals(2, domainEventThree.getSequenceNumber());
         assertEquals("id", domainEventThree.getAggregateIdentifier());
     }
@@ -205,7 +205,7 @@ class GenericJpaRepositoryTest {
         assertEquals(1, capturedEvents.size());
         EventMessage<?> eventOne = capturedEvents.get(0);
         assertFalse(eventOne instanceof DomainEventMessage);
-        assertEquals("test2", eventOne.getPayload());
+        assertEquals("test2", eventOne.payload());
     }
 
     @Test
@@ -237,15 +237,15 @@ class GenericJpaRepositoryTest {
 
         EventMessage<?> eventOne = publishedEvents.get(0);
         assertFalse(eventOne instanceof DomainEventMessage);
-        assertEquals(expectedFirstPayload, eventOne.getPayload());
+        assertEquals(expectedFirstPayload, eventOne.payload());
 
         EventMessage<?> eventTwo = publishedEvents.get(1);
         assertFalse(eventTwo instanceof DomainEventMessage);
-        assertEquals(expectedSecondPayload, eventTwo.getPayload());
+        assertEquals(expectedSecondPayload, eventTwo.payload());
 
         EventMessage<?> eventThree = publishedEvents.get(2);
         assertFalse(eventThree instanceof DomainEventMessage);
-        assertEquals(expectedThirdPayload, eventThree.getPayload());
+        assertEquals(expectedThirdPayload, eventThree.payload());
     }
 
     @Test

--- a/modelling/src/test/java/org/axonframework/modelling/entity/EntityCommandHandlingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/EntityCommandHandlingComponentTest.java
@@ -112,7 +112,7 @@ class EntityCommandHandlingComponentTest {
                                                                  .first().asCompletableFuture().join().message();
 
             verify(metamodel).handleCreate(eq(creationalCommandMessage), any());
-            assertEquals("creational", resultMessage.getPayload());
+            assertEquals("creational", resultMessage.payload());
         }
 
         @Test
@@ -164,7 +164,7 @@ class EntityCommandHandlingComponentTest {
                     instanceCommandMessage, context);
 
             verify(metamodel).handleInstance(eq(instanceCommandMessage), eq(testEntity), any());
-            Assertions.assertEquals("instance", componentResult.asCompletableFuture().join().message().getPayload());
+            Assertions.assertEquals("instance", componentResult.asCompletableFuture().join().message().payload());
         }
 
 
@@ -196,7 +196,7 @@ class EntityCommandHandlingComponentTest {
                     mixedCommandMessage, context);
             verify(metamodel).handleCreate(mixedCommandMessage, context);
             assertEquals("creational-mixed",
-                         componentResult.first().asCompletableFuture().join().message().getPayload());
+                         componentResult.first().asCompletableFuture().join().message().payload());
         }
 
         @Test
@@ -209,7 +209,7 @@ class EntityCommandHandlingComponentTest {
 
             verify(metamodel).handleInstance(mixedCommandMessage, entity, context);
             Assertions.assertEquals("instance-mixed",
-                                    componentResult.asCompletableFuture().join().message().getPayload());
+                                    componentResult.asCompletableFuture().join().message().payload());
         }
 
         @Test

--- a/modelling/src/test/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelTest.java
@@ -134,7 +134,7 @@ class PolymorphicEntityMetamodelTest {
                                                                                             entity,
                                                                                             context);
 
-        assertEquals("concrete-one", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("concrete-one", result.first().asCompletableFuture().join().message().payload());
         verify(concreteTestEntityOneEntityMetamodel, times(1)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -151,7 +151,7 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage<?>> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("concrete-one-create", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("concrete-one-create", result.first().asCompletableFuture().join().message().payload());
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(1)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -172,7 +172,7 @@ class PolymorphicEntityMetamodelTest {
                                                                                             entity,
                                                                                             context);
 
-        assertEquals("concrete-two", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("concrete-two", result.first().asCompletableFuture().join().message().payload());
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(1)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -189,7 +189,7 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage<?>> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("concrete-two-create", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("concrete-two-create", result.first().asCompletableFuture().join().message().payload());
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -209,7 +209,7 @@ class PolymorphicEntityMetamodelTest {
                                                                                             entity,
                                                                                             context);
 
-        assertEquals("super-type", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("super-type", result.first().asCompletableFuture().join().message().payload());
         verify(entityInstanceCommandHandler).handle(eq(commandMessage), same(entity), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
@@ -227,7 +227,7 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage<?>> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("super-type-create", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("super-type-create", result.first().asCompletableFuture().join().message().payload());
         verify(entityCreationalCommandHandler).handle(eq(commandMessage), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
@@ -248,7 +248,7 @@ class PolymorphicEntityMetamodelTest {
                                                                                             entity,
                                                                                             context);
 
-        assertEquals("super-type", result.first().asCompletableFuture().join().message().getPayload());
+        assertEquals("super-type", result.first().asCompletableFuture().join().message().payload());
         verify(entityInstanceCommandHandler).handle(eq(commandMessage), same(entity), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));

--- a/modelling/src/test/java/org/axonframework/modelling/entity/SimpleEntityMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/SimpleEntityMetamodelTest.java
@@ -115,7 +115,7 @@ class SimpleEntityMetamodelTest {
                     new MessageType(PARENT_ONLY_INSTANCE_COMMAND), "myPayload");
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleInstance(command, entity, context);
 
-            assertEquals("parent", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("parent", result.asCompletableFuture().join().message().payload());
             verify(parentInstanceCommandHandler, times(1)).handle(command, entity, context);
             verify(parentCreationalCommandHandler, times(0)).handle(command, context);
             verify(childModelMockOne, times(0)).handle(command, entity, context);
@@ -128,7 +128,7 @@ class SimpleEntityMetamodelTest {
                                                                                 "myPayload");
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleInstance(command, entity, context);
 
-            assertEquals("child-one", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("child-one", result.asCompletableFuture().join().message().payload());
             verify(childModelMockOne).handle(command, entity, context);
             verify(childModelMockTwo, times(0)).handle(command, entity, context);
             verify(parentInstanceCommandHandler, times(0)).handle(command, entity, context);
@@ -141,7 +141,7 @@ class SimpleEntityMetamodelTest {
                                                                                 "myPayload");
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleInstance(command, entity, context);
 
-            assertEquals("child-two", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("child-two", result.asCompletableFuture().join().message().payload());
             verify(childModelMockTwo).handle(command, entity, context);
             verify(childModelMockOne, times(0)).handle(command, entity, context);
             verify(parentInstanceCommandHandler, times(0)).handle(command, entity, context);
@@ -171,7 +171,7 @@ class SimpleEntityMetamodelTest {
             when(childModelMockTwo.canHandle(any(), any(), any())).thenReturn(false);
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleInstance(command, entity, context);
 
-            assertEquals("child-one", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("child-one", result.asCompletableFuture().join().message().payload());
             verify(childModelMockOne).handle(command, entity, context);
             verify(parentInstanceCommandHandler, times(0)).handle(command, entity, context);
             verify(parentCreationalCommandHandler, times(0)).handle(command, context);
@@ -186,7 +186,7 @@ class SimpleEntityMetamodelTest {
             when(childModelMockTwo.canHandle(any(), any(), any())).thenReturn(true);
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleInstance(command, entity, context);
 
-            assertEquals("child-two", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("child-two", result.asCompletableFuture().join().message().payload());
             verify(childModelMockTwo).handle(command, entity, context);
             verify(parentInstanceCommandHandler, times(0)).handle(command, entity, context);
             verify(parentCreationalCommandHandler, times(0)).handle(command, context);
@@ -252,7 +252,7 @@ class SimpleEntityMetamodelTest {
                     new MessageType(PARENT_ONLY_CREATIONAL_COMMAND), "myPayload");
             MessageStream.Single<CommandResultMessage<?>> result = metamodel.handleCreate(command, context);
 
-            assertEquals("parent-creational", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("parent-creational", result.asCompletableFuture().join().message().payload());
             verify(parentCreationalCommandHandler).handle(command, context);
             verify(childModelMockOne, times(0)).handle(command, entity, context);
             verify(childModelMockTwo, times(0)).handle(command, entity, context);

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AbstractAnnotatedEntityMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AbstractAnnotatedEntityMetamodelTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractAnnotatedEntityMetamodelTest<E> {
                             .first()
                             .asCompletableFuture()
                             .thenApply(MessageStream.Entry::message)
-                            .thenApply(CommandResultMessage::getPayload)
+                            .thenApply(CommandResultMessage::payload)
                             .join();
         } catch (Exception e) {
             if (e instanceof CompletionException && e.getCause() instanceof RuntimeException) {
@@ -86,7 +86,7 @@ public abstract class AbstractAnnotatedEntityMetamodelTest<E> {
                             .first()
                             .asCompletableFuture()
                             .thenApply(MessageStream.Entry::message)
-                            .thenApply(CommandResultMessage::getPayload)
+                            .thenApply(CommandResultMessage::payload)
                             .join();
         } catch (Exception e) {
             if (e instanceof CompletionException && e.getCause() instanceof RuntimeException) {

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
@@ -96,7 +96,7 @@ class ListEntityChildMetamodelTest {
             );
 
             var result = testSubject.handle(commandMessage, parentEntity, context);
-            assertEquals("1337-result", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("1337-result", result.asCompletableFuture().join().message().payload());
 
             verify(childEntityFieldDefinition).getChildValue(parentEntity);
             verify(childEntityMetamodel).handleInstance(commandMessage, entityToBeFound, context);
@@ -160,7 +160,7 @@ class ListEntityChildMetamodelTest {
             when(childEntityMetamodel.evolve(any(), any(), any())).thenAnswer(answ -> {
                 RecordingChildEntity child = answ.getArgument(0);
                 EventMessage<String> event = answ.getArgument(1);
-                return child.evolve("child evolve: " + event.getPayload());
+                return child.evolve("child evolve: " + event.payload());
             });
             when(childEntityFieldDefinition.evolveParentBasedOnChildInput(any(), any())).thenAnswer(answ -> {
                 RecordingParentEntity parent = answ.getArgument(0);

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
@@ -79,7 +79,7 @@ class SingleEntityChildMetamodelTest {
             GenericCommandMessage<String> command = new GenericCommandMessage<>(new MessageType(COMMAND), "myPayload");
 
             var result = testSubject.handle(command, parentEntity, context);
-            assertEquals("result", result.asCompletableFuture().join().message().getPayload());
+            assertEquals("result", result.asCompletableFuture().join().message().payload());
 
             verify(childEntityFieldDefinition).getChildValue(parentEntity);
             verify(childEntityMetamodel).handleInstance(command, entityToBeFound, context);
@@ -144,7 +144,7 @@ class SingleEntityChildMetamodelTest {
             when(childEntityMetamodel.evolve(any(), any(), any())).thenAnswer(answ -> {
                 RecordingChildEntity child = answ.getArgument(0);
                 EventMessage<String> event = answ.getArgument(1);
-                return child.evolve("child evolve: " + event.getPayload());
+                return child.evolve("child evolve: " + event.payload());
             });
             when(childEntityFieldDefinition.evolveParentBasedOnChildInput(any(), any())).thenAnswer(answ -> {
                 RecordingParentEntity parent = answ.getArgument(0);

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/AnnotatedSagaRepositoryTest.java
@@ -89,7 +89,7 @@ class AnnotatedSagaRepositoryTest {
         saga.getAssociationValues().add(new AssociationValue("test", "value"));
         Saga<Object> saga2 =
                 startAndGet(null).executeWithResult((ctx) -> testSubject.load(saga.getSagaIdentifier()))
-                                 .getPayload();
+                                 .payload();
 
         assertSame(saga, saga2);
         currentUnitOfWork.commit();

--- a/modelling/src/test/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStoreTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/saga/repository/jpa/JpaSagaStoreTest.java
@@ -117,7 +117,7 @@ class JpaSagaStoreTest {
     void addAndLoadSaga_ByIdentifier() {
         String identifier = unitOfWork.executeWithResult((ctx) -> repository.createInstance(
                         IdentifierFactory.getInstance().generateIdentifier(), StubSaga::new).getSagaIdentifier())
-                .getPayload();
+                .payload();
         entityManager.clear();
         startUnitOfWork();
         unitOfWork.execute((ctx) -> {
@@ -134,7 +134,7 @@ class JpaSagaStoreTest {
                     StubSaga::new);
             saga.execute(s -> s.associate("key", "value"));
             return saga.getSagaIdentifier();
-        }).getPayload();
+        }).payload();
         entityManager.clear();
         startUnitOfWork();
         unitOfWork.execute((ctx) -> {
@@ -159,7 +159,7 @@ class JpaSagaStoreTest {
                     StubSaga::new);
             saga.execute(s -> s.associate("key", "value"));
             return saga.getSagaIdentifier();
-        }).getPayload();
+        }).payload();
         entityManager.clear();
         startUnitOfWork();
         unitOfWork.execute((ctx) -> {
@@ -169,7 +169,7 @@ class JpaSagaStoreTest {
         entityManager.clear();
         startUnitOfWork();
         Set<String> found = unitOfWork.executeWithResult((ctx) -> repository.find(new AssociationValue("key", "value")))
-                .getPayload();
+                .payload();
         assertEquals(0, found.size());
     }
 
@@ -180,7 +180,7 @@ class JpaSagaStoreTest {
                     StubSaga::new);
             saga.execute(s -> s.associate("key", "value"));
             return saga.getSagaIdentifier();
-        }).getPayload();
+        }).payload();
         entityManager.clear();
         assertFalse(entityManager.createQuery("SELECT ae FROM AssociationValueEntry ae WHERE ae.sagaId = :id")
                 .setParameter("id", identifier).getResultList().isEmpty());

--- a/spring/src/main/java/org/axonframework/spring/messaging/ApplicationContextEventPublisher.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/ApplicationContextEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class ApplicationContextEventPublisher implements InitializingBean, Appli
      * @return the Spring ApplicationEvent representing the Axon EventMessage
      */
     protected ApplicationEvent convert(EventMessage<?> eventMessage) {
-        return new PayloadApplicationEvent<>(messageSource, eventMessage.getPayload());
+        return new PayloadApplicationEvent<>(messageSource, eventMessage.payload());
     }
 
     @Override

--- a/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
+++ b/spring/src/main/java/org/axonframework/spring/messaging/DefaultEventMessageConverter.java
@@ -63,7 +63,7 @@ public class DefaultEventMessageConverter implements EventMessageConverter {
             headers.put(AGGREGATE_SEQ, ((DomainEventMessage<?>) event).getSequenceNumber());
             headers.put(AGGREGATE_TYPE, ((DomainEventMessage<?>) event).getType());
         }
-        return new GenericMessage<>(event.getPayload(),
+        return new GenericMessage<>(event.payload(),
                                     new SettableTimestampMessageHeaders(headers, event.getTimestamp().toEpochMilli()));
     }
 

--- a/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
+++ b/spring/src/test/java/org/axonframework/integrationtests/deadline/AbstractDeadlineManagerTestSuite.java
@@ -562,7 +562,7 @@ public abstract class AbstractDeadlineManagerTestSuite {
         if (expected.size() != publishedMessages.size()) {
             return false;
         }
-        List<Object> published = publishedMessages.stream().map(Message::getPayload).collect(Collectors.toList());
+        List<Object> published = publishedMessages.stream().map(Message::payload).collect(Collectors.toList());
         return expected.containsAll(published) && published.containsAll(expected);
     }
 

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/deadletter/SpringJpaDeadLetteringIntegrationTest.java
@@ -141,7 +141,7 @@ class SpringJpaDeadLetteringIntegrationTest extends DeadLetteringEventIntegratio
             JpaDeadLetter<? extends EventMessage<?>> actual = ((JpaDeadLetter<? extends EventMessage<?>>) result);
 
             assertEquals(expected.getSequenceIdentifier(), actual.getSequenceIdentifier(), assertMessageSupplier);
-            assertEquals(expected.message().getPayload(), actual.message().getPayload(), assertMessageSupplier);
+            assertEquals(expected.message().payload(), actual.message().payload(), assertMessageSupplier);
             assertFalse(result.cause().isPresent(), assertMessageSupplier);
             assertEquals(expected.diagnostics(), actual.diagnostics(), assertMessageSupplier);
             assertEquals(sequenceIndex.longValue(), actual.getIndex(), assertMessageSupplier);

--- a/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
+++ b/spring/src/test/java/org/axonframework/spring/messaging/DefaultEventMessageConverterTest.java
@@ -60,7 +60,7 @@ class DefaultEventMessageConverterTest {
         assertEquals(instant, convertedAxonMessage.getTimestamp());
         assertEquals("100", convertedAxonMessage.getMetaData().get("number"));
         assertEquals("world", convertedAxonMessage.getMetaData().get("string"));
-        assertEquals("hello", convertedAxonMessage.getPayload().name);
+        assertEquals("hello", convertedAxonMessage.payload().name);
         assertEquals(id, convertedAxonMessage.identifier());
     }
 
@@ -87,7 +87,7 @@ class DefaultEventMessageConverterTest {
         assertEquals(instant, convertDomainMessage.getTimestamp());
         assertEquals("100", convertDomainMessage.getMetaData().get("number"));
         assertEquals("world", convertDomainMessage.getMetaData().get("string"));
-        assertEquals("hello", convertDomainMessage.getPayload().name);
+        assertEquals("hello", convertDomainMessage.payload().name);
         assertEquals(id, convertDomainMessage.identifier());
         assertEquals("foo", convertDomainMessage.getType());
         assertEquals(aggId, convertDomainMessage.getAggregateIdentifier());

--- a/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -400,7 +400,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
             MetaData metaData = null;
             String type = aggregateType.getSimpleName();
             if (event instanceof Message) {
-                payload = ((Message<?>) event).getPayload();
+                payload = ((Message<?>) event).payload();
                 metaData = ((Message<?>) event).getMetaData();
             }
             if (event instanceof DomainEventMessage) {
@@ -1039,7 +1039,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
                                                                     oldEvent.getSequenceNumber(),
                                                                     oldEvent.identifier(),
                                                                     oldEvent.type(),
-                                                                    oldEvent.getPayload(),
+                                                                    oldEvent.payload(),
                                                                     oldEvent.getMetaData(),
                                                                     oldEvent.getTimestamp()));
                 } else {

--- a/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/Reporter.java
@@ -457,7 +457,7 @@ public class Reporter {
     private String payloadContentType(Object event) {
         String simpleName;
         if (event instanceof EventMessage) {
-            simpleName = ((EventMessage<?>) event).getPayload().getClass().getName();
+            simpleName = ((EventMessage<?>) event).payload().getClass().getName();
         } else {
             simpleName = event.getClass().getName();
         }

--- a/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -94,7 +94,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (Object expectedEvent : expectedEvents) {
             EventMessage<?> actualEvent = iterator.next();
-            if (!verifyPayloadEquality(expectedEvent, actualEvent.getPayload())) {
+            if (!verifyPayloadEquality(expectedEvent, actualEvent.payload())) {
                 reporter.reportWrongEvent(publishedEvents, Arrays.asList(expectedEvents), actualException);
             }
         }
@@ -103,7 +103,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
 
     @Override
     public ResultValidator<T> expectEvents(EventMessage<?>... expectedEvents) {
-        this.expectEvents(Stream.of(expectedEvents).map(Message::getPayload).toArray());
+        this.expectEvents(Stream.of(expectedEvents).map(Message::payload).toArray());
 
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (EventMessage<?> expectedEvent : expectedEvents) {
@@ -327,9 +327,9 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
         expectedMatcher.describeTo(expectedDescription);
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
-        } else if (!verifyPayloadEquality(expectedPayload, actualReturnValue.getPayload())) {
+        } else if (!verifyPayloadEquality(expectedPayload, actualReturnValue.payload())) {
             PayloadMatcher<CommandResultMessage<?>> actualMatcher =
-                    new PayloadMatcher<>(CoreMatchers.equalTo(actualReturnValue.getPayload()));
+                    new PayloadMatcher<>(CoreMatchers.equalTo(actualReturnValue.payload()));
             actualMatcher.describeTo(actualDescription);
             reporter.reportWrongResult(actualDescription, expectedDescription);
         }
@@ -345,15 +345,15 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
         matcher.describeTo(expectedDescription);
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
-        } else if (!matcher.matches(actualReturnValue.getPayload())) {
-            reporter.reportWrongResult(actualReturnValue.getPayload(), expectedDescription);
+        } else if (!matcher.matches(actualReturnValue.payload())) {
+            reporter.reportWrongResult(actualReturnValue.payload(), expectedDescription);
         }
         return this;
     }
 
     @Override
     public ResultValidator<T> expectResultMessage(CommandResultMessage<?> expectedResultMessage) {
-        expectResultMessagePayload(expectedResultMessage.getPayload());
+        expectResultMessagePayload(expectedResultMessage.payload());
 
         StringDescription expectedDescription = new StringDescription();
         StringDescription actualDescription = new StringDescription();
@@ -398,7 +398,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
         exceptionMessageMatcher.describeTo(description);
 
         if (actualException == null) {
-            reporter.reportUnexpectedReturnValue(actualReturnValue.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualReturnValue.payload(), description);
         }
         if (actualException != null && !exceptionMessageMatcher.matches(actualException.getMessage())) {
             reporter.reportWrongExceptionMessage(actualException, description);
@@ -421,7 +421,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
         StringDescription description = new StringDescription();
         matcher.describeTo(description);
         if (actualException == null) {
-            reporter.reportUnexpectedReturnValue(actualReturnValue.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualReturnValue.payload(), description);
         }
         if (!matcher.matches(actualException)) {
             reporter.reportWrongException(actualException, description);
@@ -452,7 +452,7 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
             StringDescription description = new StringDescription(new StringBuilder(
                     "an exception with details matching "));
             exceptionDetailsMatcher.describeTo(description);
-            reporter.reportUnexpectedReturnValue(actualReturnValue.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualReturnValue.payload(), description);
             return this;
         }
         if (!exceptionDetailsMatcher.matches(actualDetails)) {

--- a/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/test/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -148,7 +148,7 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
      * @return the payloads of the applied events.
      */
     public List<Object> getAppliedEventPayloads() {
-        return appliedMessages.stream().map(EventMessage::getPayload).collect(Collectors.toList());
+        return appliedMessages.stream().map(EventMessage::payload).collect(Collectors.toList());
     }
 
     /**

--- a/test/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
+++ b/test/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
@@ -272,6 +272,6 @@ public class StubDeadlineManager implements DeadlineManager {
             Throwable e = resultMessage.exceptionResult();
             throw new FixtureExecutionException("Exception occurred while handling the deadline", e);
         }
-        return (DeadlineMessage<?>) resultMessage.getPayload();
+        return (DeadlineMessage<?>) resultMessage.payload();
     }
 }

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestThenCommand.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestThenCommand.java
@@ -77,9 +77,9 @@ class AxonTestThenCommand
         expectedMatcher.describeTo(expectedDescription);
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
-        } else if (!verifyPayloadEquality(expectedPayload, actualResult.getPayload())) {
+        } else if (!verifyPayloadEquality(expectedPayload, actualResult.payload())) {
             PayloadMatcher<CommandResultMessage<?>> actualMatcher =
-                    new PayloadMatcher<>(CoreMatchers.equalTo(actualResult.getPayload()));
+                    new PayloadMatcher<>(CoreMatchers.equalTo(actualResult.payload()));
             actualMatcher.describeTo(actualDescription);
             reporter.reportWrongResult(actualDescription, expectedDescription);
         }
@@ -93,10 +93,10 @@ class AxonTestThenCommand
             reporter.reportUnexpectedException(actualException, expectedDescription);
         }
         try {
-            var payload = actualResult.getPayload();
+            var payload = actualResult.payload();
             consumer.accept(payload);
         } catch (AssertionError e) {
-            reporter.reportWrongResult(actualResult.getPayload(),
+            reporter.reportWrongResult(actualResult.payload(),
                                        "Result message to satisfy custom assertions: " + e.getMessage());
         }
         return this;
@@ -106,7 +106,7 @@ class AxonTestThenCommand
     public AxonTestPhase.Then.Command exception(@Nonnull Class<? extends Throwable> type) {
         StringDescription description = new StringDescription();
         if (actualException == null) {
-            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
         }
         return super.exception(type);
     }
@@ -115,7 +115,7 @@ class AxonTestThenCommand
     public AxonTestPhase.Then.Command exception(@Nonnull Class<? extends Throwable> type, @Nonnull String message) {
         StringDescription description = new StringDescription();
         if (actualException == null) {
-            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
         }
         return super.exception(type, message);
     }
@@ -124,7 +124,7 @@ class AxonTestThenCommand
     public AxonTestPhase.Then.Command exceptionSatisfies(@Nonnull Consumer<Throwable> consumer) {
         StringDescription description = new StringDescription();
         if (actualException == null) {
-            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.getPayload(), description);
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
         }
         return super.exceptionSatisfies(consumer);
     }

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestThenMessage.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestThenMessage.java
@@ -80,7 +80,7 @@ abstract class AxonTestThenMessage<T extends AxonTestPhase.Then.Message<T>>
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();
         for (Object expectedEvent : expectedEvents) {
             EventMessage<?> actualEvent = iterator.next();
-            if (!verifyPayloadEquality(expectedEvent, actualEvent.getPayload())) {
+            if (!verifyPayloadEquality(expectedEvent, actualEvent.payload())) {
                 reporter.reportWrongEvent(publishedEvents, Arrays.asList(expectedEvents), actualException);
             }
         }
@@ -89,7 +89,7 @@ abstract class AxonTestThenMessage<T extends AxonTestPhase.Then.Message<T>>
 
     @Override
     public T events(@Nonnull EventMessage<?>... expectedEvents) {
-        this.events(Stream.of(expectedEvents).map(org.axonframework.messaging.Message::getPayload).toArray());
+        this.events(Stream.of(expectedEvents).map(org.axonframework.messaging.Message::payload).toArray());
 
         var publishedEvents = eventSink.recorded();
         Iterator<EventMessage<?>> iterator = publishedEvents.iterator();

--- a/test/src/main/java/org/axonframework/test/matchers/PayloadMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/PayloadMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class PayloadMatcher<T extends Message> extends BaseMatcher<T> {
     @Override
     public boolean matches(Object item) {
         return Message.class.isInstance(item)
-                && payloadMatcher.matches(((Message) item).getPayload());
+                && payloadMatcher.matches(((Message) item).payload());
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/matchers/PayloadsMatcher.java
+++ b/test/src/main/java/org/axonframework/test/matchers/PayloadsMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class PayloadsMatcher extends BaseMatcher<List<Message<?>>> {
         List<Object> payloads = new ArrayList<>();
         for (Object listItem : (List) item) {
             if (Message.class.isInstance(listItem)) {
-                payloads.add(((Message) listItem).getPayload());
+                payloads.add(((Message) listItem).payload());
             } else {
                 payloads.add(item);
             }

--- a/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/CommandValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class CommandValidator {
                                     + " but got <" + actualItem.getPayloadType() + ">."
                     );
                 }
-                assertCommandEquality(counter, expectedMessage.getPayload(), actualItem.getPayload());
+                assertCommandEquality(counter, expectedMessage.payload(), actualItem.payload());
                 if (!expectedMessage.getMetaData().equals(actualItem.getMetaData())) {
                     throw new AxonAssertionError(
                             "Unexpected Meta Data of command at position " + counter + " (0-based).\n"
@@ -109,7 +109,7 @@ public class CommandValidator {
                     );
                 }
             } else {
-                assertCommandEquality(counter, expectedItem, actualItem.getPayload());
+                assertCommandEquality(counter, expectedItem, actualItem.payload());
             }
             counter++;
         }

--- a/test/src/main/java/org/axonframework/test/saga/EventValidator.java
+++ b/test/src/main/java/org/axonframework/test/saga/EventValidator.java
@@ -122,10 +122,10 @@ public class EventValidator implements EventMessageHandler {
      * {@code event} as is.
      *
      * @param event either an {@link EventMessage} or the payload of an EventMessage
-     * @return the given {@code event} as is or the {@link EventMessage#getPayload()}
+     * @return the given {@code event} as is or the {@link EventMessage#payload()}
      */
     private Object unwrapEvent(Object event) {
-        return event instanceof EventMessage ? ((EventMessage) event).getPayload() : event;
+        return event instanceof EventMessage ? ((EventMessage) event).payload() : event;
     }
 
     public Set<Class<?>> supportedEventTypes() {

--- a/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -392,7 +392,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     private EventMessage<Object> timeCorrectedEventMessage(Object event) {
         EventMessage<?> msg = asEventMessage(event);
         return new GenericEventMessage<>(
-                msg.identifier(), msg.type(), msg.getPayload(), msg.getMetaData(), currentTime()
+                msg.identifier(), msg.type(), msg.payload(), msg.getMetaData(), currentTime()
         );
     }
 
@@ -527,7 +527,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
                                                              sequenceNumber++,
                                                              eventMessage.identifier(),
                                                              eventMessage.type(),
-                                                             eventMessage.getPayload(),
+                                                             eventMessage.payload(),
                                                              eventMessage.getMetaData(),
                                                              currentTime()));
             }

--- a/test/src/main/java/org/axonframework/test/utils/RecordingCommandBus.java
+++ b/test/src/main/java/org/axonframework/test/utils/RecordingCommandBus.java
@@ -57,7 +57,7 @@ public class RecordingCommandBus implements CommandBus {
         dispatchedCommands.add(command);
         try {
             return CompletableFuture.completedFuture(asCommandResultMessage(
-                    callbackBehavior.handle(command.getPayload(), command.getMetaData())
+                    callbackBehavior.handle(command.payload(), command.getMetaData())
             ));
         } catch (Throwable throwable) {
             return CompletableFuture.failedFuture(throwable);

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_CommandInterceptors.java
@@ -106,14 +106,14 @@ class FixtureTest_CommandInterceptors {
                 ArgumentCaptor.forClass(GenericCommandMessage.class);
         verify(firstMockCommandDispatchInterceptor).handle(firstCommandMessageCaptor.capture());
         GenericCommandMessage<?> firstResult = firstCommandMessageCaptor.getValue();
-        assertEquals(expectedCommand, firstResult.getPayload());
+        assertEquals(expectedCommand, firstResult.payload());
 
         //noinspection unchecked
         ArgumentCaptor<GenericCommandMessage<?>> secondCommandMessageCaptor =
                 ArgumentCaptor.forClass(GenericCommandMessage.class);
         verify(secondMockCommandDispatchInterceptor).handle(secondCommandMessageCaptor.capture());
         GenericCommandMessage<?> secondResult = secondCommandMessageCaptor.getValue();
-        assertEquals(expectedCommand, secondResult.getPayload());
+        assertEquals(expectedCommand, secondResult.payload());
     }
 
     @Test
@@ -169,7 +169,7 @@ class FixtureTest_CommandInterceptors {
         verify(mockCommandHandlerInterceptor).handle(unitOfWorkCaptor.capture(), any(), interceptorChainCaptor.capture());
         LegacyUnitOfWork<? extends CommandMessage<?>> unitOfWorkResult = unitOfWorkCaptor.getValue();
         Message<?> messageResult = unitOfWorkResult.getMessage();
-        assertEquals(expectedCommand, messageResult.getPayload());
+        assertEquals(expectedCommand, messageResult.payload());
         assertEquals(expectedMetaDataMap, messageResult.getMetaData());
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Polymorphism.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_Polymorphism.java
@@ -70,7 +70,7 @@ class FixtureTest_Polymorphism {
                    DomainEventMessage<CreatedEvent> evt = (DomainEventMessage<CreatedEvent>) events.getFirst();
                    return evt.getType().equals(aggregateType)
                            && events.size() == 1
-                           && evt.getPayload().id.equals(id);
+                           && evt.payload().id.equals(id);
                }));
     }
 

--- a/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/FixtureTest_RegisteringMethodEnhancements.java
@@ -62,7 +62,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
                    .given(new MyEvent(TEST_AGGREGATE_IDENTIFIER, 42))
                    .when(new ResolveParameterCommand(TEST_AGGREGATE_IDENTIFIER))
                    .expectEventsMatching(exactSequenceOf(predicate(eventMessage -> {
-                       Object payload = eventMessage.getPayload();
+                       Object payload = eventMessage.payload();
                        assertTrue(payload instanceof ParameterResolvedEvent);
                        AtomicBoolean assertion = ((ParameterResolvedEvent) payload).getAssertion();
                        return assertion.get();

--- a/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/ResultValidatorImplTest.java
@@ -185,7 +185,7 @@ class ResultValidatorImplTest {
     void noDeadlineInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
         ScheduledDeadlineInfo deadlineInfo = createDeadline(expiryTime);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -205,7 +205,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowFrom);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -215,7 +215,7 @@ class ResultValidatorImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtTo() {
         ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowTo);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -230,10 +230,10 @@ class ResultValidatorImplTest {
 
         assertDoesNotThrow(() -> validator.expectNoScheduledDeadline(deadlineWindowFrom,
                                                                      deadlineWindowTo,
-                                                                     deadlineBefore.deadlineMessage().getPayload()));
+                                                                     deadlineBefore.deadlineMessage().payload()));
         assertDoesNotThrow(() -> validator.expectNoScheduledDeadline(deadlineWindowFrom,
                                                                      deadlineWindowTo,
-                                                                     deadlineAfter.deadlineMessage().getPayload()));
+                                                                     deadlineAfter.deadlineMessage().payload()));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class StubAggregateLifecycleExtensionTest {
 
         assertEquals(1, TEST_SUBJECT.getAppliedEvents().size());
         assertEquals("test", TEST_SUBJECT.getAppliedEventPayloads().get(0));
-        assertEquals("test", TEST_SUBJECT.getAppliedEvents().get(0).getPayload());
+        assertEquals("test", TEST_SUBJECT.getAppliedEvents().get(0).payload());
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
+++ b/test/src/test/java/org/axonframework/test/aggregate/StubAggregateLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class StubAggregateLifecycleTest {
 
         assertEquals(1, testSubject.getAppliedEvents().size());
         assertEquals("test", testSubject.getAppliedEventPayloads().get(0));
-        assertEquals("test", testSubject.getAppliedEvents().get(0).getPayload());
+        assertEquals("test", testSubject.getAppliedEvents().get(0).payload());
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
@@ -187,7 +187,7 @@ class AxonTestFixtureMessagingTest {
                    .then()
                    .success()
                    .resultMessageSatisfies(c -> assertEquals(new CommandResult("Result name-1", "metaValue"),
-                                                             c.getPayload()));
+                                                             c.payload()));
         }
 
         @Test
@@ -223,7 +223,7 @@ class AxonTestFixtureMessagingTest {
                             .subscribe(
                                     new QualifiedName(ChangeStudentNameCommand.class),
                                     (command, context) -> {
-                                        ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.getPayload();
+                                        ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.payload();
                                         var eventSink = c.getComponent(EventSink.class);
                                         var changeNo = studentEvents.size() + 1;
                                         eventSink.publish(context,
@@ -430,8 +430,8 @@ class AxonTestFixtureMessagingTest {
                    .commandsSatisfy(commands -> {
                        assertEquals(1, commands.size());
                        var command = commands.getFirst();
-                       assertEquals("id", ((ChangeStudentNameCommand) command.getPayload()).id());
-                       assertEquals("name", ((ChangeStudentNameCommand) command.getPayload()).name());
+                       assertEquals("id", ((ChangeStudentNameCommand) command.payload()).id());
+                       assertEquals("name", ((ChangeStudentNameCommand) command.payload()).name());
                    }).commandsMatch(commands -> !commands.isEmpty())
                    .success();
         }
@@ -651,7 +651,7 @@ class AxonTestFixtureMessagingTest {
                 (c, n, d) -> d.subscribe(
                         new QualifiedName(ChangeStudentNameCommand.class),
                         (command, context) -> {
-                            ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.getPayload();
+                            ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.payload();
                             var eventSink = c.getComponent(EventSink.class);
                             eventSink.publish(context,
                                               studentNameChangedEventMessage(payload.id(), payload.name(), 1));
@@ -667,7 +667,7 @@ class AxonTestFixtureMessagingTest {
                 (c, n, d) -> d.subscribe(
                         new QualifiedName(ChangeStudentNameCommand.class),
                         (command, context) -> {
-                            ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.getPayload();
+                            ChangeStudentNameCommand payload = (ChangeStudentNameCommand) command.payload();
                             var metadataSample = (String) command.getMetaData().get("sample");
                             var eventSink = c.getComponent(EventSink.class);
                             eventSink.publish(context, studentNameChangedEventMessage(payload.id(), payload.name(), 1));

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -271,7 +271,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                             .subscribe(
                                     new QualifiedName(ChangeStudentNameCommand.class),
                                     (cmd, sm, ctx) -> {
-                                        ChangeStudentNameCommand payload = (ChangeStudentNameCommand) cmd.getPayload();
+                                        ChangeStudentNameCommand payload = (ChangeStudentNameCommand) cmd.payload();
                                         var student = sm.loadEntity(Student.class, payload.id(), ctx).join();
                                         if (!Objects.equals(student.getName(), payload.name())) {
                                             var eventSink = c.getComponent(EventSink.class);

--- a/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureExecutionResultImplTest.java
@@ -124,9 +124,9 @@ class FixtureExecutionResultImplTest {
         IllegalArgumentException secondException = new IllegalArgumentException("Second");
         errorHandler.onError(secondException, endEventMessage, eventMessageHandler);
 
-        testSubject.expectPublishedEvents(endEventMessage.getPayload());
+        testSubject.expectPublishedEvents(endEventMessage.payload());
         testSubject.expectPublishedEventsMatching(
-                payloadsMatching(exactSequenceOf(deepEquals(endEventMessage.getPayload()), andNoMore()))
+                payloadsMatching(exactSequenceOf(deepEquals(endEventMessage.payload()), andNoMore()))
         );
         testSubject.expectDispatchedCommands("Second");
         testSubject.expectDispatchedCommandsMatching(
@@ -498,7 +498,7 @@ class FixtureExecutionResultImplTest {
     void noDeadlineInTimeframeWithDeadlineInsideWindow() {
         Instant expiryTime = deadlineWindowFrom.plus(1, ChronoUnit.DAYS);
         ScheduledDeadlineInfo deadlineInfo = createDeadline(expiryTime);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -518,7 +518,7 @@ class FixtureExecutionResultImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtFrom() {
         ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowFrom);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -528,7 +528,7 @@ class FixtureExecutionResultImplTest {
     @Test
     void noDeadlineInTimeframeWithDeadlineAtTo() {
         ScheduledDeadlineInfo deadlineInfo = createDeadline(deadlineWindowTo);
-        Object deadline = deadlineInfo.deadlineMessage().getPayload();
+        Object deadline = deadlineInfo.deadlineMessage().payload();
         when(deadlineManager.getScheduledDeadlines()).thenReturn(Collections.singletonList(deadlineInfo));
 
         assertThrows(AxonAssertionError.class,
@@ -543,10 +543,10 @@ class FixtureExecutionResultImplTest {
 
         assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom,
                                                                        deadlineWindowTo,
-                                                                       deadlineBefore.deadlineMessage().getPayload()));
+                                                                       deadlineBefore.deadlineMessage().payload()));
         assertDoesNotThrow(() -> testSubject.expectNoScheduledDeadline(deadlineWindowFrom,
                                                                        deadlineWindowTo,
-                                                                       deadlineAfter.deadlineMessage().getPayload()));
+                                                                       deadlineAfter.deadlineMessage().payload()));
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
+++ b/test/src/test/java/org/axonframework/test/saga/FixtureTest_RegisteringMethodEnhancements.java
@@ -70,7 +70,7 @@ public class FixtureTest_RegisteringMethodEnhancements {
                    .published(new TriggerSagaStartEvent(TEST_AGGREGATE_IDENTIFIER))
                    .whenPublishingA(new ParameterResolvedEvent(TEST_AGGREGATE_IDENTIFIER))
                    .expectDispatchedCommandsMatching(listWithAnyOf(predicate(commandMessage -> {
-                       Object payload = commandMessage.getPayload();
+                       Object payload = commandMessage.payload();
                        assertTrue(payload instanceof ResolveParameterCommand);
                        AtomicBoolean assertion = ((ResolveParameterCommand) payload).getAssertion();
                        return assertion.get();

--- a/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
+++ b/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
@@ -23,7 +23,6 @@ import org.axonframework.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.QualifiedName;
-import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
@@ -58,12 +57,12 @@ class RecordingCommandBusTest {
         if (commandResultMessage instanceof CommandResultMessage cmr && cmr.isExceptional()) {
             fail("Didn't expect handling to fail");
         }
-        assertNull(commandResultMessage.getPayload(),
+        assertNull(commandResultMessage.payload(),
                    "Expected default callback behavior to invoke onResult(null)");
         List<CommandMessage<?>> actual = testSubject.getDispatchedCommands();
         assertEquals(2, actual.size());
-        assertEquals("First", actual.get(0).getPayload());
-        assertEquals("Second", actual.get(1).getPayload());
+        assertEquals("First", actual.get(0).payload());
+        assertEquals("Second", actual.get(1).payload());
     }
 
     @Test
@@ -78,11 +77,11 @@ class RecordingCommandBusTest {
         if (commandResultMessage instanceof CommandResultMessage cmr && cmr.isExceptional()) {
             fail("Didn't expect handling to fail");
         }
-        assertEquals("callbackResult", commandResultMessage.getPayload());
+        assertEquals("callbackResult", commandResultMessage.payload());
         List<CommandMessage<?>> actual = testSubject.getDispatchedCommands();
         assertEquals(2, actual.size());
-        assertEquals("First", actual.get(0).getPayload());
-        assertEquals("Second", actual.get(1).getPayload());
+        assertEquals("First", actual.get(0).payload());
+        assertEquals("Second", actual.get(1).payload());
     }
 
     @Test


### PR DESCRIPTION
This pull request renames `Message#getPayload` to `Message#payload`. 

We prefer the none-get-styled getters and as such are performing this clean-up task throughout.
To not enlarge the review to much, PRs are broken down per method rename. 
Given the `Message's` role in Axon Framework, it's used very frequently.