### PR TITLE
Send-and-wait API clean-up on the `CommandGateway`

### DIFF
--- a/legacy-saga/src/test/java/org/axonframework/test/saga/StubSaga.java
+++ b/legacy-saga/src/test/java/org/axonframework/test/saga/StubSaga.java
@@ -31,9 +31,7 @@ import org.axonframework.modelling.saga.SagaEventHandler;
 import org.axonframework.modelling.saga.SagaLifecycle;
 import org.axonframework.modelling.saga.StartSaga;
 
-import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -124,7 +122,7 @@ public class StubSaga {
     @SagaEventHandler(associationProperty = "identifier")
     public void handleTriggerEvent(TimerTriggeredEvent event, ProcessingContext context) {
         handledEvents.add(event);
-        String result = commandGateway.send("Say hi!", context, String.class).join();
+        String result = commandGateway.send("Say hi!", String.class, context).join();
         if (result != null) {
             commandGateway.send(result, context);
         }

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -89,6 +89,26 @@ public interface CommandGateway extends DescribableComponent {
     }
 
     /**
+     * Send the given {@code command} and waits for completion.
+     * <p>
+     * If the command was successful, its result (if any) is discarded. If it was unsuccessful an exception is thrown.
+     * Any checked exceptions that may occur as the result of running the command will be wrapped in a
+     * {@link CommandExecutionException}.
+     * <p>
+     * If the result is needed, use {@link #sendAndWait(Object, Class)} instead, as it allows for type conversion of the
+     * result payload.
+     *
+     * @param command The command payload or {@link org.axonframework.commandhandling.CommandMessage} to send.
+     * @param context The processing context, if any, to dispatch the given {@code command} in.
+     * @return The payload of the result message, or {@code null} when none is present.
+     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     */
+    @Nullable
+    default Object sendAndWait(@Nonnull Object command, @Nullable ProcessingContext context) {
+        return sendAndWait(command, Object.class, context);
+    }
+
+    /**
      * Send the given {@code command} and waits for the result converted to the {@code resultType}.
      * <p>
      * If the command was successful, its result will be converted to the specified {@code returnType} and returned. If
@@ -104,7 +124,28 @@ public interface CommandGateway extends DescribableComponent {
     @Nullable
     default <R> R sendAndWait(@Nonnull Object command,
                               @Nonnull Class<R> resultType) {
-        return send(command, null).wait(resultType);
+        return sendAndWait(command, resultType, null);
+    }
+
+    /**
+     * Send the given {@code command} and waits for the result converted to the {@code resultType}.
+     * <p>
+     * If the command was successful, its result will be converted to the specified {@code returnType} and returned. If
+     * it was unsuccessful or conversion failed, an exception is thrown. Any checked exceptions that may occur as the
+     * result of running the command will be wrapped in a {@link CommandExecutionException}.
+     *
+     * @param command    The command payload or {@link org.axonframework.commandhandling.CommandMessage} to send.
+     * @param resultType The class representing the type of the expected command result.
+     * @param context    The processing context, if any, to dispatch the given {@code command} in.
+     * @param <R>        The generic type of the expected response.
+     * @return The payload of the result message of type {@code R}, or {@code null} when none is present.
+     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     */
+    @Nullable
+    default <R> R sendAndWait(@Nonnull Object command,
+                              @Nonnull Class<R> resultType,
+                              @Nullable ProcessingContext context) {
+        return send(command, context).wait(resultType);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandGateway.java
@@ -55,21 +55,22 @@ public interface CommandGateway extends DescribableComponent {
      * {@code CommandMessage} is constructed from that message's payload and
      * {@link org.axonframework.messaging.Metadata}.
      *
-     * @param command    The command payload or {@link org.axonframework.commandhandling.CommandMessage} to send.
-     * @param context    The processing context, if any, to dispatch the given {@code command} in.
-     * @param resultType The class representing the type of the expected command result.
      * @param <R>        The generic type of the expected response.
+     * @param command    The command payload or {@link CommandMessage} to send.
+     * @param resultType The class representing the type of the expected command result.
+     * @param context    The processing context, if any, to dispatch the given {@code command} in.
      * @return A {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
      * command execution result.
      */
+    @Nonnull
     default <R> CompletableFuture<R> send(@Nonnull Object command,
-                                          @Nullable ProcessingContext context,
-                                          @Nonnull Class<R> resultType) {
+                                          @Nonnull Class<R> resultType,
+                                          @Nullable ProcessingContext context) {
         return send(command, context).resultAs(resultType);
     }
 
     /**
-     * Send the given command and waits for completion.
+     * Send the given {@code command} and waits for completion.
      * <p>
      * If the command was successful, its result (if any) is discarded. If it was unsuccessful an exception is thrown.
      * Any checked exceptions that may occur as the result of running the command will be wrapped in a
@@ -79,14 +80,16 @@ public interface CommandGateway extends DescribableComponent {
      * result payload.
      *
      * @param command The command payload or {@link org.axonframework.commandhandling.CommandMessage} to send.
+     * @return The payload of the result message, or {@code null} when none is present.
      * @throws CommandExecutionException When a checked exception occurs while handling the command.
      */
-    default void sendAndWait(@Nonnull Object command) {
-        sendAndWait(command, Object.class);
+    @Nullable
+    default Object sendAndWait(@Nonnull Object command) {
+        return sendAndWait(command, Object.class);
     }
 
     /**
-     * Send the given command and waits for the result.
+     * Send the given {@code command} and waits for the result converted to the {@code resultType}.
      * <p>
      * If the command was successful, its result will be converted to the specified {@code returnType} and returned. If
      * it was unsuccessful or conversion failed, an exception is thrown. Any checked exceptions that may occur as the
@@ -95,9 +98,10 @@ public interface CommandGateway extends DescribableComponent {
      * @param command    The command payload or {@link org.axonframework.commandhandling.CommandMessage} to send.
      * @param resultType The class representing the type of the expected command result.
      * @param <R>        The generic type of the expected response.
-     * @return The payload of the result message of type {@code R}.
+     * @return The payload of the result message of type {@code R}, or {@code null} when none is present.
      * @throws CommandExecutionException When a checked exception occurs while handling the command.
      */
+    @Nullable
     default <R> R sendAndWait(@Nonnull Object command,
                               @Nonnull Class<R> resultType) {
         return send(command, null).wait(resultType);
@@ -126,6 +130,7 @@ public interface CommandGateway extends DescribableComponent {
      * @return A command result success and failure hooks can be registered. The
      * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
      */
+    @Nonnull
     CommandResult send(@Nonnull Object command,
                        @Nullable ProcessingContext context);
 
@@ -154,6 +159,7 @@ public interface CommandGateway extends DescribableComponent {
      * @return A command result success and failure hooks can be registered. The
      * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
      */
+    @Nonnull
     CommandResult send(@Nonnull Object command,
                        @Nonnull Metadata metadata,
                        @Nullable ProcessingContext context);

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandResult.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/CommandResult.java
@@ -17,10 +17,12 @@
 package org.axonframework.commandhandling.gateway;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.commandhandling.CommandExecutionException;
 import org.axonframework.messaging.Message;
 import org.axonframework.serialization.ConversionException;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -145,5 +147,35 @@ public interface CommandResult {
             }
         });
         return this;
+    }
+
+    /**
+     * Waits for the result of command handling, cast to the given {@code type}.
+     *
+     * @param resultType The expected result type of command handling.
+     * @param <R>        The type of the command result.
+     * @return The result of command handling, cast to the given {@code type}.
+     */
+    default <R> R wait(@Nonnull Class<R> resultType) {
+        try {
+            return resultAs(resultType).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CommandExecutionException("Thread interrupted while waiting for result", e);
+        } catch (ExecutionException e) {
+            throw rethrowUnwrappedExecutionException(e);
+        }
+    }
+
+    private static RuntimeException rethrowUnwrappedExecutionException(
+            @Nonnull ExecutionException executionException
+    ) {
+        if (executionException.getCause() instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (executionException.getCause() instanceof Error error) {
+            throw error;
+        }
+        throw new CommandExecutionException("Checked exception while handling command.", executionException.getCause());
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/ConvertingCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/ConvertingCommandGateway.java
@@ -55,12 +55,14 @@ public class ConvertingCommandGateway implements CommandGateway {
     }
 
     @Override
+    @Nonnull
     public CommandResult send(@Nonnull Object command,
                               @Nullable ProcessingContext context) {
         return new ConvertingCommandResult(converter, delegate.send(command, context));
     }
 
     @Override
+    @Nonnull
     public CommandResult send(@Nonnull Object command,
                               @Nonnull Metadata metadata,
                               @Nullable ProcessingContext context) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/gateway/DefaultCommandGateway.java
@@ -74,6 +74,7 @@ public class DefaultCommandGateway implements CommandGateway {
     }
 
     @Override
+    @Nonnull
     public CommandResult send(@Nonnull Object command,
                               @Nullable ProcessingContext context) {
         CommandMessage commandMessage = asCommandMessage(command, Metadata.emptyInstance());
@@ -88,6 +89,7 @@ public class DefaultCommandGateway implements CommandGateway {
     }
 
     @Override
+    @Nonnull
     public CommandResult send(@Nonnull Object command,
                               @Nonnull Metadata metadata,
                               @Nullable ProcessingContext context) {

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/ContextAwareCommandDispatcherTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/ContextAwareCommandDispatcherTest.java
@@ -69,7 +69,7 @@ class ContextAwareCommandDispatcherTest {
         when(commandGateway.send(any(), eq(context)))
                 .thenReturn(() -> messageOneFuture)
                 .thenReturn(() -> messageTwoFuture);
-        when(commandGateway.send(any(), any(), eq(context)))
+        when(commandGateway.send(any(), any(Metadata.class), eq(context)))
                 .thenReturn(() -> messageOneFuture)
                 .thenReturn(() -> messageTwoFuture);
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/ConvertingCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/ConvertingCommandGatewayTest.java
@@ -75,7 +75,7 @@ class ConvertingCommandGatewayTest {
 
         when(mockConverter.convert(any(), eq((Type) byte[].class))).thenReturn(HELLO_BYTES);
 
-        CompletableFuture<byte[]> actual = testSubject.send("Test", null, byte[].class);
+        CompletableFuture<byte[]> actual = testSubject.send("Test", byte[].class, null);
         assertTrue(actual.isDone());
         assertArrayEquals(HELLO_BYTES, actual.get());
     }

--- a/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/gateway/DefaultCommandGatewayTest.java
@@ -167,6 +167,27 @@ class DefaultCommandGatewayTest {
         ));
         TestPayload payload = new TestPayload();
         // when...
+        Object result = testSubject.sendAndWait(payload);
+        // then...
+        assertThat(result).isEqualTo(expectedResult);
+        verify(mockCommandBus).dispatch(
+                argThat(m -> {
+                    Object resultPayload = m.payload();
+                    return resultPayload != null && resultPayload.equals(payload);
+                }),
+                isNull()
+        );
+    }
+
+    @Test
+    void sendAndWaitForResultTypeReturnsExpectedResult() {
+        // given...
+        String expectedResult = "OK";
+        when(mockCommandBus.dispatch(any(), any())).thenAnswer(i -> CompletableFuture.completedFuture(
+                new GenericCommandResultMessage(new MessageType("result"), expectedResult)
+        ));
+        TestPayload payload = new TestPayload();
+        // when...
         String result = testSubject.sendAndWait(payload, String.class);
         // then...
         assertThat(result).isEqualTo(expectedResult);


### PR DESCRIPTION
This pull request adjusts some minor pointers on the `CommandGateway` as preparation for the upcoming 5.0.0 release, being:

1. The `CommandResult` has a `wait(Class<R> resultType)` operation, which the `CommandGateway` uses on all `sendAndWait` invocations.
2. The `CommandGateway#sendAndWait(Object)` returns a nullable `Object` for consistency sake. Users may not care for the response, but then they can ignore it.
3. Add `ProcessingContext` versions of the `sendAndWait(Object)` and `sendAndWait(Object, Class<R>)` (so both with a `@Nullable ProcessingContext` parameter). Doing so aligns the `sendAndWait` operations with the other gateway operations we have.
4. Clean-up the JavaDoc throughout.
5. Add `@Nullable` and `@Nonnull` on the return values of all methods on the `CommandGateway`
6. Add tests to validate the new behavior.
7. Ensure the `@Nullable ProcessingContext` is the last parameter on all methods (when applicable).