### PR TITLE
[#3102] Remove `Message` serialization specific methods

### DIFF
--- a/axon-5/api-changes.md
+++ b/axon-5/api-changes.md
@@ -238,6 +238,40 @@ referred to as `Message#metaData()`. A similar rename occurred for the `EventMes
 `getTimestamp()` method to `timestamp()`. Lastly, the `QueryMessage` and `SubscriptionQueryMessage` have undergone the
 same rename, for `getResponseType()` and `getUpdateResponseType()` respectively.
 
+### Message Conversion / Serialization
+
+The `Message` and `ResultMessage` interfaces used to have three methods to serialize the payload, metadata, and
+exception, called:
+
+1. `Message#serializePayload(Serializer, Class<T>)`
+2. `Message#serializeMetaData(Serializer, Class<T>)`
+3. `ResultMessage#serializeExceptionResult(Serializer, Class<T>)`
+
+These methods have been removed entirely, as we have redefined the conversion flow for Axon Framework 5.
+Instead of using wrapper classes, like the `SerializedObject` returned by the above methods, the `Message` now contains
+the required information to be converted itself.
+
+This follows from the introduction of the `MessageType` (as explained [here](#message-type-and-qualified-name)), which
+takes the place of the `Message#payloadType`.
+This in turn allows the `payloadType` to reflect the format as it is stored within the `Message#payload` at that moment
+in time.
+
+On top of that, to keep providing means to retrieve a `Message's` payload in the required format, two new methods have
+been introduced:
+
+1. `Message#payloadAs(Type, Converter)`
+2. `Message#withConvertedPayload(Type, Converter)`
+
+The `payloadAs(Type, Converter)` method allows to convert the payload into the type required at that moment in time. For
+example, one Event Handler requires a "subscription canceled event" as the `SubscriptionCanceledEvent` object, while
+another simply wants it as a `JsonNode`. To that end, `EventMessage#payloadAs(Type, Converter)` may be invoked to
+extract the payload as desired.
+
+The `withConvertedPayload(Type, Converter)` method constructs a new `Message` instance, with the `payload` converted to
+the desired format.
+This is valuable if a consumer/publisher is certain that the payload will be required in a new format throughout the
+upstream/downstream of the `Message` in question.
+
 ## Message Stream
 
 We have introduced the so-called `MessageStream` to allow people to draft both imperative **and** reactive message

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventScheduler.java
@@ -214,8 +214,7 @@ public class AxonServerEventScheduler implements EventScheduler {
         MetaData metadata;
         String requestId = null;
         if (event instanceof EventMessage<?>) {
-            serializedPayload = ((EventMessage<?>) event)
-                    .serializePayload(serializer, byte[].class);
+            serializedPayload = serializer.serialize(((EventMessage<?>) event).payload(), byte[].class);
             metadata = ((EventMessage<?>) event).metaData();
             requestId = ((EventMessage<?>) event).identifier();
         } else {

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcPayloadSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/GrpcPayloadSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class GrpcPayloadSerializer implements Function<Message<?>, io.axoniq.axo
         this(new GrpcObjectSerializer.Serializer<Message<?>>() {
             @Override
             public <T> SerializedObject<T> serialize(Message<?> object, Class<T> expectedRepresentation) {
-                return object.serializePayload(serializer, expectedRepresentation);
+                return serializer.serialize(object.payload(), expectedRepresentation);
             }
         });
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/JdbcEventStorageEngineStatements.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jdbc/statements/JdbcEventStorageEngineStatements.java
@@ -108,8 +108,8 @@ public abstract class JdbcEventStorageEngineStatements {
         PreparedStatement statement = connection.prepareStatement(sql);
         for (EventMessage<?> eventMessage : events) {
             DomainEventMessage<?> event = asDomainEventMessage(eventMessage);
-            SerializedObject<?> payload = event.serializePayload(serializer, dataType);
-            SerializedObject<?> metaData = event.serializeMetaData(serializer, dataType);
+            SerializedObject<?> payload = serializer.serialize(event.payload(), dataType);
+            SerializedObject<?> metaData = serializer.serialize(event.metaData(), dataType);
             statement.setString(1, event.identifier());
             statement.setString(2, event.getAggregateIdentifier());
             statement.setLong(3, event.getSequenceNumber());
@@ -229,8 +229,8 @@ public abstract class JdbcEventStorageEngineStatements {
         final String sql = "INSERT INTO "
                 + schema.snapshotTable() + " (" + schema.domainEventFields() + ") VALUES (?,?,?,?,?,?,?,?,?)";
         PreparedStatement statement = connection.prepareStatement(sql);
-        SerializedObject<?> payload = snapshot.serializePayload(serializer, dataType);
-        SerializedObject<?> metaData = snapshot.serializeMetaData(serializer, dataType);
+        SerializedObject<?> payload = serializer.serialize(snapshot.payload(), dataType;
+        SerializedObject<?> metaData = serializer.serialize(snapshot.metaData(), dataType);
         statement.setString(1, snapshot.identifier());
         statement.setString(2, snapshot.getAggregateIdentifier());
         statement.setLong(3, snapshot.getSequenceNumber());

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/AbstractEventStoreBenchmark.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventsourcing/eventstore/benchmark/AbstractEventStoreBenchmark.java
@@ -187,8 +187,8 @@ public abstract class AbstractEventStoreBenchmark {
         return IntStream.range(startSequenceNumber, startSequenceNumber + count)
                         .mapToObj(sequenceNumber -> createDomainEvent(aggregateId, sequenceNumber))
                         .peek(event -> serializer().ifPresent(serializer -> {
-                            event.serializePayload(serializer, byte[].class);
-                            event.serializeMetaData(serializer, byte[].class);
+                            serializer.serialize(event.payload(), byte[].class);
+                            serializer.serialize(event.metaData(), byte[].class);
                         })).toArray(EventMessage[]::new);
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventEntry.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/AbstractEventEntry.java
@@ -72,8 +72,8 @@ public abstract class AbstractEventEntry<T> implements EventData<T> {
      * @param contentType  The data type of the payload and metadata after serialization
      */
     public AbstractEventEntry(EventMessage<?> eventMessage, Serializer serializer, Class<T> contentType) {
-        SerializedObject<T> payload = eventMessage.serializePayload(serializer, contentType);
-        SerializedObject<T> metaData = eventMessage.serializeMetaData(serializer, contentType);
+        SerializedObject<T> payload = serializer.serialize(eventMessage.payload(), contentType);
+        SerializedObject<T> metaData = serializer.serialize(eventMessage.metaData(), contentType);
         this.eventIdentifier = eventMessage.identifier();
         this.payloadType = payload.getType().getName();
         this.payloadRevision = payload.getType().getRevision();

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -135,8 +135,8 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
     private void setEventFields(PreparedStatement statement,
                                 AtomicInteger fieldIndex,
                                 E eventMessage) throws SQLException {
-        SerializedObject<byte[]> serializedPayload = eventMessage.serializePayload(eventSerializer, byte[].class);
-        SerializedObject<byte[]> serializedMetaData = eventMessage.serializeMetaData(eventSerializer, byte[].class);
+        SerializedObject<byte[]> serializedPayload = eventSerializer.serialize(eventMessage.payload(), byte[].class);
+        SerializedObject<byte[]> serializedMetaData = eventSerializer.serialize(eventMessage.metaData(), byte[].class);
         statement.setString(fieldIndex.getAndIncrement(), eventMessage.getClass().getName());
         statement.setString(fieldIndex.getAndIncrement(), eventMessage.identifier());
         statement.setString(fieldIndex.getAndIncrement(), eventMessage.type().toString());

--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jpa/EventMessageDeadLetterJpaConverter.java
@@ -61,7 +61,7 @@ public class EventMessageDeadLetterJpaConverter implements DeadLetterJpaConverte
 
         // Serialize the payload with message.serializePayload to make the deserialization lazy and thus
         // make us able to store deserialization errors as well.
-        SerializedObject<byte[]> serializedPayload = message.serializePayload(eventSerializer, byte[].class);
+        SerializedObject<byte[]> serializedPayload = eventSerializer.serialize(message.payload(), byte[].class);
         // For compatibility, we use the serializer directly for the metadata
         SerializedObject<byte[]> serializedMetadata = eventSerializer.serialize(message.metaData(), byte[].class);
         Optional<SerializedObject<byte[]>> serializedToken =

--- a/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/GenericResultMessage.java
@@ -187,14 +187,6 @@ public class GenericResultMessage<R> extends MessageDecorator<R> implements Resu
     }
 
     @Override
-    public <S> SerializedObject<S> serializePayload(Serializer serializer, Class<S> expectedRepresentation) {
-        if (isExceptional()) {
-            return serializer.serialize(exceptionDetails().orElse(null), expectedRepresentation);
-        }
-        return super.serializePayload(serializer, expectedRepresentation);
-    }
-
-    @Override
     @Nonnull
     public ResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData) {
         return new GenericResultMessage<>(delegate().withMetaData(metaData), exception);

--- a/messaging/src/main/java/org/axonframework/messaging/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/Message.java
@@ -22,8 +22,6 @@ import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.serialization.ConversionException;
 import org.axonframework.serialization.Converter;
-import org.axonframework.serialization.SerializedObject;
-import org.axonframework.serialization.Serializer;
 
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -226,40 +224,6 @@ public interface Message<P> {
      */
     @Nonnull
     Message<P> andMetaData(@Nonnull Map<String, String> metaData);
-
-    /**
-     * Serialize the payload of this message to the {@code expectedRepresentation} using given {@code serializer}. This
-     * method <em>should</em> return the same SerializedObject instance when invoked multiple times using the same
-     * serializer.
-     *
-     * @param serializer             The serializer to serialize payload with
-     * @param expectedRepresentation The type of data to serialize to
-     * @param <R>                    The type of the serialized data
-     * @return a SerializedObject containing the serialized representation of the message's payload
-     * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link #withConvertedPayload(Class, Converter)}
-     */
-    @Deprecated
-    default <R> SerializedObject<R> serializePayload(Serializer serializer, Class<R> expectedRepresentation) {
-        return serializer.serialize(payload(), expectedRepresentation);
-    }
-
-    /**
-     * Serialize the metadata of this message to the {@code expectedRepresentation} using given {@code serializer}. This
-     * method <em>should</em> return the same SerializedObject instance when invoked multiple times using the same
-     * serializer.
-     *
-     * @param serializer             The serializer to serialize meta data with
-     * @param expectedRepresentation The type of data to serialize to
-     * @param <R>                    The type of the serialized data
-     * @return a SerializedObject containing the serialized representation of the message's metadata
-     * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link #withConvertedPayload(Class, Converter)}
-     */
-    @Deprecated
-    default <R> SerializedObject<R> serializeMetaData(Serializer serializer, Class<R> expectedRepresentation) {
-        return serializer.serialize(metaData(), expectedRepresentation);
-    }
 
     /**
      * Returns a <b>new</b> {@code Message} implementation with its {@link #payload()} converted to the given

--- a/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageDecorator.java
@@ -88,17 +88,6 @@ public abstract class MessageDecorator<P> implements Message<P> {
 
     @Override
     @Nonnull
-    public <S> SerializedObject<S> serializePayload(Serializer serializer, Class<S> expectedRepresentation) {
-        return delegate.serializePayload(serializer, expectedRepresentation);
-    }
-
-    @Override
-    public <S> SerializedObject<S> serializeMetaData(Serializer serializer, Class<S> expectedRepresentation) {
-        return delegate.serializeMetaData(serializer, expectedRepresentation);
-    }
-
-    @Override
-    @Nonnull
     public <T> Message<T> withConvertedPayload(@Nonnull Type type, @Nonnull Converter converter) {
         return delegate.withConvertedPayload(type, converter);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -80,34 +80,6 @@ public interface ResultMessage<R> extends Message<R> {
         return optionalExceptionResult().flatMap(HandlerExecutionException::resolveDetails);
     }
 
-    @Deprecated
-    @Override
-    default <S> SerializedObject<S> serializePayload(Serializer serializer, Class<S> expectedRepresentation) {
-        if (isExceptional()) {
-            return serializer.serialize(exceptionDetails().orElse(null), expectedRepresentation);
-        }
-        return serializer.serialize(payload(), expectedRepresentation);
-    }
-
-    /**
-     * Serializes the exception result. Will create a {@link RemoteExceptionDescription} from the {@link Optional}
-     * exception in this ResultMessage instead of serializing the original exception.
-     *
-     * @param serializer             the {@link Serializer} used to serialize the exception
-     * @param expectedRepresentation a {@link Class} representing the expected format
-     * @param <T>                    the generic type representing the expected format
-     * @return the serialized exception as a {@link SerializedObject}
-     * @deprecated Serialization is removed from messages themselves. Instead, use
-     * {@link Message#withConvertedPayload(Class, org.axonframework.serialization.Converter)}
-     */
-    @Deprecated
-    default <T> SerializedObject<T> serializeExceptionResult(Serializer serializer, Class<T> expectedRepresentation) {
-        return serializer.serialize(
-                optionalExceptionResult().map(RemoteExceptionDescription::describing).orElse(null),
-                expectedRepresentation
-        );
-    }
-
     @Override
     @Nonnull
     ResultMessage<R> withMetaData(@Nonnull Map<String, String> metaData);

--- a/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/responsetypes/ConvertingResponseMessage.java
@@ -60,21 +60,6 @@ public class ConvertingResponseMessage<R> implements QueryResponseMessage<R> {
     }
 
     @Override
-    public <S> SerializedObject<S> serializePayload(Serializer serializer, Class<S> expectedRepresentation) {
-        return responseMessage.serializePayload(serializer, expectedRepresentation);
-    }
-
-    @Override
-    public <T> SerializedObject<T> serializeExceptionResult(Serializer serializer, Class<T> expectedRepresentation) {
-        return responseMessage.serializeExceptionResult(serializer, expectedRepresentation);
-    }
-
-    @Override
-    public <R1> SerializedObject<R1> serializeMetaData(Serializer serializer, Class<R1> expectedRepresentation) {
-        return responseMessage.serializeMetaData(serializer, expectedRepresentation);
-    }
-
-    @Override
     public boolean isExceptional() {
         return responseMessage.isExceptional();
     }

--- a/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericMessageTest.java
@@ -84,28 +84,6 @@ class GenericMessageTest extends MessageTestSuite<Message<?>> {
     }
 
     @Test
-    void messageSerialization() throws IOException {
-        Map<String, String> metaDataMap = Collections.singletonMap("key", "value");
-
-        Message<String> message =
-                new GenericMessage<>(new MessageType("message"), "payload", metaDataMap);
-
-        JacksonSerializer jacksonSerializer = JacksonSerializer.builder().build();
-
-
-        SerializedObject<String> serializedPayload = message.serializePayload(jacksonSerializer, String.class);
-        SerializedObject<String> serializedMetaData = message.serializeMetaData(jacksonSerializer, String.class);
-
-        assertEquals("\"payload\"", serializedPayload.getData());
-
-
-        ObjectMapper objectMapper = jacksonSerializer.getObjectMapper();
-        Map<String, String> actualMetaData = objectMapper.readValue(serializedMetaData.getData(), Map.class);
-
-        assertTrue(actualMetaData.entrySet().containsAll(metaDataMap.entrySet()));
-    }
-
-    @Test
     void whenCorrelationDataProviderThrowsException_thenCatchException() {
         unitOfWork = new LegacyDefaultUnitOfWork<>(
                 new GenericEventMessage<>(new MessageType("event"), "Input 1")

--- a/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/GenericResultMessageTest.java
@@ -54,15 +54,4 @@ class GenericResultMessageTest extends MessageTestSuite<ResultMessage<?>> {
             assertEquals(t, ipae.getCause());
         }
     }
-
-    @Test
-    void exceptionSerialization() {
-        Throwable expected = new Throwable("oops");
-        ResultMessage<?> resultMessage = asResultMessage(expected);
-        JacksonSerializer jacksonSerializer = JacksonSerializer.builder().build();
-        SerializedObject<String> serializedObject =
-                resultMessage.serializeExceptionResult(jacksonSerializer, String.class);
-        RemoteExceptionDescription actual = jacksonSerializer.deserialize(serializedObject);
-        assertEquals("java.lang.Throwable: oops", actual.getDescriptions().get(0));
-    }
 }

--- a/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/serialization/SerializedMessageTest.java
@@ -102,32 +102,6 @@ class SerializedMessageTest {
     }
 
     @Test
-    void serializePayloadImmediatelyAfterConstructionReturnsOriginalPayload() {
-        SerializedMessage<Object> testSubject =
-                new SerializedMessage<>(eventId, serializedPayload, serializedMetaData, serializer);
-
-        SerializedObject<byte[]> result = testSubject.serializePayload(serializer, byte[].class);
-        assertArrayEquals("serializedPayload".getBytes(StandardCharsets.UTF_8), result.getData());
-        // this call is allowed
-        verify(serializer, atLeast(0)).classForType(isA(SerializedType.class));
-        verify(serializer, atLeast(0)).getConverter();
-        verifyNoMoreInteractions(serializer);
-    }
-
-    @Test
-    void serializeMetaDataImmediatelyAfterConstructionReturnsOriginalMetaData() {
-        SerializedMessage<Object> testSubject =
-                new SerializedMessage<>(eventId, serializedPayload, serializedMetaData, serializer);
-
-        SerializedObject<byte[]> result = testSubject.serializeMetaData(serializer, byte[].class);
-        assertArrayEquals("serializedMetaData".getBytes(StandardCharsets.UTF_8), result.getData());
-        // this call is allowed
-        verify(serializer, atLeast(0)).classForType(isA(SerializedType.class));
-        verify(serializer, atLeast(0)).getConverter();
-        verifyNoMoreInteractions(serializer);
-    }
-
-    @Test
     void rethrowSerializationExceptionOnGetPayload() {
         SerializationException serializationException = new SerializationException("test message");
         when(serializer.deserialize(serializedMetaData)).thenThrow(serializationException);


### PR DESCRIPTION
This pull request removes the `Message`-specific serialization methods, called:

* `Message#serializePayload(Serializer, Class<T>)`
* `Message#serializeMetaData(Serializer, Class<T>)`
* `ResultMessage#serializeExceptionResult(Serializer, Class<T>)`

These methods have effectively been replaced by the new `Message#payloadAs(Type, Converter)` and `Message#withConverterPayload(Type, Converter)` methods.

Furthermore, leftover usages of these methods have been replaced by invoked the (deprecated) `Serializer` directly. 
Although this does not remove further use of the `Serializer` or `SerializedObject`, it does form one of the last clean-up acts required for the `Message` interface before release of Axon Framework 5 (as far as I can tell at this moment).
Lastly, the `Serializer` and `SerializedObject` will be clean-up as part of #3602.

As it forms part of the shift from `Serializer` to `Converter`, this PR is a part of issue #3102.