### PR TITLE
Exclude xml-apis dependency as these are part of JDK 1.6+

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -102,6 +102,10 @@
                     <groupId>xalan</groupId>
                     <artifactId>xalan</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>xml-apis</groupId>
+                	<artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
This avoids a module conflict with several classes being present in the unnamed module and in the xml module.