### PR TITLE
Fix issue in token split during replay

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/pooled/SplitTask.java
@@ -115,7 +115,7 @@ class SplitTask extends CoordinatorTask {
             TrackingToken tokenToSplit = tokenStore.fetchToken(name, segmentToSplit.getSegmentId());
             TrackerStatus[] splitStatuses = TrackerStatus.split(segmentToSplit, tokenToSplit);
             tokenStore.initializeSegment(
-                    splitStatuses[1].getTrackingToken(), name, splitStatuses[1].getSegment().getSegmentId()
+                    splitStatuses[1].getInternalTrackingToken(), name, splitStatuses[1].getSegment().getSegmentId()
             );
             tokenStore.releaseClaim(name, splitStatuses[0].getSegment().getSegmentId());
             logger.info("Processor [{}] successfully split {} into {} and {}.",


### PR DESCRIPTION
This commit fixes an issue in the PooledStreamingEventProcessor where a split of a segment during a replay would cause the split-out segment to lose the ReplayStatus.