### PR TITLE
Feature/handler test case

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/annotation/AnnotatedEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/annotation/AnnotatedEventHandlingComponent.java
@@ -22,6 +22,7 @@ import org.axonframework.eventhandling.EventHandlerRegistry;
 import org.axonframework.eventhandling.EventHandlingComponent;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.eventhandling.conversion.EventConverter;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandler;
 import org.axonframework.messaging.MessageStream;
@@ -156,7 +157,7 @@ public class AnnotatedEventHandlingComponent<T> implements EventHandlingComponen
                 qualifiedName,
                 (event, ctx) ->
                         interceptorChain.handle(
-                                event.withConvertedPayload(handler.payloadType(), ctx.component(Converter.class)),
+                                event.withConvertedPayload(handler.payloadType(), ctx.component(EventConverter.class)),
                                 ctx,
                                 target,
                                 handler

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -182,8 +182,8 @@ public interface MessageStream<M extends Message> {
      * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
      * {@code mono}, once the given {@code mono} completes.
      * <p>
-     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty.
-     * The stream will complete with an exception when the given {@code mono} completes exceptionally.
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
+     * stream will complete with an exception when the given {@code mono} completes exceptionally.
      *
      * @param mono The {@link Mono} providing the {@link Message} to contain in the stream.
      * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
@@ -199,12 +199,12 @@ public interface MessageStream<M extends Message> {
      * <p>
      * The automatically generated {@code Entry} will have the {@link Context} as given by the {@code contextSupplier}.
      * <p>
-     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty.
-     * The stream will complete with an exception when the given {@code mono} completes exceptionally.
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
+     * stream will complete with an exception when the given {@code mono} completes exceptionally.
      *
      * @param mono            The {@link Mono} providing the {@link Message} to contain in the stream.
-     * @param contextSupplier A {@link Function} ingesting the {@link Message} from the given {@code mono} returning
-     *                        the {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
+     * @param contextSupplier A {@link Function} ingesting the {@link Message} from the given {@code mono} returning the
+     *                        {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
      * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
      * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
      */

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -180,6 +180,41 @@ public interface MessageStream<M extends Message> {
 
     /**
      * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
+     * {@code mono}, once the given {@code mono} completes.
+     * <p>
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty.
+     * The stream will complete with an exception when the given {@code mono} completes exceptionally.
+     *
+     * @param mono The {@link Mono} providing the {@link Message} to contain in the stream.
+     * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
+     */
+    static <M extends Message> Single<M> fromMono(@Nonnull Mono<M> mono) {
+        return fromFuture(mono.toFuture());
+    }
+
+    /**
+     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
+     * {@code mono}, once the given {@code mono} completes.
+     * <p>
+     * The automatically generated {@code Entry} will have the {@link Context} as given by the {@code contextSupplier}.
+     * <p>
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty.
+     * The stream will complete with an exception when the given {@code mono} completes exceptionally.
+     *
+     * @param mono            The {@link Mono} providing the {@link Message} to contain in the stream.
+     * @param contextSupplier A {@link Function} ingesting the {@link Message} from the given {@code mono} returning
+     *                        the {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
+     * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
+     */
+    static <M extends Message> Single<M> fromMono(@Nonnull Mono<M> mono,
+                                                  @Nonnull Function<M, Context> contextSupplier) {
+        return fromFuture(mono.toFuture(), contextSupplier);
+    }
+
+    /**
+     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
      * {@code future}, once the given {@code future} completes.
      * <p>
      * The stream will contain at most a single entry. It may also contain no entries if the future returns

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -20,6 +20,7 @@ import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
+import org.axonframework.util.ClasspathResolver;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -38,6 +39,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import reactor.core.publisher.Mono;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
@@ -213,6 +216,9 @@ public class AnnotatedHandlerInspector<T> {
         }
         if (result instanceof MessageStream<?> stream) {
             return stream;
+        }
+        if (ClasspathResolver.projectReactorOnClasspath() && result instanceof Mono<?> mono) {
+            return MessageStream.fromMono(mono.map(r -> new GenericMessage(new MessageType(r.getClass()), r)));
         }
         return MessageStream.just(new GenericMessage(new MessageType(ObjectUtils.nullSafeTypeOf(result)), result));
     }

--- a/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotation/AnnotatedHandlerInspector.java
@@ -21,6 +21,7 @@ import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.util.ClasspathResolver;
+import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -39,8 +40,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import reactor.core.publisher.Mono;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;

--- a/messaging/src/test/java/org/axonframework/messaging/AsyncMessageHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/AsyncMessageHandlerTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+import org.awaitility.Awaitility;
+import org.axonframework.commandhandling.CommandBus;
+import org.axonframework.commandhandling.CommandBusTestUtils;
+import org.axonframework.commandhandling.CommandExecutionException;
+import org.axonframework.commandhandling.CommandResultMessage;
+import org.axonframework.commandhandling.GenericCommandResultMessage;
+import org.axonframework.commandhandling.annotation.AnnotatedCommandHandlingComponent;
+import org.axonframework.commandhandling.annotation.CommandHandler;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.gateway.DefaultCommandGateway;
+import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.SimpleEventBus;
+import org.axonframework.eventhandling.annotation.AnnotatedEventHandlingComponent;
+import org.axonframework.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.annotation.DefaultParameterResolverFactory;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.responsetypes.ResponseTypes;
+import org.axonframework.messaging.unitofwork.StubProcessingContext;
+import org.axonframework.queryhandling.DefaultQueryGateway;
+import org.axonframework.queryhandling.QueryBus;
+import org.axonframework.queryhandling.QueryGateway;
+import org.axonframework.queryhandling.SimpleQueryBus;
+import org.axonframework.serialization.PassThroughConverter;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AsyncMessageHandlerTest {
+    private static final ParameterResolverFactory PARAMETER_RESOLVER_FACTORY = new DefaultParameterResolverFactory();
+
+    private final CommandBus commandBus = CommandBusTestUtils.aCommandBus();
+    private final CommandGateway commandGateway = new DefaultCommandGateway(commandBus, new ClassBasedMessageTypeResolver());
+    private final QueryBus queryBus = SimpleQueryBus.builder().build();
+    private final QueryGateway queryGateway = DefaultQueryGateway.builder().queryBus(queryBus).messageNameResolver(new ClassBasedMessageTypeResolver()).build();
+    private final EventBus eventBus = SimpleEventBus.builder().build();  // TODO #3392 - Replace for actual EventSink implementation.
+    private final AtomicBoolean eventHandlerCalled = new AtomicBoolean();
+
+    record CheckIfPrime(int value) {}  // command
+    record GetKnownPrimes() {}         // query
+    record PrimeChecked(int value) {}  // event
+
+    @Nested
+    class AnnotationBased {
+
+        @Nested
+        class EventHandlers {
+
+            @Test
+            void withVoidReturnTypeShouldBeCalled() {
+                var ehc = new AnnotatedEventHandlingComponent<>(new VoidEventHandler(), PARAMETER_RESOLVER_FACTORY);
+
+                eventBus.subscribe(messages -> messages.forEach(m -> ehc.handle(m, new StubProcessingContext())));
+
+                assertEvents();
+            }
+
+            @Test
+            void returningMonoShouldExecuteIt() {
+                var ehc = new AnnotatedEventHandlingComponent<>(new MonoEventHandler(), PARAMETER_RESOLVER_FACTORY);
+
+                eventBus.subscribe(messages -> messages.forEach(m -> ehc.handle(m, new StubProcessingContext())));
+
+                assertEvents();
+            }
+
+            @Test
+            void returningCompletableFutureShouldExecuteIt() {
+                var ehc = new AnnotatedEventHandlingComponent<>(new CompletableFutureEventHandler(), PARAMETER_RESOLVER_FACTORY);
+
+                eventBus.subscribe(messages -> messages.forEach(m -> ehc.handle(m, new StubProcessingContext())));
+
+                assertEvents();
+            }
+        }
+
+        @Nested
+        class CommandHandlers {
+
+            @Test
+            void returningCompletableFutureShouldUseItsResult() {
+                commandBus.subscribe(new AnnotatedCommandHandlingComponent<>(new CompletableFutureCommandHandler(), PassThroughConverter.MESSAGE_INSTANCE));
+
+                assertCommands();
+            }
+
+            @Test
+            void returningMonoShouldUseItsResult() {
+                commandBus.subscribe(new AnnotatedCommandHandlingComponent<>(new MonoCommandHandler(), PassThroughConverter.MESSAGE_INSTANCE));
+
+                assertCommands();
+            }
+
+            @Test
+            void returningBooleanShouldUseResult() {
+                commandBus.subscribe(new AnnotatedCommandHandlingComponent<>(new BooleanCommandHandler(), PassThroughConverter.MESSAGE_INSTANCE));
+
+                assertCommands();
+            }
+        }
+
+        @Nested
+        class QueryHandlers {
+            // TODO #3488 - Implement once there is an AnnotatedQueryHandlingComponent
+        }
+    }
+
+    @Nested
+    class Declarative {
+
+        @Nested
+        class EventHandlers {
+            // TODO #3392 - Once EventSink is created, can adds declartive tests here which subscribe with a QualifiedName
+        }
+
+        @Nested
+        class CommandHandlers {
+
+            @Test
+            void returningCompletableFutureShouldUseItsResult() {
+                commandBus.subscribe(
+                    new QualifiedName(CheckIfPrime.class.getName()),
+                    (command, context) -> {
+                        CommandResultMessage<Boolean> value = new GenericCommandResultMessage<>(null, isPrime(((CheckIfPrime)command.payload()).value()));
+
+                        return MessageStream.fromFuture(CompletableFuture.completedFuture(value));
+                    }
+                );
+
+                assertCommands();
+            }
+
+            @Test
+            void returningMonoShouldUseItsResult() {
+                commandBus.subscribe(
+                    new QualifiedName(CheckIfPrime.class.getName()),
+                    (command, context) -> {
+                        CommandResultMessage<Boolean> data = new GenericCommandResultMessage<>(null, isPrime(((CheckIfPrime)command.payload()).value()));
+
+                        return MessageStream.fromMono(Mono.just(data));
+                    }
+                );
+
+                assertCommands();
+            }
+
+            @Test
+            void returningBooleanShouldUseResult() {
+                commandBus.subscribe(
+                    new QualifiedName(CheckIfPrime.class.getName()),
+                    (command, context) -> MessageStream.just(new GenericCommandResultMessage<>(null, isPrime(((CheckIfPrime)command.payload()).value())))
+                );
+
+                assertCommands();
+            }
+        }
+
+        @Nested
+        class QueryHandlers {
+            @Test
+            void declarativeQueryHandlerShouldUseFluxReturnType() throws Exception {
+                queryBus.subscribe(
+                    GetKnownPrimes.class.getName(),
+                    Integer.class,
+                    (query, context) -> Flux.just(2, 3, 5, 7)
+                );
+
+                assertQuery();
+            }
+
+            @Test
+            void declarativeQueryHandlerShouldUseIterableReturnType() throws Exception {
+                queryBus.subscribe(
+                    GetKnownPrimes.class.getName(),
+                    Integer.class,
+                    (query, context) -> List.of(2, 3, 5, 7)
+                );
+
+                assertQuery();
+            }
+        }
+    }
+
+    private void assertEvents() {
+        eventBus.publish(new GenericEventMessage(new MessageType(PrimeChecked.class), new PrimeChecked(5)));
+
+        Awaitility.await().untilAsserted(() -> assertThat(eventHandlerCalled).isTrue());
+    }
+
+    private void assertCommands() {
+        assertThat(commandGateway.sendAndWait(new CheckIfPrime(2), Boolean.class)).isTrue();
+        assertThat(commandGateway.sendAndWait(new CheckIfPrime(4), Boolean.class)).isFalse();
+        assertThatThrownBy(() -> commandGateway.sendAndWait(new CheckIfPrime(10), Boolean.class))
+            .isInstanceOf(CommandExecutionException.class)
+            .cause()
+            .isInstanceOf(ExecutionException.class)
+            .cause()
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("unsupported value: 10");
+    }
+
+    private void assertQuery() throws Exception {
+        List<Integer> primes = queryGateway.query(new GetKnownPrimes(), ResponseTypes.multipleInstancesOf(Integer.class)).get();
+
+        assertThat(primes).isEqualTo(List.of(2, 3, 5, 7));
+    }
+
+    private class VoidEventHandler {
+        @EventHandler
+        public void handle(PrimeChecked event) {
+            eventHandlerCalled.set(true);
+        }
+    }
+
+    private class MonoEventHandler {
+        @EventHandler
+        public Mono<Void> handle(PrimeChecked event) {
+            return Mono.fromRunnable(() -> eventHandlerCalled.set(true));
+        }
+    }
+
+    private class CompletableFutureEventHandler {
+        @EventHandler
+        public CompletableFuture<Void> handle(PrimeChecked event) {
+            return CompletableFuture.runAsync(() -> eventHandlerCalled.set(true));
+        }
+    }
+
+    private class CompletableFutureCommandHandler {
+        @CommandHandler
+        public Future<Boolean> handle(CheckIfPrime cmd) {
+            return CompletableFuture.completedFuture(isPrime(cmd.value));
+        }
+    }
+
+    private class MonoCommandHandler {
+        @CommandHandler
+        public Mono<Boolean> handle(CheckIfPrime cmd) {
+            return Mono.just(isPrime(cmd.value));
+        }
+    }
+
+    private class BooleanCommandHandler {
+        @CommandHandler
+        public boolean handle(CheckIfPrime cmd) {
+            return isPrime(cmd.value);
+        }
+    }
+
+    private static boolean isPrime(int n) {
+        return switch(n) {
+            case 0, 1, 4 -> false;
+            case 2, 3, 5 -> true;
+            default -> throw new IllegalArgumentException("unsupported value: " + n);
+        };
+    }
+}


### PR DESCRIPTION
Adds:
- support for handling Mono as return type
- a test case for various return types supported by message handlers, see #3523 

Open questions:
- Did I miss any useful cases?
- Should I leave in the comments / Disabled tests?
- Should this be named `TestSuite` or `Test`?  