### PR TITLE
Ensure `ConfigurationEnhancers` are not registered twice

### DIFF
--- a/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/configuration/ApplicationConfigurerTestSuite.java
@@ -1000,6 +1000,33 @@ public abstract class ApplicationConfigurerTestSuite<C extends ApplicationConfig
             assertEquals(TEST_COMPONENT, config.getComponent(TestComponent.class));
             assertEquals(expected, config.getComponent(TestComponent.class, "conditional"));
         }
+
+        @Test
+        void registeringSameEnhancerTypeSeveralTimesWillReplacePreviousRegistration() {
+            AtomicBoolean firstRegistration = new AtomicBoolean(false);
+            AtomicBoolean secondRegistration = new AtomicBoolean(false);
+            AtomicBoolean thirdRegistration = new AtomicBoolean(false);
+
+            testSubject.componentRegistry(
+                    cr -> cr.registerEnhancer(new TestConfigurationEnhancer(firstRegistration))
+                            .registerEnhancer(new TestConfigurationEnhancer(secondRegistration))
+                            .registerEnhancer(new TestConfigurationEnhancer(thirdRegistration))
+            );
+
+            buildConfiguration();
+
+            assertFalse(firstRegistration.get());
+            assertFalse(secondRegistration.get());
+            assertTrue(thirdRegistration.get());
+        }
+
+        record TestConfigurationEnhancer(AtomicBoolean invoked) implements ConfigurationEnhancer {
+
+            @Override
+            public void enhance(@Nonnull ComponentRegistry registry) {
+                invoked.set(true);
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
This pull request ensures that `ConfigurationEnhancers` are not accidentally registered twice.
I encountered that the `MessagingConfigurationDefaults`  `ConfigurationEnhancer` was registered twice; once through the `MessagingConfigurer` and once through the integrated Service Loader mechanism to discover `MessagingConfigurer`. 
A down-stream branch I was working on through this received duplicate `MessageHandlerInterceptors`, which may very definitely lead to unwanted side effects.

To resolve this, I have adjusted the `List` of  `ConfigurationEnhancers` to a `Map`, having a `String` key based on the `Class#getName` of the given `ConfigurationEnhancer`.
I have deliberately chosen `String` as the key, as that better aligns with our `SpringComponentRegistry`, which will search for `ConfigurationEnhancers` in Spring's Application Context, which are **always** keyed by a `String`.

If an enhancer is registered again, we log a `WARN` level message.
Furthermore, the Service Loader solution ensures it does not accidentally trigger this warning, by filtering the retrieved enhancers before registering them.