### PR TITLE
[#3565] Several Axon Framework Update Checker fixes

### DIFF
--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -49,6 +49,8 @@ public class UpdateCheckerHttpClient {
     private static final String BASE_FAILURE = "Failed to report anonymous usage data";
     private static final String STATUS_CODE_REF = "Received status code: {}";
     private static final int MAX_REDIRECTS = 5;
+    private static final int HTTP_TEMP_REDIRECT = 307;
+    private static final int HTTP_PERM_REDIRECT = 308;
 
     private final UsagePropertyProvider userProperties;
 
@@ -128,8 +130,8 @@ public class UpdateCheckerHttpClient {
         return statusCode == HttpURLConnection.HTTP_MOVED_PERM
                 || statusCode == HttpURLConnection.HTTP_MOVED_TEMP
                 || statusCode == HttpURLConnection.HTTP_SEE_OTHER
-                || statusCode == 307
-                || statusCode == 308;
+                || statusCode == HTTP_TEMP_REDIRECT
+                || statusCode == HTTP_PERM_REDIRECT;
     }
 
     private String preserveQueryParameters(String redirect, String queryString) throws MalformedURLException {

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -132,7 +132,7 @@ public class UpdateCheckerHttpClient {
             StringBuilder response = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
-                response.append(line);
+                response.append(line).append("\n");
             }
             return response.toString();
         }

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -112,7 +112,7 @@ public class UpdateCheckerHttpClient {
                                     statusCode);
                         return Optional.empty();
                     }
-                    url = new URL(redirect).toURI().getPath() + "?" + queryString;
+                    url = removeQueryParameters(redirect) + "?" + queryString;
                 } else {
                     logger.info(BASE_FAILURE + ". " + STATUS_CODE_REF, statusCode);
                     return Optional.empty();
@@ -144,5 +144,11 @@ public class UpdateCheckerHttpClient {
             }
             return response.toString();
         }
+    }
+
+    private static String removeQueryParameters(String redirect) {
+        int queryParamIndex = redirect.indexOf('?');
+        redirect = queryParamIndex != -1 ? redirect.substring(0, queryParamIndex) : redirect;
+        return redirect;
     }
 }

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -46,7 +46,7 @@ public class UpdateCheckerHttpClient {
 
     private static final String BASE_FAILURE = "Failed to report anonymous usage data";
     private static final String STATUS_CODE_REF = "Received status code: {}";
-    private static final int MAX_REDIRECTS = 10;
+    private static final int MAX_REDIRECTS = 5;
 
     private final UsagePropertyProvider userProperties;
 

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -112,7 +112,7 @@ public class UpdateCheckerHttpClient {
                                     statusCode);
                         return Optional.empty();
                     }
-                    url = preserveQueryParameters(redirect, queryString);
+                    url = new URL(redirect).toURI().getPath() + "?" + queryString;
                 } else {
                     logger.info(BASE_FAILURE + ". " + STATUS_CODE_REF, statusCode);
                     return Optional.empty();
@@ -132,14 +132,6 @@ public class UpdateCheckerHttpClient {
                 || statusCode == HttpURLConnection.HTTP_SEE_OTHER
                 || statusCode == HTTP_TEMP_REDIRECT
                 || statusCode == HTTP_PERM_REDIRECT;
-    }
-
-    private String preserveQueryParameters(String redirect, String queryString) throws MalformedURLException {
-        URL redirectUrl = new URL(redirect);
-        String redirectQuery = redirectUrl.getQuery();
-        return StringUtils.nonEmptyOrNull(redirectQuery)
-                ? redirectUrl + "&" + queryString
-                : redirectUrl + "?" + queryString;
     }
 
     private String readResponse(HttpURLConnection connection) throws IOException {

--- a/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
+++ b/messaging/src/main/java/org/axonframework/updates/UpdateCheckerHttpClient.java
@@ -126,14 +126,6 @@ public class UpdateCheckerHttpClient {
         }
     }
 
-    private static boolean shouldRedirect(int statusCode) {
-        return statusCode == HttpURLConnection.HTTP_MOVED_PERM
-                || statusCode == HttpURLConnection.HTTP_MOVED_TEMP
-                || statusCode == HttpURLConnection.HTTP_SEE_OTHER
-                || statusCode == HTTP_TEMP_REDIRECT
-                || statusCode == HTTP_PERM_REDIRECT;
-    }
-
     private String readResponse(HttpURLConnection connection) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(),
                                                                               StandardCharsets.UTF_8))) {
@@ -144,6 +136,14 @@ public class UpdateCheckerHttpClient {
             }
             return response.toString();
         }
+    }
+
+    private static boolean shouldRedirect(int statusCode) {
+        return statusCode == HttpURLConnection.HTTP_MOVED_PERM
+                || statusCode == HttpURLConnection.HTTP_MOVED_TEMP
+                || statusCode == HttpURLConnection.HTTP_SEE_OTHER
+                || statusCode == HTTP_TEMP_REDIRECT
+                || statusCode == HTTP_PERM_REDIRECT;
     }
 
     private static String removeQueryParameters(String redirect) {

--- a/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
+++ b/messaging/src/main/java/org/axonframework/updates/api/UpdateCheckRequest.java
@@ -205,7 +205,8 @@ public class UpdateCheckRequest {
                         .filter(a -> a.groupId().equals("org.axonframework"))
                         .filter(a -> a.artifactId().equals("axon-messaging"))
                         .map(Artifact::version)
-                        .findFirst().orElse("5.0.0");
+                        .findFirst()
+                        .orElse("4.12.0");
     }
 
     @Override


### PR DESCRIPTION
This pull request performs several fixes for the [Axon Framework Update Checker](https://docs.axoniq.io/axon-framework-update-checker/) flow. 

Firstly, we have adjusts the `UpdateCheckerHttpClient` to manually handle redirects.
The use of the `HttpURLConnection` makes it so that on a redirect all headers are lost.
Although an intended security measure, we should still consciously set the update-checker-specific headers, as otherwise the intended task of this component cannot be fulfilled.

As such, the `UpdateCheckerHttpClient` is adjusted to handle a maximum of 5 redirects (AFAIK the max amount used by Google), and upon a redirect.
Furthermore, it ensure the query parameters set by the `UpdateCheckRequest` are maintained, for the similar reason that without, Axon Framework's Update Checker cannot function as intended.

Secondly, although minor, we set the default AF version is set to 4.12.0 i.o. 5.0.0 in the `UpdateCheckRequest` **if** no version is found.

Lastly, the response was parsed incorrectly, as it removed intended line breaks. This has been fixed by maintaining them (as intended).

Although not directly related to the bug referred to in #3565, I am "(ab)using" that issue to resolve a number of issues with the Update Checker.
Nonetheless, we'll resolve #3565 as part of this PR.