### PR TITLE
[#3672] Abstract sourcing condition position

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
@@ -37,6 +37,7 @@ import org.axonframework.eventhandling.processors.streaming.token.GlobalSequence
 import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils;
+import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils.AggregateSequencer;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
@@ -197,7 +198,7 @@ public class AggregateBasedAxonServerEventStorageEngine implements EventStorageE
         String aggregateIdentifier = resolveAggregateIdentifier(criterion.tags());
         AggregateEventStream aggregateStream =
                 connection.eventChannel()
-                          .openAggregateStream(aggregateIdentifier, condition.start());
+                          .openAggregateStream(aggregateIdentifier, AggregateSequenceNumberPosition.toSequenceNumber(condition.start()));
 
         MessageStream<EventMessage> source =
                 MessageStream.fromStream(aggregateStream.asStream(),

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/ConditionConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/ConditionConverter.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Nonnull;
 import org.axonframework.common.annotations.Internal;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.GlobalIndexConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.GlobalIndexPosition;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventstreaming.EventCriteria;
 import org.axonframework.eventstreaming.EventCriterion;
@@ -80,7 +81,7 @@ public abstract class ConditionConverter {
      */
     public static SourceEventsRequest convertSourcingCondition(@Nonnull SourcingCondition condition) {
         return SourceEventsRequest.newBuilder()
-                                  .setFromSequence(condition.start())
+                                  .setFromSequence(GlobalIndexPosition.toIndex(condition.start()))
                                   .addAllCriterion(convertEventCriterion(condition.criteria().flatten()))
                                   .build();
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/ConditionConverterTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/ConditionConverterTest.java
@@ -25,6 +25,7 @@ import io.axoniq.axonserver.grpc.event.dcb.TagsAndNamesCriterion;
 import org.axonframework.eventhandling.processors.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.GlobalIndexConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.GlobalIndexPositions;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventstreaming.EventCriteria;
 import org.axonframework.eventstreaming.StreamingCondition;
@@ -91,7 +92,7 @@ class ConditionConverterTest {
     void convertSourcingConditionConstructsSourceEventRequestAsExpected() {
         // given...
         SourcingCondition testCondition = SourcingCondition.conditionFor(
-                START,
+                GlobalIndexPositions.of(START),
                 EventCriteria.havingTags(
                                      Tag.of("key1OnCriterion1", "value1OnCriterion1"),
                                      Tag.of("key2OnCriterion1", "value2OnCriterion1")

--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -193,6 +193,11 @@
             <artifactId>mysql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Other -->
         <dependency>

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateSequenceNumberPosition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateSequenceNumberPosition.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * An implementation of {@link Position} based on aggregate sequence numbers.
+ *
+ * @author John Hendrikx
+ * @since 5.0.0
+ */
+public final class AggregateSequenceNumberPosition implements Position {
+
+    private static final long MINIMUM_SEQUENCE_NUMBER = 0;
+
+    /**
+     * Converts the given position to a sequence number, if possible.
+     *
+     * @param position A position, cannot be {@code null}.
+     * @return A sequence number.
+     * @throws NullPointerException When any argument is {@code null}.
+     * @throws IllegalArgumentException When the given position could not be converted.
+     */
+    public static long toSequenceNumber(@Nonnull Position position) {
+        return switch (position) {
+            case AggregateSequenceNumberPosition gip -> gip.sequenceNumber;
+            case Position p when p == Position.START -> MINIMUM_SEQUENCE_NUMBER;
+            default -> throw new IllegalArgumentException("position must be of type AggregateSequenceNumberPosition: " + position);
+        };
+    }
+
+    private final long sequenceNumber;
+
+    AggregateSequenceNumberPosition(long sequenceNumber) {
+        if (sequenceNumber < 0) {
+            throw new IllegalArgumentException("sequenceNumber cannot be negative");
+        }
+
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    @Nonnull
+    @Override
+    public Position min(@Nonnull Position other) {
+        return switch (other) {
+            case Position p when p == Position.START -> Position.START;
+            case AggregateSequenceNumberPosition asnp -> sequenceNumber < asnp.sequenceNumber ? this : asnp;
+            default -> throw new IllegalArgumentException("other must be of type AggregateSequenceNumberPosition: " + other);
+        };
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AggregateSequenceNumberPosition that = (AggregateSequenceNumberPosition) o;
+        return sequenceNumber == that.sequenceNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(sequenceNumber);
+    }
+
+    @Override
+    public String toString() {
+        return "AggregateSequenceNumberPosition{sequenceNumber=%d}".formatted(sequenceNumber);
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultSourcingCondition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultSourcingCondition.java
@@ -19,7 +19,7 @@ package org.axonframework.eventsourcing.eventstore;
 import jakarta.annotation.Nonnull;
 import org.axonframework.eventstreaming.EventCriteria;
 
-import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The default {@link SourcingCondition} implementation.
@@ -30,20 +30,24 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @param start    The start position in the event sequence to retrieve of the entity to source.
  * @param criteria The {@link EventCriteria} set of the entity to source.
  * @author Steven van Beelen
+ * @author John Hendrikx
  * @since 5.0.0
  */
 record DefaultSourcingCondition(
-        long start,
+        @Nonnull Position start,
         @Nonnull EventCriteria criteria
 ) implements SourcingCondition {
 
     DefaultSourcingCondition {
-        assertNonNull(criteria, "The EventCriteria cannot be null");
+        requireNonNull(start, "start cannot be null");
+        requireNonNull(criteria, "criteria cannot be null");
     }
 
     @Override
     public SourcingCondition or(@Nonnull SourcingCondition other) {
-        var combinedCriteria = other.criteria().or(this.criteria());
-        return new DefaultSourcingCondition(Math.min(this.start, other.start()), combinedCriteria);
+        return new DefaultSourcingCondition(
+            other.start().min(start),
+            other.criteria().or(criteria)
+        );
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPosition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPosition.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * An immutable implementation of {@link Position} which represents positions
+ * with an index in the global event stream.
+ *
+ * @author John Hendrikx
+ * @since 5.0.0
+ */
+public final class GlobalIndexPosition implements Position {
+
+    private static final long MINIMUM_INDEX = Long.MIN_VALUE;
+
+    /**
+     * Converts the given position to a global index, if possible.
+     *
+     * @param position A position, cannot be {@code null}.
+     * @return A global index.
+     * @throws NullPointerException When any argument is {@code null}.
+     * @throws IllegalArgumentException When the given position could not be converted.
+     */
+    public static long toIndex(@Nonnull Position position) {
+        return switch (position) {
+            case GlobalIndexPosition gip -> gip.index;
+            case Position p when p == Position.START -> MINIMUM_INDEX;
+            default -> throw new IllegalArgumentException("position must be of type GlobalIndexPosition: " + position);
+        };
+    }
+
+    private final long index;
+
+    GlobalIndexPosition(long index) {
+        this.index = index;
+    }
+
+    @Nonnull
+    @Override
+    public Position min(@Nonnull Position other) {
+        return switch (other) {
+            case Position p when p == Position.START -> Position.START;
+            case GlobalIndexPosition gip -> index < gip.index ? this : gip;
+            default -> throw new IllegalArgumentException("other must be of type GlobalIndexPosition: " + other);
+        };
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GlobalIndexPosition that = (GlobalIndexPosition) o;
+        return index == that.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(index);
+    }
+
+    @Override
+    public String toString() {
+        return "GlobalIndexPosition{index=%d}".formatted(index);
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/Position.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/Position.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Represents a position from which sourcing may start.
+ *
+ * @author John Hendrikx
+ * @since 5.0.0
+ */
+public sealed interface Position permits GlobalIndexPosition, AggregateSequenceNumberPosition, StartPosition {
+
+    /**
+     * Represents the smallest possible position.
+     */
+    static final Position START = new StartPosition();
+
+    /**
+     * Returns the smallest of the two positions. If one of the positions is {@link #START},
+     * this function will always return this value. Implementors must ensure this operation
+     * is symmetric, and so should always return {@link #START} when called with it.
+     *
+     * @param other Another position, cannot be {@code null}.
+     * @return The smallest of the two positions, never {@code null}.
+     * @throws NullPointerException When any argument is {@code null}.
+     * @throws IllegalArgumentException When the given position is incompatible with this position.
+     */
+    @Nonnull Position min(@Nonnull Position other);
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SourcingCondition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SourcingCondition.java
@@ -44,7 +44,7 @@ public sealed interface SourcingCondition extends EventsCondition permits Defaul
      * @return A {@code SourcingCondition} that will retrieve an event sequence matching the given {@code criteria}.
      */
     static SourcingCondition conditionFor(@Nonnull EventCriteria criteria) {
-        return conditionFor(0, criteria);
+        return conditionFor(Position.START, criteria);
     }
 
     /**
@@ -57,7 +57,7 @@ public sealed interface SourcingCondition extends EventsCondition permits Defaul
      * @return A {@code SourcingCondition} that will retrieve an event sequence matching the given {@code criteria},
      * starting at the given {@code start}.
      */
-    static SourcingCondition conditionFor(long start, @Nonnull EventCriteria criteria) {
+    static SourcingCondition conditionFor(@Nonnull Position start, @Nonnull EventCriteria criteria) {
         return new DefaultSourcingCondition(start, criteria);
     }
 
@@ -65,10 +65,10 @@ public sealed interface SourcingCondition extends EventsCondition permits Defaul
      * The start position in the event sequence to source. Defaults to {@code -1L} to ensure we start at the beginning
      * of the sequence's stream complying to the {@link #criteria()}.
      *
-     * @return The start position in the event sequence to source.
+     * @return The start position in the event sequence to source, never {@code null}.
      */
-    default long start() {
-        return -1L;
+    default @Nonnull Position start() {
+        return Position.START;
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StartPosition.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StartPosition.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+
+final class StartPosition implements Position {
+    @Nonnull
+    @Override
+    public Position min(@Nonnull Position other) {
+        return START;
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.GlobalIndexConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.GlobalIndexPosition;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
 import org.axonframework.eventstreaming.EventsCondition;
@@ -183,9 +184,12 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
             logger.debug("Start sourcing events with condition [{}].", condition);
         }
 
+        // Get start position and ensure it is within valid bounds for this implementation:
+        long start = Math.max(0, GlobalIndexPosition.toIndex(condition.start()));
+
         // Set end to the CURRENT last position, to reflect it's a finite stream.
         MapBackedMessageStream messageStream = new MapBackedSourcingEventMessageStream(
-                condition.start(), eventStorage.isEmpty() ? -1 : eventStorage.lastKey(), condition
+                start, eventStorage.isEmpty() ? -1 : eventStorage.lastKey(), condition
         );
         openStreams.add(messageStream);
         return messageStream;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -35,6 +35,7 @@ import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils.AggregateSequencer;
+import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.EmptyAppendTransaction;
@@ -312,7 +313,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private AggregateSource aggregateSourceForCriterion(SourcingCondition condition, EventCriterion criterion) {
         AtomicReference<AggregateBasedConsistencyMarker> markerReference = new AtomicReference<>();
         var aggregateIdentifier = resolveAggregateIdentifier(criterion.tags());
-        long firstSequenceNumber = condition.start();
+        long firstSequenceNumber = AggregateSequenceNumberPosition.toSequenceNumber(condition.start());
         //noinspection DataFlowIssue
         StreamSpliterator<? extends AggregateEventEntry> entrySpliterator = new StreamSpliterator<>(
                 lastEntry -> transactionManager.fetchInTransaction(() -> queryEventsBy(

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -363,7 +363,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         );
 
         // when...
-        SourcingCondition testCondition = SourcingCondition.conditionFor(1, TEST_AGGREGATE_CRITERIA);
+        SourcingCondition testCondition = SourcingCondition.conditionFor(new AggregateSequenceNumberPosition(1), TEST_AGGREGATE_CRITERIA);
         MessageStream<EventMessage> result = testSubject.source(testCondition, processingContext());
         // then...
         StepVerifier.create(FluxUtils.of(result))
@@ -393,7 +393,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         // when...
         MessageStream<EventMessage> source;
         SourcingCondition testCondition =
-                SourcingCondition.conditionFor(1, TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
+                SourcingCondition.conditionFor(new AggregateSequenceNumberPosition(1), TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
         try {
             source = testSubject.source(testCondition, processingContext());
         } catch (IllegalArgumentException e) {
@@ -419,7 +419,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         ConsistencyMarker expectedMarker = testAggregateMarker.upperBound(otherAggregateMarker);
         // when...
         SourcingCondition testCondition =
-                SourcingCondition.conditionFor(0, TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
+                SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA.or(OTHER_AGGREGATE_CRITERIA));
         MessageStream<EventMessage> result = testSubject.source(testCondition, processingContext());
         // then...
         StepVerifier.create(FluxUtils.of(result))

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateSequenceNumberPositionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateSequenceNumberPositionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test for {@link AggregateSequenceNumberPosition}.
+ *
+ * @author John Hendrikx
+ */
+class AggregateSequenceNumberPositionTest {
+
+    private static final AggregateSequenceNumberPosition TEN = new AggregateSequenceNumberPosition(10);
+    private static final AggregateSequenceNumberPosition TWENTY = new AggregateSequenceNumberPosition(20);
+    private static final AggregateSequenceNumberPosition MINIMUM = new AggregateSequenceNumberPosition(0);
+
+    @Test
+    void constructorShouldRejectInvalidArguments() {
+        assertThatThrownBy(() -> new AggregateSequenceNumberPosition(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void minShouldReturnSmallestPositionAndBeSymmetric() {
+        assertThat(TEN.min(TWENTY)).isEqualTo(TEN);
+        assertThat(TWENTY.min(TEN)).isEqualTo(TEN);
+        assertThat(MINIMUM.min(TEN)).isEqualTo(MINIMUM);
+        assertThat(TEN.min(MINIMUM)).isEqualTo(MINIMUM);
+
+        // Position.START should always be smaller:
+        assertThat(TEN.min(Position.START)).isEqualTo(Position.START);
+        assertThat(Position.START.min(TEN)).isEqualTo(Position.START);
+        assertThat(MINIMUM.min(Position.START)).isEqualTo(Position.START);
+        assertThat(Position.START.min(MINIMUM)).isEqualTo(Position.START);
+    }
+
+    @Test
+    void minShouldRejectInvalidPositions() {
+        assertThatThrownBy(() -> TEN.min(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> TEN.min(new GlobalIndexPosition(5))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void toIndexShouldConvertValidPositions() {
+        assertThat(AggregateSequenceNumberPosition.toSequenceNumber(TEN)).isEqualTo(10);
+        assertThat(AggregateSequenceNumberPosition.toSequenceNumber(TWENTY)).isEqualTo(20);
+        assertThat(AggregateSequenceNumberPosition.toSequenceNumber(MINIMUM)).isEqualTo(0);
+        assertThat(AggregateSequenceNumberPosition.toSequenceNumber(Position.START)).isEqualTo(0);
+    }
+
+    @Test
+    void toIndexShouldRejectInvalidPositions() {
+        assertThatThrownBy(() -> AggregateSequenceNumberPosition.toSequenceNumber(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> AggregateSequenceNumberPosition.toSequenceNumber(new GlobalIndexPosition(5))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void equalsAndHashCodeShouldRespectContract() {
+        EqualsVerifier.forClass(AggregateSequenceNumberPosition.class).verify();
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultSourcingConditionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultSourcingConditionTest.java
@@ -26,35 +26,47 @@ import static org.junit.jupiter.api.Assertions.*;
  * Test class validating the {@link DefaultSourcingCondition}.
  *
  * @author Steven van Beelen
+ * @author John Hendrikx
  */
 class DefaultSourcingConditionTest {
 
     private static final EventCriteria TEST_CRITERIA = EventCriteria.havingTags("key", "value");
-    private static final long TEST_START = 1L;
-
-    private SourcingCondition testSubject;
-
-    @BeforeEach
-    void setUp() {
-        testSubject = new DefaultSourcingCondition(TEST_START, TEST_CRITERIA);
-    }
 
     @Test
     void throwsExceptionWhenConstructingWithNullEventCriteria() {
         //noinspection DataFlowIssue
-        assertThrows(AxonConfigurationException.class,
-                     () -> new DefaultSourcingCondition(TEST_START, null));
+        assertThrows(NullPointerException.class,
+                     () -> new DefaultSourcingCondition(Position.START, null));
     }
 
     @Test
     void combineUsesTheSmallestStartValue() {
-        long biggerStart = testSubject.start() + 10;
-        SourcingCondition testSubjectWithLargerStart =
-                new DefaultSourcingCondition(biggerStart, TEST_CRITERIA);
+        GlobalIndexPosition position1 = new GlobalIndexPosition(10);
+        GlobalIndexPosition position2 = new GlobalIndexPosition(20);
+        SourcingCondition sc1 = new DefaultSourcingCondition(position1, TEST_CRITERIA);
+        SourcingCondition sc2 = new DefaultSourcingCondition(position2, TEST_CRITERIA);
 
-        SourcingCondition result = testSubject.or(testSubjectWithLargerStart);
+        SourcingCondition result1 = sc1.or(sc2);
+        SourcingCondition result2 = sc2.or(sc1);
 
-        assertNotEquals(biggerStart, result.start());
-        assertEquals(testSubject.start(), result.start());
+        assertNotEquals(position2, result1.start());
+        assertEquals(position1, result1.start());
+        assertNotEquals(position2, result2.start());
+        assertEquals(position1, result2.start());
+    }
+
+    @Test
+    void combineWithStandardPositionUsesTheSmallestStartValue() {
+        GlobalIndexPosition position = new GlobalIndexPosition(10);
+        SourcingCondition sc1 = new DefaultSourcingCondition(Position.START, TEST_CRITERIA);
+        SourcingCondition sc2 = new DefaultSourcingCondition(position, TEST_CRITERIA);
+
+        SourcingCondition result1 = sc1.or(sc2);
+        SourcingCondition result2 = sc2.or(sc1);
+
+        assertNotEquals(position, result1.start());
+        assertEquals(Position.START, result1.start());
+        assertNotEquals(position, result2.start());
+        assertEquals(Position.START, result2.start());
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPositionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPositionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test for {@link GlobalIndexPosition}.
+ *
+ * @author John Hendrikx
+ */
+class GlobalIndexPositionTest {
+
+    private static final GlobalIndexPosition TEN = new GlobalIndexPosition(10);
+    private static final GlobalIndexPosition TWENTY = new GlobalIndexPosition(20);
+    private static final GlobalIndexPosition MINIMUM = new GlobalIndexPosition(Long.MIN_VALUE);
+
+    @Test
+    void minShouldReturnSmallestPositionAndBeSymmetric() {
+        assertThat(TEN.min(TWENTY)).isEqualTo(TEN);
+        assertThat(TWENTY.min(TEN)).isEqualTo(TEN);
+        assertThat(MINIMUM.min(TEN)).isEqualTo(MINIMUM);
+        assertThat(TEN.min(MINIMUM)).isEqualTo(MINIMUM);
+
+        // Position.START should always be smaller:
+        assertThat(TEN.min(Position.START)).isEqualTo(Position.START);
+        assertThat(Position.START.min(TEN)).isEqualTo(Position.START);
+        assertThat(MINIMUM.min(Position.START)).isEqualTo(Position.START);
+        assertThat(Position.START.min(MINIMUM)).isEqualTo(Position.START);
+    }
+
+    @Test
+    void minShouldRejectInvalidPositions() {
+        assertThatThrownBy(() -> TEN.min(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> TEN.min(new AggregateSequenceNumberPosition(5))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void toIndexShouldConvertValidPositions() {
+        assertThat(GlobalIndexPosition.toIndex(TEN)).isEqualTo(10);
+        assertThat(GlobalIndexPosition.toIndex(TWENTY)).isEqualTo(20);
+        assertThat(GlobalIndexPosition.toIndex(MINIMUM)).isEqualTo(Long.MIN_VALUE);
+        assertThat(GlobalIndexPosition.toIndex(Position.START)).isEqualTo(Long.MIN_VALUE);
+    }
+
+    @Test
+    void toIndexShouldRejectInvalidPositions() {
+        assertThatThrownBy(() -> GlobalIndexPosition.toIndex(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> GlobalIndexPosition.toIndex(new AggregateSequenceNumberPosition(5))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void equalsAndHashCodeShouldRespectContract() {
+        EqualsVerifier.forClass(GlobalIndexPosition.class).verify();
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPositions.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/GlobalIndexPositions.java
@@ -1,0 +1,17 @@
+package org.axonframework.eventsourcing.eventstore;
+
+/**
+ * Test helper class to access package private constructor.
+ */
+public class GlobalIndexPositions {
+
+    /**
+     * Constructs a new {@link GlobalIndexPosition} with the given index.
+     *
+     * @param index an index
+     * @return a new {@link GlobalIndexPosition}, never {@code null}
+     */
+    public static GlobalIndexPosition of(long index) {
+        return new GlobalIndexPosition(index);
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SourcingConditionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SourcingConditionTest.java
@@ -30,14 +30,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class SourcingConditionTest {
 
     private static final EventCriteria TEST_CRITERIA = EventCriteria.havingTags("key", "value");
-    private static final long TEST_START = 42L;
+    private static final GlobalIndexPosition TEST_START = new GlobalIndexPosition(42);
 
     @Test
     void conditionForCriteria() {
         SourcingCondition result = SourcingCondition.conditionFor(TEST_CRITERIA);
 
         assertEquals(TEST_CRITERIA, result.criteria());
-        assertEquals(0, result.start());
+        assertEquals(Position.START, result.start());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <eaio-uuid.version>3.2</eaio-uuid.version>
+        <equalsverifier.version>4.2</equalsverifier.version>
         <!-- Reactive -->
         <projectreactor.version>3.7.11</projectreactor.version>
         <reactive.streams.spec.version>1.0.4</reactive.streams.spec.version>
@@ -355,6 +356,11 @@
                 <groupId>com.eaio.uuid</groupId>
                 <artifactId>uuid</artifactId>
                 <version>${eaio-uuid.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>nl.jqno.equalsverifier</groupId>
+                <artifactId>equalsverifier</artifactId>
+                <version>${equalsverifier.version}</version>
             </dependency>
             <!-- Reactive -->
             <dependency>


### PR DESCRIPTION
The position subtypes cannot be directly constructed, as IMHO they should only ever be constructable by the event storage engines, or returned by these engines.

I think there is significant overlap now when it comes to tracking positions.  There's `TrackingToken`, `ConsistencyMarker` and now `Position`.  `Position` is the most neutral, and I think could be used for all of these, where `TrackingToken` wraps `Position` and `ConsistencyMarker` is either simply a `Position` or also wraps a `Position`.  `ConsistencyMarker` was unsuitable to use for position information (due to its name), however, the other way around I think is quite valid.

I think all we'd need to make this work is to move the `GapAwareToken` logic to a specific `Position` implementation (`GapAwarePosition`) and then have `TrackingToken` wrap a generic `Position`.  But perhaps I'm oversimplifying things.  It could be a follow-up of this PR.

There's is also a significant overlap between `SourcingCondition` and `StreamingCondition` with the primary difference being that `SourcingCondition` requires a criteria (as otherwise it would just stream all events, and it would sort of be a streaming condition).   I really don't see a need to have two of these, can just have one `EventCondition` I think.

This pull request resolves #3672.