### PR TITLE
[#3102] Use `Type` and `Converter` for `Message#withConvertedPayload`

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
@@ -135,7 +135,7 @@ public class GrpcBackedQueryMessage<P, R> implements QueryMessage<P, R> {
     }
 
     @Override
-    public <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
         return null;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedQueryMessage.java
@@ -133,4 +133,10 @@ public class GrpcBackedQueryMessage<P, R> implements QueryMessage<P, R> {
     public GrpcBackedQueryMessage<P, R> andMetaData(@Nonnull Map<String, String> metaData) {
         return withMetaData(metaData().mergedWith(metaData));
     }
+
+    @Override
+    public <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
+    }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
@@ -156,4 +156,10 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
     public GrpcBackedResponseMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
         return withMetaData(metaData().mergedWith(metaData));
     }
+
+    @Override
+    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
+    }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/GrpcBackedResponseMessage.java
@@ -158,7 +158,7 @@ public class GrpcBackedResponseMessage<R> implements QueryResponseMessage<R> {
     }
 
     @Override
-    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
         return null;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
 import org.axonframework.messaging.IllegalPayloadAccessException;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.ResultMessage;
 import org.axonframework.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.LazyDeserializingObject;
@@ -155,5 +156,11 @@ class GrpcBackedQueryUpdateMessage<U> implements SubscriptionQueryUpdateMessage<
     @Override
     public GrpcBackedQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData) {
         return withMetaData(metaData().mergedWith(metaData));
+    }
+
+    @Override
+    public <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedQueryUpdateMessage.java
@@ -159,7 +159,7 @@ class GrpcBackedQueryUpdateMessage<U> implements SubscriptionQueryUpdateMessage<
     }
 
     @Override
-    public <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> SubscriptionQueryUpdateMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
         return null;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
@@ -24,7 +24,6 @@ import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
-import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryResult;
 import org.axonframework.serialization.Converter;
@@ -136,7 +135,8 @@ public class GrpcBackedSubscriptionQueryMessage<P, I, U> implements Subscription
     }
 
     @Override
-    public <T> QueryMessage<T, I> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> SubscriptionQueryMessage<T, I, U> withConvertedPayload(@Nonnull Type type,
+                                                                      @Nonnull Converter converter) {
         // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
         return null;
     }

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/subscription/GrpcBackedSubscriptionQueryMessage.java
@@ -24,6 +24,7 @@ import org.axonframework.axonserver.connector.util.GrpcSerializedObject;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.axonframework.queryhandling.QueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryMessage;
 import org.axonframework.queryhandling.SubscriptionQueryResult;
 import org.axonframework.serialization.Converter;
@@ -132,5 +133,11 @@ public class GrpcBackedSubscriptionQueryMessage<P, I, U> implements Subscription
     @Override
     public GrpcBackedSubscriptionQueryMessage<P, I, U> andMetaData(@Nonnull Map<String, String> metaData) {
         return withMetaData(metaData().mergedWith(metaData));
+    }
+
+    @Override
+    public <T> QueryMessage<T, I> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        // TODO #3488 - Not implementing this, as the GrpcBackedResponseMessage will be removed as part of #3488
+        return null;
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngineTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngineTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.*;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -93,6 +92,6 @@ class AggregateBasedAxonServerEventStorageEngineTest extends
 
     @Override
     protected EventMessage<String> convertPayload(EventMessage<?> original) {
-        return original.withConvertedPayload(p -> new String((byte[]) p, StandardCharsets.UTF_8));
+        return original.withConvertedPayload(String.class, converter);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/AnnotationBasedEventSourcedEntityFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/AnnotationBasedEventSourcedEntityFactory.java
@@ -405,8 +405,7 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
         public ProcessingContext mapContextWithMessageIfNecessary(ProcessingContext context) {
             Message<?> eventMessage = Message.fromContext(context);
             if (eventMessage != null && expectedPayloadRepresentation != null) {
-                var convertedEvent = eventMessage.withConvertedPayload(
-                        p -> converter.convert(p, expectedPayloadRepresentation));
+                var convertedEvent = eventMessage.withConvertedPayload(expectedPayloadRepresentation, converter);
                 return Message.addToContext(context, convertedEvent);
             }
             return context;

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -29,6 +29,8 @@ import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageStream.Entry;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.ChainingContentTypeConverter;
+import org.axonframework.serialization.Converter;
 import org.junit.jupiter.api.*;
 import org.opentest4j.TestAbortedException;
 import reactor.test.StepVerifier;
@@ -70,6 +72,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     protected Set<Tag> OTHER_AGGREGATE_TAGS;
     protected EventCriteria OTHER_AGGREGATE_CRITERIA;
 
+    protected Converter converter;
+
     protected ESE testSubject;
 
     @BeforeEach
@@ -81,6 +85,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         TEST_AGGREGATE_CRITERIA = EventCriteria.havingTags(TEST_AGGREGATE_TYPE, TEST_AGGREGATE_ID);
         OTHER_AGGREGATE_TAGS = Set.of(new Tag("OTHER_AGGREGATE", OTHER_AGGREGATE_ID));
         OTHER_AGGREGATE_CRITERIA = EventCriteria.havingTags("OTHER_AGGREGATE", OTHER_AGGREGATE_ID);
+
+        converter = new ChainingContentTypeConverter();
 
         testSubject = buildStorageEngine();
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineTest.java
@@ -48,7 +48,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import javax.sql.DataSource;
@@ -92,13 +91,7 @@ class AggregateBasedJpaEventStorageEngineTest
 
     @Override
     protected EventMessage<String> convertPayload(EventMessage<?> original) {
-        return original.withConvertedPayload(payload -> {
-            try {
-                return OBJECT_MAPPER.readValue((byte[]) payload, String.class);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        return original.withConvertedPayload(String.class, converter);
     }
 
     @Test

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
@@ -17,9 +17,11 @@
 package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.Message;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -40,5 +42,15 @@ public interface CommandMessage<P> extends Message<P> {
     CommandMessage<P> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <T> CommandMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> CommandMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> CommandMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> CommandMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandMessage.java
@@ -18,9 +18,9 @@ package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.Message;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * A {@link Message} carrying a command as its payload.
@@ -40,5 +40,5 @@ public interface CommandMessage<P> extends Message<P> {
     CommandMessage<P> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <C> CommandMessage<C> withConvertedPayload(@Nonnull Function<P, C> conversion);
+    <T> CommandMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
@@ -17,9 +17,11 @@
 package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -38,5 +40,16 @@ public interface CommandResultMessage<R> extends ResultMessage<R> {
     CommandResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> CommandResultMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type,
+                                                             @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/CommandResultMessage.java
@@ -18,9 +18,9 @@ package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.ResultMessage;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * A {@link ResultMessage} that represents a result from handling a {@link CommandMessage}.
@@ -37,6 +37,6 @@ public interface CommandResultMessage<R> extends ResultMessage<R> {
     @Override
     CommandResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData);
 
-    // TODO - @Override from ResultMessage and Message
-    <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Function<R, T> conversion);
+    @Override
+    <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -91,7 +92,7 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
     }
 
     @Override
-    public <T> CommandMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> CommandMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -81,12 +81,12 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
     }
 
     @Override
-    public GenericCommandMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
+    public CommandMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericCommandMessage<>(getDelegate().withMetaData(metaData));
     }
 
     @Override
-    public GenericCommandMessage<P> andMetaData(@Nonnull Map<String, String> metaData) {
+    public CommandMessage<P> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericCommandMessage<>(getDelegate().andMetaData(metaData));
     }
 

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandMessage.java
@@ -83,12 +83,12 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
 
     @Override
     public CommandMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericCommandMessage<>(getDelegate().withMetaData(metaData));
+        return new GenericCommandMessage<>(delegate().withMetaData(metaData));
     }
 
     @Override
     public CommandMessage<P> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericCommandMessage<>(getDelegate().andMetaData(metaData));
+        return new GenericCommandMessage<>(delegate().andMetaData(metaData));
     }
 
     @Override
@@ -98,7 +98,7 @@ public class GenericCommandMessage<P> extends MessageDecorator<P> implements Com
             //noinspection unchecked
             return (CommandMessage<T>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         return new GenericCommandMessage<>(new GenericMessage<T>(delegate.identifier(),
                                                                  delegate.type(),
                                                                  convertedPayload,

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
@@ -130,13 +130,13 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
     @Override
     public CommandResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
         Throwable exception = optionalExceptionResult().orElse(null);
-        return new GenericCommandResultMessage<>(getDelegate().withMetaData(metaData), exception);
+        return new GenericCommandResultMessage<>(delegate().withMetaData(metaData), exception);
     }
 
     @Override
     public CommandResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
         Throwable exception = optionalExceptionResult().orElse(null);
-        return new GenericCommandResultMessage<>(getDelegate().andMetaData(metaData), exception);
+        return new GenericCommandResultMessage<>(delegate().andMetaData(metaData), exception);
     }
 
     @Override
@@ -147,7 +147,7 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
             //noinspection unchecked
             return (CommandResultMessage<T>) this;
         }
-        Message<R> delegate = getDelegate();
+        Message<R> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.MessageType;
 import org.axonframework.queryhandling.QueryResponseMessage;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -139,7 +140,7 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
     }
 
     @Override
-    public <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Class<T> type,
+    public <T> CommandResultMessage<T> withConvertedPayload(@Nonnull Type type,
                                                             @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
@@ -115,9 +115,9 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
-     *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
-     *                  {@link Message#metaData() metadata} for the {@link QueryResponseMessage} to reconstruct.
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
+     *                  {@link Message#identifier() identifier} and {@link Message#metaData() metadata} for the
+     *                  {@link QueryResponseMessage} to reconstruct.
      * @param exception The {@link Throwable} describing the error representing the response of this
      *                  {@link CommandResultMessage}.
      */
@@ -127,13 +127,13 @@ public class GenericCommandResultMessage<R> extends GenericResultMessage<R> impl
     }
 
     @Override
-    public GenericCommandResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
+    public CommandResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
         Throwable exception = optionalExceptionResult().orElse(null);
         return new GenericCommandResultMessage<>(getDelegate().withMetaData(metaData), exception);
     }
 
     @Override
-    public GenericCommandResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
+    public CommandResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
         Throwable exception = optionalExceptionResult().orElse(null);
         return new GenericCommandResultMessage<>(getDelegate().andMetaData(metaData), exception);
     }

--- a/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
@@ -17,9 +17,11 @@
 package org.axonframework.deadline;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -51,5 +53,15 @@ public interface DeadlineMessage<P> extends EventMessage<P> {
     DeadlineMessage<P> andMetaData(@Nonnull Map<String, String> additionalMetaData);
 
     @Override
-    <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> DeadlineMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.deadline;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
 
@@ -48,4 +49,7 @@ public interface DeadlineMessage<P> extends EventMessage<P> {
 
     @Override
     DeadlineMessage<P> andMetaData(@Nonnull Map<String, String> additionalMetaData);
+
+    @Override
+    <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/DeadlineMessage.java
@@ -29,8 +29,8 @@ import java.util.Map;
  * Implementations of the {@link DeadlineMessage} represent a fact (it's a specialization of {@code EventMessage}) that
  * some deadline was reached. The optional payload contains relevant data of the scheduled deadline.
  *
- * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
- *            if no payload was provided.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void} if
+ *            no payload was provided.
  * @author Milan Savic
  * @author Steven van Beelen
  * @since 3.3.0

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -141,13 +141,13 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
 
     @Override
     public DeadlineMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericDeadlineMessage<>(deadlineName, getDelegate().withMetaData(metaData), this::timestamp);
+        return new GenericDeadlineMessage<>(deadlineName, delegate().withMetaData(metaData), this::timestamp);
     }
 
     @Override
     public DeadlineMessage<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new GenericDeadlineMessage<>(
-                deadlineName, getDelegate().andMetaData(additionalMetaData), this::timestamp
+                deadlineName, delegate().andMetaData(additionalMetaData), this::timestamp
         );
     }
 
@@ -158,7 +158,7 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
             //noinspection unchecked
             return (DeadlineMessage<T>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -32,8 +32,8 @@ import java.util.function.Supplier;
 /**
  * Generic implementation of the {@link DeadlineMessage} interface.
  *
- * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void}
- *            if no payload was provided.
+ * @param <P> The type of {@link #payload() payload} contained in this {@link DeadlineMessage}. May be {@link Void} if
+ *            no payload was provided.
  * @author Milan Savic
  * @author Steven van Beelen
  * @since 3.3.0
@@ -139,12 +139,12 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
     }
 
     @Override
-    public GenericDeadlineMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
+    public DeadlineMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericDeadlineMessage<>(deadlineName, getDelegate().withMetaData(metaData), this::timestamp);
     }
 
     @Override
-    public GenericDeadlineMessage<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
+    public DeadlineMessage<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new GenericDeadlineMessage<>(
                 deadlineName, getDelegate().andMetaData(additionalMetaData), this::timestamp
         );

--- a/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
+++ b/messaging/src/main/java/org/axonframework/deadline/GenericDeadlineMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -151,7 +152,7 @@ public class GenericDeadlineMessage<P> extends GenericEventMessage<P> implements
     }
 
     @Override
-    public <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> DeadlineMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
@@ -17,9 +17,11 @@
 package org.axonframework.eventhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.Message;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Map;
 
@@ -73,5 +75,15 @@ public interface EventMessage<P> extends Message<P> {
     EventMessage<P> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <T> EventMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> EventMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> EventMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> EventMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
@@ -18,11 +18,10 @@ package org.axonframework.eventhandling;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.Message;
+import org.axonframework.serialization.Converter;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * A {@link Message} wrapping an event, which is represented by its {@link #payload() payload}.
@@ -73,20 +72,6 @@ public interface EventMessage<P> extends Message<P> {
     @Override
     EventMessage<P> andMetaData(@Nonnull Map<String, String> metaData);
 
-    /**
-     * Returns a copy of this EventMessage with its payload converted using given {@code conversion} function. If the
-     * function returns an equal payload, this Event Message instance is returned.
-     *
-     * @param conversion The function to apply to the payload of this message
-     * @param <C>        The type of payload returned by the conversion
-     * @return a copy of this message with the payload converted
-     */
-    default <C> EventMessage<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        P payload = payload();
-        if (Objects.equals(payload, conversion.apply(payload))) {
-            //noinspection unchecked
-            return (EventMessage<C>) this;
-        }
-        throw new UnsupportedOperationException("To be implemented");
-    }
+    @Override
+    <T> EventMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventMessage.java
@@ -41,8 +41,8 @@ public interface EventMessage<P> extends Message<P> {
      * Returns the identifier of this {@link EventMessage event}.
      * <p>
      * The identifier is used to define the uniqueness of an event. Two events may contain similar (or equal)
-     * {@link #payload() payloads} and {@link #timestamp() timestamp}, if the event identifiers are different,
-     * they both represent a different occurrence of an Event.
+     * {@link #payload() payloads} and {@link #timestamp() timestamp}, if the event identifiers are different, they both
+     * represent a different occurrence of an Event.
      * <p>
      * If two messages have the same identifier, they both represent the same unique occurrence of an event, even though
      * the resulting view may be different. You may not assume two messages are equal (i.e. interchangeable) if their

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericDomainEventMessage.java
@@ -204,7 +204,7 @@ public class GenericDomainEventMessage<P> extends GenericEventMessage<P> impleme
         return new GenericDomainEventMessage<>(aggregateType,
                                                aggregateIdentifier,
                                                sequenceNumber,
-                                               getDelegate().withMetaData(metaData),
+                                               delegate().withMetaData(metaData),
                                                timestamp());
     }
 
@@ -217,7 +217,7 @@ public class GenericDomainEventMessage<P> extends GenericEventMessage<P> impleme
         return new GenericDomainEventMessage<>(aggregateType,
                                                aggregateIdentifier,
                                                sequenceNumber,
-                                               getDelegate().andMetaData(metaData),
+                                               delegate().andMetaData(metaData),
                                                timestamp());
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.CachingSupplier;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
@@ -162,7 +163,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
     }
 
     @Override
-    public <T> EventMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> EventMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -128,9 +128,9 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
-     *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
-     *                  {@link Message#metaData() metadata} for the {@link EventMessage} to reconstruct.
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
+     *                  {@link Message#identifier() identifier} and {@link Message#metaData() metadata} for the
+     *                  {@link EventMessage} to reconstruct.
      * @param timestamp The {@link Instant timestamp} of this {@link EventMessage GenericEventMessage's} creation.
      */
     protected GenericEventMessage(@Nonnull Message<P> delegate,
@@ -145,7 +145,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
     }
 
     @Override
-    public GenericEventMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
+    public EventMessage<P> withMetaData(@Nonnull Map<String, String> metaData) {
         if (metaData().equals(metaData)) {
             return this;
         }
@@ -153,7 +153,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
     }
 
     @Override
-    public GenericEventMessage<P> andMetaData(@Nonnull Map<String, String> metaData) {
+    public EventMessage<P> andMetaData(@Nonnull Map<String, String> metaData) {
         //noinspection ConstantConditions
         if (metaData == null || metaData.isEmpty() || metaData().equals(metaData)) {
             return this;

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericEventMessage.java
@@ -150,7 +150,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
         if (metaData().equals(metaData)) {
             return this;
         }
-        return new GenericEventMessage<>(getDelegate().withMetaData(metaData), timestampSupplier);
+        return new GenericEventMessage<>(delegate().withMetaData(metaData), timestampSupplier);
     }
 
     @Override
@@ -159,7 +159,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
         if (metaData == null || metaData.isEmpty() || metaData().equals(metaData)) {
             return this;
         }
-        return new GenericEventMessage<>(getDelegate().andMetaData(metaData), timestampSupplier);
+        return new GenericEventMessage<>(delegate().andMetaData(metaData), timestampSupplier);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class GenericEventMessage<P> extends MessageDecorator<P> implements Event
             //noinspection unchecked
             return (EventMessage<T>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/GenericTrackedDomainEventMessage.java
@@ -90,14 +90,14 @@ public class GenericTrackedDomainEventMessage<T>
     @Override
     public GenericTrackedDomainEventMessage<T> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericTrackedDomainEventMessage<>(trackingToken, getType(), getAggregateIdentifier(),
-                                                      getSequenceNumber(), getDelegate().withMetaData(metaData),
+                                                      getSequenceNumber(), delegate().withMetaData(metaData),
                                                       timestamp());
     }
 
     @Override
     public GenericTrackedDomainEventMessage<T> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericTrackedDomainEventMessage<>(trackingToken, getType(), getAggregateIdentifier(),
-                                                      getSequenceNumber(), getDelegate().andMetaData(metaData),
+                                                      getSequenceNumber(), delegate().andMetaData(metaData),
                                                       timestamp());
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
@@ -79,12 +79,12 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
     }
 
     @Override
-    public GenericResetContext<P> withMetaData(@Nonnull Map<String, String> metaData) {
+    public ResetContext<P> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericResetContext<>(getDelegate().withMetaData(metaData));
     }
 
     @Override
-    public GenericResetContext<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
+    public ResetContext<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new GenericResetContext<>(getDelegate().andMetaData(additionalMetaData));
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageDecorator;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
 
@@ -85,6 +86,20 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
     @Override
     public GenericResetContext<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new GenericResetContext<>(getDelegate().andMetaData(additionalMetaData));
+    }
+
+    @Override
+    public <T> ResetContext<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        T convertedPayload = this.payloadAs(type, converter);
+        if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
+            //noinspection unchecked
+            return (ResetContext<T>) this;
+        }
+        Message<P> delegate = getDelegate();
+        return new GenericResetContext<>(new GenericMessage<T>(delegate.identifier(),
+                                                               delegate.type(),
+                                                               convertedPayload,
+                                                               delegate.metaData()));
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
@@ -81,12 +81,12 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
 
     @Override
     public ResetContext<P> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericResetContext<>(getDelegate().withMetaData(metaData));
+        return new GenericResetContext<>(delegate().withMetaData(metaData));
     }
 
     @Override
     public ResetContext<P> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
-        return new GenericResetContext<>(getDelegate().andMetaData(additionalMetaData));
+        return new GenericResetContext<>(delegate().andMetaData(additionalMetaData));
     }
 
     @Override
@@ -96,7 +96,7 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
             //noinspection unchecked
             return (ResetContext<T>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         return new GenericResetContext<>(new GenericMessage<T>(delegate.identifier(),
                                                                delegate.type(),
                                                                convertedPayload,

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/GenericResetContext.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -89,7 +90,7 @@ public class GenericResetContext<P> extends MessageDecorator<P> implements Reset
     }
 
     @Override
-    public <T> ResetContext<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> ResetContext<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = this.payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
@@ -16,10 +16,11 @@
 
 package org.axonframework.eventhandling.replay;
 
+import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.Message;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
-import jakarta.annotation.Nonnull;
 
 /**
  * A {@link Message} initiating the reset of an Event Handling Component.
@@ -37,4 +38,7 @@ public interface ResetContext<P> extends Message<P> {
 
     @Override
     ResetContext<P> andMetaData(@Nonnull Map<String, String> metaData);
+
+    @Override
+    <T> ResetContext<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/replay/ResetContext.java
@@ -17,9 +17,11 @@
 package org.axonframework.eventhandling.replay;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.Message;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -40,5 +42,15 @@ public interface ResetContext<P> extends Message<P> {
     ResetContext<P> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <T> ResetContext<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> ResetContext<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> ResetContext<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> ResetContext<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -30,7 +30,6 @@ import org.axonframework.serialization.Serializer;
 import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * Generic implementation of the {@link Message} interface containing the {@link #payload() payload} and
@@ -226,8 +225,12 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     }
 
     @Override
-    public <C> Message<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        C convertedPayload = conversion.apply(payload());
-        return new GenericMessage<>(type(), convertedPayload, MetaData.from(metaData));
+    public <T> Message<T> withConvertedPayload(@Nonnull Class<T> type,
+                                               @Nonnull Converter converter) {
+        T convertedPayload = payloadAs(type, converter);
+        //noinspection unchecked
+        return payloadType().isAssignableFrom(convertedPayload.getClass())
+                ? (Message<T>) this
+                : new GenericMessage<T>(identifier(), type(), convertedPayload, metaData());
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericMessage.java
@@ -225,7 +225,7 @@ public class GenericMessage<P> extends AbstractMessage<P> {
     }
 
     @Override
-    public <T> Message<T> withConvertedPayload(@Nonnull Class<T> type,
+    public <T> Message<T> withConvertedPayload(@Nonnull Type type,
                                                @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
@@ -195,12 +195,12 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
 
     @Override
     public ResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericResultMessage<>(getDelegate().withMetaData(metaData), exception);
+        return new GenericResultMessage<>(delegate().withMetaData(metaData), exception);
     }
 
     @Override
     public ResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericResultMessage<>(getDelegate().andMetaData(metaData), exception);
+        return new GenericResultMessage<>(delegate().andMetaData(metaData), exception);
     }
 
     @Override
@@ -210,7 +210,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
             //noinspection unchecked
             return (ResultMessage<T>) this;
         }
-        Message<R> delegate = getDelegate();
+        Message<R> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
@@ -23,6 +23,7 @@ import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 
@@ -203,7 +204,7 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
     }
 
     @Override
-    public <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> ResultMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
@@ -114,9 +114,9 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
      * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
      * of Work.
      *
-     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
-     *                  {@link Message#type() type}, {@link Message#identifier() identifier} and
-     *                  {@link Message#metaData() metadata} for the {@link QueryResponseMessage} to reconstruct.
+     * @param delegate  The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
+     *                  {@link Message#identifier() identifier} and {@link Message#metaData() metadata} for the
+     *                  {@link QueryResponseMessage} to reconstruct.
      * @param exception The {@link Throwable} describing the error representing the response of this
      *                  {@link ResultMessage}.
      */
@@ -193,12 +193,12 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
     }
 
     @Override
-    public GenericResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
+    public ResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericResultMessage<>(getDelegate().withMetaData(metaData), exception);
     }
 
     @Override
-    public GenericResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
+    public ResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericResultMessage<>(getDelegate().andMetaData(metaData), exception);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -26,8 +26,6 @@ import org.axonframework.serialization.Serializer;
 
 import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * Representation of a {@link Message}, containing a {@link MessageType type}, payload of type {@code T}, and
@@ -232,7 +230,7 @@ public interface Message<P> {
      * @param <R>                    The type of the serialized data
      * @return a SerializedObject containing the serialized representation of the message's payload
      * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link #withConvertedPayload(Function)}
+     * {@link #withConvertedPayload(Class, Converter)}
      */
     @Deprecated
     default <R> SerializedObject<R> serializePayload(Serializer serializer, Class<R> expectedRepresentation) {
@@ -249,7 +247,7 @@ public interface Message<P> {
      * @param <R>                    The type of the serialized data
      * @return a SerializedObject containing the serialized representation of the message's metadata
      * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link #withConvertedPayload(Function)}
+     * {@link #withConvertedPayload(Class, Converter)}
      */
     @Deprecated
     default <R> SerializedObject<R> serializeMetaData(Serializer serializer, Class<R> expectedRepresentation) {
@@ -257,21 +255,18 @@ public interface Message<P> {
     }
 
     /**
-     * Returns a message which is effectively a copy of this Message with its payload converted using the given
-     * {@code conversion} function.
+     * Returns a <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}. This new {@code Message} is effectively a copy of
+     * {@code this Message} with a renewed payload and {@link #payloadType()}.
      * <p>
-     * Will only return the same instance if the conversion returns a payload object that is equal to the current
-     * payload.
+     * Will return the {@code this} instance if the payload type is
+     * {@link Class#isAssignableFrom(Class) assignable from} the given {@code type}.
      *
-     * @param conversion The function to apply to the payload of this message
-     * @param <C>        The new type of payload
-     * @return a message with the converted payload
+     * @param <T>       The new type of {@link #payload()}.
+     * @param type      The type to convert the {@link #payload()} to.
+     * @param converter The converter to convert the {@link #payload()} with.
+     * @return A <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}.
      */
-    default <C> Message<C> withConvertedPayload(@Nonnull Function<P, C> conversion) {
-        if (Objects.equals(payload(), conversion.apply(payload()))) {
-            //noinspection unchecked
-            return (Message<C>) this;
-        }
-        throw new UnsupportedOperationException("To be implemented");
-    }
+    <T> Message<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -257,8 +257,8 @@ public interface Message<P> {
      * {@code type} by the given {@code converter}. This new {@code Message} is effectively a copy of
      * {@code this Message} with a renewed payload and {@link #payloadType()}.
      * <p>
-     * Will return the {@code this} instance if the payload type is
-     * {@link Class#isAssignableFrom(Class) assignable from} the given {@code type}.
+     * Will return the {@code this} instance if the {@link #payloadType() payload type} is
+     * {@link Class#isAssignableFrom(Class) assignable from} the converted result.
      *
      * @param <T>       The new type of {@link #payload()}.
      * @param type      The type to convert the {@link #payload()} to.
@@ -266,5 +266,41 @@ public interface Message<P> {
      * @return A <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
      * {@code type} by the given {@code converter}.
      */
-    <T> Message<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> Message<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    /**
+     * Returns a <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}. This new {@code Message} is effectively a copy of
+     * {@code this Message} with a renewed payload and {@link #payloadType()}.
+     * <p>
+     * Will return the {@code this} instance if the {@link #payloadType() payload type} is
+     * {@link Class#isAssignableFrom(Class) assignable from} the converted result.
+     *
+     * @param <T>       The new type of {@link #payload()}.
+     * @param type      The type to convert the {@link #payload()} to.
+     * @param converter The converter to convert the {@link #payload()} with.
+     * @return A <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}.
+     */
+    default <T> Message<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    /**
+     * Returns a <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}. This new {@code Message} is effectively a copy of
+     * {@code this Message} with a renewed payload and {@link #payloadType()}.
+     * <p>
+     * Will return the {@code this} instance if the {@link #payloadType() payload type} is
+     * {@link Class#isAssignableFrom(Class) assignable from} the converted result.
+     *
+     * @param <T>       The new type of {@link #payload()}.
+     * @param type      The type to convert the {@link #payload()} to.
+     * @param converter The converter to convert the {@link #payload()} with.
+     * @return A <b>new</b> {@link Message} implementation with its {@link #payload()} converted to the given
+     * {@code type} by the given {@code converter}.
+     */
+    <T> Message<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -50,9 +50,8 @@ public interface Message<P> {
 
     /**
      * The {@link Context.ResourceKey} used to store and retrieve the {@link Message} from the
-     * {@link ProcessingContext}. Should always be the message for which a handler is being called.
-     * For example, if an event handler is called within the context of a command, the message should be the event
-     * message.
+     * {@link ProcessingContext}. Should always be the message for which a handler is being called. For example, if an
+     * event handler is called within the context of a command, the message should be the event message.
      */
     Context.ResourceKey<Message<?>> RESOURCE_KEY = Context.ResourceKey.withLabel("Message");
 
@@ -147,8 +146,7 @@ public interface Message<P> {
      * Returns the payload of this {@code Message}, converted to the given {@code type} by the given {@code converter}.
      * <p>
      * If {@link #payloadType()} is {@link Class#isAssignableFrom(Class) assignable from} the given
-     * {@link TypeReference#getType()}, {@link #payload()} may be invoked instead of using the given
-     * {@code converter}.
+     * {@link TypeReference#getType()}, {@link #payload()} may be invoked instead of using the given {@code converter}.
      * <p>
      * Implementers of this operation may optimize by storing the converted payloads, thus saving a
      * {@link Converter#convert(Object, Class)} invocation in the process. Only when this optimization is in place will
@@ -210,8 +208,8 @@ public interface Message<P> {
     Message<P> withMetaData(@Nonnull Map<String, String> metaData);
 
     /**
-     * Returns a copy of this {@code Message} (implementation) with its {@link Message#metaData() metadata} merged
-     * with the given {@code metaData}.
+     * Returns a copy of this {@code Message} (implementation) with its {@link Message#metaData() metadata} merged with
+     * the given {@code metaData}.
      * <p>
      * All others fields, like for example the {@link #payload()}, remain unchanged.
      *

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -101,7 +101,7 @@ public abstract class MessageDecorator<P> implements Message<P> {
      *
      * @return The wrapped {@link Message} delegated by this decorator.
      */
-    protected Message<P> getDelegate() {
+    protected Message<P> delegate() {
         return delegate;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -91,6 +91,11 @@ public abstract class MessageDecorator<P> implements Message<P> {
         return delegate.serializeMetaData(serializer, expectedRepresentation);
     }
 
+    @Override
+    public <T> Message<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
+        return delegate.withConvertedPayload(type, converter);
+    }
+
     /**
      * Returns the wrapped {@link Message} delegated by this decorator.
      *

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -92,9 +92,9 @@ public abstract class MessageDecorator<P> implements Message<P> {
     }
 
     /**
-     * Returns the wrapped message delegate.
+     * Returns the wrapped {@link Message} delegated by this decorator.
      *
-     * @return the delegate message
+     * @return The wrapped {@link Message} delegated by this decorator.
      */
     protected Message<P> getDelegate() {
         return delegate;
@@ -118,7 +118,7 @@ public abstract class MessageDecorator<P> implements Message<P> {
      * may be appended without enclosing. All properties should be preceded by a comma when appending, or finish with a
      * comma when prefixing values.
      *
-     * @param stringBuilder the builder to append data to
+     * @param stringBuilder The builder to append data to.
      */
     protected void describeTo(StringBuilder stringBuilder) {
         stringBuilder.append("type={")
@@ -140,7 +140,7 @@ public abstract class MessageDecorator<P> implements Message<P> {
      * <p>
      * Defaults to the simple class name of the actual instance.
      *
-     * @return the type of message
+     * @return The type of the message.
      */
     protected String describeType() {
         return getClass().getSimpleName();

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -17,10 +17,12 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 
@@ -113,5 +115,15 @@ public interface ResultMessage<R> extends Message<R> {
     ResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData);
 
     @Override
-    <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> ResultMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> ResultMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -16,13 +16,13 @@
 
 package org.axonframework.messaging;
 
+import jakarta.annotation.Nonnull;
+import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.Serializer;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
-import jakarta.annotation.Nonnull;
 
 /**
  * A {@link Message} that represents a result of handling some form of request message.
@@ -96,7 +96,7 @@ public interface ResultMessage<R> extends Message<R> {
      * @param <T>                    the generic type representing the expected format
      * @return the serialized exception as a {@link SerializedObject}
      * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link #withConvertedPayload(Function)}
+     * {@link Message#withConvertedPayload(Class, org.axonframework.serialization.Converter)}
      */
     @Deprecated
     default <T> SerializedObject<T> serializeExceptionResult(Serializer serializer, Class<T> expectedRepresentation) {
@@ -111,4 +111,7 @@ public interface ResultMessage<R> extends Message<R> {
 
     @Override
     ResultMessage<R> andMetaData(@Nonnull Map<String, String> metaData);
+
+    @Override
+    <T> ResultMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
@@ -140,7 +140,7 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
     }
 
     @Override
-    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         return responseMessage.withConvertedPayload(type, converter);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
@@ -138,4 +138,9 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
     public QueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new ConvertingResponseMessage<>(expectedResponseType, responseMessage.andMetaData(additionalMetaData));
     }
+
+    @Override
+    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return responseMessage.withConvertedPayload(type, converter);
+    }
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -86,12 +86,12 @@ public class GenericQueryMessage<P, R> extends MessageDecorator<P> implements Qu
 
     @Override
     public QueryMessage<P, R> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericQueryMessage<>(getDelegate().withMetaData(metaData), responseType);
+        return new GenericQueryMessage<>(delegate().withMetaData(metaData), responseType);
     }
 
     @Override
     public QueryMessage<P, R> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericQueryMessage<>(getDelegate().andMetaData(metaData), responseType);
+        return new GenericQueryMessage<>(delegate().andMetaData(metaData), responseType);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class GenericQueryMessage<P, R> extends MessageDecorator<P> implements Qu
             //noinspection unchecked
             return (QueryMessage<T, R>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.MetaData;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -94,7 +95,7 @@ public class GenericQueryMessage<P, R> extends MessageDecorator<P> implements Qu
     }
 
     @Override
-    public <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryMessage.java
@@ -42,8 +42,7 @@ public class GenericQueryMessage<P, R> extends MessageDecorator<P> implements Qu
 
 
     /**
-     * Constructs a {@link GenericQueryMessage} for the given {@code type}, {@code payload}, and
-     * {@code responseType}.
+     * Constructs a {@link GenericQueryMessage} for the given {@code type}, {@code payload}, and {@code responseType}.
      * <p>
      * The {@link MetaData} defaults to an empty instance. Initializes the message with the given {@code payload} and
      * expected {@code responseType}.

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -178,7 +179,7 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
     }
 
     @Override
-    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         T convertedPayload = payloadAs(type, converter);
         if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
             //noinspection unchecked

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
@@ -168,12 +168,12 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
     }
 
     @Override
-    public GenericQueryResponseMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
+    public QueryResponseMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericQueryResponseMessage<>(getDelegate().withMetaData(metaData));
     }
 
     @Override
-    public GenericQueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
+    public QueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
         return new GenericQueryResponseMessage<>(getDelegate().andMetaData(additionalMetaData));
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
@@ -170,12 +170,12 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
 
     @Override
     public QueryResponseMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericQueryResponseMessage<>(getDelegate().withMetaData(metaData));
+        return new GenericQueryResponseMessage<>(delegate().withMetaData(metaData));
     }
 
     @Override
     public QueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData) {
-        return new GenericQueryResponseMessage<>(getDelegate().andMetaData(additionalMetaData));
+        return new GenericQueryResponseMessage<>(delegate().andMetaData(additionalMetaData));
     }
 
     @Override
@@ -185,7 +185,7 @@ public class GenericQueryResponseMessage<R> extends GenericResultMessage<R> impl
             //noinspection unchecked
             return (QueryResponseMessage<T>) this;
         }
-        Message<R> delegate = getDelegate();
+        Message<R> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                      delegate.type(),
                                                      convertedPayload,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * Generic implementation of the {@link StreamingQueryMessage} interface.
  *
  * @param <P> The type of {@link #payload() payload} expressing the query in this {@link StreamingQueryMessage}.
- * @param <R> The type of {@link #responseType() response} expected from this {@link StreamingQueryMessage} streamed
- *            via {@link Publisher}.
+ * @param <R> The type of {@link #responseType() response} expected from this {@link StreamingQueryMessage} streamed via
+ *            {@link Publisher}.
  * @author Milan Savic
  * @author Stefan Dragisic
  * @author Steven van Beelen
@@ -62,8 +62,8 @@ public class GenericStreamingQueryMessage<P, R>
     }
 
     /**
-     * Constructs a {@code GenericStreamingQueryMessage} for the given {@code type}, {@code payload},
-     * and {@code responseType}.
+     * Constructs a {@code GenericStreamingQueryMessage} for the given {@code type}, {@code payload}, and
+     * {@code responseType}.
      * <p>
      * The {@link MetaData} defaults to an empty instance.
      *
@@ -78,8 +78,7 @@ public class GenericStreamingQueryMessage<P, R>
     }
 
     /**
-     * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and
-     * {@code responseType}.
+     * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and {@code responseType}.
      * <p>
      * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#metaData() metadata} and {@link Message#identifier() identifier} of the resulting
@@ -90,8 +89,7 @@ public class GenericStreamingQueryMessage<P, R>
      *
      * @param delegate     The {@link Message} containing {@link Message#payload() payload},
      *                     {@link Message#type() type}, {@link Message#identifier() identifier} and
-     *                     {@link Message#metaData() metadata} for the {@link SubscriptionQueryMessage} to
-     *                     reconstruct.
+     *                     {@link Message#metaData() metadata} for the {@link SubscriptionQueryMessage} to reconstruct.
      * @param responseType The expected {@link Class response type} for this {@link StreamingQueryMessage}.
      */
     public GenericStreamingQueryMessage(@Nonnull Message<P> delegate,
@@ -100,8 +98,7 @@ public class GenericStreamingQueryMessage<P, R>
     }
 
     /**
-     * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and
-     * {@code responseType}.
+     * Constructs a {@code GenericStreamingQueryMessage} with given {@code delegate}, and {@code responseType}.
      * <p>
      * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#metaData() metadata} and {@link Message#identifier() identifier} of the resulting
@@ -112,8 +109,7 @@ public class GenericStreamingQueryMessage<P, R>
      *
      * @param delegate     The {@link Message} containing {@link Message#payload() payload},
      *                     {@link Message#type() type}, {@link Message#identifier() identifier} and
-     *                     {@link Message#metaData() metadata} for the {@link SubscriptionQueryMessage} to
-     *                     reconstruct.
+     *                     {@link Message#metaData() metadata} for the {@link SubscriptionQueryMessage} to reconstruct.
      * @param responseType The expected {@link ResponseType response type} for this {@link StreamingQueryMessage}.
      */
     public GenericStreamingQueryMessage(@Nonnull Message<P> delegate,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericStreamingQueryMessage.java
@@ -119,13 +119,13 @@ public class GenericStreamingQueryMessage<P, R>
 
     @Override
     public StreamingQueryMessage<P, R> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericStreamingQueryMessage<>(getDelegate().withMetaData(metaData),
+        return new GenericStreamingQueryMessage<>(delegate().withMetaData(metaData),
                                                   responseType());
     }
 
     @Override
     public StreamingQueryMessage<P, R> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericStreamingQueryMessage<>(getDelegate().andMetaData(metaData),
+        return new GenericStreamingQueryMessage<>(delegate().andMetaData(metaData),
                                                   responseType());
     }
 
@@ -136,7 +136,7 @@ public class GenericStreamingQueryMessage<P, R>
             //noinspection unchecked
             return (StreamingQueryMessage<T, R>) super.withConvertedPayload(type, converter);
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         GenericMessage<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                             delegate.type(),
                                                             convertedPayload,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
@@ -100,14 +100,14 @@ public class GenericSubscriptionQueryMessage<P, I, U>
 
     @Override
     public SubscriptionQueryMessage<P, I, U> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericSubscriptionQueryMessage<>(getDelegate().withMetaData(metaData),
+        return new GenericSubscriptionQueryMessage<>(delegate().withMetaData(metaData),
                                                      responseType(),
                                                      updateResponseType);
     }
 
     @Override
     public SubscriptionQueryMessage<P, I, U> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericSubscriptionQueryMessage<>(getDelegate().andMetaData(metaData),
+        return new GenericSubscriptionQueryMessage<>(delegate().andMetaData(metaData),
                                                      responseType(),
                                                      updateResponseType);
     }
@@ -120,7 +120,7 @@ public class GenericSubscriptionQueryMessage<P, I, U>
             //noinspection unchecked
             return (SubscriptionQueryMessage<T, I, U>) this;
         }
-        Message<P> delegate = getDelegate();
+        Message<P> delegate = delegate();
         Message<T> converted = new GenericMessage<T>(delegate.identifier(),
                                                     delegate.type(),
                                                     convertedPayload,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryMessage.java
@@ -31,8 +31,7 @@ import java.util.Map;
  * Generic implementation of the {@link SubscriptionQueryMessage} interface.
  *
  * @param <P> The type of {@link #payload() payload} expressing the query in this {@link SubscriptionQueryMessage}.
- * @param <I> The type of {@link #responseType() initial response} expected from this
- *            {@link SubscriptionQueryMessage}.
+ * @param <I> The type of {@link #responseType() initial response} expected from this {@link SubscriptionQueryMessage}.
  * @param <U> The type of {@link #updatesResponseType() incremental updates} expected from this
  *            {@link SubscriptionQueryMessage}.
  * @author Allard Buijze
@@ -68,8 +67,8 @@ public class GenericSubscriptionQueryMessage<P, I, U>
     }
 
     /**
-     * Constructs a {@code GenericSubscriptionQueryMessage} with given {@code delegate},
-     * {@code responseType}, and {@code updateResponseType}.
+     * Constructs a {@code GenericSubscriptionQueryMessage} with given {@code delegate}, {@code responseType}, and
+     * {@code updateResponseType}.
      * <p>
      * The {@code delegate} will be used supply the {@link Message#payload() payload}, {@link Message#type() type},
      * {@link Message#metaData() metadata} and {@link Message#identifier() identifier} of the resulting
@@ -100,14 +99,14 @@ public class GenericSubscriptionQueryMessage<P, I, U>
     }
 
     @Override
-    public GenericSubscriptionQueryMessage<P, I, U> withMetaData(@Nonnull Map<String, String> metaData) {
+    public SubscriptionQueryMessage<P, I, U> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericSubscriptionQueryMessage<>(getDelegate().withMetaData(metaData),
                                                      responseType(),
                                                      updateResponseType);
     }
 
     @Override
-    public GenericSubscriptionQueryMessage<P, I, U> andMetaData(@Nonnull Map<String, String> metaData) {
+    public SubscriptionQueryMessage<P, I, U> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericSubscriptionQueryMessage<>(getDelegate().andMetaData(metaData),
                                                      responseType(),
                                                      updateResponseType);

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
@@ -121,12 +121,12 @@ public class GenericSubscriptionQueryUpdateMessage<U>
     }
 
     @Override
-    public GenericSubscriptionQueryUpdateMessage<U> withMetaData(@Nonnull Map<String, String> metaData) {
+    public SubscriptionQueryUpdateMessage<U> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericSubscriptionQueryUpdateMessage<>(getDelegate().withMetaData(metaData));
     }
 
     @Override
-    public GenericSubscriptionQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData) {
+    public SubscriptionQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericSubscriptionQueryUpdateMessage<>(getDelegate().andMetaData(metaData));
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
@@ -122,12 +122,12 @@ public class GenericSubscriptionQueryUpdateMessage<U>
 
     @Override
     public SubscriptionQueryUpdateMessage<U> withMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericSubscriptionQueryUpdateMessage<>(getDelegate().withMetaData(metaData));
+        return new GenericSubscriptionQueryUpdateMessage<>(delegate().withMetaData(metaData));
     }
 
     @Override
     public SubscriptionQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData) {
-        return new GenericSubscriptionQueryUpdateMessage<>(getDelegate().andMetaData(metaData));
+        return new GenericSubscriptionQueryUpdateMessage<>(delegate().andMetaData(metaData));
     }
 
     @Override
@@ -138,7 +138,7 @@ public class GenericSubscriptionQueryUpdateMessage<U>
             //noinspection unchecked
             return (SubscriptionQueryUpdateMessage<T>) this;
         }
-        Message<U> delegate = getDelegate();
+        Message<U> delegate = delegate();
         return new GenericSubscriptionQueryUpdateMessage<>(new GenericMessage<T>(delegate.identifier(),
                                                                                  delegate.type(),
                                                                                  convertedPayload,

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessage.java
@@ -23,7 +23,9 @@ import org.axonframework.messaging.GenericResultMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -126,6 +128,21 @@ public class GenericSubscriptionQueryUpdateMessage<U>
     @Override
     public GenericSubscriptionQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericSubscriptionQueryUpdateMessage<>(getDelegate().andMetaData(metaData));
+    }
+
+    @Override
+    public <T> SubscriptionQueryUpdateMessage<T> withConvertedPayload(@Nonnull Type type,
+                                                                      @Nonnull Converter converter) {
+        T convertedPayload = payloadAs(type, converter);
+        if (payloadType().isAssignableFrom(convertedPayload.getClass())) {
+            //noinspection unchecked
+            return (SubscriptionQueryUpdateMessage<T>) this;
+        }
+        Message<U> delegate = getDelegate();
+        return new GenericSubscriptionQueryUpdateMessage<>(new GenericMessage<T>(delegate.identifier(),
+                                                                                 delegate.type(),
+                                                                                 convertedPayload,
+                                                                                 delegate.metaData()));
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.queryhandling;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
 
@@ -48,4 +49,7 @@ public interface QueryMessage<P, R> extends Message<P> {
 
     @Override
     QueryMessage<P, R> andMetaData(@Nonnull Map<String, String> additionalMetaData);
+
+    @Override
+    <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryMessage.java
@@ -16,10 +16,12 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.responsetypes.ResponseType;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -51,5 +53,15 @@ public interface QueryMessage<P, R> extends Message<P> {
     QueryMessage<P, R> andMetaData(@Nonnull Map<String, String> additionalMetaData);
 
     @Override
-    <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> QueryMessage<T, R> withConvertedPayload(@Nonnull TypeReference<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> QueryMessage<T, R> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
@@ -17,9 +17,11 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.ResultMessage;
 import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -38,5 +40,16 @@ public interface QueryResponseMessage<R> extends ResultMessage<R> {
     QueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData);
 
     @Override
-    <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
+    default <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type,
+                                                             @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryResponseMessage.java
@@ -18,6 +18,7 @@ package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.ResultMessage;
+import org.axonframework.serialization.Converter;
 
 import java.util.Map;
 
@@ -35,4 +36,7 @@ public interface QueryResponseMessage<R> extends ResultMessage<R> {
 
     @Override
     QueryResponseMessage<R> andMetaData(@Nonnull Map<String, String> additionalMetaData);
+
+    @Override
+    <T> QueryResponseMessage<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
@@ -32,8 +32,8 @@ import java.util.Map;
  * It hard codes the {@link #responseType() response type} to an {@link PublisherResponseType} implementation.
  *
  * @param <P> The type of {@link #payload() payload} expressing the query in this {@link StreamingQueryMessage}.
- * @param <R> The type of {@link #responseType() response} expected from this {@link StreamingQueryMessage} streamed
- *            via {@link Publisher}.
+ * @param <R> The type of {@link #responseType() response} expected from this {@link StreamingQueryMessage} streamed via
+ *            {@link Publisher}.
  * @author Milan Savic
  * @author Stefan Dragisic
  * @since 4.6.0

--- a/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/StreamingQueryMessage.java
@@ -17,10 +17,13 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.responsetypes.PublisherResponseType;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.axonframework.serialization.Converter;
 import org.reactivestreams.Publisher;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -45,4 +48,18 @@ public interface StreamingQueryMessage<P, R> extends QueryMessage<P, Publisher<R
 
     @Override
     StreamingQueryMessage<P, R> andMetaData(@Nonnull Map<String, String> additionalMetaData);
+
+    @Override
+    default <T> StreamingQueryMessage<T, R> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> StreamingQueryMessage<T, R> withConvertedPayload(@Nonnull TypeReference<T> type,
+                                                                 @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> StreamingQueryMessage<T, R> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryMessage.java
@@ -17,8 +17,11 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.responsetypes.ResponseType;
+import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -51,4 +54,19 @@ public interface SubscriptionQueryMessage<P, I, U> extends QueryMessage<P, I> {
 
     @Override
     SubscriptionQueryMessage<P, I, U> andMetaData(@Nonnull Map<String, String> additionalMetaData);
+
+    @Override
+    default <T> SubscriptionQueryMessage<T, I, U> withConvertedPayload(@Nonnull Class<T> type,
+                                                                       @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> SubscriptionQueryMessage<T, I, U> withConvertedPayload(@Nonnull TypeReference<T> type,
+                                                                       @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> SubscriptionQueryMessage<T, I, U> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SubscriptionQueryUpdateMessage.java
@@ -17,8 +17,11 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.ResultMessage;
+import org.axonframework.serialization.Converter;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 /**
@@ -35,4 +38,19 @@ public interface SubscriptionQueryUpdateMessage<U> extends ResultMessage<U> {
 
     @Override
     SubscriptionQueryUpdateMessage<U> andMetaData(@Nonnull Map<String, String> metaData);
+
+    @Override
+    default <T> SubscriptionQueryUpdateMessage<T> withConvertedPayload(@Nonnull Class<T> type,
+                                                                       @Nonnull Converter converter) {
+        return withConvertedPayload((Type) type, converter);
+    }
+
+    @Override
+    default <T> SubscriptionQueryUpdateMessage<T> withConvertedPayload(@Nonnull TypeReference<T> type,
+                                                                       @Nonnull Converter converter) {
+        return withConvertedPayload(type.getType(), converter);
+    }
+
+    @Override
+    <T> SubscriptionQueryUpdateMessage<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter);
 }

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
@@ -19,6 +19,7 @@ package org.axonframework.serialization;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.messaging.AbstractMessage;
+import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MetaData;
 
@@ -153,6 +154,12 @@ public class SerializedMessage<P> extends AbstractMessage<P> {
             return serializer.getConverter().convert(metaData.getSerializedObject(), expectedRepresentation);
         }
         return serializer.serialize(metaData.getObject(), expectedRepresentation);
+    }
+
+    @Override
+    public <T> Message<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+        // This class will be removed/replaced by the ConversionAwareMessage, so skipping implementation
+        return null;
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
+++ b/messaging/src/main/java/org/axonframework/serialization/SerializedMessage.java
@@ -157,7 +157,7 @@ public class SerializedMessage<P> extends AbstractMessage<P> {
     }
 
     @Override
-    public <T> Message<T> withConvertedPayload(@Nonnull Class<T> type, @Nonnull Converter converter) {
+    public <T> Message<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         // This class will be removed/replaced by the ConversionAwareMessage, so skipping implementation
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -75,10 +75,9 @@ class GenericCommandMessageTest extends MessageTestSuite {
         Map<String, String> metaDataMap = Collections.singletonMap("key", "value");
         MetaData metaData = MetaData.from(metaDataMap);
         GenericCommandMessage<Object> message = new GenericCommandMessage<>(TEST_TYPE, payload, metaData);
-        GenericCommandMessage<Object> message1 = message.withMetaData(MetaData.emptyInstance());
-        GenericCommandMessage<Object> message2 = message.withMetaData(
-                MetaData.from(Collections.singletonMap("key", "otherValue"))
-        );
+        CommandMessage<Object> message1 = message.withMetaData(MetaData.emptyInstance());
+        CommandMessage<Object> message2 =
+                message.withMetaData(MetaData.from(Collections.singletonMap("key", "otherValue")));
 
         assertEquals(0, message1.metaData().size());
         assertEquals(1, message2.metaData().size());

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandMessageTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.commandhandling;
 
+import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
@@ -37,9 +39,9 @@ class GenericCommandMessageTest extends MessageTestSuite {
     private static final MessageType TEST_TYPE = new MessageType("command");
 
     @Override
-    protected <P, M extends Message<P>> M buildMessage(P payload) {
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericCommandMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericCommandMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandResultMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandResultMessageTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.commandhandling;
+
+import jakarta.annotation.Nullable;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
+
+/**
+ * Test class validating the {@link GenericCommandResultMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericCommandResultMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
+        //noinspection unchecked
+        return (M) new GenericCommandResultMessage<>(new MessageType(payload.getClass()), payload);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandResultMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/GenericCommandResultMessageTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 
@@ -30,6 +31,7 @@ class GenericCommandResultMessageTest extends MessageTestSuite {
     @Override
     protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericCommandResultMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericCommandResultMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)),
+                                                     payload);
     }
 }

--- a/messaging/src/test/java/org/axonframework/deadline/GenericDeadlineMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/GenericDeadlineMessageTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.deadline;
 
 import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 
@@ -30,6 +31,8 @@ class GenericDeadlineMessageTest extends MessageTestSuite {
     @Override
     protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericDeadlineMessage<>("deadlineName", new MessageType(payload.getClass()), payload);
+        return (M) new GenericDeadlineMessage<>("deadlineName",
+                                                new MessageType(ObjectUtils.nullSafeTypeOf(payload)),
+                                                payload);
     }
 }

--- a/messaging/src/test/java/org/axonframework/deadline/GenericDeadlineMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/deadline/GenericDeadlineMessageTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.deadline;
+
+import jakarta.annotation.Nullable;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
+
+/**
+ * Test class validating the {@link GenericDeadlineMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericDeadlineMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
+        //noinspection unchecked
+        return (M) new GenericDeadlineMessage<>("deadlineName", new MessageType(payload.getClass()), payload);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -76,9 +76,9 @@ class GenericEventMessageTest extends MessageTestSuite {
         MetaData metaData = MetaData.from(metaDataMap);
         GenericEventMessage<Object> message =
                 new GenericEventMessage<>(new MessageType("event"), payload, metaData);
-        GenericEventMessage<Object> message1 = message.withMetaData(MetaData.emptyInstance());
-        GenericEventMessage<Object> message2 = message.withMetaData(
-                MetaData.from(Collections.singletonMap("key", "otherValue")));
+        EventMessage<Object> message1 = message.withMetaData(MetaData.emptyInstance());
+        EventMessage<Object> message2 =
+                message.withMetaData(MetaData.from(Collections.singletonMap("key", "otherValue")));
 
         assertEquals(0, message1.metaData().size());
         assertEquals(1, message2.metaData().size());
@@ -91,9 +91,9 @@ class GenericEventMessageTest extends MessageTestSuite {
         MetaData metaData = MetaData.from(metaDataMap);
         GenericEventMessage<Object> message =
                 new GenericEventMessage<>(new MessageType("event"), payload, metaData);
-        GenericEventMessage<Object> message1 = message.andMetaData(MetaData.emptyInstance());
-        GenericEventMessage<Object> message2 = message.andMetaData(
-                MetaData.from(Collections.singletonMap("key", "otherValue")));
+        EventMessage<Object> message1 = message.andMetaData(MetaData.emptyInstance());
+        EventMessage<Object> message2 =
+                message.andMetaData(MetaData.from(Collections.singletonMap("key", "otherValue")));
 
         assertEquals(1, message1.metaData().size());
         assertEquals("value", message1.metaData().get("key"));

--- a/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/GenericEventMessageTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling;
 
+import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
@@ -35,9 +37,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericEventMessageTest extends MessageTestSuite {
 
     @Override
-    protected <P, M extends Message<P>> M buildMessage(P payload) {
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericEventMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericEventMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/replay/GenericResetContextTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventhandling.replay;
 
+import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 import org.axonframework.messaging.MessageType;
@@ -38,9 +40,9 @@ class GenericResetContextTest extends MessageTestSuite {
     private static final Object TEST_PAYLOAD = new Object();
 
     @Override
-    protected <P, M extends Message<P>> M buildMessage(P payload) {
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericResetContext<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericResetContext<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -17,6 +17,8 @@
 package org.axonframework.messaging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.correlation.ThrowingCorrelationDataProvider;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
@@ -54,9 +56,9 @@ class GenericMessageTest extends MessageTestSuite {
     }
 
     @Override
-    protected <P, M extends Message<P>> M buildMessage(P payload) {
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 
     @AfterEach

--- a/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging;
 
+import jakarta.annotation.Nullable;
 import org.axonframework.common.TypeReference;
 import org.axonframework.serialization.ChainingContentTypeConverter;
 import org.axonframework.serialization.Converter;
@@ -48,7 +49,7 @@ public abstract class MessageTestSuite {
      * @param <M> The {@link Message} implementation under test.
      * @return a {@link Message} used by this test suite.
      */
-    protected abstract <P, M extends Message<P>> M buildMessage(P payload);
+    protected abstract <P, M extends Message<P>> M buildMessage(@Nullable P payload);
 
     @Test
     void payloadAsWithClassAssignableFromPayloadTypeInvokesPayloadDirectly() {

--- a/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
@@ -34,8 +34,6 @@ import static org.mockito.Mockito.*;
  */
 public abstract class MessageTestSuite {
 
-    private static final String STRING_PAYLOAD = "some-string-payload";
-    private static final ChainingContentTypeConverter CONVERTER = new ChainingContentTypeConverter();
     private static final TypeReference<byte[]> BYTE_ARRAY_TYPE_REF = new TypeReference<>() {
     };
 
@@ -50,8 +48,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = STRING_PAYLOAD;
-        Converter testConverter = spy(CONVERTER);
+        String testPayload = "some-string-payload";
+        Converter testConverter = spy(new ChainingContentTypeConverter());
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -63,18 +61,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassConvertsPayload() {
-        String testPayload = STRING_PAYLOAD;
+        String testPayload = "some-string-payload";
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(byte[].class, CONVERTER);
+        byte[] result = testSubject.payloadAs(byte[].class, new ChainingContentTypeConverter());
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithClassThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+        Message<String> testSubject = buildMessage("some-string-payload");
 
         assertThatThrownBy(() -> testSubject.payloadAs(byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -82,18 +80,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeReferenceConvertsPayload() {
-        String testPayload = STRING_PAYLOAD;
+        String testPayload = "some-string-payload";
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, CONVERTER);
+        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, new ChainingContentTypeConverter());
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeReferenceThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+        Message<String> testSubject = buildMessage("some-string-payload");
 
         assertThatThrownBy(() -> testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -101,8 +99,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeInstanceOfClassAndAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = STRING_PAYLOAD;
-        Converter testConverter = spy(CONVERTER);
+        String testPayload = "some-string-payload";
+        Converter testConverter = spy(new ChainingContentTypeConverter());
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -114,52 +112,20 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeConvertsPayload() {
-        String testPayload = STRING_PAYLOAD;
+        String testPayload = "some-string-payload";
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs((Type) byte[].class, CONVERTER);
+        byte[] result = testSubject.payloadAs((Type) byte[].class, new ChainingContentTypeConverter());
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+        Message<String> testSubject = buildMessage("some-string-payload");
 
         assertThatThrownBy(() -> testSubject.payloadAs((Type) byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    void withConvertedPayloadForClassReturnsSameInstance() {
-        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
-
-        testSubject.withConvertedPayload(byte[].class, CONVERTER);
-    }
-
-    @Test
-    void withConvertedPayloadForClassReturnsNewMessageInstanceWithConvertedPayload() {
-
-    }
-
-    @Test
-    void withConvertedPayloadForTypeReferenceReturnsSameInstance() {
-
-    }
-
-    @Test
-    void withConvertedPayloadForTypeReferenceReturnsNewMessageInstanceWithConvertedPayload() {
-
-    }
-
-    @Test
-    void withConvertedPayloadForTypeReturnsSameInstance() {
-
-    }
-
-    @Test
-    void withConvertedPayloadForTypeReturnsNewMessageInstanceWithConvertedPayload() {
-
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.*;
  */
 public abstract class MessageTestSuite {
 
+    private static final String STRING_PAYLOAD = "some-string-payload";
+    private static final ChainingContentTypeConverter CONVERTER = new ChainingContentTypeConverter();
     private static final TypeReference<byte[]> BYTE_ARRAY_TYPE_REF = new TypeReference<>() {
     };
 
@@ -48,8 +50,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = "some-string-payload";
-        Converter testConverter = spy(new ChainingContentTypeConverter());
+        String testPayload = STRING_PAYLOAD;
+        Converter testConverter = spy(CONVERTER);
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -61,18 +63,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(byte[].class, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs(byte[].class, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithClassThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs(byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -80,18 +82,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeReferenceConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeReferenceThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -99,8 +101,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeInstanceOfClassAndAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = "some-string-payload";
-        Converter testConverter = spy(new ChainingContentTypeConverter());
+        String testPayload = STRING_PAYLOAD;
+        Converter testConverter = spy(CONVERTER);
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -112,20 +114,52 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs((Type) byte[].class, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs((Type) byte[].class, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs((Type) byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void withConvertedPayloadForClassReturnsSameInstance() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        testSubject.withConvertedPayload(byte[].class, CONVERTER);
+    }
+
+    @Test
+    void withConvertedPayloadForClassReturnsNewMessageInstanceWithConvertedPayload() {
+
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReferenceReturnsSameInstance() {
+
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReferenceReturnsNewMessageInstanceWithConvertedPayload() {
+
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReturnsSameInstance() {
+
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReturnsNewMessageInstanceWithConvertedPayload() {
+
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageTestSuite.java
@@ -34,7 +34,11 @@ import static org.mockito.Mockito.*;
  */
 public abstract class MessageTestSuite {
 
+    private static final String STRING_PAYLOAD = "some-string-payload";
+    private static final ChainingContentTypeConverter CONVERTER = new ChainingContentTypeConverter();
     private static final TypeReference<byte[]> BYTE_ARRAY_TYPE_REF = new TypeReference<>() {
+    };
+    private static final TypeReference<String> STRING_TYPE_REFERENCE = new TypeReference<>() {
     };
 
     /**
@@ -48,8 +52,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = "some-string-payload";
-        Converter testConverter = spy(new ChainingContentTypeConverter());
+        String testPayload = STRING_PAYLOAD;
+        Converter testConverter = spy(CONVERTER);
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -61,18 +65,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithClassConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(byte[].class, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs(byte[].class, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithClassThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs(byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -80,18 +84,18 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeReferenceConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeReferenceThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, null))
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -99,8 +103,8 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeInstanceOfClassAndAssignableFromPayloadTypeInvokesPayloadDirectly() {
-        String testPayload = "some-string-payload";
-        Converter testConverter = spy(new ChainingContentTypeConverter());
+        String testPayload = STRING_PAYLOAD;
+        Converter testConverter = spy(CONVERTER);
 
         Message<String> testSubject = buildMessage(testPayload);
 
@@ -112,20 +116,80 @@ public abstract class MessageTestSuite {
 
     @Test
     void payloadAsWithTypeConvertsPayload() {
-        String testPayload = "some-string-payload";
+        String testPayload = STRING_PAYLOAD;
 
         Message<String> testSubject = buildMessage(testPayload);
 
-        byte[] result = testSubject.payloadAs((Type) byte[].class, new ChainingContentTypeConverter());
+        byte[] result = testSubject.payloadAs((Type) byte[].class, CONVERTER);
 
         assertThat(testPayload.getBytes()).isEqualTo(result);
     }
 
     @Test
     void payloadAsWithTypeThrowsNullPointerExceptionForNullConverter() {
-        Message<String> testSubject = buildMessage("some-string-payload");
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs((Type) byte[].class, null))
                 .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void withConvertedPayloadForClassReturnsSameInstance() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        assertThat(testSubject.withConvertedPayload(String.class, CONVERTER)).isSameAs(testSubject);
+    }
+
+    @Test
+    void withConvertedPayloadForClassReturnsNewMessageInstanceWithConvertedPayload() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        Message<byte[]> result = testSubject.withConvertedPayload(byte[].class, CONVERTER);
+
+        assertThat(testSubject.identifier()).isEqualTo(result.identifier());
+        assertThat(testSubject.type()).isEqualTo(result.type());
+        assertThat(testSubject.metaData()).isEqualTo(result.metaData());
+        assertThat(testSubject.payloadType()).isNotEqualTo(result.payloadType());
+        assertThat(testSubject.payload().getBytes()).isEqualTo(result.payload());
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReferenceReturnsSameInstance() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        assertThat(testSubject.withConvertedPayload(STRING_TYPE_REFERENCE, CONVERTER)).isSameAs(testSubject);
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReferenceReturnsNewMessageInstanceWithConvertedPayload() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        Message<byte[]> result = testSubject.withConvertedPayload(BYTE_ARRAY_TYPE_REF, CONVERTER);
+
+        assertThat(testSubject.identifier()).isEqualTo(result.identifier());
+        assertThat(testSubject.type()).isEqualTo(result.type());
+        assertThat(testSubject.metaData()).isEqualTo(result.metaData());
+        assertThat(testSubject.payloadType()).isNotEqualTo(result.payloadType());
+        assertThat(testSubject.payload().getBytes()).isEqualTo(result.payload());
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReturnsSameInstance() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        assertThat(testSubject.withConvertedPayload((Type) String.class, CONVERTER)).isSameAs(testSubject);
+    }
+
+    @Test
+    void withConvertedPayloadForTypeReturnsNewMessageInstanceWithConvertedPayload() {
+        Message<String> testSubject = buildMessage(STRING_PAYLOAD);
+
+        Message<byte[]> result = testSubject.withConvertedPayload((Type) byte[].class, CONVERTER);
+
+        assertThat(testSubject.identifier()).isEqualTo(result.identifier());
+        assertThat(testSubject.type()).isEqualTo(result.type());
+        assertThat(testSubject.metaData()).isEqualTo(result.metaData());
+        assertThat(testSubject.payloadType()).isNotEqualTo(result.payloadType());
+        assertThat(testSubject.payload().getBytes()).isEqualTo(result.payload());
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
@@ -18,6 +18,7 @@ package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 
@@ -31,6 +32,6 @@ class GenericQueryMessageTest extends MessageTestSuite {
     @Override
     protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericQueryMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericQueryMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryMessageTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
+
+/**
+ * Test class validating the {@link GenericQueryMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericQueryMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
+        //noinspection unchecked
+        return (M) new GenericQueryMessage<>(new MessageType(payload.getClass()), payload);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryResponseMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryResponseMessageTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import jakarta.annotation.Nullable;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
+
+/**
+ * Test class validating the {@link GenericQueryResponseMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericQueryResponseMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
+        //noinspection unchecked
+        return (M) new GenericQueryResponseMessage<>(new MessageType(payload.getClass()), payload);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryResponseMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericQueryResponseMessageTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 
@@ -30,6 +31,7 @@ class GenericQueryResponseMessageTest extends MessageTestSuite {
     @Override
     protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericQueryResponseMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericQueryResponseMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)),
+                                                     payload);
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericStreamingQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericStreamingQueryMessageTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.queryhandling;
+
+import jakarta.annotation.Nullable;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageTestSuite;
+
+import java.awt.*;
+
+/**
+ * Test class validating the {@link GenericStreamingQueryMessage}.
+ *
+ * @author Steven van Beelen
+ */
+class GenericStreamingQueryMessageTest extends MessageTestSuite {
+
+    @Override
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
+        //noinspection unchecked
+        return (M) new GenericStreamingQueryMessage<>(new MessageType(payload.getClass()), payload, String.class);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericStreamingQueryMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericStreamingQueryMessageTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.queryhandling;
 
 import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
 
@@ -32,6 +33,8 @@ class GenericStreamingQueryMessageTest extends MessageTestSuite {
     @Override
     protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericStreamingQueryMessage<>(new MessageType(payload.getClass()), payload, String.class);
+        return (M) new GenericStreamingQueryMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)),
+                                                      payload,
+                                                      String.class);
     }
 }

--- a/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/GenericSubscriptionQueryUpdateMessageTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.queryhandling;
 
+import jakarta.annotation.Nullable;
+import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageTestSuite;
@@ -36,9 +38,10 @@ import static org.junit.jupiter.api.Assertions.*;
 class GenericSubscriptionQueryUpdateMessageTest extends MessageTestSuite {
 
     @Override
-    protected <P, M extends Message<P>> M buildMessage(P payload) {
+    protected <P, M extends Message<P>> M buildMessage(@Nullable P payload) {
         //noinspection unchecked
-        return (M) new GenericSubscriptionQueryUpdateMessage<>(new MessageType(payload.getClass()), payload);
+        return (M) new GenericSubscriptionQueryUpdateMessage<>(new MessageType(ObjectUtils.nullSafeTypeOf(payload)),
+                                                               payload);
     }
 
     @Test

--- a/modelling/src/main/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponent.java
@@ -103,7 +103,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
 
             E evolvedEntity = entity;
             for (var handler : handlers) {
-                var convertedEvent = event.withConvertedPayload(p -> converter.convert(p, handler.payloadType()));
+                var convertedEvent = event.withConvertedPayload(handler.payloadType(), converter);
                 if (!handler.canHandle(convertedEvent, context)) {
                     continue;
                 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
@@ -69,8 +69,7 @@ public class AnnotatedEntityIdResolver<ID> implements EntityIdResolver<ID>, Desc
     public ID resolve(@Nonnull Message<?> message, @Nonnull ProcessingContext context) {
         Class<?> expectedRepresentation = metamodel.getExpectedRepresentation(message.type().qualifiedName());
         if (expectedRepresentation != null) {
-            Message<?> convertedMessage = message.withConvertedPayload(p -> converter.convert(p,
-                                                                                              expectedRepresentation));
+            Message<?> convertedMessage = message.withConvertedPayload(expectedRepresentation, converter);
             return delegate.resolve(convertedMessage, context);
         }
         throw new AxonConfigurationException(


### PR DESCRIPTION
This pull request adjusts the `Message#withConvertedPayload` method to essentially align with the `payloadAs` method introduced in PR #3566.

The `withConvertedPayload` constructs a **new** `Message` instance but replaces the `payload` (and thus `payloadType`) with the conversion result.
All other fields stay the same.

To align with the `payloadAs` flow, there are now three `withConvertedPayload` methods:

1. `Message#withConvertedPayload(Class<T>, Converter)` - Defaulted by invoking `Message#withConvertedPayload(Type, Converter)` by casting the `Class` to a `Type`.
2. `Message#withConvertedPayload(TypeReference<T>, Converter)` - Defaulted by invoking `Message#withConvertedPayload(Type, Converter)` by doing `TypeReference#getType`.
3. `Message#withConvertedPayload(Type, Converter)`

Every `Message` interface implementation (e.g. `CommandMessage`, `EventMessage`, `QueryMessage`,...) overrides these methods to ensure the correct `Message` implementation is returned.
To validate these methods work as expected, I have added tests to the `MessageTestSuite` (introduced in #3566 as well).
Lastly, I have included several new `MessageTestSuite` implementations, specifically for `Message` implementation that **did not** have a test class yet.

By doing the above this PR is a part of issue #3102.