### PR TITLE
Replace TokenStore Builders

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStore.java
@@ -38,16 +38,13 @@ import org.axonframework.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.management.ManagementFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +53,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 import static org.axonframework.common.jdbc.JdbcUtils.*;
@@ -85,36 +81,28 @@ public class JdbcTokenStore implements TokenStore {
     private final Class<?> contentType;
 
     /**
-     * Instantiate a {@link JdbcTokenStore} based on the fields contained in the {@link Builder}.
+     * Instantiate a {@code JdbcTokenStore} based on the fields contained in the
+     * {@link JdbcTokenStoreConfiguration configuration}.
      * <p>
-     * Will assert that the {@link ConnectionProvider}, {@link Serializer}, {@link TokenSchema}, {@code claimTimeout},
-     * {@code nodeId} and {@code contentType} are not {@code null}, and will throw an {@link AxonConfigurationException}
-     * if any of them is {@code null}.
+     * Will assert that the {@link ConnectionProvider}, {@link Serializer} and {@link JdbcTokenStoreConfiguration} are
+     * not {@code null}, otherwise an {@link AxonConfigurationException} will be thrown.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link JdbcTokenStore} instance
+     * @param connectionProvider The {@link ConnectionProvider} used to provide connections to the underlying database.
+     * @param serializer         The {@link Serializer} used to de-/serialize {@link TrackingToken}'s with.
+     * @param configuration      The {@link JdbcTokenStoreConfiguration} used to instantiate a {@code JdbcTokenStore}
+     *                           instance
      */
-    protected JdbcTokenStore(Builder builder) {
-        builder.validate();
-        this.connectionProvider = builder.connectionProvider;
-        this.serializer = builder.serializer;
-        this.schema = builder.schema;
-        this.claimTimeout = builder.claimTimeout;
-        this.nodeId = builder.nodeId;
-        this.contentType = builder.contentType;
-    }
-
-    /**
-     * Instantiate a Builder to be able to create a {@link JdbcTokenStore}.
-     * <p>
-     * The {@code schema} is defaulted to an {@link TokenSchema}, the {@code claimTimeout} to a 10 seconds duration,
-     * {@code nodeId} is defaulted to the name of the managed bean for the runtime system of the Java virtual machine
-     * and the {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and
-     * {@link Serializer} are <b>hard requirements</b> and as such should be provided.
-     *
-     * @return a Builder to be able to create a {@link JdbcTokenStore}
-     */
-    public static Builder builder() {
-        return new Builder();
+    public JdbcTokenStore(@Nonnull ConnectionProvider connectionProvider, @Nonnull Serializer serializer,
+                          @Nonnull JdbcTokenStoreConfiguration configuration) {
+        assertNonNull(connectionProvider, "The ConnectionProvider is a hard requirement and should be provided");
+        assertNonNull(serializer, "The Serializer is a hard requirement and should be provided");
+        assertNonNull(configuration, "The JdbcTokenStoreConfiguration should be provided");
+        this.connectionProvider = connectionProvider;
+        this.serializer = serializer;
+        this.schema = configuration.schema();
+        this.claimTimeout = configuration.claimTimeout();
+        this.nodeId = configuration.nodeId();
+        this.contentType = configuration.contentType();
     }
 
     /**
@@ -883,127 +871,6 @@ public class JdbcTokenStore implements TokenStore {
             return connectionProvider.getConnection();
         } catch (SQLException e) {
             throw new JdbcException("Failed to obtain a database connection", e);
-        }
-    }
-
-    /**
-     * Builder class to instantiate a {@link JdbcTokenStore}.
-     * <p>
-     * The {@code schema} is defaulted to an {@link TokenSchema}, the {@code claimTimeout} to a 10 seconds duration,
-     * {@code nodeId} is defaulted to the name of the managed bean for the runtime system of the Java virtual machine
-     * and the {@code contentType} to a {@code byte[]} {@link Class}. The {@link ConnectionProvider} and
-     * {@link Serializer} are <b>hard requirements</b> and as such should be provided.
-     */
-    public static class Builder {
-
-        private ConnectionProvider connectionProvider;
-        private Serializer serializer;
-        private TokenSchema schema = new TokenSchema();
-        private TemporalAmount claimTimeout = Duration.ofSeconds(10);
-        private String nodeId = ManagementFactory.getRuntimeMXBean().getName();
-        private Class<?> contentType = byte[].class;
-
-        /**
-         * Sets the {@link ConnectionProvider} used to provide connections to the underlying database.
-         *
-         * @param connectionProvider a {@link ConnectionProvider} used to provide connections to the underlying
-         *                           database
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder connectionProvider(ConnectionProvider connectionProvider) {
-            assertNonNull(connectionProvider, "ConnectionProvider may not be null");
-            this.connectionProvider = connectionProvider;
-            return this;
-        }
-
-        /**
-         * Sets the {@link Serializer} used to de-/serialize {@link TrackingToken}s with.
-         *
-         * @param serializer a {@link Serializer} used to de-/serialize {@link TrackingToken}s with
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder serializer(Serializer serializer) {
-            assertNonNull(serializer, "Serializer may not be null");
-            this.serializer = serializer;
-            return this;
-        }
-
-        /**
-         * Sets the {@code schema} which describes a JDBC token entry for this {@link TokenStore}. Defaults to a default
-         * {@link TokenSchema} instance.
-         *
-         * @param schema a {@link TokenSchema} which describes a JDBC token entry for this {@link TokenStore}
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder schema(TokenSchema schema) {
-            assertNonNull(schema, "TokenSchema may not be null");
-            this.schema = schema;
-            return this;
-        }
-
-        /**
-         * Sets the {@code claimTimeout} specifying the amount of time this process will wait after which this process
-         * will force a claim of a {@link TrackingToken}. Thus if a claim has not been updated for the given
-         * {@code claimTimeout}, this process will 'steal' the claim. Defaults to a duration of 10 seconds.
-         *
-         * @param claimTimeout a timeout specifying the time after which this process will force a claim
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder claimTimeout(TemporalAmount claimTimeout) {
-            assertNonNull(claimTimeout, "The claim timeout may not be null");
-            this.claimTimeout = claimTimeout;
-            return this;
-        }
-
-        /**
-         * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to the name of the managed bean for the
-         * runtime system of the Java virtual machine
-         *
-         * @param nodeId the id as a {@link String} to identify ownership of the tokens
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder nodeId(String nodeId) {
-            assertNodeId(nodeId, "The nodeId may not be null or empty");
-            this.nodeId = nodeId;
-            return this;
-        }
-
-        /**
-         * Sets the {@code contentType} to which a {@link TrackingToken} should be serialized. Defaults to a
-         * {@code byte[]} {@link Class} type.
-         *
-         * @param contentType the content type as a {@link Class }to which a {@link TrackingToken} should be serialized
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder contentType(Class<?> contentType) {
-            assertNonNull(contentType, "The content type may not be null");
-            this.contentType = contentType;
-            return this;
-        }
-
-        /**
-         * Initializes a {@link JdbcTokenStore} as specified through this Builder.
-         *
-         * @return a {@link JdbcTokenStore} as specified through this Builder
-         */
-        public JdbcTokenStore build() {
-            return new JdbcTokenStore(this);
-        }
-
-        /**
-         * Validates whether the fields contained in this Builder are set accordingly.
-         *
-         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
-         *                                    specifications
-         */
-        protected void validate() throws AxonConfigurationException {
-            assertNonNull(connectionProvider, "The ConnectionProvider is a hard requirement and should be provided");
-            assertNonNull(serializer, "The Serializer is a hard requirement and should be provided");
-            assertNodeId(nodeId, "The nodeId is a hard requirement and should be provided");
-        }
-
-        private void assertNodeId(String nodeId, String exceptionMessage) {
-            assertThat(nodeId, name -> Objects.nonNull(name) && !"".equals(name), exceptionMessage);
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStoreConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStoreConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.processors.streaming.token.store.jdbc;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
+import org.axonframework.eventhandling.processors.streaming.token.store.TokenStore;
+
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.time.temporal.TemporalAmount;
+import java.util.Objects;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.common.BuilderUtils.assertThat;
+import static org.axonframework.common.ObjectUtils.getOrDefault;
+
+/**
+ * Configuration for the {@link JdbcTokenStore}.
+ * <p>
+ * Can be used to modify the {@link JdbcTokenStore}'s settings.
+ *
+ * @param schema       a {@link TokenSchema} which describes a JDBC token entry for this {@link TokenStore}.
+ * @param claimTimeout a timeout specifying the time after which this process will force a claim.
+ * @param nodeId       the id as a {@link String} to identify ownership of the tokens.
+ * @param contentType  the content type as a {@link Class} to which a {@link TrackingToken} should be serialized.
+ * @author Jens Mayer
+ * @since 5.0.0
+ */
+public record JdbcTokenStoreConfiguration(
+        @Nullable TokenSchema schema,
+        @Nullable TemporalAmount claimTimeout,
+        @Nullable String nodeId,
+        @Nullable Class<?> contentType
+) {
+
+    /**
+     * A {@code JdbcTokenStoreConfiguration} instance with the following default values:
+     * <ul>
+     *     <li>The {@code schema} defaults to {@code new TokenSchema()}</li>
+     *     <li>The {@code claimTimeout} defaults to 10 seconds</li>
+     *     <li>The {@code nodeId} defaults to the name of the managed bean for the runtime system of the Java virtual machine</li>
+     *     <li>The {@code contentType} defaults to a {@code byte[]}-{@link Class}</li>
+     * </ul>
+     */
+    public static final JdbcTokenStoreConfiguration DEFAULT = new JdbcTokenStoreConfiguration(null, null, null, null);
+
+    /**
+     * Compact constructor setting defaults.
+     */
+    @SuppressWarnings("MissingJavadoc")
+    public JdbcTokenStoreConfiguration {
+        schema = getOrDefault(schema, new TokenSchema());
+        claimTimeout = getOrDefault(claimTimeout, Duration.ofSeconds(10));
+        nodeId = getOrDefault(nodeId, ManagementFactory.getRuntimeMXBean().getName());
+        assertNodeId(nodeId, "The nodeId may not be empty");
+        contentType = getOrDefault(contentType, byte[].class);
+    }
+
+    /**
+     * Sets the {@code schema} which describes a JDBC token entry for this {@link TokenStore}. Defaults to a default
+     * {@link TokenSchema} instance.
+     *
+     * @param schema a {@link TokenSchema} which describes a JDBC token entry for this {@link TokenStore}
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JdbcTokenStoreConfiguration schema(@Nonnull TokenSchema schema) {
+        assertNonNull(schema, "TokenSchema may not be null");
+        return new JdbcTokenStoreConfiguration(schema,
+                                               claimTimeout,
+                                               nodeId,
+                                               contentType);
+    }
+
+    /**
+     * Sets the {@code claimTimeout} specifying the amount of time a process will wait after which this process will
+     * force a claim of a {@link TrackingToken}. Thus, if a claim has not been updated for the given
+     * {@code claimTimeout}, this process will 'steal' the claim. Defaults to a duration of 10 seconds.
+     *
+     * @param claimTimeout a timeout specifying the time after which this process will force a claim
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JdbcTokenStoreConfiguration claimTimeout(@Nonnull TemporalAmount claimTimeout) {
+        assertNonNull(claimTimeout, "The claim timeout may not be null");
+        return new JdbcTokenStoreConfiguration(schema,
+                                               claimTimeout,
+                                               nodeId,
+                                               contentType);
+    }
+
+    /**
+     * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to the name of the managed bean for the
+     * runtime system of the Java virtual machine.
+     *
+     * @param nodeId the id as a {@link String} to identify ownership of the tokens
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JdbcTokenStoreConfiguration nodeId(@Nonnull String nodeId) {
+        assertNodeId(nodeId, "The nodeId may not be null or empty");
+        return new JdbcTokenStoreConfiguration(schema,
+                                               claimTimeout,
+                                               nodeId,
+                                               contentType);
+    }
+
+    /**
+     * Sets the {@code contentType} to which a {@link TrackingToken} should be serialized. Defaults to a {@code byte[]}
+     * {@link Class} type.
+     *
+     * @param contentType the content type as a {@link Class} to which a {@link TrackingToken} should be serialized
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JdbcTokenStoreConfiguration contentType(@Nonnull Class<?> contentType) {
+        assertNonNull(contentType, "The content type may not be null");
+        return new JdbcTokenStoreConfiguration(schema,
+                                               claimTimeout,
+                                               nodeId,
+                                               contentType);
+    }
+
+    private void assertNodeId(String nodeId, String exceptionMessage) {
+        assertThat(nodeId, name -> Objects.nonNull(name) && !name.isEmpty(), exceptionMessage);
+    }
+
+}

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jpa/JpaTokenStoreConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/token/store/jpa/JpaTokenStoreConfiguration.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventhandling.processors.streaming.token.store.jpa;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.LockModeType;
+import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
+
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.time.temporal.TemporalAmount;
+import java.util.Objects;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.common.BuilderUtils.assertThat;
+import static org.axonframework.common.ObjectUtils.getOrDefault;
+
+/**
+ * Configuration for the {@link JpaTokenStore}.
+ * <p>
+ * Can be used to modify the {@link JpaTokenStore}'s settings.
+ *
+ * @param loadingLockMode The lock mode to use when retrieving tokens from the underlying store.
+ * @param claimTimeout    A timeout specifying the time after which this process will force a claim.
+ * @param nodeId          The id as a {@link String} to identify ownership of the tokens.
+ * @author Jens Mayer
+ * @since 5.0.0
+ */
+public record JpaTokenStoreConfiguration(
+        @Nullable LockModeType loadingLockMode,
+        @Nullable TemporalAmount claimTimeout,
+        @Nullable String nodeId
+) {
+
+    /**
+     * A {@code JpaTokenStoreConfiguration} instance with the following default values:
+     * <ul>
+     *     <li>The {@code loadingLockMode} defaults to {@link LockModeType#PESSIMISTIC_WRITE}</li>
+     *     <li>The {@code claimTimeout} defaults to 10 seconds</li>
+     *     <li>The {@code nodeId} defaults to the name of the managed bean for the runtime system of the Java virtual machine</li>
+     * </ul>
+     */
+    public static JpaTokenStoreConfiguration DEFAULT = new JpaTokenStoreConfiguration(null, null, null);
+
+    /**
+     * Compact constructor setting defaults.
+     */
+    @SuppressWarnings("MissingJavadoc")
+    public JpaTokenStoreConfiguration {
+        loadingLockMode = getOrDefault(loadingLockMode, LockModeType.PESSIMISTIC_WRITE);
+        claimTimeout = getOrDefault(claimTimeout, Duration.ofSeconds(10));
+        nodeId = getOrDefault(nodeId, ManagementFactory.getRuntimeMXBean().getName());
+        assertNodeId(nodeId, "The nodeId may not be empty");
+    }
+
+    /**
+     * The {@link LockModeType} to use when loading tokens from the underlying database. Defaults to
+     * {@code LockModeType.PESSIMISTIC_WRITE}, to force a write lock, which prevents lock upgrading and potential
+     * resulting deadlocks.
+     *
+     * @param loadingLockMode The lock mode to use when retrieving tokens from the underlying store.
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JpaTokenStoreConfiguration loadingLockMode(LockModeType loadingLockMode) {
+        assertNonNull(loadingLockMode, "The loading lock mode may not be null");
+        return new JpaTokenStoreConfiguration(loadingLockMode, claimTimeout, nodeId);
+    }
+
+    /**
+     * Sets the {@code claimTimeout} specifying the amount of time a process will wait after which this process will
+     * force a claim of a {@link TrackingToken}. Thus, if a claim has not been updated for the given
+     * {@code claimTimeout}, this process will 'steal' the claim. Defaults to a duration of 10 seconds.
+     *
+     * @param claimTimeout A timeout specifying the time after which this process will force a claim.
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JpaTokenStoreConfiguration claimTimeout(TemporalAmount claimTimeout) {
+        assertNonNull(claimTimeout, "The claim timeout may not be null");
+        return new JpaTokenStoreConfiguration(loadingLockMode, claimTimeout, nodeId);
+    }
+
+    /**
+     * Sets the {@code nodeId} to identify ownership of the tokens. Defaults to the name of the managed bean for the
+     * runtime system of the Java virtual machine.
+     *
+     * @param nodeId The id as a {@link String} to identify ownership of the tokens
+     * @return The configuration itself, for fluent API usage.
+     */
+    public JpaTokenStoreConfiguration nodeId(String nodeId) {
+        assertNodeId(nodeId, "The nodeId may not be null or empty");
+        return new JpaTokenStoreConfiguration(loadingLockMode, claimTimeout, nodeId);
+    }
+
+    private void assertNodeId(String nodeId, String exceptionMessage) {
+        assertThat(nodeId, name -> Objects.nonNull(name) && !name.isEmpty(), exceptionMessage);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/token/store/jdbc/JdbcTokenStoreTest.java
@@ -57,7 +57,6 @@ import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -605,30 +604,27 @@ class JdbcTokenStoreTest {
 
         @Bean
         public JdbcTokenStore tokenStore(DataSource dataSource) {
-            return JdbcTokenStore.builder()
-                                 .connectionProvider(dataSource::getConnection)
-                                 .serializer(TestSerializer.JACKSON.getSerializer())
-                                 .build();
+            return new JdbcTokenStore(dataSource::getConnection,
+                                      TestSerializer.JACKSON.getSerializer(),
+                                      JdbcTokenStoreConfiguration.DEFAULT);
         }
 
         @Bean
         public JdbcTokenStore concurrentTokenStore(DataSource dataSource) {
-            return JdbcTokenStore.builder()
-                                 .connectionProvider(dataSource::getConnection)
-                                 .serializer(TestSerializer.JACKSON.getSerializer())
-                                 .claimTimeout(Duration.ofSeconds(2))
-                                 .nodeId("concurrent")
-                                 .build();
+            var config = JdbcTokenStoreConfiguration.DEFAULT
+                    .claimTimeout(Duration.ofSeconds(2))
+                    .nodeId("concurrent");
+            return new JdbcTokenStore(dataSource::getConnection,
+                                      TestSerializer.JACKSON.getSerializer(), config);
         }
 
         @Bean
         public JdbcTokenStore stealingTokenStore(DataSource dataSource) {
-            return JdbcTokenStore.builder()
-                                 .connectionProvider(dataSource::getConnection)
-                                 .serializer(TestSerializer.JACKSON.getSerializer())
-                                 .claimTimeout(Duration.ofSeconds(-1))
-                                 .nodeId("stealing")
-                                 .build();
+            var config = JdbcTokenStoreConfiguration.DEFAULT
+                    .claimTimeout(Duration.ofSeconds(-1))
+                    .nodeId("stealing");
+            return new JdbcTokenStore(dataSource::getConnection,
+                                      TestSerializer.JACKSON.getSerializer(), config);
         }
 
         @Bean

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/JpaAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue;
 import org.axonframework.eventhandling.processors.streaming.token.store.TokenStore;
 import org.axonframework.eventhandling.processors.streaming.token.store.jpa.JpaTokenStore;
+import org.axonframework.eventhandling.processors.streaming.token.store.jpa.JpaTokenStoreConfiguration;
 import org.axonframework.eventsourcing.eventstore.jpa.SQLErrorCodesResolver;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.springboot.EventProcessorProperties;
@@ -74,11 +75,8 @@ public class JpaAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public TokenStore tokenStore(Serializer serializer, EntityManagerProvider entityManagerProvider) {
-        return JpaTokenStore.builder()
-                            .entityManagerProvider(entityManagerProvider)
-                            .serializer(serializer)
-                            .claimTimeout(tokenStoreProperties.getClaimTimeout())
-                            .build();
+        var config = JpaTokenStoreConfiguration.DEFAULT.claimTimeout(tokenStoreProperties.getClaimTimeout());
+        return new JpaTokenStore(entityManagerProvider,serializer, config);
     }
 
     @Bean

--- a/spring/src/test/java/org/axonframework/spring/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
+++ b/spring/src/test/java/org/axonframework/spring/eventhandling/tokenstore/jpa/JpaTokenStoreTest.java
@@ -23,6 +23,7 @@ import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.common.transaction.Transaction;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.eventhandling.processors.streaming.token.store.jpa.JpaTokenStore;
+import org.axonframework.eventhandling.processors.streaming.token.store.jpa.JpaTokenStoreConfiguration;
 import org.axonframework.eventhandling.processors.streaming.token.store.jpa.TokenEntry;
 import org.axonframework.serialization.json.JacksonSerializer;
 import org.hibernate.dialect.HSQLDialect;
@@ -141,21 +142,14 @@ class JpaTokenStoreTest {
 
         @Bean
         public JpaTokenStore jpaTokenStore(EntityManagerProvider entityManagerProvider) {
-            return JpaTokenStore.builder()
-                    .entityManagerProvider(entityManagerProvider)
-                    .serializer(JacksonSerializer.defaultSerializer())
-                    .nodeId("local")
-                    .build();
+            var config = JpaTokenStoreConfiguration.DEFAULT.nodeId("local");
+            return new JpaTokenStore(entityManagerProvider, JacksonSerializer.defaultSerializer(), config);
         }
 
         @Bean
         public JpaTokenStore stealingJpaTokenStore(EntityManagerProvider entityManagerProvider) {
-            return JpaTokenStore.builder()
-                    .entityManagerProvider(entityManagerProvider)
-                    .serializer(JacksonSerializer.defaultSerializer())
-                    .claimTimeout(Duration.ofSeconds(-1))
-                    .nodeId("stealing")
-                    .build();
+            var config = JpaTokenStoreConfiguration.DEFAULT.nodeId("stealing").claimTimeout(Duration.ofSeconds(-1));
+            return new JpaTokenStore(entityManagerProvider, JacksonSerializer.defaultSerializer(), config);
         }
 
         @Bean

--- a/todo/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/todo/src/main/java/org/axonframework/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.axonframework.eventhandling.deadletter.jdbc.DeadLetterSchema;
 import org.axonframework.eventhandling.deadletter.jdbc.JdbcSequencedDeadLetterQueue;
 import org.axonframework.eventhandling.processors.streaming.token.store.TokenStore;
 import org.axonframework.eventhandling.processors.streaming.token.store.jdbc.JdbcTokenStore;
+import org.axonframework.eventhandling.processors.streaming.token.store.jdbc.JdbcTokenStoreConfiguration;
 import org.axonframework.eventhandling.processors.streaming.token.store.jdbc.TokenSchema;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.LegacyEventStorageEngine;
@@ -116,12 +117,10 @@ public class JdbcAutoConfiguration {
     @ConditionalOnMissingBean(TokenStore.class)
     public TokenStore tokenStore(ConnectionProvider connectionProvider, Serializer serializer,
                                  TokenSchema tokenSchema) {
-        return JdbcTokenStore.builder()
-                             .connectionProvider(connectionProvider)
+        var config = JdbcTokenStoreConfiguration.DEFAULT
                              .schema(tokenSchema)
-                             .serializer(serializer)
-                             .claimTimeout(tokenStoreProperties.getClaimTimeout())
-                             .build();
+                             .claimTimeout(tokenStoreProperties.getClaimTimeout());
+        return new JdbcTokenStore(connectionProvider::getConnection, serializer, config);
     }
 
 //    @Bean


### PR DESCRIPTION
Replaces the Builder classes in `JpaTokenStore` and `JdbcTokenStore` with corresponding `Configuration` classes. While the hard requirements are implemented as constructor parameters, everything else is located in the `Configuration` classes, allowing us to declare static defaults.