### PR TITLE
Fixed inconsistent responses issue in DistributedQueryBus

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/QualifiedName.java
+++ b/messaging/src/main/java/org/axonframework/messaging/QualifiedName.java
@@ -116,11 +116,12 @@ public record QualifiedName(@Nonnull String name) {
 
     /**
      * Returns the full name of this QualifiedName, consisting of the namespace and localName, separated by a "."
-     * (dot).
+     * (dot). If no namespace is defined, it returns the localName only.
      *
      * @return the full name of this QualifiedName
+     * @see #name()
      */
     public String fullName() {
-        return namespace() + "." + localName();
+        return name;
     }
 }

--- a/messaging/src/main/java/org/axonframework/queryhandling/distributed/DistributedQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/queryhandling/distributed/DistributedQueryBus.java
@@ -197,16 +197,7 @@ public class DistributedQueryBus implements QueryBus {
             queryingExecutor.execute(
                     new PriorityRunnable(() -> {
                         try {
-                            var result = localSegment.query(query, null);
-                            result.first()
-                                  .asCompletableFuture()
-                                  .whenComplete((firstMessage, error) -> {
-                                      if (error != null) {
-                                          localResult.completeExceptionally(error);
-                                      } else {
-                                          localResult.complete(result);
-                                      }
-                                  });
+                            localResult.complete(localSegment.query(query, null));
                         } catch (Exception e) {
                             localResult.completeExceptionally(e);
                         }


### PR DESCRIPTION
Resolves an issue where the initial result was truncated and wouldn't return the first item of the stream.