### PR TITLE
The EventBuffer should rethrow InterruptExceptions

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/EventBuffer.java
@@ -137,7 +137,7 @@ public class EventBuffer implements TrackingEventStream {
     }
 
     @Override
-    public boolean hasNextAvailable(int timeout, TimeUnit timeUnit) {
+    public boolean hasNextAvailable(int timeout, TimeUnit timeUnit) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
         try {
             while (peekNullable() == null && System.currentTimeMillis() < deadline) {
@@ -162,7 +162,7 @@ public class EventBuffer implements TrackingEventStream {
         } catch (InterruptedException e) {
             logger.warn("Event consumer thread was interrupted. Returning thread to event processor.", e);
             Thread.currentThread().interrupt();
-            return false;
+            throw e;
         }
     }
 
@@ -180,7 +180,7 @@ public class EventBuffer implements TrackingEventStream {
     }
 
     @Override
-    public TrackedEventMessage<?> nextAvailable() {
+    public TrackedEventMessage<?> nextAvailable() throws InterruptedException {
         try {
             hasNextAvailable(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
             return peekEvent == null ? eventStream.next() : peekEvent;

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventBufferTest.java
@@ -97,7 +97,7 @@ class EventBufferTest {
 
     @Test
     @Timeout(value = 450, unit = TimeUnit.MILLISECONDS)
-    void dataUpcastAndDeserialized() {
+    void dataUpcastAndDeserialized() throws InterruptedException {
         assertFalse(testSubject.hasNextAvailable());
         eventStream.onNext(TEST_EVENT_WITH_TOKEN);
         assertTrue(testSubject.hasNextAvailable());
@@ -105,7 +105,7 @@ class EventBufferTest {
         TrackedEventMessage<?> peeked =
                 testSubject.peek().orElseThrow(() -> new AssertionError("Expected value to be available"));
         assertEquals(new GlobalSequenceTrackingToken(1L), peeked.trackingToken());
-        assertTrue(peeked instanceof DomainEventMessage<?>);
+        assertInstanceOf(DomainEventMessage.class, peeked);
 
         assertTrue(testSubject.hasNextAvailable());
         assertTrue(testSubject.hasNextAvailable(1, TimeUnit.SECONDS));


### PR DESCRIPTION
Instead of simply returning false on isAvailable, the EventBuffer should rethrow an InterruptException to ensure proper downstream handling.

In the TrackingEventProcessor, this resulted in an indefinite retry flow without backoff.