### PR TITLE
chore: handler interceptors use generic super message type

### DIFF
--- a/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -95,7 +95,7 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     private final LinkedList<ParameterResolverFactory> registeredParameterResolverFactories = new LinkedList<>();
     private final LinkedList<HandlerDefinition> registeredHandlerDefinitions = new LinkedList<>();
     private final LinkedList<HandlerEnhancerDefinition> registeredHandlerEnhancerDefinitions = new LinkedList<>();
-    private final LinkedList<MessageHandlerInterceptor<EventMessage>> eventHandlerInterceptors = new LinkedList<>();
+    private final LinkedList<MessageHandlerInterceptor<? super EventMessage>> eventHandlerInterceptors = new LinkedList<>();
     private final RecordingListenerInvocationErrorHandler recordingListenerInvocationErrorHandler;
 
     private final Class<T> sagaType;

--- a/messaging/src/main/java/org/axonframework/commandhandling/interceptors/CommandMessageHandlerInterceptorChain.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/interceptors/CommandMessageHandlerInterceptorChain.java
@@ -52,9 +52,9 @@ public class CommandMessageHandlerInterceptorChain implements MessageHandlerInte
      * @param interceptors   The list of handler interceptors that are part of this chain.
      * @param commandHandler The command handler to be invoked at the end of the interceptor chain.
      */
-    public CommandMessageHandlerInterceptorChain(@Nonnull List<MessageHandlerInterceptor<CommandMessage>> interceptors,
+    public CommandMessageHandlerInterceptorChain(@Nonnull List<MessageHandlerInterceptor<? super CommandMessage>> interceptors,
                                                  @Nonnull CommandHandler commandHandler) {
-        Iterator<MessageHandlerInterceptor<CommandMessage>> interceptorIterator =
+        Iterator<MessageHandlerInterceptor<? super CommandMessage>> interceptorIterator =
                 new LinkedList<>(interceptors).descendingIterator();
         CommandHandler handler = Objects.requireNonNull(commandHandler, "The Command Handler may not be null.");
         while (interceptorIterator.hasNext()) {

--- a/messaging/src/main/java/org/axonframework/commandhandling/interceptors/InterceptingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/interceptors/InterceptingCommandBus.java
@@ -72,7 +72,7 @@ public class InterceptingCommandBus implements CommandBus {
     public static final int DECORATION_ORDER = Integer.MIN_VALUE + 100;
 
     private final CommandBus delegate;
-    private final List<MessageHandlerInterceptor<CommandMessage>> handlerInterceptors;
+    private final List<MessageHandlerInterceptor<? super CommandMessage>> handlerInterceptors;
     private final List<MessageDispatchInterceptor<? super CommandMessage>> dispatchInterceptors;
     private final InterceptingDispatcher interceptingDispatcher;
 
@@ -89,7 +89,7 @@ public class InterceptingCommandBus implements CommandBus {
      */
     public InterceptingCommandBus(
             @Nonnull CommandBus delegate,
-            @Nonnull List<MessageHandlerInterceptor<CommandMessage>> handlerInterceptors,
+            @Nonnull List<MessageHandlerInterceptor<? super CommandMessage>> handlerInterceptors,
             @Nonnull List<MessageDispatchInterceptor<? super CommandMessage>> dispatchInterceptors
     ) {
         this.delegate = requireNonNull(delegate, "The command bus delegate must be null.");
@@ -136,7 +136,7 @@ public class InterceptingCommandBus implements CommandBus {
         private final CommandMessageHandlerInterceptorChain interceptorChain;
 
         private InterceptingHandler(CommandHandler handler,
-                                    List<MessageHandlerInterceptor<CommandMessage>> interceptors) {
+                                    List<MessageHandlerInterceptor<? super CommandMessage>> interceptors) {
             this.interceptorChain = new CommandMessageHandlerInterceptorChain(interceptors, handler);
         }
 

--- a/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/configuration/MessagingConfigurationDefaults.java
@@ -295,7 +295,7 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
                 CommandBus.class,
                 InterceptingCommandBus.DECORATION_ORDER,
                 (config, name, delegate) -> {
-                    List<MessageHandlerInterceptor<CommandMessage>> handlerInterceptors =
+                    List<MessageHandlerInterceptor<? super CommandMessage>> handlerInterceptors =
                             config.getComponent(HandlerInterceptorRegistry.class).commandInterceptors(config);
                     List<MessageDispatchInterceptor<? super CommandMessage>> dispatchInterceptors =
                             config.getComponent(DispatchInterceptorRegistry.class).commandInterceptors(config);

--- a/messaging/src/main/java/org/axonframework/eventhandling/configuration/EventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/configuration/EventProcessorConfiguration.java
@@ -69,7 +69,7 @@ public class EventProcessorConfiguration implements DescribableComponent {
                                                                                       .spanFactory(NoOpSpanFactory.INSTANCE)
                                                                                       .build();
     protected UnitOfWorkFactory unitOfWorkFactory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
-    protected List<MessageHandlerInterceptor<EventMessage>> interceptors = new ArrayList<>();
+    protected List<MessageHandlerInterceptor<? super EventMessage>> interceptors = new ArrayList<>();
 
     /**
      * Constructs a new {@code EventProcessorConfiguration} with just default values. Do not retrieve any global default
@@ -218,7 +218,7 @@ public class EventProcessorConfiguration implements DescribableComponent {
      * @return The list of {@link EventMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors} to
      * add to the {@link EventProcessor} under construction with this configuration implementation.
      */
-    public List<MessageHandlerInterceptor<EventMessage>> interceptors() {
+    public List<MessageHandlerInterceptor<? super EventMessage>> interceptors() {
         return new ArrayList<>(interceptors);
     }
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/interceptors/EventMessageHandlerInterceptorChain.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/interceptors/EventMessageHandlerInterceptorChain.java
@@ -52,9 +52,9 @@ public class EventMessageHandlerInterceptorChain implements MessageHandlerInterc
      * @param interceptors The list of handler interceptors that are part of this chain.
      * @param eventHandler The event handler to be invoked at the end of the interceptor chain.
      */
-    public EventMessageHandlerInterceptorChain(@Nonnull List<MessageHandlerInterceptor<EventMessage>> interceptors,
+    public EventMessageHandlerInterceptorChain(@Nonnull List<MessageHandlerInterceptor<? super EventMessage>> interceptors,
                                                @Nonnull EventHandler eventHandler) {
-        Iterator<MessageHandlerInterceptor<EventMessage>> interceptorIterator =
+        Iterator<MessageHandlerInterceptor<? super EventMessage>> interceptorIterator =
                 new LinkedList<>(interceptors).descendingIterator();
         EventHandler interceptingHandler = Objects.requireNonNull(eventHandler, "The Event Handler may not be null.");
         while (interceptorIterator.hasNext()) {

--- a/messaging/src/main/java/org/axonframework/eventhandling/interceptors/InterceptingEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/interceptors/InterceptingEventHandlingComponent.java
@@ -68,7 +68,7 @@ public class InterceptingEventHandlingComponent extends DelegatingEventHandlingC
      * @param messageHandlerInterceptors The list of interceptors to initialize with.
      */
     public InterceptingEventHandlingComponent(
-            @Nonnull List<MessageHandlerInterceptor<EventMessage>> messageHandlerInterceptors,
+            @Nonnull List<MessageHandlerInterceptor<? super EventMessage>> messageHandlerInterceptors,
             @Nonnull EventHandlingComponent delegate
     ) {
         super(delegate);

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/DefaultHandlerInterceptorRegistry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/DefaultHandlerInterceptorRegistry.java
@@ -49,16 +49,16 @@ public class DefaultHandlerInterceptorRegistry implements HandlerInterceptorRegi
 
     private static final TypeReference<MessageHandlerInterceptor<Message>> MESSAGE_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
     };
-    private static final TypeReference<MessageHandlerInterceptor<CommandMessage>> COMMAND_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
+    private static final TypeReference<MessageHandlerInterceptor<? super CommandMessage>> COMMAND_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
     };
-    private static final TypeReference<MessageHandlerInterceptor<EventMessage>> EVENT_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
+    private static final TypeReference<MessageHandlerInterceptor<? super EventMessage>> EVENT_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
     };
-    private static final TypeReference<MessageHandlerInterceptor<QueryMessage>> QUERY_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
+    private static final TypeReference<MessageHandlerInterceptor<? super QueryMessage>> QUERY_INTERCEPTOR_TYPE_REF = new TypeReference<>() {
     };
 
-    private final List<ComponentDefinition<MessageHandlerInterceptor<CommandMessage>>> commandInterceptorDefinitions = new ArrayList<>();
-    private final List<ComponentDefinition<MessageHandlerInterceptor<EventMessage>>> eventInterceptorDefinitions = new ArrayList<>();
-    private final List<ComponentDefinition<MessageHandlerInterceptor<QueryMessage>>> queryInterceptorDefinitions = new ArrayList<>();
+    private final List<ComponentDefinition<MessageHandlerInterceptor<? super CommandMessage>>> commandInterceptorDefinitions = new ArrayList<>();
+    private final List<ComponentDefinition<MessageHandlerInterceptor<? super EventMessage>>> eventInterceptorDefinitions = new ArrayList<>();
+    private final List<ComponentDefinition<MessageHandlerInterceptor<? super QueryMessage>>> queryInterceptorDefinitions = new ArrayList<>();
 
     @Nonnull
     @Override
@@ -141,19 +141,19 @@ public class DefaultHandlerInterceptorRegistry implements HandlerInterceptorRegi
 
     @Nonnull
     @Override
-    public List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors(@Nonnull Configuration config) {
+    public List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors(@Nonnull Configuration config) {
         return resolveInterceptors(commandInterceptorDefinitions, config);
     }
 
     @Nonnull
     @Override
-    public List<MessageHandlerInterceptor<EventMessage>> eventInterceptors(@Nonnull Configuration config) {
+    public List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors(@Nonnull Configuration config) {
         return resolveInterceptors(eventInterceptorDefinitions, config);
     }
 
     @Nonnull
     @Override
-    public List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors(@Nonnull Configuration config) {
+    public List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors(@Nonnull Configuration config) {
         return resolveInterceptors(queryInterceptorDefinitions, config);
     }
 
@@ -166,17 +166,17 @@ public class DefaultHandlerInterceptorRegistry implements HandlerInterceptorRegi
 
 
     // Solves common verification, creation and combining for all handler interceptors.
-    private static <T extends Message> List<MessageHandlerInterceptor<T>> resolveInterceptors(
-            List<ComponentDefinition<MessageHandlerInterceptor<T>>> definitions,
+    private static <T extends Message> List<MessageHandlerInterceptor<? super T>> resolveInterceptors(
+            List<ComponentDefinition<MessageHandlerInterceptor<? super T>>> definitions,
             Configuration config
     ) {
-        List<MessageHandlerInterceptor<T>> handlerInterceptors = new ArrayList<>();
-        for (ComponentDefinition<MessageHandlerInterceptor<T>> interceptorBuilder : definitions) {
-            if (!(interceptorBuilder instanceof ComponentDefinition.ComponentCreator<MessageHandlerInterceptor<T>> creator)) {
+        List<MessageHandlerInterceptor<? super T>> handlerInterceptors = new ArrayList<>();
+        for (ComponentDefinition<MessageHandlerInterceptor<? super T>> interceptorBuilder : definitions) {
+            if (!(interceptorBuilder instanceof ComponentDefinition.ComponentCreator<MessageHandlerInterceptor<? super T>> creator)) {
                 // The compiler should avoid this from happening.
                 throw new IllegalArgumentException("Unsupported component definition type: " + interceptorBuilder);
             }
-            MessageHandlerInterceptor<T> handlerInterceptor = creator.createComponent().resolve(config);
+            MessageHandlerInterceptor<? super T> handlerInterceptor = creator.createComponent().resolve(config);
             handlerInterceptors.add(handlerInterceptor);
         }
         return handlerInterceptors;

--- a/messaging/src/main/java/org/axonframework/messaging/interceptors/HandlerInterceptorRegistry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/interceptors/HandlerInterceptorRegistry.java
@@ -116,7 +116,7 @@ public interface HandlerInterceptorRegistry extends DescribableComponent {
      * @return The list of {@link CommandMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors}.
      */
     @Nonnull
-    List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors(@Nonnull Configuration config);
+    List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors(@Nonnull Configuration config);
 
     /**
      * Returns the list of {@link EventMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors}
@@ -130,7 +130,7 @@ public interface HandlerInterceptorRegistry extends DescribableComponent {
      * @return The list of {@link EventMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors}.
      */
     @Nonnull
-    List<MessageHandlerInterceptor<EventMessage>> eventInterceptors(@Nonnull Configuration config);
+    List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors(@Nonnull Configuration config);
 
     /**
      * Returns the list of {@link QueryMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors}
@@ -144,5 +144,5 @@ public interface HandlerInterceptorRegistry extends DescribableComponent {
      * @return The list of {@link QueryMessage}-specific {@link MessageHandlerInterceptor MessageHandlerInterceptors}.
      */
     @Nonnull
-    List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors(@Nonnull Configuration config);
+    List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors(@Nonnull Configuration config);
 }

--- a/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurerTest.java
+++ b/messaging/src/test/java/org/axonframework/configuration/MessagingConfigurerTest.java
@@ -311,21 +311,21 @@ class MessagingConfigurerTest extends ApplicationConfigurerTestSuite<MessagingCo
                                           .build();
         HandlerInterceptorRegistry handlerInterceptorRegistry = result.getComponent(HandlerInterceptorRegistry.class);
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors =
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors =
                 handlerInterceptorRegistry.commandInterceptors(result);
         assertThat(commandInterceptors).hasSize(1);
         //noinspection DataFlowIssue | Input is not important to validate invocation
         commandInterceptors.getFirst().interceptOnHandle(null, null, null);
         assertThat(counter).hasValue(1);
 
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors =
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors =
                 handlerInterceptorRegistry.eventInterceptors(result);
         assertThat(eventInterceptors).hasSize(1);
         //noinspection DataFlowIssue | Input is not important to validate invocation
         eventInterceptors.getFirst().interceptOnHandle(null, null, null);
         assertThat(counter).hasValue(2);
 
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors =
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors =
                 handlerInterceptorRegistry.queryInterceptors(result);
         assertThat(queryInterceptors).hasSize(1);
         //noinspection DataFlowIssue | Input is not important to validate invocation
@@ -341,7 +341,7 @@ class MessagingConfigurerTest extends ApplicationConfigurerTestSuite<MessagingCo
         Configuration result = testSubject.registerCommandHandlerInterceptor(c -> handlerInterceptor)
                                           .build();
 
-        List<MessageHandlerInterceptor<CommandMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
+        List<MessageHandlerInterceptor<? super CommandMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
                                                                              .commandInterceptors(result);
         assertThat(interceptors).contains(handlerInterceptor);
     }
@@ -354,7 +354,7 @@ class MessagingConfigurerTest extends ApplicationConfigurerTestSuite<MessagingCo
         Configuration result = testSubject.registerEventHandlerInterceptor(c -> handlerInterceptor)
                                           .build();
 
-        List<MessageHandlerInterceptor<EventMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
+        List<MessageHandlerInterceptor<? super EventMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
                                                                            .eventInterceptors(result);
         assertThat(interceptors).contains(handlerInterceptor);
     }
@@ -367,7 +367,7 @@ class MessagingConfigurerTest extends ApplicationConfigurerTestSuite<MessagingCo
         Configuration result = testSubject.registerQueryHandlerInterceptor(c -> handlerInterceptor)
                                           .build();
 
-        List<MessageHandlerInterceptor<QueryMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
+        List<MessageHandlerInterceptor<? super QueryMessage>> interceptors = result.getComponent(HandlerInterceptorRegistry.class)
                                                                            .queryInterceptors(result);
         assertThat(interceptors).contains(handlerInterceptor);
     }

--- a/messaging/src/test/java/org/axonframework/messaging/interceptors/DefaultHandlerInterceptorRegistryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/interceptors/DefaultHandlerInterceptorRegistryTest.java
@@ -56,11 +56,11 @@ class DefaultHandlerInterceptorRegistryTest {
     void registeredGenericInterceptorsIsReturnedForAllTypes() {
         HandlerInterceptorRegistry result = testSubject.registerInterceptor(c -> new GenericMessageHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(1);
     }
 
@@ -86,11 +86,11 @@ class DefaultHandlerInterceptorRegistryTest {
     void registeredCommandInterceptorsIsReturnedFromCommandInterceptorsOnly() {
         HandlerInterceptorRegistry result = testSubject.registerCommandInterceptor(c -> new CommandHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(0);
     }
 
@@ -103,7 +103,7 @@ class DefaultHandlerInterceptorRegistryTest {
         });
 
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
         commandInterceptors = result.commandInterceptors(config);
         commandInterceptors = result.commandInterceptors(config);
@@ -116,11 +116,11 @@ class DefaultHandlerInterceptorRegistryTest {
         HandlerInterceptorRegistry result =
                 testSubject.registerCommandInterceptor(c -> new GenericMessageHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(0);
     }
 
@@ -128,11 +128,11 @@ class DefaultHandlerInterceptorRegistryTest {
     void registeredEventInterceptorsIsReturnedFromEventInterceptorsOnly() {
         HandlerInterceptorRegistry result = testSubject.registerEventInterceptor(c -> new EventHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(0);
     }
 
@@ -145,7 +145,7 @@ class DefaultHandlerInterceptorRegistryTest {
         });
 
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
         eventInterceptors = result.eventInterceptors(config);
         eventInterceptors = result.eventInterceptors(config);
@@ -158,11 +158,11 @@ class DefaultHandlerInterceptorRegistryTest {
         HandlerInterceptorRegistry result =
                 testSubject.registerEventInterceptor(c -> new GenericMessageHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(1);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(0);
     }
 
@@ -170,11 +170,11 @@ class DefaultHandlerInterceptorRegistryTest {
     void registeredQueryInterceptorsIsReturnedFromQueryInterceptorsOnly() {
         HandlerInterceptorRegistry result = testSubject.registerQueryInterceptor(c -> new QueryHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(1);
     }
 
@@ -187,7 +187,7 @@ class DefaultHandlerInterceptorRegistryTest {
         });
 
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         //noinspection UnusedAssignment | Additional invocations are on purpose to validate the builder is invoked once.
         queryInterceptors = result.queryInterceptors(config);
         queryInterceptors = result.queryInterceptors(config);
@@ -200,11 +200,11 @@ class DefaultHandlerInterceptorRegistryTest {
         HandlerInterceptorRegistry result =
                 testSubject.registerQueryInterceptor(c -> new GenericMessageHandlerInterceptor());
 
-        List<MessageHandlerInterceptor<CommandMessage>> commandInterceptors = result.commandInterceptors(config);
+        List<MessageHandlerInterceptor<? super CommandMessage>> commandInterceptors = result.commandInterceptors(config);
         assertThat(commandInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<EventMessage>> eventInterceptors = result.eventInterceptors(config);
+        List<MessageHandlerInterceptor<? super EventMessage>> eventInterceptors = result.eventInterceptors(config);
         assertThat(eventInterceptors).size().isEqualTo(0);
-        List<MessageHandlerInterceptor<QueryMessage>> queryInterceptors = result.queryInterceptors(config);
+        List<MessageHandlerInterceptor<? super QueryMessage>> queryInterceptors = result.queryInterceptors(config);
         assertThat(queryInterceptors).size().isEqualTo(1);
     }
 


### PR DESCRIPTION
- this was asymmetric to dispatch interceptors