### PR TITLE
Clean-up `ErrorHandler` API

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/ErrorContext.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/ErrorContext.java
@@ -16,62 +16,42 @@
 
 package org.axonframework.eventhandling.processors.errorhandling;
 
-import java.util.List;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.Context;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
- * Describes the context of an error.
+ * Describes the context of an error caught by an {@link org.axonframework.eventhandling.processors.EventProcessor}
+ * while processing a batch of events.
  *
+ * @param eventProcessor The name of the {@link org.axonframework.eventhandling.processors.EventProcessor} that failed
+ *                       to process the given {@code failedEvents}.
+ * @param error          The error that was raised during processing of the {@code failedEvents}.
+ * @param failedEvents   The list of events that triggered the error.
+ * @param context        The {@code Context} carrying the resources that applied for the given {@code failedEvents} when
+ *                       they were handled.
  * @author Allard Buijze
- * @since 3.0
+ * @since 3.0.0
  */
-public class ErrorContext {
-
-    private final String eventProcessor;
-    private final Throwable error;
-    private final List<? extends EventMessage> failedEvents;
-
-    /**
-     * Instantiate an ErrorContext for the given {@code eventProcessor}, due to the given {@code error}, with the given
-     * {@code failedEvents}.
-     *
-     * @param eventProcessor the name of the event processor that failed to process the given events
-     * @param error          the error that was raised during processing
-     * @param failedEvents   the list of events that triggered the error
-     */
-    public ErrorContext(@Nonnull String eventProcessor, @Nonnull Throwable error,
-                        @Nonnull List<? extends EventMessage> failedEvents) {
-        this.eventProcessor = eventProcessor;
-        this.error = error;
-        this.failedEvents = failedEvents;
-    }
+public record ErrorContext(
+        @Nonnull String eventProcessor,
+        @Nonnull Throwable error,
+        @Nonnull List<? extends EventMessage> failedEvents,
+        @Nonnull Context context
+) {
 
     /**
-     * Returns the name of the Event Processor where the error occurred.
-     *
-     * @return the name of the Event Processor where the error occurred
+     * Compact constructor of the {@code ErrorContext} to validate the {@code eventProcessor}, {@code error},
+     * {@code failedEvents}, and {@code context} are not null.
      */
-    public String eventProcessor() {
-        return eventProcessor;
-    }
-
-    /**
-     * Returns the error that was raised in the processor
-     *
-     * @return the error that was raised in the processor
-     */
-    public Throwable error() {
-        return error;
-    }
-
-    /**
-     * The events part of the batch that failed. May be empty if an error occurred outside of the scope of processing a
-     * batch (e.g. while preparing the next batch).
-     *
-     * @return events part of the batch that failed, if any
-     */
-    public List<? extends EventMessage> failedEvents() {
-        return failedEvents;
+    @SuppressWarnings("MissingJavadoc")
+    public ErrorContext {
+        Objects.requireNonNull(eventProcessor, "The event processor must not be null.");
+        Objects.requireNonNull(error, "The error must not be null.");
+        Objects.requireNonNull(failedEvents, "The failed events must not be null.");
+        Objects.requireNonNull(context, "The context must not be null.");
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/ErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/ErrorHandler.java
@@ -20,29 +20,37 @@ import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.processors.streaming.pooled.PooledStreamingEventProcessor;
 
 /**
- * Interface of the error handler that will be invoked if event processing fails. The error handler is generally invoked
- * by an EventProcessor when the UnitOfWork created to coordinate the event processing was rolled back.
+ * Interface of the error handler that will be invoked if event processing fails.
+ * <p>
+ * The error handler is generally invoked by an {@link org.axonframework.eventhandling.processors.EventProcessor} when
+ * the {@link org.axonframework.messaging.unitofwork.ProcessingContext} created to coordinate the event processing was
+ * rolled back.
  *
  * @author Rene de Waele
+ * @since 3.0.0
  */
+@FunctionalInterface
 public interface ErrorHandler {
 
     /**
-     * Handle an error raised during event processing. Generally this means that the UnitOfWork created to coordinate
-     * the event processing was rolled back. Using default configuration the ErrorHandler is only invoked when there is
-     * a serious error, for instance when the database transaction connected to the UnitOfWork can not be committed.
+     * Handle an error raised during event processing.
      * <p>
-     * The error handler has the option to simply log or ignore the error. Depending on the type of EventProcessor this
-     * will put an end to the processing of any further events (in case of a {@link PooledStreamingEventProcessor}) or simply
-     * skip over the list of given {@code failedEvents}.
+     * Generally this means that the {@link org.axonframework.messaging.unitofwork.ProcessingContext} created to
+     * coordinate the event processing was rolled back. Using default configuration the {@code ErrorHandler} is only
+     * invoked when there is a serious error, for instance when the database transaction connected to the
+     * {@code ProcessingContext} can not be committed.
      * <p>
-     * Note that although the UnitOfWork and hence any related database transactions have been rolled back when the
-     * error handler is invoked, the processing of one or more of the failedEvents may in fact have caused other side
-     * effects which could not be reverted.
+     * The error handler has the option to simply log or ignore the error. Depending on the type of
+     * {@code EventProcessor} this will put an end to the processing of any further events (in case of a
+     * {@link PooledStreamingEventProcessor}) or simply skip over the list of {@code failedEvents} in the given
+     * {@code errorContext}.
+     * <p>
+     * Note that although the {@code ProcessingContext} and hence any related database transactions have been rolled
+     * back when the error handler is invoked, the processing of one or more of the {@link ErrorContext#failedEvents()}
+     * may in fact have caused other side effects which could not be reverted.
      *
-     * @param errorContext Contextual information describing the error
-     * @throws Exception if the handler decides to propagate the error
+     * @param errorContext Contextual information describing the error.
+     * @throws Exception If this handler decides to propagate the error.
      */
     void handleError(@Nonnull ErrorContext errorContext) throws Exception;
-
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/PropagatingErrorHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/errorhandling/PropagatingErrorHandler.java
@@ -20,9 +20,10 @@ import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.processors.EventProcessingException;
 
 /**
- * Singleton ErrorHandler implementation that does not do anything.
+ * An {@link ErrorHandler} implementation that rethrows the {@link ErrorContext#error() ErrorContext exception}.
  *
  * @author Rene de Waele
+ * @since 3.0.0
  */
 public enum PropagatingErrorHandler implements ErrorHandler {
 
@@ -32,9 +33,9 @@ public enum PropagatingErrorHandler implements ErrorHandler {
     INSTANCE;
 
     /**
-     * Singleton instance of a {@link PropagatingErrorHandler}.
+     * Singleton instance of a {@code PropagatingErrorHandler}.
      *
-     * @return the singleton instance of {@link PropagatingErrorHandler}
+     * @return The singleton instance of {@code PropagatingErrorHandler}
      */
     public static PropagatingErrorHandler instance() {
         return INSTANCE;
@@ -48,7 +49,7 @@ public enum PropagatingErrorHandler implements ErrorHandler {
         } else if (error instanceof Exception) {
             throw (Exception) error;
         } else {
-            throw new EventProcessingException("An error occurred while handling an event", error);
+            throw new EventProcessingException("An error occurred while handling an event.", error);
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/DefaultWorkPackageEventFilter.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/DefaultWorkPackageEventFilter.java
@@ -18,11 +18,11 @@ package org.axonframework.eventhandling.processors.streaming.pooled;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.common.annotations.Internal;
-import org.axonframework.eventhandling.processors.errorhandling.ErrorContext;
-import org.axonframework.eventhandling.processors.errorhandling.ErrorHandler;
 import org.axonframework.eventhandling.EventHandlingComponent;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.processors.ProcessorEventHandlingComponents;
+import org.axonframework.eventhandling.processors.errorhandling.ErrorContext;
+import org.axonframework.eventhandling.processors.errorhandling.ErrorHandler;
 import org.axonframework.eventhandling.processors.streaming.segmenting.Segment;
 import org.axonframework.eventhandling.processors.streaming.segmenting.SegmentMatcher;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
@@ -69,7 +69,7 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
      * @param eventMessage The message for which to identify if the processor can handle it.
      * @param segment      The segment for which the event should be processed.
      * @return {@code true} if the event message should be handled, otherwise {@code false}.
-     * @throws Exception if the {@code errorHandler} throws an Exception back on the
+     * @throws Exception If the {@code errorHandler} throws an Exception back on the
      *                   {@link ErrorHandler#handleError(ErrorContext)} call.
      */
     @Override
@@ -85,10 +85,13 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
                 return false;
             }
             var sequenceIdentifiers = eventHandlingComponents.sequenceIdentifiersFor(eventMessage, context);
-            return sequenceIdentifiers.stream()
-                                      .anyMatch(identifier -> new SegmentMatcher((e, ctx) -> Optional.of(identifier)).matches(segment, eventMessage, context));
+            return sequenceIdentifiers.stream().anyMatch(identifier -> new SegmentMatcher(
+                    (e, ctx) -> Optional.of(identifier)).matches(segment, eventMessage, context)
+            );
         } catch (Exception e) {
-            errorHandler.handleError(new ErrorContext(eventProcessor, e, Collections.singletonList(eventMessage)));
+            errorHandler.handleError(
+                    new ErrorContext(eventProcessor, e, Collections.singletonList(eventMessage), context)
+            );
             return false;
         }
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessor.java
@@ -353,15 +353,14 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
         return eventHandlingComponents.handle(events, context)
                                       .onErrorContinue(ex -> {
                                           try {
-                                              configuration.errorHandler().handleError(new ErrorContext(name,
-                                                                                                        ex,
-                                                                                                        events));
+                                              configuration.errorHandler()
+                                                           .handleError(new ErrorContext(name, ex, events, context));
                                           } catch (RuntimeException re) {
                                               return MessageStream.failed(re);
                                           } catch (Exception e) {
                                               return MessageStream.failed(new EventProcessingException(
-                                                      "Exception occurred while processing events",
-                                                      e));
+                                                      "Exception occurred while processing events", e
+                                              ));
                                           }
                                           return MessageStream.empty().cast();
                                       })

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/subscribing/SubscribingEventProcessor.java
@@ -72,10 +72,12 @@ public class SubscribingEventProcessor implements EventProcessor {
      *     <li>A {@link SubscribableMessageSource}.</li>
      * </ul>
      * If any of these is not present or does not comply to the requirements an {@link AxonConfigurationException} is thrown.
-
-     * @param name A {@link String} defining this {@link EventProcessor} instance.
-     * @param eventHandlingComponents The {@link EventHandlingComponent}s which will handle all the individual {@link EventMessage}s.
-     * @param configuration The {@link SubscribingEventProcessorConfiguration} used to configure a {@code SubscribingEventProcessor} instance.
+     *
+     * @param name                    A {@link String} defining this {@link EventProcessor} instance.
+     * @param eventHandlingComponents The {@link EventHandlingComponent}s which will handle all the individual
+     *                                {@link EventMessage}s.
+     * @param configuration           The {@link SubscribingEventProcessorConfiguration} used to configure a
+     *                                {@code SubscribingEventProcessor} instance.
      */
     public SubscribingEventProcessor(
             @Nonnull String name,
@@ -151,13 +153,13 @@ public class SubscribingEventProcessor implements EventProcessor {
         return eventHandlingComponents.handle(events, context)
                                       .onErrorContinue(ex -> {
                                           try {
-                                              errorHandler.handleError(new ErrorContext(name, ex, events));
+                                              errorHandler.handleError(new ErrorContext(name, ex, events, context));
                                           } catch (RuntimeException re) {
                                               return MessageStream.failed(re);
                                           } catch (Exception e) {
                                               return MessageStream.failed(new EventProcessingException(
-                                                      "Exception occurred while processing events",
-                                                      e));
+                                                      "Exception occurred while processing events", e
+                                              ));
                                           }
                                           return MessageStream.empty().cast();
                                       })

--- a/messaging/src/test/java/org/axonframework/eventhandling/processors/errorhandling/PropagatingErrorHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/processors/errorhandling/PropagatingErrorHandlerTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventhandling.processors.errorhandling;
 
 import org.axonframework.eventhandling.processors.EventProcessingException;
+import org.axonframework.messaging.Context;
 import org.axonframework.utils.MockException;
 import org.junit.jupiter.api.*;
 
@@ -24,32 +25,43 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validating the {@link PropagatingErrorHandler}.
+ *
+ * @author Allard Buijze
+ */
 class PropagatingErrorHandlerTest {
 
-    private PropagatingErrorHandler testSubject = PropagatingErrorHandler.instance();
+    private final PropagatingErrorHandler testSubject = PropagatingErrorHandler.instance();
 
     @Test
-    void handleErrorRethrowsOriginalWhenError() throws Exception {
-        ErrorContext context = new ErrorContext("test", new MockError(), Collections.emptyList());
+    void handleErrorRethrowsOriginalWhenError() {
+        ErrorContext context = new ErrorContext("test", new MockError(), Collections.emptyList(), Context.empty());
 
         assertThrows(MockError.class, () -> testSubject.handleError(context));
     }
 
     @Test
-    void handleErrorRethrowsOriginalWhenException() throws Exception {
-        ErrorContext context = new ErrorContext("test", new MockException(), Collections.emptyList());
+    void handleErrorRethrowsOriginalWhenException() {
+        ErrorContext context = new ErrorContext("test", new MockException(), Collections.emptyList(), Context.empty());
 
         assertThrows(MockException.class, () -> testSubject.handleError(context));
     }
 
     @Test
-    void handleErrorWrapsOriginalWhenThrowable() throws Exception {
-        ErrorContext context = new ErrorContext("test", new Throwable("Unknown"), Collections.emptyList());
+    void handleErrorWrapsOriginalWhenThrowable() {
+        ErrorContext context = new ErrorContext("test",
+                                                new Throwable("Unknown"),
+                                                Collections.emptyList(),
+                                                Context.empty());
 
         assertThrows(EventProcessingException.class, () -> testSubject.handleError(context));
     }
 
     private static class MockError extends Error {
-        public MockError() {super("Mock");}
+
+        public MockError() {
+            super("Mock");
+        }
     }
 }

--- a/todo/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
+++ b/todo/src/main/java/org/axonframework/eventhandling/deadletter/DeadLetteringEventHandlerInvoker.java
@@ -29,6 +29,7 @@ import org.axonframework.eventhandling.processors.errorhandling.PropagatingError
 import org.axonframework.eventhandling.processors.streaming.segmenting.Segment;
 import org.axonframework.eventhandling.sequencing.SequencingPolicy;
 import org.axonframework.eventhandling.sequencing.SequentialPerAggregatePolicy;
+import org.axonframework.messaging.Context;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.deadletter.DeadLetter;
 import org.axonframework.messaging.deadletter.Decisions;
@@ -285,7 +286,7 @@ public class DeadLetteringEventHandlerInvoker
             // Otherwise, faulty events would not be dead lettered.
             super.listenerInvocationErrorHandler(
                     (exception, event, eventHandler) -> PropagatingErrorHandler.instance().handleError(
-                            new ErrorContext("processor", exception, List.of(event))
+                            new ErrorContext("processor", exception, List.of(event), Context.empty())
                     )
             );
         }


### PR DESCRIPTION
This pull request does a number of small things to prepare the `ErrorHandler` (for event processing) for the upcoming 5.0.0 release, being:

- Make the `ErrorHandler` a functional interface.
- Make the `ErrorContext` a `record`.
- Add `Context` to the `ErrorContext`, so that Unit of Work resources are present.
- Clean-up JavaDoc.
- Clean-up usages of the `ErrorContext`.