### PR TITLE
Move static factory methods for reactor types to MessageStreamUtils

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTrans
 import org.axonframework.eventstreaming.EventCriteria;
 import org.axonframework.eventstreaming.StreamingCondition;
 import org.axonframework.eventstreaming.Tag;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.LegacyResources;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageStream.Entry;
@@ -150,7 +151,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         MessageStream<EventMessage> result =
                 testSubject.stream(StreamingCondition.startingFrom(trackingTokenAt(0)), processingContext());
 
-        StepVerifier.create(result.asFlux())
+        StepVerifier.create(FluxUtils.of(result))
                     .assertNext(entry -> assertTrackedEntry(entry, expectedEventOne.event(), 1))
                     .assertNext(entry -> assertTrackedEntry(entry, expectedEventTwo.event(), 2))
                     .expectNextCount(2)
@@ -180,7 +181,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         MessageStream<EventMessage> result =
                 testSubject.stream(StreamingCondition.startingFrom(trackingTokenAt(2)), processingContext());
 
-        StepVerifier.create(result.asFlux())
+        StepVerifier.create(FluxUtils.of(result))
                     // we've skipped the first two
                     .expectNextCount(2).assertNext(entry -> assertTrackedEntry(entry, expectedEventThree.event(), 5))
                     .expectNextCount(2).thenCancel().verify();
@@ -235,7 +236,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
             taggedEventMessage("event-0", TEST_AGGREGATE_TAGS)
         );
 
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext())))
                     .expectNextMatches(entryWithAggregateEvent("event-0", 0))
                     .expectNextMatches(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
                     .verifyComplete();
@@ -256,7 +257,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
             )
         );
 
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext())))
                     .expectNextMatches(entryWithAggregateEvent("event-0", 0))
                     .expectNextMatches(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
                     .verifyComplete();
@@ -281,7 +282,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
             taggedEventMessage("event-6", OTHER_AGGREGATE_TAGS)
         );
 
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext())))
                     .expectNextMatches(entryWithAggregateEvent("event-0", 0))
                     .expectNextMatches(entryWithAggregateEvent("event-1", 1))
                     .expectNextMatches(entryWithAggregateEvent("event-2", 2))
@@ -300,7 +301,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
             taggedEventMessage("event-4", Set.of())
         );
 
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext())))
                     .expectNextMatches(entryWithAggregateEvent("event-1", 0))
                     .expectNextMatches(entryWithAggregateEvent("event-3", 1))
                     .expectNextMatches(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
@@ -316,7 +317,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
             taggedEventMessage("event-6", TEST_AGGREGATE_TAGS)
         );
 
-        StepVerifier.create(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA), processingContext())))
                     .expectNextMatches(entryWithAggregateEvent("event-4", 0))
                     .expectNextMatches(entryWithAggregateEvent("event-5", 1))
                     .expectNextMatches(entryWithAggregateEvent("event-6", 2))
@@ -339,7 +340,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         SourcingCondition testCondition =
                 SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
 
-        StepVerifier.create(testSubject.source(testCondition, processingContext()).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.source(testCondition, processingContext())))
                     .expectNextCount(6)
                     .assertNext(entry -> assertEquals(appendMarker, entry.getResource(ConsistencyMarker.RESOURCE_KEY)))
                     .verifyComplete();
@@ -365,7 +366,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         SourcingCondition testCondition = SourcingCondition.conditionFor(1, TEST_AGGREGATE_CRITERIA);
         MessageStream<EventMessage> result = testSubject.source(testCondition, processingContext());
         // then...
-        StepVerifier.create(result.asFlux())
+        StepVerifier.create(FluxUtils.of(result))
                     .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payloadAs(String.class)))
                     .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payloadAs(String.class)))
                     .assertNext(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
@@ -400,7 +401,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         }
 
         // then...
-        StepVerifier.create(source.asFlux())
+        StepVerifier.create(FluxUtils.of(source))
                     .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payloadAs(String.class)))
                     .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payloadAs(String.class)))
                     .consumeNextWith(entry -> actual.add(entry.map(this::convertPayload).message().payloadAs(String.class)))
@@ -421,7 +422,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
                 SourcingCondition.conditionFor(0, TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
         MessageStream<EventMessage> result = testSubject.source(testCondition, processingContext());
         // then...
-        StepVerifier.create(result.asFlux())
+        StepVerifier.create(FluxUtils.of(result))
                     .assertNext(entry -> assertEquals(
                             expectedMarker, entry.getResource(ConsistencyMarker.RESOURCE_KEY)
                     ))

--- a/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/CompletionCallbackMessageStream.java
@@ -17,7 +17,6 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
-import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -53,12 +52,6 @@ class CompletionCallbackMessageStream<M extends Message> extends DelegatingMessa
         this.delegate = delegate;
         this.completeHandler = completeHandler;
         delegate.onAvailable(this::invokeCompletionHandlerIfCompleted);
-    }
-
-    @Override
-    public Flux<Entry<M>> asFlux() {
-        return delegate.asFlux()
-                       .doOnComplete(completeHandler);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ConcatenatingMessageStream.java
@@ -17,7 +17,6 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
-import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -54,12 +53,6 @@ class ConcatenatingMessageStream<M extends Message> implements MessageStream<M> 
     }
 
     @Override
-    public Flux<Entry<M>> asFlux() {
-        return first.asFlux()
-                    .concatWith(second.asFlux());
-    }
-
-    @Override
     public Optional<Entry<M>> next() {
         if (first.isCompleted() && first.error().isEmpty()) {
             return second.next();
@@ -85,7 +78,7 @@ class ConcatenatingMessageStream<M extends Message> implements MessageStream<M> 
 
     @Override
     public boolean isCompleted() {
-        return first.isCompleted() && second.isCompleted();
+        return first.isCompleted() && (second.isCompleted() || first.error().isPresent());
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/DelayedMessageStream.java
@@ -17,8 +17,6 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -104,11 +102,6 @@ public class DelayedMessageStream<M extends Message> implements MessageStream<M>
             }
         }
         return new DelayedMessageStream.Single<>(safeDelegate);
-    }
-
-    @Override
-    public Flux<Entry<M>> asFlux() {
-        return Mono.fromFuture(delegate).flatMapMany(MessageStream::asFlux);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/EmptyMessageStream.java
@@ -18,7 +18,6 @@ package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.common.FutureUtils;
-import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -52,11 +51,6 @@ class EmptyMessageStream implements MessageStream.Empty<Message> {
     @Override
     public CompletableFuture<Entry<Message>> asCompletableFuture() {
         return FutureUtils.emptyCompletedFuture();
-    }
-
-    @Override
-    public Flux<Entry<Message>> asFlux() {
-        return Flux.empty();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FailedMessageStream.java
@@ -17,7 +17,6 @@
 package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
-import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -48,11 +47,6 @@ class FailedMessageStream<M extends Message> implements MessageStream.Empty<M> {
     @Override
     public CompletableFuture<Entry<M>> asCompletableFuture() {
         return CompletableFuture.failedFuture(error);
-    }
-
-    @Override
-    public Flux<Entry<M>> asFlux() {
-        return Flux.error(error);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxMessageStream.java
@@ -60,11 +60,6 @@ class FluxMessageStream<M extends Message> implements MessageStream<M> {
     }
 
     @Override
-    public Flux<Entry<M>> asFlux() {
-        return source;
-    }
-
-    @Override
     public <RM extends Message> MessageStream<RM> map(@Nonnull Function<Entry<M>, Entry<RM>> mapper) {
         return new FluxMessageStream<>(source.map(mapper));
     }
@@ -167,7 +162,7 @@ class FluxMessageStream<M extends Message> implements MessageStream<M> {
 
     @Override
     public MessageStream<M> onErrorContinue(@Nonnull Function<Throwable, MessageStream<M>> onError) {
-        return new FluxMessageStream<>(source.onErrorResume(exception -> onError.apply(exception).asFlux()));
+        return new FluxMessageStream<>(source.onErrorResume(exception -> FluxUtils.of(onError.apply(exception))));
     }
 
 }

--- a/messaging/src/main/java/org/axonframework/messaging/FluxUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/FluxUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.messaging.MessageStream.Entry;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+/**
+ * Utility methods to work with Project Reactor's {@link Flux fluxes}.
+ *
+ * @author John Hendrikx
+ * @since 5.0.0
+ */
+public abstract class FluxUtils {
+
+    private FluxUtils() {
+    }
+
+    /**
+     * Creates a Flux containing the {@link MessageStream.Entry entries} provided by the given {@code source}. Note that
+     * multiple invocations of this method on the same {@code source}, or otherwise any components consuming entries
+     * from the given {@code source} will cause entries to be consumed by only one of the fluxes or competing
+     * consumers.
+     *
+     * @param source The MessageStream providing the elements.
+     * @param <M>    The type of Message returned by the source.
+     * @return A Flux with the elements provided by the source.
+     */
+    public static <M extends Message> Flux<MessageStream.Entry<M>> of(@Nonnull MessageStream<M> source) {
+        return Flux.create(emitter -> {
+            FluxStreamAdapter<M> fluxTask = new FluxStreamAdapter<>(source, emitter);
+            emitter.onRequest(i -> fluxTask.process());
+            emitter.onCancel(source::close);
+            source.onAvailable(fluxTask::process);
+        });
+    }
+
+    /**
+     * Create a stream that provides the {@link Message Messages} returned by the given {@code flux}, automatically
+     * wrapped in an {@link Entry}.
+     *
+     * @param flux The {@link Flux} providing the {@link Message Messages} to stream.
+     * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream of {@link Entry entries} that returns the {@link Message Messages} provided by the given
+     *     {@code flux}.
+     */
+    public static <M extends Message> MessageStream<M> asMessageStream(@Nonnull Flux<M> flux) {
+        return asMessageStream(flux, message -> Context.empty());
+    }
+
+    /**
+     * Create a stream that provides the {@link Message Messages} returned by the given {@code flux}, automatically
+     * wrapped in an {@link Entry} with the resulting {@link Context} from the {@code contextSupplier}.
+     *
+     * @param flux            The {@link Flux} providing the {@link Message Messages} to stream.
+     * @param contextSupplier A {@link Function} ingesting each {@link Message} from the given {@code flux} returning
+     *                        the {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
+     * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream of {@link Entry entries} that returns the {@link Message Messages} provided by the given
+     * {@code flux} with a {@link Context} provided by the {@code contextSupplier}.
+     */
+    public static <M extends Message> MessageStream<M> asMessageStream(@Nonnull Flux<M> flux,
+                                                                       @Nonnull Function<M, Context> contextSupplier) {
+        return new FluxMessageStream<>(flux.map(message -> new SimpleEntry<>(message, contextSupplier.apply(message))));
+    }
+
+    static class FluxStreamAdapter<M extends Message> {
+
+        private final AtomicBoolean processingGate = new AtomicBoolean(false);
+        private final MessageStream<M> source;
+        private final FluxSink<MessageStream.Entry<M>> emitter;
+
+        public FluxStreamAdapter(MessageStream<M> source, FluxSink<MessageStream.Entry<M>> emitter) {
+            this.source = source;
+            this.emitter = emitter;
+        }
+
+        public void process() {
+            if (!processingGate.getAndSet(true)) {
+                try {
+                    long remaining = emitter.requestedFromDownstream();
+
+                    while (remaining-- > 0 && source.hasNextAvailable() && !emitter.isCancelled()) {
+                        source.next().ifPresent(emitter::next);
+                    }
+
+                    if (source.isCompleted()) {
+                        source.error().ifPresentOrElse(emitter::error, emitter::complete);
+                    }
+                } catch (Exception e) {
+                    emitter.error(e);
+                    source.close();
+                } finally {
+                    processingGate.set(false);
+                }
+            }
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MessageStream.java
@@ -18,8 +18,6 @@ package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +72,7 @@ public interface MessageStream<M extends Message> {
      * {@code iterable} with a {@link Context} provided by the {@code contextSupplier}.
      */
     static <M extends Message> MessageStream<M> fromIterable(@Nonnull Iterable<M> iterable,
-                                                                @Nonnull Function<M, Context> contextSupplier) {
+                                                             @Nonnull Function<M, Context> contextSupplier) {
         return new IteratorMessageStream<>(StreamSupport.stream(iterable.spliterator(), false)
                                                         .<Entry<M>>map(message -> new SimpleEntry<>(message,
                                                                                                     contextSupplier.apply(
@@ -113,7 +111,7 @@ public interface MessageStream<M extends Message> {
      * {@code stream} with a {@link Context} provided by the {@code contextSupplier}.
      */
     static <M extends Message> MessageStream<M> fromStream(@Nonnull Stream<M> stream,
-                                                              @Nonnull Function<M, Context> contextSupplier) {
+                                                           @Nonnull Function<M, Context> contextSupplier) {
         return new IteratorMessageStream<>(stream.map(m -> (Entry<M>) new SimpleEntry<>(m, contextSupplier.apply(m)))
                                                  .iterator());
     }
@@ -142,75 +140,11 @@ public interface MessageStream<M extends Message> {
      * {@code messageSupplier} with a {@link Context} provided by the {@code contextSupplier}.
      */
     static <T, M extends Message> MessageStream<M> fromStream(@Nonnull Stream<T> stream,
-                                                                 @Nonnull Function<T, M> messageSupplier,
-                                                                 @Nonnull Function<T, Context> contextSupplier) {
+                                                              @Nonnull Function<T, M> messageSupplier,
+                                                              @Nonnull Function<T, Context> contextSupplier) {
         return new IteratorMessageStream<>(stream.map(item -> new SimpleEntry<>(messageSupplier.apply(item),
                                                                                 contextSupplier.apply(item)))
                                                  .iterator());
-    }
-
-    /**
-     * Create a stream that provides the {@link Message Messages} returned by the given {@code flux}, automatically
-     * wrapped in an {@link Entry}.
-     *
-     * @param flux The {@link Flux} providing the {@link Message Messages} to stream.
-     * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
-     * @return A stream of {@link Entry entries} that returns the {@link Message Messages} provided by the given
-     * {@code flux}.
-     */
-    static <M extends Message> MessageStream<M> fromFlux(@Nonnull Flux<M> flux) {
-        return fromFlux(flux, message -> Context.empty());
-    }
-
-    /**
-     * Create a stream that provides the {@link Message Messages} returned by the given {@code flux}, automatically
-     * wrapped in an {@link Entry} with the resulting {@link Context} from the {@code contextSupplier}.
-     *
-     * @param flux            The {@link Flux} providing the {@link Message Messages} to stream.
-     * @param contextSupplier A {@link Function} ingesting each {@link Message} from the given {@code flux} returning
-     *                        the {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
-     * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
-     * @return A stream of {@link Entry entries} that returns the {@link Message Messages} provided by the given
-     * {@code flux} with a {@link Context} provided by the {@code contextSupplier}.
-     */
-    static <M extends Message> MessageStream<M> fromFlux(@Nonnull Flux<M> flux,
-                                                            @Nonnull Function<M, Context> contextSupplier) {
-        return new FluxMessageStream<>(flux.map(message -> new SimpleEntry<>(message, contextSupplier.apply(message))));
-    }
-
-    /**
-     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
-     * {@code mono}, once the given {@code mono} completes.
-     * <p>
-     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
-     * stream will complete with an exception when the given {@code mono} completes exceptionally.
-     *
-     * @param mono The {@link Mono} providing the {@link Message} to contain in the stream.
-     * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
-     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
-     */
-    static <M extends Message> Single<M> fromMono(@Nonnull Mono<M> mono) {
-        return fromFuture(mono.toFuture());
-    }
-
-    /**
-     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
-     * {@code mono}, once the given {@code mono} completes.
-     * <p>
-     * The automatically generated {@code Entry} will have the {@link Context} as given by the {@code contextSupplier}.
-     * <p>
-     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
-     * stream will complete with an exception when the given {@code mono} completes exceptionally.
-     *
-     * @param mono            The {@link Mono} providing the {@link Message} to contain in the stream.
-     * @param contextSupplier A {@link Function} ingesting the {@link Message} from the given {@code mono} returning the
-     *                        {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
-     * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
-     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
-     */
-    static <M extends Message> Single<M> fromMono(@Nonnull Mono<M> mono,
-                                                  @Nonnull Function<M, Context> contextSupplier) {
-        return fromFuture(mono.toFuture(), contextSupplier);
     }
 
     /**
@@ -245,7 +179,7 @@ public interface MessageStream<M extends Message> {
      * provided by the {@code contextSupplier}.
      */
     static <M extends Message> Single<M> fromFuture(@Nonnull CompletableFuture<M> future,
-                                                       @Nonnull Function<M, Context> contextSupplier) {
+                                                    @Nonnull Function<M, Context> contextSupplier) {
         return new SingleValueMessageStream<>(
                 future.thenApply(message -> new SimpleEntry<>(message, contextSupplier.apply(message)))
         );
@@ -277,7 +211,7 @@ public interface MessageStream<M extends Message> {
      * {@link Context} provided by the {@code contextSupplier}.
      */
     static <M extends Message> Single<M> just(@Nullable M message,
-                                                 @Nonnull Function<M, Context> contextSupplier) {
+                                              @Nonnull Function<M, Context> contextSupplier) {
         return new SingleValueMessageStream<>(new SimpleEntry<>(message, contextSupplier.apply(message)));
     }
 
@@ -307,18 +241,6 @@ public interface MessageStream<M extends Message> {
      */
     static Empty<Message> empty() {
         return EmptyMessageStream.instance();
-    }
-
-    /**
-     * Creates a {@link Flux} that consumes the {@link Entry entries} from this stream.
-     * <p>
-     * The returned {@code Flux} will complete successfully if the stream does so, and exceptionally if the stream
-     * completed with an error.
-     *
-     * @return A {@link Flux} carrying the {@link Entry entries} of this stream.
-     */
-    default Flux<Entry<M>> asFlux() {
-        return MessageStreamUtils.asFlux(this);
     }
 
     /**
@@ -620,9 +542,9 @@ public interface MessageStream<M extends Message> {
             return new CompletionCallbackMessageStream.Single<>(this, completeHandler);
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         default <R extends Message> Single<R> cast() {
-            //noinspection unchecked
             return (Single<R>) this;
         }
 
@@ -641,18 +563,6 @@ public interface MessageStream<M extends Message> {
          */
         default CompletableFuture<Entry<M>> asCompletableFuture() {
             return MessageStreamUtils.asCompletableFuture(this);
-        }
-
-        /**
-         * Creates a {@link Mono} that consumes the singular {@link Entry} from this stream.
-         * <p>
-         * The returned {@code Mono} will complete successfully if the stream does so, and exceptionally if the stream
-         * completed with an error.
-         *
-         * @return A {@link Mono} carrying the singular {@link Entry} of this stream.
-         */
-        default Mono<Entry<M>> asMono() {
-            return asFlux().singleOrEmpty();
         }
     }
 
@@ -704,9 +614,9 @@ public interface MessageStream<M extends Message> {
             return new CompletionCallbackMessageStream.Empty<>(this, completeHandler);
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         default <T extends Message> Empty<T> cast() {
-            //noinspection unchecked
             return (Empty<T>) this;
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/MonoUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/MonoUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.messaging.MessageStream.Single;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+/**
+ * Utility methods to work with Project Reactor's {@link Mono monos}.
+ *
+ * @author John Hendrikx
+ * @since 5.0.0
+ */
+public abstract class MonoUtils {
+
+    private MonoUtils() {
+    }
+
+    /**
+     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
+     * {@code mono}, once the given {@code mono} completes.
+     * <p>
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
+     * stream will complete with an exception when the given {@code mono} completes exceptionally.
+     *
+     * @param mono The {@link Mono} providing the {@link Message} to contain in the stream.
+     * @param <M>  The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
+     */
+    public static <M extends Message> Single<M> asSingle(@Nonnull Mono<M> mono) {
+        return MessageStream.fromFuture(mono.toFuture());
+    }
+
+    /**
+     * Create a stream that returns a single {@link Entry entry} wrapping the {@link Message} from the given
+     * {@code mono}, once the given {@code mono} completes.
+     * <p>
+     * The automatically generated {@code Entry} will have the {@link Context} as given by the {@code contextSupplier}.
+     * <p>
+     * The stream will contain at most a single entry. It may also contain no entries if the mono completes empty. The
+     * stream will complete with an exception when the given {@code mono} completes exceptionally.
+     *
+     * @param mono            The {@link Mono} providing the {@link Message} to contain in the stream.
+     * @param contextSupplier A {@link Function} ingesting the {@link Message} from the given {@code mono} returning the
+     *                        {@link Context} to set for the {@link Entry} the {@code Message} is wrapped in.
+     * @param <M>             The type of {@link Message} contained in the {@link Entry entries} of this stream.
+     * @return A stream containing at most one {@link Entry entry} from the given {@code mono}.
+     */
+    public static <M extends Message> Single<M> asSingle(@Nonnull Mono<M> mono,
+                                                         @Nonnull Function<M, Context> contextSupplier) {
+        return MessageStream.fromFuture(mono.toFuture(), contextSupplier);
+    }
+
+}

--- a/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/SingleValueMessageStream.java
@@ -18,8 +18,6 @@ package org.axonframework.messaging;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -66,16 +64,6 @@ class SingleValueMessageStream<M extends Message> implements MessageStream.Singl
     @Override
     public CompletableFuture<Entry<M>> asCompletableFuture() {
         return source;
-    }
-
-    @Override
-    public Flux<Entry<M>> asFlux() {
-        return Flux.from(asMono());
-    }
-
-    @Override
-    public Mono<Entry<M>> asMono() {
-        return Mono.fromFuture(source);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/annotations/MessageStreamResolverUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/annotations/MessageStreamResolverUtils.java
@@ -19,11 +19,13 @@ package org.axonframework.messaging.annotations;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.annotations.Internal;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.MessageTypeResolver;
+import org.axonframework.messaging.MonoUtils;
 import org.axonframework.util.ClasspathResolver;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -78,10 +80,10 @@ public class MessageStreamResolverUtils {
         // Handle Project Reactor types first with traditional if-statements
         if (ClasspathResolver.projectReactorOnClasspath()) {
             if (result instanceof Mono<?> mono) {
-                return MessageStream.fromMono(mono.map(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r)));
+                return MonoUtils.asSingle(mono.map(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r)));
             }
             if (result instanceof Flux<?> flux) {
-                return MessageStream.fromFlux(flux.map(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r)));
+                return FluxUtils.asMessageStream(flux.map(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r)));
             }
         }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/QueryBus.java
@@ -18,6 +18,7 @@ package org.axonframework.queryhandling;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
 import org.axonframework.messaging.QualifiedName;
@@ -99,7 +100,7 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
     default Publisher<QueryResponseMessage> streamingQuery(@Nonnull QueryMessage query,
                                                            @Nullable ProcessingContext context) {
         return Mono.fromSupplier(() -> query(query, context))
-                   .flatMapMany(MessageStream::asFlux)
+                   .flatMapMany(FluxUtils::of)
                    .map(MessageStream.Entry::message);
     }
 

--- a/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/SimpleQueryBus.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nullable;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.Context.ResourceKey;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.QualifiedName;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
@@ -160,7 +161,7 @@ public class SimpleQueryBus implements QueryBus {
                                                                @Nullable ProcessingContext context,
                                                                int updateBufferSize) {
         Flux<QueryResponseMessage> initialStream =
-                Flux.defer(() -> query(query, context).asFlux())
+                Flux.defer(() -> FluxUtils.of(query(query, context)))
                     .map(MessageStream.Entry::message)
                     .doOnError(error -> logger.error(
                             "An error happened while trying to report an initial result. Query: {}",
@@ -173,6 +174,7 @@ public class SimpleQueryBus implements QueryBus {
                                                             updateHandler::complete);
     }
 
+    @Override
     @Nonnull
     public UpdateHandler subscribeToUpdates(@Nonnull SubscriptionQueryMessage query,
                                             int updateBufferSize) {

--- a/messaging/src/test/java/org/axonframework/commandhandling/CommandMessageHandlerInterceptorChainTest.java
+++ b/messaging/src/test/java/org/axonframework/commandhandling/CommandMessageHandlerInterceptorChainTest.java
@@ -18,6 +18,7 @@ package org.axonframework.commandhandling;
 
 import jakarta.annotation.Nonnull;
 import org.axonframework.commandhandling.interceptors.CommandMessageHandlerInterceptorChain;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptorChain;
@@ -51,7 +52,7 @@ class CommandMessageHandlerInterceptorChainTest {
     void setUp() {
         mockHandler = mock();
         when(mockHandler.handle(any(), any()))
-                .thenReturn(MessageStream.just(commandResult("result", "Result")).cast());
+                .then(invocation -> MessageStream.just(commandResult("result", "Result")));
     }
 
     @Test
@@ -65,18 +66,17 @@ class CommandMessageHandlerInterceptorChainTest {
         MessageHandlerInterceptorChain<CommandMessage> testSubject =
                 new CommandMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
-        Message result = testSubject.proceed(testCommand, StubProcessingContext.forMessage(testCommand))
-                                    .first()
-                                    .asMono()
-                                    .map(MessageStream.Entry::message)
-                                    .block();
+        Message result = FluxUtils.of(testSubject.proceed(testCommand, StubProcessingContext.forMessage(testCommand)).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         assertNotNull(result);
         assertSame("Result", result.payload());
         verify(mockHandler).handle(argThat(x -> (x != null) && "testing".equals(x.payload())), any());
     }
 
     @Test
-    void subsequentChainInvocationsSTartFromBeginningAndInvokeInOrder() {
+    void subsequentChainInvocationsStartFromBeginningAndInvokeInOrder() {
         // given...
         AtomicInteger invocationCount = new AtomicInteger(0);
         CommandMessage firstCommand = command("message", "first");
@@ -110,11 +110,10 @@ class CommandMessageHandlerInterceptorChainTest {
                 new CommandMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
         // when first invocation...
-        Message firstResult = testSubject.proceed(firstCommand, firstContext)
-                                         .first()
-                                         .asMono()
-                                         .map(MessageStream.Entry::message)
-                                         .block();
+        Message firstResult = FluxUtils.of(testSubject.proceed(firstCommand, firstContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNotNull(firstResult);
         assertSame("Result", firstResult.payload());
@@ -124,14 +123,13 @@ class CommandMessageHandlerInterceptorChainTest {
         firstInterceptorOrder.verify(interceptorOne).interceptOnHandle(eq(firstCommand), eq(firstContext), any());
         firstInterceptorOrder.verify(interceptorTwo).interceptOnHandle(eq(firstCommand), eq(firstContext), any());
         // when second invocation...
-        Message secondResult = testSubject.proceed(secondCommand, secondContext)
-                                          .first()
-                                          .asMono()
-                                          .map(MessageStream.Entry::message)
-                                          .block();
+        Message secondResult = FluxUtils.of(testSubject.proceed(secondCommand, secondContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNotNull(secondResult);
-        assertSame("Result", firstResult.payload());
+        assertSame("Result", secondResult.payload());
         assertThat(invocationCount.get()).isEqualTo(4);
         // and ordering is...
         InOrder secondInterceptorOrder = inOrder(interceptorOne, interceptorTwo);

--- a/messaging/src/test/java/org/axonframework/eventhandling/interceptors/EventMessageHandlerInterceptorChainTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/interceptors/EventMessageHandlerInterceptorChainTest.java
@@ -19,6 +19,7 @@ package org.axonframework.eventhandling.interceptors;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptorChain;
@@ -64,11 +65,10 @@ class EventMessageHandlerInterceptorChainTest {
         MessageHandlerInterceptorChain<EventMessage> testSubject =
                 new EventMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
-        Message result = testSubject.proceed(testEvent, StubProcessingContext.forMessage(testEvent))
-                                    .first()
-                                    .asMono()
-                                    .map(MessageStream.Entry::message)
-                                    .block();
+        Message result = FluxUtils.of(testSubject.proceed(testEvent, StubProcessingContext.forMessage(testEvent)).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         assertNull(result);
         verify(mockHandler).handle(argThat(x -> (x != null) && "testing".equals(x.payload())), any());
     }
@@ -106,11 +106,10 @@ class EventMessageHandlerInterceptorChainTest {
                 new EventMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
         // when first invocation...
-        Message firstResult = testSubject.proceed(firstEvent, firstContext)
-                                         .first()
-                                         .asMono()
-                                         .map(MessageStream.Entry::message)
-                                         .block();
+        Message firstResult = FluxUtils.of(testSubject.proceed(firstEvent, firstContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNull(firstResult);
         assertThat(invocationCount.get()).isEqualTo(2);
@@ -120,11 +119,10 @@ class EventMessageHandlerInterceptorChainTest {
         firstInterceptorOrder.verify(interceptorTwo).interceptOnHandle(eq(firstEvent), eq(firstContext), any());
 
         // when second invocation...
-        Message secondResult = testSubject.proceed(secondEvent, secondContext)
-                                          .first()
-                                          .asMono()
-                                          .map(MessageStream.Entry::message)
-                                          .block();
+        Message secondResult = FluxUtils.of(testSubject.proceed(secondEvent, secondContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNull(secondResult);
         assertThat(invocationCount.get()).isEqualTo(4);

--- a/messaging/src/test/java/org/axonframework/messaging/AsyncMessageHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/AsyncMessageHandlerTest.java
@@ -297,7 +297,7 @@ class AsyncMessageHandlerTest {
                                     null, isPrime(((CheckIfPrime) command.payload()).value())
                             );
 
-                            return MessageStream.fromMono(Mono.just(data));
+                            return MonoUtils.asSingle(Mono.just(data));
                         }
                 );
 
@@ -325,7 +325,7 @@ class AsyncMessageHandlerTest {
                 queryBus.subscribe(
                         new QualifiedName(GetKnownPrimes.class),
                         new QualifiedName(Integer.class),
-                        (query, context) -> MessageStream.fromFlux(
+                        (query, context) -> FluxUtils.asMessageStream(
                                 Flux.just(2, 3, 5, 7)
                                     .map(i -> new GenericQueryResponseMessage(new MessageType(Integer.class), i))
                         )

--- a/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
@@ -112,7 +112,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             MessageStream<Message> testSubject = DelayedMessageStream.create(testFuture)
                                                                              .whenComplete(() -> invoked.set(true));
 
-            StepVerifier.create(testSubject.asFlux())
+            StepVerifier.create(FluxUtils.of(testSubject))
                         .verifyTimeout(Duration.ofMillis(250));
             // Verify timeout cancels the Flux, so we need to create the test subject again after this.
             assertFalse(invoked.get());
@@ -121,7 +121,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             testSubject = DelayedMessageStream.create(testFuture)
                                               .whenComplete(() -> invoked.set(true));
 
-            StepVerifier.create(testSubject.asFlux())
+            StepVerifier.create(FluxUtils.of(testSubject))
                         .expectNextMatches(entry -> entry.message().equals(expected))
                         .verifyComplete();
             assertTrue(invoked.get());
@@ -270,7 +270,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             MessageStream<Message> testSubject = DelayedMessageStream.createSingle(testFuture)
                                                                              .whenComplete(() -> invoked.set(true));
 
-            StepVerifier.create(testSubject.asFlux())
+            StepVerifier.create(FluxUtils.of(testSubject))
                         .verifyTimeout(Duration.ofMillis(250));
             // Verify timeout cancels the Flux, so we need to create the test subject again after this.
             assertFalse(invoked.get());
@@ -279,7 +279,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             testSubject = DelayedMessageStream.createSingle(testFuture)
                                               .whenComplete(() -> invoked.set(true));
 
-            StepVerifier.create(testSubject.asFlux())
+            StepVerifier.create(FluxUtils.of(testSubject))
                         .expectNextMatches(entry -> entry.message().equals(expected))
                         .verifyComplete();
             assertTrue(invoked.get());

--- a/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
@@ -37,7 +37,7 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
     MessageStream<Message> completedTestSubject(List<Message> messages) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages));
+        return FluxUtils.asMessageStream(Flux.fromIterable(messages));
     }
 
     @Override
@@ -56,7 +56,7 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
     @Override
     protected MessageStream<Message> uncompletedTestSubject(List<Message> messages,
                                                                     CompletableFuture<Void> completionMarker) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages).concatWith(
+        return FluxUtils.asMessageStream(Flux.fromIterable(messages).concatWith(
                 Flux.create(emitter -> completionMarker.whenComplete(
                         (v, e) -> {
                             if (e != null) {
@@ -70,7 +70,7 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
     MessageStream<Message> failingTestSubject(List<Message> messages, Exception failure) {
-        return MessageStream.fromFlux(Flux.fromIterable(messages).concatWith(Mono.error(failure)));
+        return FluxUtils.asMessageStream(Flux.fromIterable(messages).concatWith(Mono.error(failure)));
     }
 
     @Override
@@ -85,7 +85,7 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
         Flux<Message> flux;
         flux = Flux.fromIterable(List.of(createRandomMessage(), createRandomMessage(), createRandomMessage()))
                    .doOnCancel(() -> invoked.set(true));
-        MessageStream<Message> testSubject = MessageStream.fromFlux(flux);
+        MessageStream<Message> testSubject = FluxUtils.asMessageStream(flux);
 
         assertTrue(testSubject.next().isPresent());
         assertFalse(invoked.get());

--- a/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MessageStreamTest.java
@@ -387,7 +387,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(in));
 
-        StepVerifier.create(testSubject.map(entry -> entry.map(input -> out)).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.map(entry -> entry.map(input -> out))))
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .verifyComplete();
     }
@@ -399,7 +399,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
 
-        StepVerifier.create(testSubject.map(entry -> entry.map(input -> out)).asMono())
+        StepVerifier.create(FluxUtils.of(testSubject.map(entry -> entry.map(input -> out))).singleOrEmpty())
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .verifyComplete();
     }
@@ -411,7 +411,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(in));
 
-        StepVerifier.create(testSubject.mapMessage(input -> out).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.mapMessage(input -> out)))
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .verifyComplete();
     }
@@ -423,7 +423,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(in);
 
-        StepVerifier.create(testSubject.mapMessage(input -> out).asMono())
+        StepVerifier.create(FluxUtils.of(testSubject.mapMessage(input -> out)).singleOrEmpty())
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .verifyComplete();
     }
@@ -437,7 +437,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(in1, in2));
 
-        StepVerifier.create(testSubject.map(entry -> entry.map(input -> input == in1 ? out1 : out2)).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.map(entry -> entry.map(input -> input == in1 ? out1 : out2))))
                     .expectNextMatches(entry -> entry.message().equals(out1))
                     .expectNextMatches(entry -> entry.message().equals(out2))
                     .verifyComplete();
@@ -452,7 +452,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(in1, in2));
 
-        StepVerifier.create(testSubject.mapMessage(input -> input == in1 ? out1 : out2).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.mapMessage(input -> input == in1 ? out1 : out2)))
                     .expectNextMatches(entry -> entry.message().equals(out1))
                     .expectNextMatches(entry -> entry.message().equals(out2))
                     .verifyComplete();
@@ -467,7 +467,7 @@ public abstract class MessageStreamTest<M extends Message> {
                 .map(entry -> entry.map(input -> out))
                 .onErrorContinue(MessageStream::failed);
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .expectErrorMatches(MockException.class::isInstance)
                     .verify();
@@ -482,7 +482,7 @@ public abstract class MessageStreamTest<M extends Message> {
                 .mapMessage(input -> out)
                 .onErrorContinue(MessageStream::failed);
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .expectNextMatches(entry -> entry.message().equals(out))
                     .expectErrorMatches(MockException.class::isInstance)
                     .verify();
@@ -546,7 +546,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return entry;
                 });
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -561,7 +561,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return entry;
                 });
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -576,7 +576,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return entry;
                 });
 
-        StepVerifier.create(testSubject.asMono())
+        StepVerifier.create(FluxUtils.of(testSubject).singleOrEmpty())
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -591,7 +591,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return message;
                 });
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -606,7 +606,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return message;
                 });
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -621,7 +621,7 @@ public abstract class MessageStreamTest<M extends Message> {
                     return message;
                 });
 
-        StepVerifier.create(testSubject.asMono())
+        StepVerifier.create(FluxUtils.of(testSubject).singleOrEmpty())
                     .verifyComplete();
         assertFalse(invoked.get(), "Mapper function should not be invoked for empty streams");
     }
@@ -772,8 +772,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(expected));
 
-        StepVerifier.create(testSubject.onNext(entry -> invoked.set(true))
-                                       .asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.onNext(entry -> invoked.set(true))))
                     .expectNextMatches(entry -> entry.message().equals(expected))
                     .verifyComplete();
         assertTrue(invoked.get());
@@ -807,14 +806,15 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = failingTestSubject(List.of(expectedFirst), expectedError);
 
-        StepVerifier.create(testSubject.onErrorContinue(error -> {
-                                           assertEquals(expectedError, FutureUtils.unwrap(error));
-                                           return onErrorStream;
-                                       })
-                                       .asFlux())
-                    .expectNextMatches(entry -> entry.message().equals(expectedFirst))
-                    .expectNextMatches(entry -> entry.message().equals(expectedSecond))
-                    .verifyComplete();
+        StepVerifier.create(
+            FluxUtils.of(testSubject.onErrorContinue(error -> {
+                assertEquals(expectedError, FutureUtils.unwrap(error));
+                return onErrorStream;
+            })
+        ))
+        .expectNextMatches(entry -> entry.message().equals(expectedFirst))
+        .expectNextMatches(entry -> entry.message().equals(expectedSecond))
+        .verifyComplete();
     }
 
     @Test
@@ -851,7 +851,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(expectedFirst));
 
-        StepVerifier.create(testSubject.concatWith(secondStream).asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.concatWith(secondStream)))
                     .expectNextMatches(entry -> entry.message().equals(expectedFirst))
                     .expectNextMatches(entry -> entry.message().equals(expectedSecond))
                     .verifyComplete();
@@ -869,7 +869,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> concatenated = stream1.concatWith(stream2).concatWith(stream3);
 
-        StepVerifier.create(concatenated.asFlux())
+        StepVerifier.create(FluxUtils.of(concatenated))
                     .expectNextMatches(entry -> entry.message().equals(first))
                     .expectNextMatches(entry -> entry.message().equals(second))
                     .expectNextMatches(entry -> entry.message().equals(third))
@@ -884,7 +884,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> concatenated = firstStream.concatWith(secondStream);
 
-        StepVerifier.create(concatenated.asFlux())
+        StepVerifier.create(FluxUtils.of(concatenated))
                     .expectErrorMatches(e -> e instanceof RuntimeException && e.getMessage().equals("First stream failed"))
                     .verify();
     }
@@ -898,7 +898,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> concatenated = firstStream.concatWith(secondStream);
 
-        StepVerifier.create(concatenated.asFlux())
+        StepVerifier.create(FluxUtils.of(concatenated))
                     .expectNextMatches(entry -> entry.message().equals(firstMessage))
                     .expectErrorMatches(e -> e instanceof RuntimeException && e.getMessage().equals("Second stream failed"))
                     .verify();
@@ -916,7 +916,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> concatenated = stream1.concatWith(stream2);
 
-        StepVerifier.create(concatenated.asFlux())
+        StepVerifier.create(FluxUtils.of(concatenated))
                     .expectNextMatches(entry -> entry.message().equals(first1))
                     .expectNextMatches(entry -> entry.message().equals(first2))
                     .expectNextMatches(entry -> entry.message().equals(second1))
@@ -957,8 +957,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of());
 
-        StepVerifier.create(testSubject.whenComplete(() -> invoked.set(true))
-                                       .asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.whenComplete(() -> invoked.set(true))))
                     .verifyComplete();
         assertTrue(invoked.get());
     }
@@ -969,8 +968,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream.Single<M> testSubject = completedSingleStreamTestSubject(createRandomMessage());
 
-        StepVerifier.create(testSubject.whenComplete(() -> invoked.set(true))
-                                       .asMono())
+        StepVerifier.create(FluxUtils.of(testSubject.whenComplete(() -> invoked.set(true))).singleOrEmpty())
                     .expectNextCount(1)
                     .verifyComplete();
         assertTrue(invoked.get());
@@ -983,8 +981,7 @@ public abstract class MessageStreamTest<M extends Message> {
         RuntimeException oops = new RuntimeException("oops");
         MessageStream<M> testSubject = failingTestSubject(List.of(), oops);
 
-        StepVerifier.create(testSubject.whenComplete(() -> invoked.set(true))
-                                       .asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject.whenComplete(() -> invoked.set(true))))
                     .verifyErrorMatches(e -> e == oops);
         assertFalse(invoked.get());
     }
@@ -997,9 +994,12 @@ public abstract class MessageStreamTest<M extends Message> {
         MessageStream<M> testSubject = failingTestSubject(List.of(), oops);
         Assumptions.assumeTrue(testSubject instanceof MessageStream.Single<M>);
 
-        StepVerifier.create(((MessageStream.Single<M>) testSubject).whenComplete(() -> invoked.set(true))
-                                                                   .asMono())
-                    .verifyErrorMatches(e -> e == oops);
+        StepVerifier.create(
+            FluxUtils.of(((MessageStream.Single<M>) testSubject).whenComplete(() -> invoked.set(true)))
+                .singleOrEmpty()
+        )
+        .verifyErrorMatches(e -> e == oops);
+
         assertFalse(invoked.get());
     }
 
@@ -1010,12 +1010,13 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> testSubject = completedTestSubject(List.of(expectedMessage));
 
-        StepVerifier.create(testSubject.whenComplete(() -> {
-                                           throw expected;
-                                       })
-                                       .asFlux())
-                    .expectNextMatches(entry -> entry.message().equals(expectedMessage))
-                    .verifyErrorMatches(expected::equals);
+        StepVerifier.create(
+            FluxUtils.of(testSubject.whenComplete(() -> {
+                throw expected;
+            }))
+        )
+        .expectNextMatches(entry -> entry.message().equals(expectedMessage))
+        .verifyErrorMatches(expected::equals);
     }
 
     @Test
@@ -1031,7 +1032,7 @@ public abstract class MessageStreamTest<M extends Message> {
             })
             .whenComplete(() -> callbackExecuted.set(true));
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .expectNextCount(3)
                     .verifyComplete();
 
@@ -1047,7 +1048,7 @@ public abstract class MessageStreamTest<M extends Message> {
         MessageStream<M> testSubject = failingTestSubject(List.of(), testException)
             .whenComplete(() -> callbackExecuted.set(true));
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .expectErrorMatches(e -> e instanceof RuntimeException && e.getMessage().equals("Stream failed"))
                     .verify();
 
@@ -1062,7 +1063,7 @@ public abstract class MessageStreamTest<M extends Message> {
         MessageStream<M> original = completedTestSubject(originalMessages);
         MessageStream<M> withCallback = original.whenComplete(() -> callbackExecuted.set(true));
 
-        StepVerifier.create(withCallback.asFlux())
+        StepVerifier.create(FluxUtils.of(withCallback))
                     .expectNextMatches(entry -> entry.message().equals(originalMessages.get(0)))
                     .expectNextMatches(entry -> entry.message().equals(originalMessages.get(1)))
                     .expectNextMatches(entry -> entry.message().equals(originalMessages.get(2)))
@@ -1080,7 +1081,7 @@ public abstract class MessageStreamTest<M extends Message> {
             .whenComplete(callbackCount::incrementAndGet)
             .whenComplete(callbackCount::incrementAndGet);
 
-        StepVerifier.create(testSubject.asFlux())
+        StepVerifier.create(FluxUtils.of(testSubject))
                     .expectNextCount(1)
                     .verifyComplete();
 
@@ -1100,7 +1101,7 @@ public abstract class MessageStreamTest<M extends Message> {
 
         MessageStream<M> concatenated = stream1.concatWith(stream2);
 
-        StepVerifier.create(concatenated.asFlux())
+        StepVerifier.create(FluxUtils.of(concatenated))
                     .expectNextCount(2)
                     .verifyComplete();
 

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -104,11 +104,9 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message> {
         Message second = createRandomMessage();
         List<Message> messages = List.of(first, second);
 
-        StepVerifier.create(MessageStream.fromIterable(messages)
-                                         .onNext(seen::add)
-                                         .asFlux())
-                    .expectNextCount(2)
-                    .verifyComplete();
+        StepVerifier.create(FluxUtils.of(MessageStream.fromIterable(messages).onNext(seen::add)))
+            .expectNextCount(2)
+            .verifyComplete();
 
         assertEquals(2, seen.size());
         assertEquals(first, seen.getFirst().message());

--- a/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/retry/AsyncRetrySchedulerTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.retry;
 
 import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.GenericMessage;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageStream;
@@ -150,7 +151,7 @@ class AsyncRetrySchedulerTest {
 
         assertTrue(actual.hasNextAvailable());
 
-        StepVerifier.create(actual.asFlux())
+        StepVerifier.create(FluxUtils.of(actual))
                     .expectNextCount(1)
                     .verifyError(MockException.class);
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/StreamingQueryTest.java
@@ -313,7 +313,7 @@ class StreamingQueryTest {
 
         @QueryHandler(queryName = "streamingAfterHandlerCompletesQuery")
         public Flux<Long> streamingAfterHandlerCompletesQuery(String criteria) {
-            return Flux.interval(Duration.ofSeconds(1))
+            return Flux.interval(Duration.ofMillis(100))
                        .take(5);
         }
 

--- a/messaging/src/test/java/org/axonframework/queryhandling/interceptors/QueryMessageHandlerInterceptorChainTest.java
+++ b/messaging/src/test/java/org/axonframework/queryhandling/interceptors/QueryMessageHandlerInterceptorChainTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.queryhandling.interceptors;
 
 import jakarta.annotation.Nonnull;
+import org.axonframework.messaging.FluxUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.MessageHandlerInterceptor;
 import org.axonframework.messaging.MessageHandlerInterceptorChain;
@@ -52,7 +53,7 @@ class QueryMessageHandlerInterceptorChainTest {
     void setUp() {
         mockHandler = mock();
         when(mockHandler.handle(any(), any()))
-                .thenReturn(MessageStream.just(queryResponse("response")));
+                .then(invocation -> MessageStream.just(queryResponse("response")));
     }
 
     @Test
@@ -66,11 +67,10 @@ class QueryMessageHandlerInterceptorChainTest {
         MessageHandlerInterceptorChain<QueryMessage> testSubject =
                 new QueryMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
-        Message result = testSubject.proceed(testQuery, StubProcessingContext.forMessage(testQuery))
-                                    .first()
-                                    .asMono()
-                                    .map(MessageStream.Entry::message)
-                                    .block();
+        Message result = FluxUtils.of(testSubject.proceed(testQuery, StubProcessingContext.forMessage(testQuery)).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         assertNotNull(result);
         assertSame("response", result.payload());
         verify(mockHandler).handle(argThat(x -> (x != null) && "testing".equals(x.payload())), any());
@@ -111,11 +111,10 @@ class QueryMessageHandlerInterceptorChainTest {
                 new QueryMessageHandlerInterceptorChain(asList(interceptorOne, interceptorTwo), mockHandler);
 
         // when first invocation...
-        Message firstResult = testSubject.proceed(firstQuery, firstContext)
-                                         .first()
-                                         .asMono()
-                                         .map(MessageStream.Entry::message)
-                                         .block();
+        Message firstResult = FluxUtils.of(testSubject.proceed(firstQuery, firstContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNotNull(firstResult);
         assertSame("response", firstResult.payload());
@@ -125,11 +124,10 @@ class QueryMessageHandlerInterceptorChainTest {
         firstInterceptorOrder.verify(interceptorOne).interceptOnHandle(eq(firstQuery), eq(firstContext), any());
         firstInterceptorOrder.verify(interceptorTwo).interceptOnHandle(eq(firstQuery), eq(firstContext), any());
         // when second invocation...
-        Message secondResult = testSubject.proceed(secondQuery, secondContext)
-                                          .first()
-                                          .asMono()
-                                          .map(MessageStream.Entry::message)
-                                          .block();
+        Message secondResult = FluxUtils.of(testSubject.proceed(secondQuery, secondContext).first())
+            .singleOrEmpty()
+            .map(MessageStream.Entry::message)
+            .block();
         // then response is...
         assertNotNull(secondResult);
         assertSame("response", firstResult.payload());


### PR DESCRIPTION
This is part of issue #3177 

This moves the methods to create fluxes / mono's from `MessageStream` to `MessageStreamUtils`.

We could also consider creating helper classes `Fluxes` and `Monos` with various `static` `of`, `from` or `create` style methods to create them (more easily discoverable and avoids the nasty "Utils" extension :))

**Note:** As part of this change, the `asFlux` methods in sub-types like `DelayedMessageStream`, `ConcatMessageStream`, etc. were removed.  These formerly would leave a lot of their logic to Reactor code (if converted to `Flux` as they often are in tests).  This exposed at least two bugs:

- `isCompleted` in `ConcatMessageStream` was subtly wrong
- The `FluxStreamAdapter` would fail to yield control back to Reactor if stream was cancelled for an infinite source (`requestedFromDownstream` remains > 0, and we'd have an infinite loop).  I've rewritten this to be safer and yield back control more often.

So when reviewing, take a good look at the `asFlux` methods that were removed in these streams.  I don't think there are further issues though.