### PR TITLE
[#3577] Disable enhancer scanning for `BaseModule` implementations

### DIFF
--- a/messaging/src/main/java/org/axonframework/configuration/BaseModule.java
+++ b/messaging/src/main/java/org/axonframework/configuration/BaseModule.java
@@ -52,7 +52,10 @@ public abstract class BaseModule<S extends BaseModule<S>> implements Module {
 
     @Override
     public Configuration build(@Nonnull Configuration parent, @Nonnull LifecycleRegistry lifecycleRegistry) {
-        return postProcessConfiguration(componentRegistry.buildNested(parent, lifecycleRegistry));
+        return postProcessConfiguration(
+                componentRegistry.disableEnhancerScanning()
+                                 .buildNested(parent, lifecycleRegistry)
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request disable enhancer scanning in the `BaseModule`.
This is done to ensure disabled enhancers aren't accidentally enabled again for `Modules`.
Furthermore, this ensure we do not have Axon Server logging spammed for every `Module` we create while Axon Server is enabled.

This is a partial solution until issue #3577, which states `Modules` should inherit disabled enhancers from their parent, is resolved.