### PR TITLE
Set jackson-core to test scope so it isn't available transitively in eventsourcing module

### DIFF
--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -71,6 +71,11 @@
         <!-- Conversion -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Alternatively, we can not specifically set these to test at all since axon-messaging (on which eventsourcing depends) already needs them.