### PR TITLE
chore: make functional interface

### DIFF
--- a/messaging/src/main/java/org/axonframework/common/property/Property.java
+++ b/messaging/src/main/java/org/axonframework/common/property/Property.java
@@ -24,6 +24,7 @@ package org.axonframework.common.property;
  * @author Allard Buijze
  * @since 2.0
  */
+@FunctionalInterface
 public interface Property<T> {
 
     /**


### PR DESCRIPTION
Property declares only one method and making it a functionl interface helps to implement a custom Property (for example when creating a custom PropertyAccessStrategy).