### PR TITLE
[#3103] Event `MessageDispatchInterceptor` support for publishing and appending events

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
@@ -45,6 +45,11 @@ import java.util.List;
  *     <li>Registers a {@link SimpleEventStore} for class {@link EventStore}</li>
  *     <li>Registers a {@link org.axonframework.eventsourcing.AggregateSnapshotter} for class {@link Snapshotter}</li>
  * </ul>
+ * Furthermore, this enhancer will decorate the:
+ * <ul>
+ *     <li>The {@link EventStore} in a {@link InterceptingEventStore} <b>if</b> there are any
+ *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry}.</li>
+ * </ul>
  *
  * @author Steven van Beelen
  * @since 5.0.0

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nonnull;
 import org.axonframework.configuration.ComponentRegistry;
 import org.axonframework.configuration.Configuration;
 import org.axonframework.configuration.ConfigurationEnhancer;
+import org.axonframework.configuration.MessagingConfigurationDefaults;
 import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
@@ -44,9 +45,15 @@ import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageE
  */
 public class EventSourcingConfigurationDefaults implements ConfigurationEnhancer {
 
+    /**
+     * The order of {@code this} enhancer compared to others, equal to 100 positions before
+     * {@link MessagingConfigurationDefaults} (thus, {@link MessagingConfigurationDefaults#ENHANCER_ORDER} - 100).
+     */
+    public static final int ENHANCER_ORDER = MessagingConfigurationDefaults.ENHANCER_ORDER - 100;
+
     @Override
     public int order() {
-        return Integer.MAX_VALUE - 10;
+        return ENHANCER_ORDER;
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
@@ -83,7 +83,7 @@ public class InterceptingEventStore implements EventStore {
      * {@link #publish(ProcessingContext, List) publishing} is done by the given {@code delegate}.
      *
      * @param delegate     The delegate {@code EventSink} that will handle all dispatching and handling logic.
-     * @param interceptors The interceptors to invoke before dispatching a command and on the command result.
+     * @param interceptors The interceptors to invoke before appending and publishing an event.
      */
     @Internal
     public InterceptingEventStore(@Nonnull EventStore delegate,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.configuration.ComponentRegistry;
+import org.axonframework.configuration.DecoratorDefinition;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
+import org.axonframework.eventstreaming.StreamingCondition;
+import org.axonframework.messaging.Context;
+import org.axonframework.messaging.DefaultMessageDispatchInterceptorChain;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Decorator around the {@link EventStore} intercepting all {@link EventMessage events} before they are
+ * {@link EventStoreTransaction#appendEvent(EventMessage) appended} or
+ * {@link #publish(ProcessingContext, List) published} with {@link MessageDispatchInterceptor dispatch interceptors}.
+ * <p>
+ * This {@code InterceptingEventStore} is typically registered as a
+ * {@link ComponentRegistry#registerDecorator(DecoratorDefinition) decorator} and automatically kicks in whenever
+ * {@code MessageDispatchInterceptors} are present.
+ *
+ * @author Steven van Beelen
+ * @since 5.0.0
+ */
+@Internal
+public class InterceptingEventStore implements EventStore {
+
+    /**
+     * The order in which the {@link InterceptingEventStore} is applied as a
+     * {@link ComponentRegistry#registerDecorator(DecoratorDefinition) decorator} to the {@link EventStore}.
+     * <p>
+     * As such, any decorator with a lower value will be applied to the delegate, and any higher value will be applied
+     * to the {@code InterceptingEventStore} itself. Using the same value can either lead to application of the
+     * decorator to the delegate or the {@code InterceptingEventStore}, depending on the order of registration.
+     * <p>
+     * The order of the {@code InterceptingEventStore} is set to {@code Integer.MIN_VALUE + 50} to ensure it is applied
+     * very early in the configuration process, but not the earliest to allow for other decorators to be applied.
+     */
+    public static final int DECORATION_ORDER = Integer.MIN_VALUE + 50;
+
+    private final EventStore delegate;
+    private final List<MessageDispatchInterceptor<? super Message>> interceptors;
+    private final InterceptingAppender interceptingAppender;
+    private final InterceptingPublisher interceptingPublisher;
+
+    private final Context.ResourceKey<EventStoreTransaction> delegateTransactionKey;
+    private final Context.ResourceKey<EventStoreTransaction> interceptingTransactionKey;
+
+    /**
+     * Constructs a {@code InterceptingEventStore}, delegating all operation to the given {@code delegate}.
+     * <p>
+     * The given {@code interceptors} are invoked before {@link EventStoreTransaction#appendEvent(EventMessage)} or
+     * {@link #publish(ProcessingContext, List) publishing} is done by the given {@code delegate}.
+     *
+     * @param delegate     The delegate {@code EventSink} that will handle all dispatching and handling logic.
+     * @param interceptors The interceptors to invoke before dispatching a command and on the command result.
+     */
+    @Internal
+    public InterceptingEventStore(@Nonnull EventStore delegate,
+                                  @Nonnull List<MessageDispatchInterceptor<? super Message>> interceptors) {
+        this.delegateTransactionKey = Context.ResourceKey.withLabel("delegateTransaction");
+        this.interceptingTransactionKey = Context.ResourceKey.withLabel("interceptingTransaction");
+
+        this.delegate = Objects.requireNonNull(delegate, "The EventStore may not be null.");
+        this.interceptors = Objects.requireNonNull(interceptors, "The dispatch interceptors must not be null.");
+        this.interceptingAppender = new InterceptingAppender(interceptors,
+                                                             context -> context.getResource(delegateTransactionKey));
+        this.interceptingPublisher = new InterceptingPublisher(interceptors, this::publishEvent);
+    }
+
+    @Override
+    public EventStoreTransaction transaction(@Nonnull ProcessingContext processingContext) {
+        // Set the delegate transaction to ensure the InterceptingAppender can reach the correct EventStoreTransaction.
+        EventStoreTransaction delegateTransaction = processingContext.computeResourceIfAbsent(
+                delegateTransactionKey,
+                () -> delegate.transaction(processingContext)
+        );
+        // Set the intercepting transaction to ensure subsequent transaction operation receive the same intercepting transaction.
+        return processingContext.computeResourceIfAbsent(
+                interceptingTransactionKey,
+                () -> new InterceptingEventStoreTransaction(processingContext, delegateTransaction)
+        );
+    }
+
+    @Override
+    public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
+                                           @Nonnull List<EventMessage> events) {
+        return interceptingPublisher.interceptAndPublish(events, context);
+    }
+
+    private MessageStream.Empty<Message> publishEvent(@Nonnull Message message,
+                                                      @Nullable ProcessingContext context) {
+        if (!(message instanceof EventMessage event)) {
+            // The compiler should avoid this from happening.
+            throw new IllegalArgumentException("Unsupported message implementation: " + message);
+        }
+        return MessageStream.fromFuture(delegate.publish(context, event)
+                                                .thenApply(v -> null))
+                            .ignoreEntries();
+    }
+
+    @Override
+    public MessageStream<EventMessage> open(@Nonnull StreamingCondition condition) {
+        return delegate.open(condition);
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> firstToken() {
+        return delegate.firstToken();
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> latestToken() {
+        return delegate.latestToken();
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> tokenAt(@Nonnull Instant at) {
+        return delegate.tokenAt(at);
+    }
+
+    @Override
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+        descriptor.describeProperty("dispatchInterceptors", interceptors);
+    }
+
+    private class InterceptingEventStoreTransaction implements EventStoreTransaction {
+
+        private final ProcessingContext context;
+        private final EventStoreTransaction delegate;
+
+        private InterceptingEventStoreTransaction(@Nonnull ProcessingContext context,
+                                                  @Nonnull EventStoreTransaction delegate) {
+            this.delegate = delegate;
+            this.context = context;
+        }
+
+        @Override
+        public MessageStream<? extends EventMessage> source(@Nonnull SourcingCondition condition) {
+            return delegate.source(condition);
+        }
+
+        @Override
+        public void appendEvent(@Nonnull EventMessage eventMessage) {
+            interceptingAppender.interceptAndAppend(eventMessage, context);
+        }
+
+        @Override
+        public void onAppend(@Nonnull Consumer<EventMessage> callback) {
+            delegate.onAppend(callback);
+        }
+
+        @Override
+        public ConsistencyMarker appendPosition() {
+            return delegate.appendPosition();
+        }
+    }
+
+    private static class InterceptingAppender {
+
+        private final DefaultMessageDispatchInterceptorChain<Message> interceptorChain;
+
+        private InterceptingAppender(List<MessageDispatchInterceptor<? super Message>> interceptors,
+                                     Function<ProcessingContext, EventStoreTransaction> transactionProvider) {
+            this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors, (message, context) -> {
+                if (!(message instanceof EventMessage event)) {
+                    // The compiler should avoid this from happening.
+                    throw new IllegalArgumentException("Unsupported message implementation: " + message);
+                }
+                transactionProvider.apply(context)
+                                   .appendEvent(event);
+                return MessageStream.empty();
+            });
+        }
+
+        private void interceptAndAppend(@Nonnull EventMessage event,
+                                        @Nullable ProcessingContext context) {
+            interceptorChain.proceed(event, context)
+                            .ignoreEntries()
+                            .asCompletableFuture()
+                            .join();
+        }
+    }
+
+    private static class InterceptingPublisher {
+
+        private final DefaultMessageDispatchInterceptorChain<Message> interceptorChain;
+
+        private InterceptingPublisher(List<MessageDispatchInterceptor<? super Message>> interceptors,
+                                      BiFunction<? super Message, ProcessingContext, MessageStream<?>> publisher) {
+            this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors, publisher);
+        }
+
+        private CompletableFuture<Void> interceptAndPublish(
+                @Nonnull List<EventMessage> events,
+                @Nullable ProcessingContext context
+        ) {
+            MessageStream<Message> resultStream = MessageStream.empty();
+            for (EventMessage event : events) {
+                resultStream = resultStream.concatWith(interceptorChain.proceed(event, context)
+                                                                       .cast());
+            }
+            return resultStream.ignoreEntries()
+                               .asCompletableFuture()
+                               .thenApply(v -> null);
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -52,8 +52,8 @@ class EventSourcingConfigurationDefaultsTest {
     }
 
     @Test
-    void orderEqualsMaxInteger() {
-        assertEquals(Integer.MAX_VALUE - 10, testSubject.order());
+    void orderEqualsEnhancerOrderConstant() {
+        assertEquals(EventSourcingConfigurationDefaults.ENHANCER_ORDER, testSubject.order());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -26,16 +26,20 @@ import org.axonframework.eventsourcing.Snapshotter;
 import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.InterceptingEventStore;
 import org.axonframework.eventsourcing.eventstore.SimpleEventStore;
 import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.eventstreaming.StreamableEventSource;
 import org.axonframework.eventstreaming.Tag;
+import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.junit.jupiter.api.*;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link EventSourcingConfigurationDefaults}.
@@ -96,6 +100,18 @@ class EventSourcingConfigurationDefaultsTest {
                                                       .getComponent(TagResolver.class);
 
         assertEquals(testTagResolver, configuredTagResolver);
+    }
+
+    @Test
+    void decoratorsEventStoreAsInterceptorEventStoreWhenDispatchInterceptorIsPresent() {
+        //noinspection unchecked
+        MessagingConfigurer configurer =
+                MessagingConfigurer.create()
+                                   .registerDispatchInterceptor(c -> mock(MessageDispatchInterceptor.class));
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStore.class)).isInstanceOf(InterceptingEventStore.class);
     }
 
     private static class TestTagResolver implements TagResolver {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
@@ -20,6 +20,7 @@ import org.axonframework.common.FutureUtils;
 import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.InterceptingEventSink;
 import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
 import org.axonframework.eventstreaming.EventCriteria;
 import org.axonframework.eventstreaming.StreamingCondition;
@@ -237,7 +238,7 @@ class InterceptingEventStoreTest {
         testSubject.describeTo(descriptor);
 
         Map<String, Object> describedProperties = descriptor.getDescribedProperties();
-        assertThat(describedProperties).size().isEqualTo(2);
+        assertThat(describedProperties).size().isEqualTo(3);
         assertThat(describedProperties).containsKey("delegate");
         assertThat(describedProperties.get("delegate")).isEqualTo(eventStore);
         assertThat(describedProperties).containsKey("dispatchInterceptors");
@@ -245,5 +246,7 @@ class InterceptingEventStoreTest {
         List<MessageDispatchInterceptor<? super Message>> dispatchInterceptors =
                 (List<MessageDispatchInterceptor<? super Message>>) describedProperties.get("dispatchInterceptors");
         assertThat(dispatchInterceptors).containsExactly(interceptorOne, interceptorTwo);
+        assertThat(describedProperties).containsKey("delegateSink");
+        assertThat(describedProperties.get("delegateSink")).isInstanceOf(InterceptingEventSink.class);
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.common.FutureUtils;
+import org.axonframework.common.infra.MockComponentDescriptor;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
+import org.axonframework.eventstreaming.EventCriteria;
+import org.axonframework.eventstreaming.StreamingCondition;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+import org.axonframework.messaging.unitofwork.StubProcessingContext;
+import org.axonframework.utils.MockException;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link InterceptingEventStore}.
+ *
+ * @author Steven van Beelen
+ */
+class InterceptingEventStoreTest {
+
+    private static final MessageType TEST_EVENT_TYPE = new MessageType("event");
+
+    private EventStoreTransaction eventStoreTransaction;
+    private EventStore eventStore;
+    private AtomicInteger interceptorCounterOne;
+    private MessageDispatchInterceptor<Message> interceptorOne;
+    private AtomicInteger interceptorCounterTwo;
+    private MessageDispatchInterceptor<Message> interceptorTwo;
+
+    private InterceptingEventStore testSubject;
+
+    @BeforeEach
+    void setUp() {
+        eventStoreTransaction = mock(EventStoreTransaction.class);
+        eventStore = mock(EventStore.class);
+        when(eventStore.transaction(any())).thenReturn(eventStoreTransaction);
+        //noinspection unchecked
+        when(eventStore.publish(any(), any(List.class)))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+        when(eventStore.publish(any(), any(EventMessage.class)))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+
+        interceptorCounterOne = new AtomicInteger(0);
+        interceptorOne = (message, context, chain) -> {
+            interceptorCounterOne.incrementAndGet();
+            return chain.proceed(message, context);
+        };
+        interceptorCounterTwo = new AtomicInteger(0);
+        interceptorTwo = (message, context, chain) -> {
+            interceptorCounterTwo.incrementAndGet();
+            return chain.proceed(message, context);
+        };
+
+        testSubject = new InterceptingEventStore(eventStore, List.of(interceptorOne, interceptorTwo));
+    }
+
+    @Test
+    void dispatchInterceptorsInvokedOnTransactionAppend() {
+        EventMessage testEvent = new GenericEventMessage(TEST_EVENT_TYPE, "test");
+        ProcessingContext testContext = StubProcessingContext.forMessage(testEvent);
+
+        EventStoreTransaction transaction = testSubject.transaction(testContext);
+
+        transaction.appendEvent(testEvent);
+
+        ArgumentCaptor<EventMessage> appendedEvent = ArgumentCaptor.forClass(EventMessage.class);
+        verify(eventStore).transaction(testContext);
+        verify(eventStoreTransaction).appendEvent(appendedEvent.capture());
+
+        assertThat(appendedEvent.getValue()).isEqualTo(testEvent);
+        assertThat(interceptorCounterOne).hasValue(1);
+        assertThat(interceptorCounterTwo).hasValue(1);
+    }
+
+    @Test
+    void dispatchInterceptorsAreInvokedForEveryEventOnTransactionAppend() {
+        EventMessage firstEvent = new GenericEventMessage(TEST_EVENT_TYPE, "first");
+        EventMessage secondEvent = new GenericEventMessage(TEST_EVENT_TYPE, "second");
+        EventMessage thirdEvent = new GenericEventMessage(TEST_EVENT_TYPE, "third");
+        EventMessage fourthEvent = new GenericEventMessage(TEST_EVENT_TYPE, "fourth");
+
+        EventStoreTransaction firstTransaction = testSubject.transaction(new StubProcessingContext());
+        firstTransaction.appendEvent(firstEvent);
+        firstTransaction.appendEvent(secondEvent);
+        EventStoreTransaction secondTransaction = testSubject.transaction(new StubProcessingContext());
+        secondTransaction.appendEvent(thirdEvent);
+        secondTransaction.appendEvent(fourthEvent);
+
+        assertThat(interceptorCounterOne.get()).isEqualTo(4);
+        assertThat(interceptorCounterTwo.get()).isEqualTo(4);
+    }
+
+    @Test
+    void delegateTransactionSourceDirectly() {
+        SourcingCondition testCondition = SourcingCondition.conditionFor(EventCriteria.havingAnyTag());
+
+        testSubject.transaction(new StubProcessingContext())
+                   .source(testCondition);
+
+        verify(eventStoreTransaction).source(testCondition);
+    }
+
+    @Test
+    void delegateTransactionOnAppendDirectly() {
+        Consumer<EventMessage> testOnAppend = (event) -> {
+        };
+
+        testSubject.transaction(new StubProcessingContext())
+                   .onAppend(testOnAppend);
+
+        verify(eventStoreTransaction).onAppend(testOnAppend);
+    }
+
+    @Test
+    void delegateTransactionAppendPositionDirectly() {
+        testSubject.transaction(new StubProcessingContext())
+                   .appendPosition();
+
+        verify(eventStoreTransaction).appendPosition();
+    }
+
+    @Test
+    void dispatchInterceptorsInvokedOnPublish() {
+        EventMessage testEvent = new GenericEventMessage(TEST_EVENT_TYPE, "test");
+
+        CompletableFuture<Void> result =
+                testSubject.publish(StubProcessingContext.forMessage(testEvent), testEvent);
+
+        ArgumentCaptor<EventMessage> publishedEvent = ArgumentCaptor.forClass(EventMessage.class);
+        verify(eventStore).publish(any(), publishedEvent.capture());
+
+        assertThat(publishedEvent.getValue()).isEqualTo(testEvent);
+        assertThat(interceptorCounterOne).hasValue(1);
+        assertThat(interceptorCounterTwo).hasValue(1);
+        assertThat(result).isDone();
+    }
+
+    @Test
+    void dispatchInterceptorsAreInvokedForEveryEventOnPublish() throws Exception {
+        EventMessage firstEvent = new GenericEventMessage(TEST_EVENT_TYPE, "first");
+        EventMessage secondEvent = new GenericEventMessage(TEST_EVENT_TYPE, "second");
+        EventMessage thirdEvent = new GenericEventMessage(TEST_EVENT_TYPE, "third");
+        EventMessage fourthEvent = new GenericEventMessage(TEST_EVENT_TYPE, "fourth");
+
+        testSubject.publish(null, firstEvent, secondEvent).get();
+        testSubject.publish(null, thirdEvent, fourthEvent).get();
+
+        assertThat(interceptorCounterOne.get()).isEqualTo(4);
+        assertThat(interceptorCounterTwo.get()).isEqualTo(4);
+    }
+
+    @Test
+    void exceptionsInDispatchInterceptorReturnFailedStreamOnPublish() {
+        EventMessage testEvent = new GenericEventMessage(TEST_EVENT_TYPE, "test");
+
+        MessageDispatchInterceptor<Message> faultyInterceptor = (message, context, chain) -> {
+            throw new MockException();
+        };
+        InterceptingEventStore faultyInterceptingEventStore =
+                new InterceptingEventStore(eventStore, List.of(faultyInterceptor));
+
+        CompletableFuture<Void> result = faultyInterceptingEventStore.publish(null, testEvent);
+
+        assertThat(result).isDone();
+        assertThat(result).isCompletedExceptionally();
+        assertThat(result.exceptionNow()).isInstanceOf(MockException.class);
+    }
+
+    @Test
+    void delegateOpenStreamDirectly() {
+        StreamingCondition testCondition = StreamingCondition.startingFrom(TrackingToken.FIRST);
+
+        testSubject.open(testCondition);
+
+        verify(eventStore).open(testCondition);
+    }
+
+    @Test
+    void delegateFirstTokenDirectly() {
+        testSubject.firstToken();
+
+        verify(eventStore).firstToken();
+    }
+
+    @Test
+    void delegateLatestTokenDirectly() {
+        testSubject.latestToken();
+
+        verify(eventStore).latestToken();
+    }
+
+    @Test
+    void delegateTokenAtDirectly() {
+        Instant testInstant = Instant.now();
+
+        testSubject.tokenAt(testInstant);
+
+        verify(eventStore).tokenAt(testInstant);
+    }
+
+    @Test
+    void describeIncludesAllRelevantProperties() {
+        MockComponentDescriptor descriptor = new MockComponentDescriptor();
+
+        testSubject.describeTo(descriptor);
+
+        Map<String, Object> describedProperties = descriptor.getDescribedProperties();
+        assertThat(describedProperties).size().isEqualTo(2);
+        assertThat(describedProperties).containsKey("delegate");
+        assertThat(describedProperties.get("delegate")).isEqualTo(eventStore);
+        assertThat(describedProperties).containsKey("dispatchInterceptors");
+        //noinspection unchecked
+        List<MessageDispatchInterceptor<? super Message>> dispatchInterceptors =
+                (List<MessageDispatchInterceptor<? super Message>>) describedProperties.get("dispatchInterceptors");
+        assertThat(dispatchInterceptors).containsExactly(interceptorOne, interceptorTwo);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
@@ -65,6 +65,7 @@ import org.axonframework.queryhandling.SimpleQueryUpdateEmitter;
 import org.axonframework.serialization.Converter;
 import org.axonframework.serialization.json.JacksonConverter;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -280,6 +281,9 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
                 EventSink.class,
                 InterceptingEventSink.DECORATION_ORDER,
                 (config, name, delegate) -> {
+                    if (!isDirectImplementationOf(delegate, EventSink.class)) {
+                        return delegate;
+                    }
                     List<MessageDispatchInterceptor<? super Message>> dispatchInterceptors =
                             config.getComponent(DispatchInterceptorRegistry.class).interceptors(config);
                     return dispatchInterceptors.isEmpty()
@@ -287,5 +291,11 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
                             : new InterceptingEventSink(delegate, dispatchInterceptors);
                 }
         );
+    }
+
+    private static boolean isDirectImplementationOf(@Nonnull Object component,
+                                                    @Nonnull Class<EventSink> clazz) {
+        return Arrays.stream(component.getClass().getInterfaces())
+                     .anyMatch(iface -> iface == clazz);
     }
 }

--- a/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
@@ -102,6 +102,8 @@ import java.util.concurrent.CompletableFuture;
  *     <li>The {@link CommandBus} in a {@link InterceptingCommandBus} <b>if</b> there are any
  *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry} or
  *     {@link MessageHandlerInterceptor MessageHandlerInterceptors} present in the {@link HandlerInterceptorRegistry}.</li>
+ *     <li>The {@link EventSink} in a {@link InterceptingEventSink} <b>if</b> there are any
+ *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry}.</li>
  * </ul>
  *
  * @author Steven van Beelen

--- a/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
@@ -104,6 +104,10 @@ import java.util.List;
 public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
 
     /**
+     * The order of {@code this} enhancer compared to others, equal to {@link Integer#MAX_VALUE}.
+     */
+    public static final int ENHANCER_ORDER = Integer.MAX_VALUE;
+    /**
      * The order in which the {@link ConvertingCommandGateway} is applied to the {@link CommandGateway} in the
      * {@link ComponentRegistry}. As such, any decorator with a lower value will be applied to the delegate, and any
      * higher value will be applied to the {@link ConvertingCommandGateway} itself. Using the same value can either lead
@@ -118,7 +122,7 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
 
     @Override
     public int order() {
-        return Integer.MAX_VALUE;
+        return ENHANCER_ORDER;
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
@@ -32,6 +32,7 @@ import org.axonframework.common.transaction.NoTransactionManager;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.EventSink;
+import org.axonframework.eventhandling.InterceptingEventSink;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.eventhandling.conversion.EventConverter;
@@ -269,6 +270,17 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
                     return handlerInterceptors.isEmpty() && dispatchInterceptors.isEmpty()
                             ? delegate
                             : new InterceptingCommandBus(delegate, handlerInterceptors, dispatchInterceptors);
+                }
+        );
+        registry.registerDecorator(
+                EventSink.class,
+                InterceptingEventSink.DECORATION_ORDER,
+                (config, name, delegate) -> {
+                    List<MessageDispatchInterceptor<? super Message>> dispatchInterceptors =
+                            config.getComponent(DispatchInterceptorRegistry.class).interceptors(config);
+                    return dispatchInterceptors.isEmpty()
+                            ? delegate
+                            : new InterceptingEventSink(delegate, dispatchInterceptors);
                 }
         );
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
@@ -46,7 +46,7 @@ import java.util.function.BiFunction;
  * @since 5.0.0
  */
 @Internal
-public class InterceptingEventSink implements EventSink, DescribableComponent {
+public class InterceptingEventSink implements EventSink {
 
     /**
      * The order in which the {@link InterceptingEventSink} is applied as a

--- a/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
@@ -20,7 +20,6 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
-import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.configuration.ComponentRegistry;
 import org.axonframework.configuration.DecoratorDefinition;
 import org.axonframework.messaging.DefaultMessageDispatchInterceptorChain;
@@ -72,7 +71,7 @@ public class InterceptingEventSink implements EventSink {
      * the given {@code delegate}.
      *
      * @param delegate     The delegate {@code EventSink} that will handle all dispatching and handling logic.
-     * @param interceptors The interceptors to invoke before dispatching a command and on the command result.
+     * @param interceptors The interceptors to invoke before publishing an event.
      */
     public InterceptingEventSink(@Nonnull EventSink delegate,
                                  @Nonnull List<MessageDispatchInterceptor<? super Message>> interceptors) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
@@ -110,9 +110,9 @@ public class InterceptingEventSink implements EventSink, DescribableComponent {
 
         private InterceptingPublisher(
                 List<MessageDispatchInterceptor<? super Message>> interceptors,
-                BiFunction<? super Message, ProcessingContext, MessageStream<?>> dispatcher
+                BiFunction<? super Message, ProcessingContext, MessageStream<?>> publisher
         ) {
-            this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors, dispatcher);
+            this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors, publisher);
         }
 
         private CompletableFuture<Void> interceptAndPublish(

--- a/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/InterceptingEventSink.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.configuration.ComponentRegistry;
+import org.axonframework.configuration.DecoratorDefinition;
+import org.axonframework.messaging.DefaultMessageDispatchInterceptorChain;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.unitofwork.ProcessingContext;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+/**
+ * Decorator around the {@link EventSink} intercepting all {@link EventMessage events} before they are
+ * {@link #publish(ProcessingContext, List) published} with {@link MessageDispatchInterceptor dispatch interceptors}.
+ * <p>
+ * This {@code InterceptingEventSink} is typically registered as a
+ * {@link ComponentRegistry#registerDecorator(DecoratorDefinition) decorator} and automatically kicks in whenever
+ * {@code MessageDispatchInterceptors} are present.
+ *
+ * @author Steven van Beelen
+ * @since 5.0.0
+ */
+@Internal
+public class InterceptingEventSink implements EventSink, DescribableComponent {
+
+    /**
+     * The order in which the {@link InterceptingEventSink} is applied as a
+     * {@link ComponentRegistry#registerDecorator(DecoratorDefinition) decorator} to the {@link EventSink}.
+     * <p>
+     * As such, any decorator with a lower value will be applied to the delegate, and any higher value will be applied
+     * to the {@code InterceptingEventSink} itself. Using the same value can either lead to application of the decorator
+     * to the delegate or the {@code InterceptingEventSink}, depending on the order of registration.
+     * <p>
+     * The order of the {@code InterceptingEventSink} is set to {@code Integer.MIN_VALUE + 100} to ensure it is applied
+     * very early in the configuration process, but not the earliest to allow for other decorators to be applied.
+     */
+    public static final int DECORATION_ORDER = Integer.MIN_VALUE + 100;
+
+    private final EventSink delegate;
+    private final List<MessageDispatchInterceptor<? super Message>> interceptors;
+    private final InterceptingPublisher interceptingPublisher;
+
+    /**
+     * Constructs a {@code InterceptingEventSink}, delegating publishing to the given {@code delegate}.
+     * <p>
+     * The given {@code interceptors} are invoked before {@link #publish(ProcessingContext, List) publishing} is done by
+     * the given {@code delegate}.
+     *
+     * @param delegate     The delegate {@code EventSink} that will handle all dispatching and handling logic.
+     * @param interceptors The interceptors to invoke before dispatching a command and on the command result.
+     */
+    public InterceptingEventSink(@Nonnull EventSink delegate,
+                                 @Nonnull List<MessageDispatchInterceptor<? super Message>> interceptors) {
+        this.delegate = Objects.requireNonNull(delegate, "The EventSink may not be null.");
+        this.interceptors = Objects.requireNonNull(interceptors, "The dispatch interceptors must not be null.");
+        this.interceptingPublisher = new InterceptingPublisher(interceptors, this::publishEvent);
+    }
+
+    @Override
+    public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
+                                           @Nonnull List<EventMessage> events) {
+        return interceptingPublisher.interceptAndPublish(events, context);
+    }
+
+    private MessageStream.Empty<Message> publishEvent(@Nonnull Message message,
+                                                      @Nullable ProcessingContext context) {
+        if (!(message instanceof EventMessage event)) {
+            // The compiler should avoid this from happening.
+            throw new IllegalArgumentException("Unsupported message implementation: " + message);
+        }
+        return MessageStream.fromFuture(delegate.publish(context, event)
+                                                .thenApply(v -> null))
+                            .ignoreEntries();
+    }
+
+    @Override
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+        descriptor.describeProperty("dispatchInterceptors", interceptors);
+    }
+
+    private static class InterceptingPublisher {
+
+        private final DefaultMessageDispatchInterceptorChain<Message> interceptorChain;
+
+        private InterceptingPublisher(
+                List<MessageDispatchInterceptor<? super Message>> interceptors,
+                BiFunction<? super Message, ProcessingContext, MessageStream<?>> dispatcher
+        ) {
+            this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors, dispatcher);
+        }
+
+        private CompletableFuture<Void> interceptAndPublish(
+                @Nonnull List<EventMessage> events,
+                @Nullable ProcessingContext context
+        ) {
+
+            MessageStream<Message> resultStream = MessageStream.empty();
+            for (EventMessage event : events) {
+                resultStream = resultStream.concatWith(interceptorChain.proceed(event, context)
+                                                                       .cast());
+            }
+            return resultStream.ignoreEntries()
+                               .asCompletableFuture()
+                               .thenApply(v -> null);
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/InterceptingCommandBusTest.java
@@ -120,7 +120,7 @@ class InterceptingCommandBusTest {
 
         countingTestSubject.dispatch(firstCommand, StubProcessingContext.forMessage(firstCommand))
                            .get();
-        countingTestSubject.dispatch(secondCommand, StubProcessingContext.forMessage(firstCommand))
+        countingTestSubject.dispatch(secondCommand, StubProcessingContext.forMessage(secondCommand))
                            .get();
 
         assertThat(counter.get()).isEqualTo(2);

--- a/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurationDefaultsTest.java
+++ b/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurationDefaultsTest.java
@@ -30,6 +30,8 @@ import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.axonframework.commandhandling.gateway.ConvertingCommandGateway;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventhandling.EventBus;
+import org.axonframework.eventhandling.EventSink;
+import org.axonframework.eventhandling.InterceptingEventSink;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.eventhandling.conversion.EventConverter;
@@ -173,6 +175,18 @@ class MessagingConfigurationDefaultsTest {
         Configuration resultConfig = configurer.build();
 
         assertThat(resultConfig.getComponent(CommandBus.class)).isInstanceOf(InterceptingCommandBus.class);
+    }
+
+    @Test
+    void decoratorsEventSinkAsInterceptorEventSinkWhenDispatchInterceptorIsPresent() {
+        //noinspection unchecked
+        MessagingConfigurer configurer =
+                MessagingConfigurer.create()
+                                   .registerDispatchInterceptor(c -> mock(MessageDispatchInterceptor.class));
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventSink.class)).isInstanceOf(InterceptingEventSink.class);
     }
 
     private static class TestCommandBus implements CommandBus {

--- a/messaging/src/test/java/org/axonframework/eventhandling/InterceptingEventSinkTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/InterceptingEventSinkTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling;
+
+import org.axonframework.common.FutureUtils;
+import org.axonframework.common.infra.MockComponentDescriptor;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.MessageDispatchInterceptor;
+import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.unitofwork.StubProcessingContext;
+import org.axonframework.utils.MockException;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link InterceptingEventSink}.
+ *
+ * @author Steven van Beelen
+ */
+class InterceptingEventSinkTest {
+
+    private static final MessageType TEST_EVENT_TYPE = new MessageType("event");
+
+    private EventSink eventSink;
+    private AtomicInteger interceptorCounterOne;
+    private MessageDispatchInterceptor<Message> interceptorOne;
+    private AtomicInteger interceptorCounterTwo;
+    private MessageDispatchInterceptor<Message> interceptorTwo;
+
+    private InterceptingEventSink testSubject;
+
+    @BeforeEach
+    void setUp() {
+        eventSink = mock(EventSink.class);
+        //noinspection unchecked
+        when(eventSink.publish(any(), any(List.class)))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+        when(eventSink.publish(any(), any(EventMessage.class)))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+
+        interceptorCounterOne = new AtomicInteger(0);
+        interceptorOne = (message, context, chain) -> {
+            interceptorCounterOne.incrementAndGet();
+            return chain.proceed(message, context);
+        };
+        interceptorCounterTwo = new AtomicInteger(0);
+        interceptorTwo = (message, context, chain) -> {
+            interceptorCounterTwo.incrementAndGet();
+            return chain.proceed(message, context);
+        };
+
+        testSubject = new InterceptingEventSink(eventSink, List.of(interceptorOne, interceptorTwo));
+    }
+
+    @Test
+    void dispatchInterceptorsInvokedOnPublish() {
+        EventMessage testEvent = new GenericEventMessage(TEST_EVENT_TYPE, "test");
+
+        CompletableFuture<Void> result =
+                testSubject.publish(StubProcessingContext.forMessage(testEvent), testEvent);
+
+        ArgumentCaptor<EventMessage> publishedEvent = ArgumentCaptor.forClass(EventMessage.class);
+        verify(eventSink).publish(any(), publishedEvent.capture());
+
+        assertThat(publishedEvent.getValue()).isEqualTo(testEvent);
+        assertThat(interceptorCounterOne).hasValue(1);
+        assertThat(interceptorCounterTwo).hasValue(1);
+        assertThat(result).isDone();
+    }
+
+    @Test
+    void dispatchInterceptorsAreInvokedForEveryEvent() throws Exception {
+        EventMessage firstEvent = new GenericEventMessage(TEST_EVENT_TYPE, "first");
+        EventMessage secondEvent = new GenericEventMessage(TEST_EVENT_TYPE, "second");
+        EventMessage thirdEvent = new GenericEventMessage(TEST_EVENT_TYPE, "third");
+        EventMessage fourthEvent = new GenericEventMessage(TEST_EVENT_TYPE, "fourth");
+
+        testSubject.publish(null, firstEvent, secondEvent).get();
+        testSubject.publish(null, thirdEvent, fourthEvent).get();
+
+        assertThat(interceptorCounterOne.get()).isEqualTo(4);
+        assertThat(interceptorCounterTwo.get()).isEqualTo(4);
+    }
+
+    @Test
+    void exceptionsInDispatchInterceptorReturnFailedStream() {
+        EventMessage testEvent = new GenericEventMessage(TEST_EVENT_TYPE, "test");
+
+        MessageDispatchInterceptor<Message> faultyInterceptor = (message, context, chain) -> {
+            throw new MockException();
+        };
+        InterceptingEventSink faultyInterceptingEventSink =
+                new InterceptingEventSink(eventSink, List.of(faultyInterceptor));
+
+        CompletableFuture<Void> result = faultyInterceptingEventSink.publish(null, testEvent);
+
+        assertThat(result).isDone();
+        assertThat(result).isCompletedExceptionally();
+        assertThat(result.exceptionNow()).isInstanceOf(MockException.class);
+    }
+
+    @Test
+    void describeIncludesAllRelevantProperties() {
+        MockComponentDescriptor descriptor = new MockComponentDescriptor();
+
+        testSubject.describeTo(descriptor);
+
+        Map<String, Object> describedProperties = descriptor.getDescribedProperties();
+        assertThat(describedProperties).size().isEqualTo(2);
+        assertThat(describedProperties).containsKey("delegate");
+        assertThat(describedProperties.get("delegate")).isEqualTo(eventSink);
+        assertThat(describedProperties).containsKey("dispatchInterceptors");
+        //noinspection unchecked
+        List<MessageDispatchInterceptor<? super Message>> dispatchInterceptors =
+                (List<MessageDispatchInterceptor<? super Message>>) describedProperties.get("dispatchInterceptors");
+        assertThat(dispatchInterceptors).containsExactly(interceptorOne, interceptorTwo);
+    }
+}


### PR DESCRIPTION
This pull request introduces two new components dedicated to intercepting `EventMessages` during publication.
These components are:

1. The `InterceptingEventSink` - a decorator around the `EventSink`.
2. The `InterceptingEventStore` - a decorator around the `EventStore`.

Both implementation create the `MessageDispatchInterceptorChain` once, to safe on chain-calculation costs.
In that regard they are styled equal to the `InterceptingCommandBus` (and in doing so providing a common grounds on how we construct our intercepting infrastructure).
As such, the `InterceptingEventSink` has an internal `static class` (the `InterceptingPublisher`) to ensure the chain of interceptor is only constructed once.
The `InterceptingEventStore` has a similar construct to ensure appending events by the `EventStoreTransaction` is always done with the same chain instance.
Furthermore, the `InterceptingEventStore` constructs an `InterceptingEventSink` to ensure the `EventStore#publish` intercepting logic is not duplicated.

Both the `InterceptingEventSink` and `InterceptingEventStore` are registered as a decorator, in the `MessagingConfigurationDefaults` and `EventSourcingConfigurationDefaults` respectively.
On top of that, both the intercepting sink and store contain a public constant of their decoration order.

While working on this part of issue #3103, I made minor clean-up tweaks to the `IntereptingCommandBus` and `MessagingConfigurationDefaults` as well.

By doing the above, this pull request should be regarded as a part of #3103.