### PR TITLE
[#3253] Move `TagResolver` from `DefaultEventStoreTransaction` to `SimpleEventStore`

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -125,7 +125,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
 
     @Override
     public void appendEvent(@Nonnull EventMessage eventMessage) {
-        var eventQueue = processingContext.computeResourceIfAbsent(
+        List<TaggedEventMessage<?>> eventQueue = processingContext.computeResourceIfAbsent(
                 eventQueueKey,
                 () -> {
                     attachAppendEventsStep();
@@ -164,10 +164,9 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
         return tx.commit()
                  .whenComplete((position, exception) -> {
                      if (position != null) {
-                         commitContext.updateResource(appendPositionKey,
-                                                      other -> position.upperBound(Objects.requireNonNullElse(
-                                                              other,
-                                                              ConsistencyMarker.ORIGIN)));
+                         commitContext.updateResource(
+                                 appendPositionKey,
+                                 other -> position.upperBound(requireNonNullElse(other, ConsistencyMarker.ORIGIN)));
                      }
                  });
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SimpleEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SimpleEventStore.java
@@ -71,7 +71,7 @@ public class SimpleEventStore implements EventStore, StreamableEventSource<Event
     public EventStoreTransaction transaction(@Nonnull ProcessingContext processingContext) {
         return processingContext.computeResourceIfAbsent(
                 eventStoreTransactionKey,
-                () -> new DefaultEventStoreTransaction(eventStorageEngine, processingContext, tagResolver)
+                () -> new DefaultEventStoreTransaction(eventStorageEngine, processingContext, this::preProcessEvents)
         );
     }
 
@@ -82,7 +82,7 @@ public class SimpleEventStore implements EventStore, StreamableEventSource<Event
             AppendCondition none = AppendCondition.none();
             List<TaggedEventMessage<?>> taggedEvents = new ArrayList<>();
             for (EventMessage event : events) {
-                taggedEvents.add(new GenericTaggedEventMessage<>(event, tagResolver.resolve(event)));
+                taggedEvents.add(preProcessEvents(event));
             }
             return eventStorageEngine.appendEvents(none, taggedEvents)
                                      .thenApply(EventStorageEngine.AppendTransaction::commit)
@@ -93,6 +93,10 @@ public class SimpleEventStore implements EventStore, StreamableEventSource<Event
             appendToTransaction(context, events);
             return FutureUtils.emptyCompletedFuture();
         }
+    }
+
+    private TaggedEventMessage<EventMessage> preProcessEvents(EventMessage event) {
+        return new GenericTaggedEventMessage<>(event, tagResolver.resolve(event));
     }
 
     private void appendToTransaction(ProcessingContext context,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SimpleEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SimpleEventStore.java
@@ -130,5 +130,6 @@ public class SimpleEventStore implements EventStore, StreamableEventSource<Event
     @Override
     public void describeTo(@Nonnull ComponentDescriptor descriptor) {
         descriptor.describeProperty("eventStorageEngine", eventStorageEngine);
+        descriptor.describeProperty("tagResolver", tagResolver);
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -171,8 +171,9 @@ class DefaultEventStoreTransactionTest {
         private ConsistencyMarker appendEventForTag(Tag tag) {
             return eventStorageEngine.appendEvents(AppendCondition.none(),
                                                    new GenericTaggedEventMessage<>(
-                                                           new GenericEventMessage(new MessageType(String.class),
-                                                                                     "my payload"),
+                                                           new GenericEventMessage(
+                                                                   new MessageType(String.class), "my payload"
+                                                           ),
                                                            Set.of(tag)
                                                    )).join().commit().join();
         }
@@ -365,12 +366,13 @@ class DefaultEventStoreTransactionTest {
 
     private EventStoreTransaction defaultEventStoreTransactionFor(ProcessingContext processingContext,
                                                                   TagResolver tagResolver) {
-        return processingContext.computeResourceIfAbsent(testEventStoreTransactionKey,
-                                                         () -> new DefaultEventStoreTransaction(
-                                                                 eventStorageEngine,
-                                                                 processingContext,
-                                                                 tagResolver
-                                                         )
+        return processingContext.computeResourceIfAbsent(
+                testEventStoreTransactionKey,
+                () -> new DefaultEventStoreTransaction(
+                        eventStorageEngine,
+                        processingContext,
+                        event -> new GenericTaggedEventMessage<>(event, tagResolver.resolve(event))
+                )
         );
     }
 


### PR DESCRIPTION
This pull request resolves #3253 by moving the tagging from the `DefaultEventStoreTransaction` to the `SimpleEventStore`.
This is achieved by taking in a `Function<EventMessage, TaggedEventMessage>` in the `DefaultEventStoreTransaction` instead of the `TagResolver`.
The lambda is inclined to return a `TaggedEventMessage`, as that's expected of the `EventStorageEngine#append` operation.