### PR TITLE
ECJ compiler fix in the `AnnotatedHandlerInspector`

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AnnotationEventHandlerAdapter.java
@@ -120,7 +120,11 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
         assertNonNull(messageTypeResolver, "The Message Type Resolver may not be null");
         this.annotatedEventListener = annotatedEventListener;
         this.listenerType = annotatedEventListener.getClass();
-        this.inspector = AnnotatedHandlerInspector.inspectType(annotatedEventListener.getClass(),
+
+        @SuppressWarnings("unchecked")
+        Class<Object> cls = (Class<Object>)annotatedEventListener.getClass();
+
+        this.inspector = AnnotatedHandlerInspector.inspectType(cls,
                                                                parameterResolverFactory,
                                                                handlerDefinition);
         this.messageTypeResolver = messageTypeResolver;

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -85,7 +85,7 @@ public class AnnotatedHandlerInspector<T> {
      * @param <T>         the handler's type
      * @return a new inspector instance for the inspected class
      */
-    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType) {
+    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType) {
         return inspectType(handlerType, ClasspathParameterResolverFactory.forClass(handlerType));
     }
 
@@ -98,7 +98,7 @@ public class AnnotatedHandlerInspector<T> {
      * @param <T>                      the handler's type
      * @return a new inspector instance for the inspected class
      */
-    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType,
+    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
                                                                ParameterResolverFactory parameterResolverFactory) {
         return inspectType(handlerType,
                            parameterResolverFactory,
@@ -115,7 +115,7 @@ public class AnnotatedHandlerInspector<T> {
      * @param <T>                      the handler's type
      * @return a new inspector instance for the inspected class
      */
-    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType,
+    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
                                                                ParameterResolverFactory parameterResolverFactory,
                                                                HandlerDefinition handlerDefinition) {
         return inspectType(handlerType, parameterResolverFactory, handlerDefinition, emptySet());
@@ -133,7 +133,7 @@ public class AnnotatedHandlerInspector<T> {
      * @param <T>                      the handler's type
      * @return a new inspector instance for the inspected class
      */
-    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<? extends T> handlerType,
+    public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
                                                                ParameterResolverFactory parameterResolverFactory,
                                                                HandlerDefinition handlerDefinition,
                                                                Set<Class<? extends T>> declaredSubtypes) {
@@ -145,14 +145,14 @@ public class AnnotatedHandlerInspector<T> {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> AnnotatedHandlerInspector<T> createInspector(Class<? extends T> inspectedType,
+    private static <T> AnnotatedHandlerInspector<T> createInspector(Class<T> inspectedType,
                                                                     ParameterResolverFactory parameterResolverFactory,
                                                                     HandlerDefinition handlerDefinition,
                                                                     Map<Class<?>, AnnotatedHandlerInspector<?>> registry,
                                                                     Set<Class<? extends T>> declaredSubtypes) {
         if (!registry.containsKey(inspectedType)) {
             registry.put(inspectedType,
-                         AnnotatedHandlerInspector.initialize((Class<T>) inspectedType,
+                         AnnotatedHandlerInspector.initialize(inspectedType,
                                                               parameterResolverFactory,
                                                               handlerDefinition,
                                                               registry,
@@ -169,7 +169,10 @@ public class AnnotatedHandlerInspector<T> {
                                                                Set<Class<? extends T>> declaredSubtypes) {
         List<AnnotatedHandlerInspector<? super T>> parents = new ArrayList<>();
         for (Class<?> iFace : inspectedType.getInterfaces()) {
-            parents.add(createInspector(iFace,
+            @SuppressWarnings("unchecked")  // Safe cast: all interfaces of T are guaranteed to be supertypes of T
+            Class<? super T> castIF = (Class<? super T>)iFace;
+
+            parents.add(createInspector(castIF,
                                         parameterResolverFactory,
                                         handlerDefinition,
                                         registry,
@@ -275,7 +278,7 @@ public class AnnotatedHandlerInspector<T> {
      * @param <C>        the handler's type
      * @return a new inspector for the given type
      */
-    public <C> AnnotatedHandlerInspector<C> inspect(Class<? extends C> entityType) {
+    public <C> AnnotatedHandlerInspector<C> inspect(Class<C> entityType) {
         return AnnotatedHandlerInspector.createInspector(entityType,
                                                          parameterResolverFactory,
                                                          handlerDefinition,

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityCollectionDefinition.java
@@ -70,7 +70,11 @@ public class AggregateMemberAnnotatedChildEntityCollectionDefinition extends Abs
                     "Aggregate Member type should be a concrete implementation instead of [" + entityType + "]."
             );
         }
-        return declaringEntity.modelOf(entityType);
+
+        @SuppressWarnings("unchecked")
+        Class<Object> castEntityType = (Class<Object>)entityType;
+
+        return declaringEntity.modelOf(castEntityType);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityDefinition.java
@@ -56,7 +56,11 @@ public class AggregateMemberAnnotatedChildEntityDefinition extends AbstractChild
                     "Aggregate Member type should be a concrete implementation instead of [" + entityClass + "]."
             );
         }
-        return declaringEntity.modelOf(entityClass);
+
+        @SuppressWarnings("unchecked")
+        Class<Object> castEntityClass = (Class<Object>)entityClass;
+
+        return declaringEntity.modelOf(castEntityClass);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMemberAnnotatedChildEntityMapDefinition.java
@@ -69,7 +69,11 @@ public class AggregateMemberAnnotatedChildEntityMapDefinition extends AbstractCh
                     "Aggregate Member type should be a concrete implementation instead of [" + entityType + "]."
             );
         }
-        return declaringEntity.modelOf(entityType);
+
+        @SuppressWarnings("unchecked")
+        Class<Object> castEntityType = (Class<Object>)entityType;
+
+        return declaringEntity.modelOf(castEntityType);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateMetaModelFactory.java
@@ -32,7 +32,7 @@ public interface AggregateMetaModelFactory {
      * @param <T>           The Aggregate type
      * @return Model describing the capabilities and characteristics of the inspected Aggregate class
      */
-    default <T> AggregateModel<T> createModel(Class<? extends T> aggregateType) {
+    default <T> AggregateModel<T> createModel(Class<T> aggregateType) {
         return createModel(aggregateType, Collections.emptySet());
     }
 
@@ -45,5 +45,5 @@ public interface AggregateMetaModelFactory {
      * @param <T>           The Aggregate type
      * @return Model describing the capabilities and characteristics of the inspected Aggregate class and its subtypes
      */
-    <T> AggregateModel<T> createModel(Class<? extends T> aggregateType, Set<Class<? extends T>> subtypes);
+    <T> AggregateModel<T> createModel(Class<T> aggregateType, Set<Class<? extends T>> subtypes);
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -190,7 +190,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
     }
 
     @Override
-    public <T> AnnotatedAggregateModel<T> createModel(Class<? extends T> aggregateType,
+    public <T> AnnotatedAggregateModel<T> createModel(Class<T> aggregateType,
                                                       Set<Class<? extends T>> subtypes) {
         if (!registry.containsKey(aggregateType)) {
             AnnotatedHandlerInspector<T> inspector = AnnotatedHandlerInspector.inspectType(aggregateType,
@@ -522,7 +522,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
 
         @SuppressWarnings("unchecked")
         private AnnotatedAggregateModel<T> runtimeModelOf(T target) {
-            return modelOf((Class<? extends T>) target.getClass());
+            return modelOf((Class<T>) target.getClass());
         }
 
         @Override
@@ -543,7 +543,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
         }
 
         @Override
-        public <C> AnnotatedAggregateModel<C> modelOf(Class<? extends C> childEntityType) {
+        public <C> AnnotatedAggregateModel<C> modelOf(Class<C> childEntityType) {
             // using empty list subtypes because this model is already in the registry, so it doesn't matter
             return AnnotatedAggregateMetaModelFactory.this.createModel(childEntityType, Collections.emptySet());
         }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/EntityModel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/EntityModel.java
@@ -111,7 +111,7 @@ public interface EntityModel<T> {
      * @param <C>             the type of the child entity
      * @return An EntityModel for the child entity
      */
-    <C> EntityModel<C> modelOf(Class<? extends C> childEntityType);
+    <C> EntityModel<C> modelOf(Class<C> childEntityType);
 
     /**
      * Returns the class this model describes


### PR DESCRIPTION
This fixes generics in several places where something is being _consumed_ and subsequently _produced_ based on a type.  Using wildcards in those cases will lead to the wrong conclusions.  For example, calling `EntityModel#modelOf` in this way was allowed:

      EntityModel<Parent> em1 =  modelOf(Parent.class);
      EntityModel<Parent> em2 =  modelOf(Child.class);

Here it may seem that `em1` is the same as `em2` but it really isn't, as `em2` will also include fields/annotations/etc from the child class, while `em1` will not have those.  To avoid this, defining `modelOf` to only accept the exact type will make `em2` a compile error.

I discovered this because some of the code doesn't compile with `ecj` due to a generic mismatch (all the way down to `AnnotatedHandlerInspector`).
      