### PR TITLE
chore: clean conventions for Utility classes

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/MetadataConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/MetadataConverter.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @since 5.0.0
  */
 @Internal
-public class MetadataConverter {
+public final class MetadataConverter {
 
     private MetadataConverter() {
         // Utility class

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/command/CommandConverter.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.MetadataConverter;
-import org.axonframework.axonserver.connector.util.ProcessingInstructionHelper;
+import org.axonframework.axonserver.connector.util.ProcessingInstructionUtils;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
@@ -47,8 +47,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.axonframework.axonserver.connector.MetadataConverter.convertMetadataValuesToGrpc;
-import static org.axonframework.axonserver.connector.util.ProcessingInstructionHelper.createProcessingInstruction;
-import static org.axonframework.axonserver.connector.util.ProcessingInstructionHelper.priority;
+import static org.axonframework.axonserver.connector.util.ProcessingInstructionUtils.createProcessingInstruction;
+import static org.axonframework.axonserver.connector.util.ProcessingInstructionUtils.priority;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
@@ -70,7 +70,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @since 5.0.0
  */
 @Internal
-public class CommandConverter {
+public final class CommandConverter {
 
     private CommandConverter() {
         // Utility class
@@ -192,7 +192,7 @@ public class CommandConverter {
     public static CommandMessage convertCommand(@Nonnull Command command) {
         SerializedObject commandPayload = command.getPayload();
         int priority = priority(command.getProcessingInstructionsList());
-        String routingKey = ProcessingInstructionHelper.routingKey(command.getProcessingInstructionsList());
+        String routingKey = ProcessingInstructionUtils.routingKey(command.getProcessingInstructionsList());
         return new GenericCommandMessage(
                 new GenericMessage(
                         command.getMessageIdentifier(),

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/ConditionConverter.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/ConditionConverter.java
@@ -46,7 +46,7 @@ import java.util.Set;
  * @since 5.0.0
  */
 @Internal
-public abstract class ConditionConverter {
+public final class ConditionConverter {
 
     /**
      * Converts the given {@code condition} into a {@link ConsistencyCondition}.

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/EventProcessorInfoUtils.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/EventProcessorInfoUtils.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toList;
  * @since 4.0.0
  */
 @Internal
-class EventProcessorInfoUtils {
+final class EventProcessorInfoUtils {
 
     private static final String POOLED_STREAMING = "Pooled Streaming";
     private static final String SUBSCRIBING = "Subscribing";

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/AxonServerQueryBus.java
@@ -38,7 +38,7 @@ import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.query.subscription.SubscriptionMessageSerializer;
 import org.axonframework.axonserver.connector.util.ExceptionSerializer;
 import org.axonframework.axonserver.connector.util.PriorityTaskSchedulers;
-import org.axonframework.axonserver.connector.util.ProcessingInstructionHelper;
+import org.axonframework.axonserver.connector.util.ProcessingInstructionUtils;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonException;
 import org.axonframework.common.AxonThreadFactory;
@@ -1031,7 +1031,7 @@ public class AxonServerQueryBus implements QueryBus, Distributed<QueryBus> {
             CloseAwareReplyChannel<QueryResponse> closeAwareReplyChannel =
                     new CloseAwareReplyChannel<>(responseHandler, onClose);
 
-            long priority = ProcessingInstructionHelper.priority(query.getProcessingInstructionsList());
+            long priority = ProcessingInstructionUtils.priority(query.getProcessingInstructionsList());
             QueryProcessingTask processingTask = new QueryProcessingTask(
                     localSegment, query, closeAwareReplyChannel, serializer, configuration.getClientId(), spanFactory
             );

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/query/QueryProcessingTask.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static org.axonframework.axonserver.connector.util.ProcessingInstructionHelper.*;
+import static org.axonframework.axonserver.connector.util.ProcessingInstructionUtils.*;
 
 /**
  * The task that processes a single incoming query message from Axon Server. It decides which query type should be

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExceptionSerializer.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ExceptionSerializer.java
@@ -26,7 +26,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @author Marc Gathier
  * @since 4.0
  */
-public abstract class ExceptionSerializer {
+public final class ExceptionSerializer {
 
     private ExceptionSerializer() {
         // Utility class

--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ProcessingInstructionUtils.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/util/ProcessingInstructionUtils.java
@@ -30,9 +30,9 @@ import java.util.Optional;
  * @author Marc Gathier
  * @since 4.0
  */
-public abstract class ProcessingInstructionHelper {
+public final class ProcessingInstructionUtils {
 
-    private ProcessingInstructionHelper() {
+    private ProcessingInstructionUtils() {
         // Utility class
     }
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -28,7 +28,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.event.StubServer;
-import org.axonframework.axonserver.connector.util.TcpUtil;
+import org.axonframework.axonserver.connector.util.TcpUtils;
 import org.axonframework.axonserver.connector.utils.PlatformService;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
@@ -59,8 +59,8 @@ class AxonServerConnectionManagerTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        int port1 = TcpUtil.findFreePort();
-        int port2 = TcpUtil.findFreePort();
+        int port1 = TcpUtils.findFreePort();
+        int port2 = TcpUtils.findFreePort();
         stubServer = new StubServer(port1, port2);
         secondNode = new StubServer(port2, port2);
         stubServer.start();
@@ -111,7 +111,7 @@ class AxonServerConnectionManagerTest {
     @Test
     void connectionTimeout() throws IOException, InterruptedException {
         stubServer.shutdown();
-        stubServer = new StubServer(TcpUtil.findFreePort(), new PlatformService(TcpUtil.findFreePort()) {
+        stubServer = new StubServer(TcpUtils.findFreePort(), new PlatformService(TcpUtils.findFreePort()) {
             @Override
             public void getPlatformServer(ClientIdentification request, StreamObserver<PlatformInfo> responseObserver) {
                 // ignore calls

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/DummyMessagePlatformServer.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/command/DummyMessagePlatformServer.java
@@ -31,7 +31,7 @@ import io.grpc.stub.StreamObserver;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.utils.PlatformService;
 import org.axonframework.axonserver.connector.event.EventStoreImpl;
-import org.axonframework.axonserver.connector.util.TcpUtil;
+import org.axonframework.axonserver.connector.util.TcpUtils;
 import org.axonframework.axonserver.connector.utils.ContextInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +63,7 @@ public class DummyMessagePlatformServer {
     private final Set<String> unsubscribedCommands = new CopyOnWriteArraySet<>();
 
     public DummyMessagePlatformServer() {
-        this(TcpUtil.findFreePort());
+        this(TcpUtils.findFreePort());
     }
 
     public DummyMessagePlatformServer(int port) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventProcessorInfoConfigurationTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/EventProcessorInfoConfigurationTest.java
@@ -18,7 +18,7 @@ package org.axonframework.axonserver.connector.event.axon;
 
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.event.StubServer;
-import org.axonframework.axonserver.connector.util.TcpUtil;
+import org.axonframework.axonserver.connector.util.TcpUtils;
 import org.axonframework.configuration.AxonConfiguration;
 import org.axonframework.configuration.MessagingConfigurer;
 import org.junit.jupiter.api.*;
@@ -34,7 +34,7 @@ class EventProcessorInfoConfigurationTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        port = TcpUtil.findFreePort();
+        port = TcpUtils.findFreePort();
         stubServer = new StubServer(port);
         stubServer.start();
     }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/AxonServerQueryBusTest.java
@@ -35,7 +35,7 @@ import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.axonserver.connector.ErrorCode;
 import org.axonframework.axonserver.connector.TargetContextResolver;
 import org.axonframework.axonserver.connector.TestTargetContextResolver;
-import org.axonframework.axonserver.connector.util.ProcessingInstructionHelper;
+import org.axonframework.axonserver.connector.util.ProcessingInstructionUtils;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.lifecycle.ShutdownInProgressException;
@@ -411,7 +411,7 @@ class AxonServerQueryBusTest {
         //noinspection resource
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
-                        && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
+                        && 1 == ProcessingInstructionUtils.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
                    spanFactory.verifySpanCompleted("QueryBus.streamingQueryDistributed", testQuery);
@@ -435,7 +435,7 @@ class AxonServerQueryBusTest {
         //noinspection resource
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
-                        && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
+                        && 1 == ProcessingInstructionUtils.numberOfResults(r.getProcessingInstructionsList())));
         await().atMost(Duration.ofSeconds(3))
                .untilAsserted(() -> {
                    spanFactory.verifySpanCompleted("QueryBus.streamingQueryDistributed");
@@ -458,7 +458,7 @@ class AxonServerQueryBusTest {
         //noinspection resource
         verify(mockQueryChannel).query(argThat(
                 r -> r.getPayload().getData().toStringUtf8().equals("<string>Hello, World</string>")
-                        && 1 == ProcessingInstructionHelper.numberOfResults(r.getProcessingInstructionsList())));
+                        && 1 == ProcessingInstructionUtils.numberOfResults(r.getProcessingInstructionsList())));
     }
 
     @Test

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ProcessingInstructionUtilsTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/ProcessingInstructionUtilsTest.java
@@ -26,11 +26,11 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test class validating the {@link ProcessingInstructionHelper}.
+ * Test class validating the {@link ProcessingInstructionUtils}.
  *
  * @author Steven van Beelen
  */
-class ProcessingInstructionHelperTest {
+class ProcessingInstructionUtilsTest {
 
     private static final long EXPECTED_VALUE = 1729L;
     private static final MetaDataValue TEST_META_DATA_VALUE = MetaDataValue.newBuilder()
@@ -39,7 +39,7 @@ class ProcessingInstructionHelperTest {
 
     @Test
     void priorityDefaultsToZero() {
-        assertEquals(0L, ProcessingInstructionHelper.priority(Collections.emptyList()));
+        assertEquals(0L, ProcessingInstructionUtils.priority(Collections.emptyList()));
     }
 
     @Test
@@ -50,12 +50,12 @@ class ProcessingInstructionHelperTest {
                                      .setValue(TEST_META_DATA_VALUE)
                                      .build();
         assertEquals(EXPECTED_VALUE,
-                     ProcessingInstructionHelper.priority(Collections.singletonList(testProcessingInstruction)));
+                     ProcessingInstructionUtils.priority(Collections.singletonList(testProcessingInstruction)));
     }
 
     @Test
     void numberOfResultsDefaultsToZero() {
-        assertEquals(1L, ProcessingInstructionHelper.numberOfResults(Collections.emptyList()));
+        assertEquals(1L, ProcessingInstructionUtils.numberOfResults(Collections.emptyList()));
     }
 
     @Test
@@ -66,12 +66,12 @@ class ProcessingInstructionHelperTest {
                                      .setValue(TEST_META_DATA_VALUE)
                                      .build();
         assertEquals(EXPECTED_VALUE,
-                     ProcessingInstructionHelper.numberOfResults(Collections.singletonList(testProcessingInstruction)));
+                     ProcessingInstructionUtils.numberOfResults(Collections.singletonList(testProcessingInstruction)));
     }
 
     @Test
     void timeoutDefaultsToZero() {
-        assertEquals(0L, ProcessingInstructionHelper.timeout(Collections.emptyList()));
+        assertEquals(0L, ProcessingInstructionUtils.timeout(Collections.emptyList()));
     }
 
     @Test
@@ -82,6 +82,6 @@ class ProcessingInstructionHelperTest {
                                      .setValue(TEST_META_DATA_VALUE)
                                      .build();
         assertEquals(EXPECTED_VALUE,
-                     ProcessingInstructionHelper.timeout(Collections.singletonList(testProcessingInstruction)));
+                     ProcessingInstructionUtils.timeout(Collections.singletonList(testProcessingInstruction)));
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/TcpUtils.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/util/TcpUtils.java
@@ -24,9 +24,9 @@ import java.net.ServerSocket;
 /**
  * Class for networking related utility methods
  */
-public abstract class TcpUtil {
+public final class TcpUtils {
 
-    private TcpUtil() {
+    private TcpUtils() {
     }
 
     /**

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/utils/AssertUtils.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/utils/AssertUtils.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  * @author Sara Pellegrini
  * @author Steven van Beelen
  */
-public abstract class AssertUtils {
+public final class AssertUtils {
 
     private AssertUtils() {
         // Utility class

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/utils/FutureUtils.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/utils/FutureUtils.java
@@ -18,7 +18,7 @@ package org.axonframework.axonserver.connector.utils;
 
 import java.util.concurrent.CompletableFuture;
 
-public abstract class FutureUtils {
+public final class FutureUtils {
 
     private FutureUtils() {
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedEventStorageEngineUtils.java
@@ -35,7 +35,7 @@ import static org.axonframework.eventsourcing.eventstore.AppendEventsTransaction
  * @author Allard Buijze
  * @since 5.0.0
  */
-public class AggregateBasedEventStorageEngineUtils {
+public final class AggregateBasedEventStorageEngineUtils {
 
     /**
      * Validates the tags associated with a list of event messages. Ensures that no event has more than one tag, as the

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/SpringUtils.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/SpringUtils.java
@@ -38,7 +38,7 @@ import static org.springframework.core.annotation.AnnotationUtils.getAnnotation;
  * @author Steven van Beelen
  * @since 3.1
  */
-public class SpringUtils {
+public final class SpringUtils {
 
     private SpringUtils() {
         // Private constructor to enforce as utility class.

--- a/messaging/src/main/java/org/axonframework/common/Assert.java
+++ b/messaging/src/main/java/org/axonframework/common/Assert.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
  * @author Allard Buijze
  * @since 0.3
  */
-public abstract class Assert {
+public final class Assert {
 
     private Assert() {
         // Utility class

--- a/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/BuilderUtils.java
@@ -25,7 +25,7 @@ import java.util.function.Predicate;
  * @author Steven van Beelen
  * @since 4.0
  */
-public abstract class BuilderUtils {
+public final class BuilderUtils {
 
     private BuilderUtils() {
         // Utility class

--- a/messaging/src/main/java/org/axonframework/common/ClassUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ClassUtils.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Utility for creating classes by name containing a class cache.
  */
-public class ClassUtils {
+public final class ClassUtils {
 
     private static ClassLoader classLoader = ClassUtils.class.getClassLoader();
     private static ConcurrentHashMap<String, Class<?>> cache = new ConcurrentHashMap<>();

--- a/messaging/src/main/java/org/axonframework/common/CollectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/CollectionUtils.java
@@ -35,7 +35,7 @@ import static java.util.stream.Collectors.toList;
  * @author Allard Buijze
  * @since 0.7
  */
-public abstract class CollectionUtils {
+public final class CollectionUtils {
 
     private CollectionUtils() {
         // prevent instantiation

--- a/messaging/src/main/java/org/axonframework/common/ConstructorUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ConstructorUtils.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
-public class ConstructorUtils {
+public final class ConstructorUtils {
 
     /**
      * Returns a function that constructs an instance of the given type using the zero-argument constructor. If the type

--- a/messaging/src/main/java/org/axonframework/common/DateTimeUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/DateTimeUtils.java
@@ -31,7 +31,7 @@ import static java.time.temporal.ChronoField.*;
  * @author Allard Buijze
  * @since 3.1
  */
-public abstract class DateTimeUtils {
+public final class DateTimeUtils {
 
     private static final DateTimeFormatter ISO_UTC_DATE_TIME = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()

--- a/messaging/src/main/java/org/axonframework/common/ExceptionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ExceptionUtils.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
  *
  * @author Rene de Waele
  */
-public abstract class ExceptionUtils {
+public final class ExceptionUtils {
 
     private ExceptionUtils() {
     }

--- a/messaging/src/main/java/org/axonframework/common/FutureUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/FutureUtils.java
@@ -30,7 +30,7 @@ import java.util.function.BiConsumer;
  * @author Allard Buijze
  * @since 5.0.0
  */
-public abstract class FutureUtils {
+public final class FutureUtils {
 
     private FutureUtils() {
         // Utility class

--- a/messaging/src/main/java/org/axonframework/common/ListUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ListUtils.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  * @author Stefan Andjelkovic
  * @since 4.4
  */
-public abstract class ListUtils {
+public final class ListUtils {
 
     private ListUtils() {
         // prevent instantiation

--- a/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ObjectUtils.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
  * @author Allard Buijze
  * @since 3.0
  */
-public abstract class ObjectUtils {
+public final class ObjectUtils {
 
     private ObjectUtils() {
         // Utility class

--- a/messaging/src/main/java/org/axonframework/common/ProcessUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ProcessUtils.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
  * @author Marc Gathier
  * @since 4.2
  */
-public abstract class ProcessUtils {
+public final class ProcessUtils {
 
     private ProcessUtils() {
     }

--- a/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -48,7 +48,7 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * @author Allard Buijze
  * @since 0.7
  */
-public abstract class ReflectionUtils {
+public final class ReflectionUtils {
 
     /**
      * A map of Primitive types to their respective wrapper types.

--- a/messaging/src/main/java/org/axonframework/common/StringUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/StringUtils.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * @author Steven van Beelen
  * @since 4.5
  */
-public abstract class StringUtils {
+public final class StringUtils {
 
     private static final String EMPTY_STRING = "";
 

--- a/messaging/src/main/java/org/axonframework/common/TypeReflectionUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/TypeReflectionUtils.java
@@ -41,7 +41,7 @@ import java.util.stream.IntStream;
  * @author Steven van Beelen
  * @since 3.2
  */
-public abstract class TypeReflectionUtils {
+public final class TypeReflectionUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(TypeReflectionUtils.class);
 

--- a/messaging/src/main/java/org/axonframework/common/annotations/AnnotationUtils.java
+++ b/messaging/src/main/java/org/axonframework/common/annotations/AnnotationUtils.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * @author Allard Buijze
  * @since 3.0
  */
-public abstract class AnnotationUtils {
+public final class AnnotationUtils {
 
     /**
      * Boolean specifying that a {@link #findAnnotationAttributes(AnnotatedElement, String, boolean)} invocation should

--- a/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
+++ b/messaging/src/main/java/org/axonframework/lifecycle/Phase.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
  * @see org.axonframework.configuration.ComponentDefinition#onShutdown(int, Consumer)
  * @since 4.3.0
  */
-public abstract class Phase {
+public final class Phase {
 
     private Phase() {
         // Utility class


### PR DESCRIPTION
- only static methods
- private constructor
- final (not abstract, as this allows subclassing)
- e.g. named *Utils