### PR TITLE
Revert "feat(event-sourcing): support `@EventCriteriaBuilder` detection in nested classes (#3538)

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/AnnotationBasedEventCriteriaResolverTest.java
@@ -335,29 +335,5 @@ class AnnotationBasedEventCriteriaResolverTest {
                 return EventCriteria.havingTags("aggregateIdentifier", id);
             }
         }
-
-        @Test
-        void canResolveEventCriteriaBuilderInNestedStaticClass() {
-            var resolver = new AnnotationBasedEventCriteriaResolver<>(
-                    EntityWithNestedStaticClass.class,
-                    Object.class,
-                    configuration
-            );
-
-            var criteria = resolver.resolve("nestedId", new StubProcessingContext());
-            assertEquals(EventCriteria.havingTags("nestedAggregateIdentifier", "nestedId"), criteria);
-        }
-
-        @EventSourcedEntity
-        static class EntityWithNestedStaticClass {
-
-            @SuppressWarnings("unused")
-            static class NestedClass {
-                @EventCriteriaBuilder
-                public static EventCriteria buildCriteria(String id) {
-                    return EventCriteria.havingTags("nestedAggregateIdentifier", id);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Reverting because of the bug:
https://github.com/AxonFramework/AxonFramework/issues/3680