### PR TITLE
refactor: `StreamableEventSource` - remove generic parameter

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStore.java
@@ -54,7 +54,7 @@ import java.util.List;
  * @author Steven van Beelen
  * @since 0.1.0
  */
-public interface EventStore extends StreamableEventSource<EventMessage>, EventBus, DescribableComponent {
+public interface EventStore extends StreamableEventSource, EventBus, DescribableComponent {
 
     /**
      * Retrieves the {@link EventStoreTransaction transaction for appending events} for the given

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -80,7 +80,7 @@ class EventSourcingConfigurationDefaultsTest {
         assertInstanceOf(InterceptingEventStore.class, eventSink);
         assertInstanceOf(InterceptingEventStore.class, eventBus);
 
-        StreamableEventSource<?> streamableEventSource = resultConfig.getComponent(StreamableEventSource.class);
+        StreamableEventSource streamableEventSource = resultConfig.getComponent(StreamableEventSource.class);
         assertEquals(eventBus, streamableEventSource);
 
         SubscribableEventSource subscribableEventSource = resultConfig.getComponent(SubscribableEventSource.class);

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/Coordinator.java
@@ -21,7 +21,6 @@ import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.processors.streaming.StreamingEventProcessor;
 import org.axonframework.eventhandling.processors.streaming.segmenting.Segment;
 import org.axonframework.eventhandling.processors.streaming.segmenting.TrackerStatus;
-import org.axonframework.eventhandling.processors.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.processors.streaming.token.ReplayToken;
 import org.axonframework.eventhandling.processors.streaming.token.TrackingToken;
 import org.axonframework.eventhandling.processors.streaming.token.WrappedToken;
@@ -85,7 +84,7 @@ class Coordinator {
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final String name;
-    private final StreamableEventSource<? extends EventMessage> eventSource;
+    private final StreamableEventSource eventSource;
     private final TokenStore tokenStore;
     private final UnitOfWorkFactory unitOfWorkFactory;
     private final ScheduledExecutorService executorService;
@@ -394,7 +393,7 @@ class Coordinator {
     static class Builder {
 
         private String name;
-        private StreamableEventSource<? extends EventMessage> eventSource;
+        private StreamableEventSource eventSource;
         private TokenStore tokenStore;
         private UnitOfWorkFactory unitOfWorkFactory;
         private ScheduledExecutorService executorService;
@@ -432,7 +431,7 @@ class Coordinator {
          * @param eventSource The source of events this coordinator should schedule per work package.
          * @return The current Builder instance, for fluent interfacing.
          */
-        Builder eventSource(StreamableEventSource<? extends EventMessage> eventSource) {
+        Builder eventSource(StreamableEventSource eventSource) {
             this.eventSource = eventSource;
             return this;
         }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessor.java
@@ -88,7 +88,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
 
     private final String name;
     private final PooledStreamingEventProcessorConfiguration configuration;
-    private final StreamableEventSource<? extends EventMessage> eventSource;
+    private final StreamableEventSource eventSource;
     private final ProcessorEventHandlingComponents eventHandlingComponents;
     private final EventCriteria eventCriteria;
     private final UnitOfWorkFactory unitOfWorkFactory;

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -48,7 +48,6 @@ import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitor;
 
 import java.time.Clock;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -92,7 +91,7 @@ import static org.axonframework.common.BuilderUtils.assertStrictPositive;
  */
 public class PooledStreamingEventProcessorConfiguration extends EventProcessorConfiguration {
 
-    private StreamableEventSource<? extends EventMessage> eventSource;
+    private StreamableEventSource eventSource;
     private TokenStore tokenStore;
     private ScheduledExecutorService coordinatorExecutor;
     private ScheduledExecutorService workerExecutor;
@@ -191,7 +190,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * @return The current instance, for fluent interfacing.
      */
     public PooledStreamingEventProcessorConfiguration eventSource(
-            @Nonnull StreamableEventSource<? extends EventMessage> eventSource) {
+            @Nonnull StreamableEventSource eventSource) {
         assertNonNull(eventSource, "StreamableEventSource may not be null");
         this.eventSource = eventSource;
         return this;
@@ -500,7 +499,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      *
      * @return The {@link StreamableEventSource} for this processor.
      */
-    public StreamableEventSource<? extends EventMessage> eventSource() {
+    public StreamableEventSource eventSource() {
         return eventSource;
     }
 

--- a/messaging/src/main/java/org/axonframework/eventstreaming/StreamableEventSource.java
+++ b/messaging/src/main/java/org/axonframework/eventstreaming/StreamableEventSource.java
@@ -30,13 +30,12 @@ import org.axonframework.messaging.unitofwork.ProcessingContext;
  * Provides functionality to {@link #open(StreamingCondition, ProcessingContext) open} an
  * {@link MessageStream event stream}.
  *
- * @param <E> The type of {@link EventMessage} streamed by this source.
  * @author Allard Buijze
  * @author Rene de Waele
  * @author Steven van Beelen
  * @since 3.0
  */
-public interface StreamableEventSource<E extends EventMessage> extends TrackingTokenSource {
+public interface StreamableEventSource extends TrackingTokenSource {
 
     /**
      * Open an {@link MessageStream event stream} containing all {@link EventMessage events} matching the given
@@ -58,6 +57,6 @@ public interface StreamableEventSource<E extends EventMessage> extends TrackingT
      * @param context   The current {@link ProcessingContext}, if any.
      * @return An {@link MessageStream event stream} matching the given {@code condition}.
      */
-    MessageStream<E> open(@Nonnull StreamingCondition condition, @Nullable ProcessingContext context);
+    MessageStream<EventMessage> open(@Nonnull StreamingCondition condition, @Nullable ProcessingContext context);
 
 }

--- a/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/CoordinatorTest.java
@@ -73,7 +73,7 @@ class CoordinatorTest {
     private final TokenStore tokenStore = mock(TokenStore.class);
     private final ScheduledThreadPoolExecutor executorService = mock(ScheduledThreadPoolExecutor.class);
     @SuppressWarnings("unchecked")
-    private final StreamableEventSource<EventMessage> messageSource = mock(StreamableEventSource.class);
+    private final StreamableEventSource messageSource = mock(StreamableEventSource.class);
     private final WorkPackage workPackage = mock(WorkPackage.class);
     private Coordinator testSubject;
 

--- a/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/utils/AsyncInMemoryStreamableEventSource.java
@@ -75,7 +75,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author Mateusz Nowak
  * @since 5.0.0
  */
-public class AsyncInMemoryStreamableEventSource implements StreamableEventSource<EventMessage> {
+public class AsyncInMemoryStreamableEventSource implements StreamableEventSource {
 
     /**
      * An {@link EventMessage#payload()} representing a failed event.


### PR DESCRIPTION
Follow the approach we've done in other parts like `SubscribableEventSource`.