### PR TITLE
Removed exceptional results references from ResultMessage

### DIFF
--- a/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
+++ b/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/ResultValidatorImpl.java
@@ -22,7 +22,6 @@ import org.axonframework.commandhandling.CommandResultMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.messaging.HandlerExecutionException;
 import org.axonframework.messaging.Message;
-import org.axonframework.messaging.ResultMessage;
 import org.axonframework.messaging.unitofwork.LegacyDefaultUnitOfWork;
 import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.test.FixtureExecutionException;
@@ -481,8 +480,8 @@ public class ResultValidatorImpl<T> implements ResultValidator<T> {
 
     public void recordResult(@Nonnull CommandMessage commandMessage,
                              @Nonnull Message result) {
-        if (result instanceof ResultMessage commandResultMessage && commandResultMessage.isExceptional()) {
-            recordException(commandResultMessage.exceptionResult());
+        if (result.payload() instanceof Throwable e) {
+            recordException(e);
         } else {
             actualReturnValue = result;
         }

--- a/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -188,10 +188,10 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
                 ).proceed(unitOfWork.getMessage(), context)
         );
 
-        if (resultMessage.isExceptional()) {
-            Throwable e = resultMessage.exceptionResult();
-            if (Error.class.isAssignableFrom(e.getClass())) {
-                throw (Error) e;
+        if (resultMessage.payload() instanceof Throwable) {
+            Throwable e = resultMessage.payloadAs(Throwable.class);
+            if (e instanceof Error error) {
+                throw error;
             }
             throw new FixtureExecutionException("Exception occurred while handling an event", e);
         }

--- a/legacy-saga/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
+++ b/legacy-saga/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaManagerTest.java
@@ -190,8 +190,8 @@ public class AnnotatedSagaManagerTest {
             testSubject.handle(event, ctx, Segment.ROOT_SEGMENT);
             return null;
         });
-        if (resultMessage.isExceptional()) {
-            throw (Exception) resultMessage.exceptionResult();
+        if (resultMessage.payload() instanceof Exception ex) {
+            throw ex;
         }
     }
 

--- a/legacy-saga/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
+++ b/legacy-saga/src/test/java/org/axonframework/modelling/saga/SagaManagerTest.java
@@ -157,8 +157,7 @@ class SagaManagerTest {
             testSubject.handle(event, ctx, Segment.ROOT_SEGMENT);
             return null;
         });
-        if (resultMessage.isExceptional()) {
-            Throwable e = resultMessage.exceptionResult();
+        if (resultMessage.payload() instanceof Throwable e) {
             assertEquals("Mock", e.getMessage());
         } else {
             fail("Expected exception to be propagated");

--- a/legacy/src/main/java/org/axonframework/messaging/unitofwork/ExecutionResult.java
+++ b/legacy/src/main/java/org/axonframework/messaging/unitofwork/ExecutionResult.java
@@ -56,7 +56,7 @@ public class ExecutionResult {
      * @return The exception raised during execution of the task if any, {@code null} otherwise.
      */
     public Throwable getExceptionResult() {
-        return isExceptionResult() ? result.exceptionResult() : null;
+        return result.payload() instanceof Throwable ? (Throwable) result.payload() : null;
     }
 
     /**
@@ -65,7 +65,7 @@ public class ExecutionResult {
      * @return {@code true} if execution of the task gave rise to an exception, {@code false} otherwise.
      */
     public boolean isExceptionResult() {
-        return result.isExceptional();
+        return result.payload() instanceof Throwable;
     }
 
     @Override

--- a/legacy/src/main/java/org/axonframework/messaging/unitofwork/LegacyUnitOfWork.java
+++ b/legacy/src/main/java/org/axonframework/messaging/unitofwork/LegacyUnitOfWork.java
@@ -310,11 +310,11 @@ public interface LegacyUnitOfWork<T extends Message> {
             task.accept(ctx);
             return null;
         }, rollbackConfiguration);
-        if (resultMessage.isExceptional()) {
-            if (resultMessage.exceptionResult() instanceof RuntimeException exception) {
+        if (resultMessage.payload() instanceof Throwable e) {
+            if (e instanceof RuntimeException exception) {
                 throw exception;
             }
-            throw new RuntimeException(resultMessage.exceptionResult());
+            throw new RuntimeException(e);
         }
     }
 

--- a/legacy/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
+++ b/legacy/src/test/java/org/axonframework/messaging/unitofwork/BatchingUnitOfWorkTest.java
@@ -170,20 +170,20 @@ class BatchingUnitOfWorkTest {
                                                       .map(ExecutionResult::getResult)
                                                       .collect(Collectors.toList());
         List<?> expectedPayloads = expectedMessages.stream()
-                                                   .filter(crm -> !crm.isExceptional())
+                                                   .filter(crm -> !(crm.payload() instanceof Throwable))
                                                    .map(Message::payload)
                                                    .collect(Collectors.toList());
         List<?> actualPayloads = actualMessages.stream()
-                                               .filter(crm -> !crm.isExceptional())
+                                               .filter(crm -> !(crm.payload() instanceof Throwable))
                                                .map(Message::payload)
                                                .collect(Collectors.toList());
         List<Throwable> expectedExceptions = expectedMessages.stream()
-                                                             .filter(ResultMessage::isExceptional)
-                                                             .map(ResultMessage::exceptionResult)
+                                                             .filter(crm -> (crm.payload() instanceof Throwable))
+                                                             .map(crm -> (Throwable) crm.payload())
                                                              .collect(Collectors.toList());
         List<Throwable> actualExceptions = actualMessages.stream()
-                                                         .filter(ResultMessage::isExceptional)
-                                                         .map(ResultMessage::exceptionResult)
+                                                         .filter(crm -> (crm.payload() instanceof Throwable))
+                                                         .map(crm -> (Throwable) crm.payload())
                                                          .collect(Collectors.toList());
         List<Metadata> expectedMetadata = expectedMessages.stream()
                                                           .map(Message::metadata)

--- a/legacy/src/test/java/org/axonframework/messaging/unitofwork/ExecutionResultTest.java
+++ b/legacy/src/test/java/org/axonframework/messaging/unitofwork/ExecutionResultTest.java
@@ -44,7 +44,7 @@ class ExecutionResultTest {
         ExecutionResult subject = new ExecutionResult(resultMessage);
         assertTrue(subject.isExceptionResult());
         assertSame(mockException, subject.getExceptionResult());
-        assertSame(mockException, subject.getResult().exceptionResult());
+        assertSame(mockException, subject.getResult().payload());
     }
 
     @Test
@@ -54,6 +54,6 @@ class ExecutionResultTest {
         ExecutionResult subject = new ExecutionResult(resultMessage);
         assertTrue(subject.isExceptionResult());
         assertSame(mockException, subject.getExceptionResult());
-        assertSame(mockException, subject.getResult().exceptionResult());
+        assertSame(mockException, subject.getResult().payload());
     }
 }

--- a/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/commandhandling/GenericCommandResultMessage.java
@@ -111,37 +111,16 @@ public class GenericCommandResultMessage extends GenericResultMessage implements
         super(delegate);
     }
 
-    /**
-     * Constructs a {@code GenericCommandResultMessage} for the given {@code delegate} and {@code exception} as a cause
-     * for the failure, intended to reconstruct another {@link CommandResultMessage}.
-     * <p>
-     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
-     * of Work.
-     *
-     * @param delegate  The {@link Message} containing {@link Message#payload() payload}, {@link Message#type() type},
-     *                  {@link Message#identifier() identifier} and {@link Message#metadata() metadata} for the
-     *                  {@link QueryResponseMessage} to reconstruct.
-     * @param exception The {@link Throwable} describing the error representing the response of this
-     *                  {@link CommandResultMessage}.
-     */
-    @Deprecated
-    public GenericCommandResultMessage(@Nonnull Message delegate,
-                                       @Nullable Throwable exception) {
-        super(delegate, exception);
-    }
-
     @Override
     @Nonnull
     public CommandResultMessage withMetadata(@Nonnull Map<String, String> metadata) {
-        Throwable exception = optionalExceptionResult().orElse(null);
-        return new GenericCommandResultMessage(delegate().withMetadata(metadata), exception);
+        return new GenericCommandResultMessage(delegate().withMetadata(metadata));
     }
 
     @Override
     @Nonnull
     public CommandResultMessage andMetadata(@Nonnull Map<String, String> metadata) {
-        Throwable exception = optionalExceptionResult().orElse(null);
-        return new GenericCommandResultMessage(delegate().andMetadata(metadata), exception);
+        return new GenericCommandResultMessage(delegate().andMetadata(metadata));
     }
 
     @Override
@@ -157,7 +136,7 @@ public class GenericCommandResultMessage extends GenericResultMessage implements
                                                delegate.type(),
                                                convertedPayload,
                                                delegate.metadata());
-        return new GenericCommandResultMessage(converted, optionalExceptionResult().orElse(null));
+        return new GenericCommandResultMessage(converted);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/ResultMessage.java
@@ -22,60 +22,14 @@ import org.axonframework.serialization.Converter;
 
 import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.Optional;
 
 /**
- * A {@link Message} that represents a result of handling some form of request message.
+ * A {@link Message} that represents a result of handling some form of a request message.
  *
  * @author Milan Savic
  * @since 4.0.0
  */
 public interface ResultMessage extends Message {
-
-    /**
-     * Indicates whether the ResultMessage represents unsuccessful execution.
-     *
-     * @return {@code true} if execution was unsuccessful, {@code false} otherwise
-     * @deprecated Exceptional results will be reported as an exception or using a failed MessageStream
-     */
-    @Deprecated
-    boolean isExceptional();
-
-    /**
-     * Returns the Exception in case of exceptional result message or an empty {@link Optional} in case of successful
-     * execution.
-     *
-     * @return an {@link Optional} containing exception result or an empty Optional in case of a successful execution
-     * @deprecated Exceptional results will be reported as an exception or using a failed MessageStream
-     */
-    @Deprecated
-    Optional<Throwable> optionalExceptionResult();
-
-    /**
-     * Returns the exception result. This method is to be called if {@link #isExceptional()} returns {@code true}.
-     *
-     * @return a {@link Throwable} defining the exception result
-     * @throws IllegalStateException if this ResultMessage is not exceptional
-     * @deprecated Exceptional results will be reported as an exception or using a failed MessageStream
-     */
-    @Deprecated
-    default Throwable exceptionResult() throws IllegalStateException {
-        return optionalExceptionResult().orElseThrow(IllegalStateException::new);
-    }
-
-    /**
-     * If the this message contains an exception result, returns the details provided in the exception, if available. If
-     * this message does not carry an exception result, or the exception result doesn't provide any application-specific
-     * details, an empty optional is returned.
-     *
-     * @param <D> The type of application-specific details expected
-     * @return an optional containing application-specific error details, if present
-     * @deprecated Exceptional results will be reported as an exception or using a failed MessageStream
-     */
-    @Deprecated
-    default <D> Optional<D> exceptionDetails() {
-        return optionalExceptionResult().flatMap(HandlerExecutionException::resolveDetails);
-    }
 
     @Override
     @Nonnull

--- a/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/GenericQueryResponseMessage.java
@@ -70,20 +70,6 @@ public class GenericQueryResponseMessage extends GenericResultMessage implements
     }
 
     /**
-     * Constructs a {@code GenericQueryResponseMessage} for the given {@code type} and {@code exception}.
-     *
-     * @param type               The {@link MessageType type} for this {@link QueryResponseMessage}.
-     * @param exception          The {@link Throwable} describing the error representing the response of this
-     *                           {@link QueryResponseMessage}.
-     * @param declaredResultType The declared result type of this {@link QueryResponseMessage}.
-     */
-    public GenericQueryResponseMessage(@Nonnull MessageType type,
-                                       @Nonnull Throwable exception,
-                                       @Nonnull Class<?> declaredResultType) {
-        this(type, exception, declaredResultType, Metadata.emptyInstance());
-    }
-
-    /**
      * Constructs a {@code GenericQueryResponseMessage} for the given {@code type}, {@code result}, and
      * {@code metadata}.
      * <p>
@@ -120,23 +106,6 @@ public class GenericQueryResponseMessage extends GenericResultMessage implements
     }
 
     /**
-     * Constructs a {@code GenericQueryResponseMessage} for the given {@code type}, {@code exception}, and
-     * {@code metadata}.
-     *
-     * @param type               The {@link MessageType type} for this {@link QueryResponseMessage}.
-     * @param exception          The {@link Throwable} describing the error representing the response of this
-     *                           {@link QueryResponseMessage}.
-     * @param declaredResultType The declared result type of this {@link QueryResponseMessage}.
-     * @param metadata           The metadata for this {@link QueryResponseMessage}.
-     */
-    public GenericQueryResponseMessage(@Nonnull MessageType type,
-                                       @Nonnull Throwable exception,
-                                       @Nonnull Class<?> declaredResultType,
-                                       @Nonnull Map<String, String> metadata) {
-        super(new GenericMessage(type, null, declaredResultType, metadata), exception);
-    }
-
-    /**
      * Constructs a {@code GenericQueryResponseMessage} for the given {@code delegate}, intended to reconstruct another
      * {@link QueryResponseMessage}.
      * <p>
@@ -149,24 +118,6 @@ public class GenericQueryResponseMessage extends GenericResultMessage implements
      */
     public GenericQueryResponseMessage(@Nonnull Message delegate) {
         super(delegate);
-    }
-
-    /**
-     * Constructs a {@code GenericQueryResponseMessage} for the given {@code delegate} and {@code exception} as a cause
-     * for the failure, intended to reconstruct another {@link QueryResponseMessage}.
-     * <p>
-     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
-     * of Work.
-     *
-     * @param delegate  The {@link Message} containing {@link Message#payload() payload},
-     *                  {@link Message#type() type, {@link Message#identifier() identifier} and {@link
-     *                  Message#metadata() metadata} for the {@link QueryResponseMessage} to reconstruct.
-     * @param exception The {@link Throwable} describing the error representing the response of this
-     *                  {@link QueryResponseMessage}.
-     */
-    public GenericQueryResponseMessage(@Nonnull Message delegate,
-                                       @Nonnull Throwable exception) {
-        super(delegate, exception);
     }
 
     @Override
@@ -193,8 +144,6 @@ public class GenericQueryResponseMessage extends GenericResultMessage implements
                                                delegate.type(),
                                                convertedPayload,
                                                delegate.metadata());
-        return optionalExceptionResult().isPresent()
-                ? new GenericQueryResponseMessage(converted, optionalExceptionResult().get())
-                : new GenericQueryResponseMessage(converted);
+        return new GenericQueryResponseMessage(converted);
     }
 }

--- a/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
+++ b/test/src/test/java/org/axonframework/test/utils/RecordingCommandBusTest.java
@@ -54,7 +54,7 @@ class RecordingCommandBusTest {
         var result = testSubject.dispatch(secondTestCommand, null);
 
         Message commandResultMessage = result.get();
-        if (commandResultMessage instanceof CommandResultMessage cmr && cmr.isExceptional()) {
+        if (commandResultMessage.payload() instanceof Exception) {
             fail("Didn't expect handling to fail");
         }
         assertNull(commandResultMessage.payload(),
@@ -74,7 +74,7 @@ class RecordingCommandBusTest {
         testSubject.dispatch(firstTestCommand, null);
 
         var commandResultMessage = testSubject.dispatch(secondTestCommand, null).get();
-        if (commandResultMessage instanceof CommandResultMessage cmr && cmr.isExceptional()) {
+        if (commandResultMessage.payload() instanceof Exception) {
             fail("Didn't expect handling to fail");
         }
         assertEquals("callbackResult", commandResultMessage.payload());

--- a/todo/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
+++ b/todo/src/main/java/org/axonframework/test/deadline/StubDeadlineManager.java
@@ -297,8 +297,7 @@ public class StubDeadlineManager implements DeadlineManager {
             return processingResult;
         });
         if (resultMessage != null) {
-            if (resultMessage.isExceptional()) {
-                Throwable e = resultMessage.exceptionResult();
+            if (resultMessage.payload() instanceof Throwable e) {
                 throw new FixtureExecutionException("Exception occurred while handling the deadline", e);
             }
             return (DeadlineMessage) resultMessage.payload();


### PR DESCRIPTION
Exceptional results are no longer part of the ResultMessage, but of the stream itself that carries the messages.

Resolves #3758