### PR TITLE
Polling mechanism for event stores relying on a relational database

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStream.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStream.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.common.Registration;
+import org.axonframework.common.annotations.Internal;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MessageStream;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A {@link MessageStream} implementation that continuously fetches event messages
+ * from a configurable data source. This stream has no defined end and will
+ * continue retrieving new batches of data as they become available.
+ * <p>
+ * The stream relies on externally provided functional strategies to control its
+ * behavior:
+ * <ul>
+ *     <li>A {@code fetcher} to obtain the next batch of elements based on the last item fetched.</li>
+ *     <li>A {@code converter} to transform fetched elements into {@link Entry} instances.</li>
+ *     <li>A {@code callbackTracker} to manage callback registration for new data availability.</li>
+ * </ul>
+ * The stream supports lifecycle management through {@link #close()} and
+ * callback registration via {@link #setCallback(Runnable)}.
+ *
+ * @param <E> the type of the raw elements returned by the fetcher before conversion to {@link EventMessage}s
+ */
+@Internal
+public final class ContinuousMessageStream<E> implements MessageStream<EventMessage> {
+    private final Function<E, List<E>> fetcher;
+    private final BiFunction<ContinuousMessageStream<?>, Runnable, Registration> callbackTracker;
+    private final Function<E, Entry<EventMessage>> converter;
+
+    private E lastItem;
+    private List<E> data = List.of();
+    private Entry<EventMessage> nextEntry;
+    private Throwable error;
+    private int position;  // position within data
+    private Registration callbackRegistration;
+    private Runnable callback;
+    private boolean closed;
+
+    /**
+     * Creates a new {@code ContinuousMessageStream} instance configured with the given strategies.
+     *
+     * @param fetcher          a function that, given the last fetched element (or {@code null} for the first call),
+     *                         retrieves the next batch of elements; must not return {@code null}
+     * @param converter        a function converting each fetched element into an {@link Entry} containing an {@link EventMessage}
+     * @param callbackTracker  a function that, given this stream and a callback {@link Runnable}, registers
+     *                         a listener and returns a {@link Registration} allowing it to be canceled
+     */
+    public ContinuousMessageStream(
+        @Nonnull Function<E, List<E>> fetcher,
+        @Nonnull Function<E, Entry<EventMessage>> converter,
+        @Nonnull BiFunction<ContinuousMessageStream<?>, Runnable, Registration> callbackTracker
+    ) {
+        this.fetcher = Objects.requireNonNull(fetcher, "fetcher");
+        this.converter = Objects.requireNonNull(converter, "converter");
+        this.callbackTracker = Objects.requireNonNull(callbackTracker, "callbackTracker");
+    }
+
+    @Override
+    public synchronized void setCallback(Runnable callback) {
+        if (!closed) {
+            this.callback = callback;
+
+            if (callback == null) {
+                callbackRegistration.cancel();
+                callbackRegistration = null;
+            }
+            else if (callbackRegistration == null) {
+                this.callbackRegistration = callbackTracker.apply(this, this::invokeCallback);
+            }
+
+            invokeCallback();  // safe, it checks for null
+        }
+    }
+
+    @Override
+    public synchronized Optional<Entry<EventMessage>> next() {
+        try {
+            return peek();
+        }
+        finally {
+            nextEntry = null;
+        }
+    }
+
+    @Override
+    public synchronized Optional<Entry<EventMessage>> peek() {
+        if (closed) {
+            return Optional.empty();
+        }
+
+        if (nextEntry == null) {
+            if (position >= data.size()) {
+                fetchMore();  // TODO #3854 - ContinuousMessageStream may block in its MessageStream::peek call (and methods that rely on it) which is not allowed
+
+                if (closed || data.isEmpty()) {  // closed may happen here if fetch had an error
+                    return Optional.empty();
+                }
+            }
+
+            E element = data.get(position++);
+
+            nextEntry = converter.apply(element);
+        }
+
+        return Optional.of(nextEntry);
+    }
+
+    @Override
+    public synchronized Optional<Throwable> error() {
+        return Optional.ofNullable(error);
+    }
+
+    @Override
+    public synchronized boolean isCompleted() {
+        return error != null;  // an infinite stream only completes when an error occurred
+    }
+
+    @Override
+    public synchronized boolean hasNextAvailable() {
+        return peek().isPresent();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!closed) {
+            closed = true;
+            data = null;
+
+            if (callbackRegistration != null) {
+                invokeCallback();
+
+                callback = null;
+                callbackRegistration.cancel();
+            }
+        }
+    }
+
+    private void invokeCallback() {
+        try {
+            if (callback != null) {
+                callback.run();
+            }
+        }
+        catch (Exception e) {
+            error = e;
+            close();
+        }
+    }
+
+    private void fetchMore() {
+        try {
+            this.data = fetcher.apply(lastItem);
+            this.position = 0;
+
+            if (!data.isEmpty()) {
+                this.lastItem = data.getLast();
+            }
+        }
+        catch (Exception e) {
+            error = e;
+            close();
+        }
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventCoordinator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventCoordinator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.common.annotations.Internal;
+
+import java.util.List;
+
+/**
+ * Coordinates appended events notifications for event storage engines.
+ * <p>
+ * Implementations can notify only within the current process, or coordinate
+ * between multiple instances using mechanisms such as polling, messaging,
+ * or database notifications.
+ */
+@Internal
+public interface EventCoordinator {
+
+    /**
+     * A coordinator that only forwards append notifications within a single
+     * event storage engine. It does not coordinate between multiple instances.
+     */
+    public static EventCoordinator SIMPLE = callback -> new Handle() {
+        @Override
+        public void onEventsAppended(List<TaggedEventMessage<?>> events) {
+            callback.run();
+        }
+
+        @Override
+        public void terminate() {}
+    };
+
+    /**
+     * Starts a coordination instance that will invoke the given callback
+     * when new events are appended.
+     * <p>
+     * The callback may be invoked on an arbitrary thread. Implementations
+     * should ensure the callback does not perform long-running or blocking
+     * operations. If the callback throws an exception, the coordination
+     * is terminated.
+     *
+     * @param onAppendDetected the callback to invoke when new events are detected;
+     *                         must not be {@code null}
+     * @return a handle to interact with the coordination instance, including
+     *         notifying of new events and terminating the coordination; never {@code null}
+     */
+    Handle startCoordination(Runnable onAppendDetected);
+
+    /**
+     * Represents a handle to a coordination instance, allowing the engine
+     * to notify of new events and to terminate the coordination.
+     */
+    interface Handle {
+
+        /**
+         * Invoked by the storage engine when new events have been appended.
+         * <p>
+         * This method may be called concurrently from multiple threads.
+         * Implementations should avoid heavy or blocking operations.
+         *
+         * @param events the events that were appended; never {@code null} or empty
+         */
+        void onEventsAppended(List<TaggedEventMessage<?>> events);
+
+        /**
+         * Terminates this coordination instance, releasing any resources
+         * or threads used internally.
+         * <p>
+         * After termination, the handle should not be used again.
+         */
+        void terminate();
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -38,9 +38,10 @@ import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngi
 import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.ContinuousMessageStream;
 import org.axonframework.eventsourcing.eventstore.EmptyAppendTransaction;
+import org.axonframework.eventsourcing.eventstore.EventCoordinator;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
-import org.axonframework.messaging.LegacyResources;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.StreamSpliterator;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
@@ -48,8 +49,10 @@ import org.axonframework.eventstreaming.EventCriterion;
 import org.axonframework.eventstreaming.StreamingCondition;
 import org.axonframework.eventstreaming.Tag;
 import org.axonframework.messaging.Context;
+import org.axonframework.messaging.LegacyResources;
 import org.axonframework.messaging.MessageStream;
 import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.SimpleEntry;
 import org.axonframework.messaging.unitofwork.ProcessingContext;
 import org.axonframework.serialization.Converter;
 import org.slf4j.Logger;
@@ -65,6 +68,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -95,14 +99,6 @@ import static org.axonframework.eventsourcing.eventstore.AggregateBasedEventStor
 public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(AggregateBasedJpaEventStorageEngine.class);
-
-    /**
-     * The batch optimization is intended to *not* retrieve a second batch of events to cover for potential gaps in the
-     * first batch. This optimization is desirable for aggregate event streams, as these close once the end is reached.
-     * For token-based event reading the stream does not necessarily close once reaching the end, thus the optimization
-     * will block further event retrieval.
-     */
-    private static final boolean BATCH_OPTIMIZATION_DISABLED = false;
 
     private static final TypeReference<Map<String, String>> METADATA_MAP_TYPE_REF = new TypeReference<>() {
     };
@@ -151,6 +147,14 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private final GapAwareTrackingTokenOperations tokenOperations;
 
     /**
+     * Tracks runnables for callbacks attached to streams for when new events may
+     * have become available.
+     */
+    private final Map<Object, Runnable> streamCallbacks = new ConcurrentHashMap<>();
+
+    private EventCoordinator.Handle eventCoordinatorHandle;
+
+    /**
      * Constructs an {@code AggregateBasedJpaEventStorageEngine} with the given parameters.
      *
      * @param entityManagerProvider The {@link jakarta.persistence.EntityManager} provided for this storage solution.
@@ -170,7 +174,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         this.transactionManager = requireNonNull(transactionManager, "The transactionManager may not be null.");
         this.converter = requireNonNull(converter, "The converter may not be null.");
 
-        var config = requireNonNull(configurer, "the configurationOverride may not be null.")
+        var config = requireNonNull(configurer, "The configurer may not be null.")
                 .apply(AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT);
         this.persistenceExceptionResolver = config.persistenceExceptionResolver();
         this.finalBatchPredicate = config.finalBatchPredicate();
@@ -180,6 +184,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         this.maxGapOffset = config.maxGapOffset();
 
         this.tokenOperations = new GapAwareTrackingTokenOperations(config.gapTimeout(), logger);
+        this.eventCoordinatorHandle = config.eventCoordinator().startCoordination(this::onAppendDetected);
     }
 
     /**
@@ -226,6 +231,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                 try {
                     entityManagerPersistEvents(aggregateSequencer, events);
                     tx.commit();
+                    eventCoordinatorHandle.onEventsAppended(events);
                     txResult.complete(null);
                 } catch (Exception e) {
                     tx.rollback();
@@ -367,14 +373,16 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     @Override
     public MessageStream<EventMessage> stream(@Nonnull StreamingCondition condition, @Nullable ProcessingContext processingContext) {
         GapAwareTrackingToken trackingToken = tokenOperations.assertGapAwareTrackingToken(condition.position());
-        StreamSpliterator<? extends TokenAndEvent> entrySpliterator = new StreamSpliterator<>(
-                lastItem -> queryTokensAndEventsBy(lastItem == null ? trackingToken : lastItem.token()),
-                batch -> BATCH_OPTIMIZATION_DISABLED
-        );
 
-        return MessageStream.fromStream(StreamSupport.stream(entrySpliterator, false),
-                                        tokenEntry -> convertToEventMessage(tokenEntry.event()),
-                                        AggregateBasedJpaEventStorageEngine::buildTrackedContext);
+        return new ContinuousMessageStream<TokenAndEvent>(
+            last -> queryTokensAndEventsBy(last == null ? trackingToken : last.token),
+            tae -> new SimpleEntry<>(convertToEventMessage(tae.event), buildTrackedContext(tae)),
+            (ms, r) -> {
+                streamCallbacks.put(ms, r);
+
+                return () -> streamCallbacks.remove(ms) != null;
+            }
+        );
     }
 
     private List<TokenAndEvent> queryTokensAndEventsBy(TrackingToken start) {
@@ -508,6 +516,22 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         descriptor.describeProperty("converter", converter);
         descriptor.describeProperty("persistenceExceptionResolver", persistenceExceptionResolver);
         descriptor.describeProperty("tokenOperations", tokenOperations);
+    }
+
+    /**
+     * Releases any resources associated with this engine.
+     */
+    public void close() {
+        if (eventCoordinatorHandle != null) {
+            eventCoordinatorHandle.terminate();
+            eventCoordinatorHandle = null;
+        }
+    }
+
+    private void onAppendDetected() {
+        for (Runnable callback : streamCallbacks.values()) {
+            callback.run();
+        }
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.EntityManager;
+import org.axonframework.common.annotations.Internal;
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.eventsourcing.eventstore.EventCoordinator;
+import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An {@link EventCoordinator} implementation that polls a JPA-managed event table
+ * to detect newly appended events.
+ * <p>
+ * This coordinator periodically counts all entries in the event table. If the total
+ * number of events changes since the last poll, it triggers the provided callback.
+ */
+@Internal
+public class JpaPollingEventCoordinator implements EventCoordinator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JpaPollingEventCoordinator.class);
+    private static final ThreadFactory THREAD_FACTORY = Thread.ofPlatform()
+        .daemon()
+        .name(JpaPollingEventCoordinator.class.getSimpleName(), 1)
+        .factory();
+
+    private static final String COUNT_EVENTS =
+        """
+        SELECT COUNT(*) FROM AggregateEventEntry
+        """;
+
+    private final EntityManagerProvider entityManagerProvider;
+    private final Duration pollingInterval;
+
+    /**
+     * Creates a new JPA polling event coordinator.
+     *
+     * @param entityManagerProvider provides {@link EntityManager} instances for querying the event table; must not be {@code null}
+     * @param pollingInterval the duration between polling cycles; must be positive and not {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     * @throws IllegalArgumentException if {@code pollingInterval} is not positive
+     */
+    public JpaPollingEventCoordinator(
+        @Nonnull EntityManagerProvider entityManagerProvider,
+        @Nonnull Duration pollingInterval
+    ) {
+        this.entityManagerProvider = Objects.requireNonNull(entityManagerProvider, "entityManagerProvider");
+        this.pollingInterval = Objects.requireNonNull(pollingInterval, "pollingInterval");
+
+        if (!pollingInterval.isPositive()) {
+            throw new IllegalArgumentException("pollingInterval must be positive: " + pollingInterval);
+        }
+    }
+
+    /*
+     * Interrupts are used in two ways:
+     *
+     * - To immediately trigger a notification when onEventsAppended is called.
+     * - To terminate the polling thread when terminate is invoked.
+     *
+     * The COUNT(*) query is intentionally used for the JPA variant as it does not
+     * have a gapless monotonic index that can be relied on.
+     *
+     * Exceptions during polling are logged and do not terminate the coordination; the next
+     * poll will retry. However, if the callback itself throws an exception, coordination
+     * is terminated.
+     */
+
+    @Override
+    public Handle startCoordination(Runnable onAppendDetected) {
+        AtomicBoolean terminated = new AtomicBoolean();
+        Thread pollingThread = THREAD_FACTORY.newThread(() -> {
+            long lastTotalEvents = 0;
+
+            for (;;) {
+                try {
+                    Thread.sleep(pollingInterval);
+
+                    long totalEvents = countEvents();
+
+                    if (totalEvents == lastTotalEvents) {
+                        continue;
+                    }
+
+                    lastTotalEvents = totalEvents;
+                }
+                catch (InterruptedException e) {
+                    // Received request to stop or to recheck
+                    if (terminated.get()) {
+                        break;
+                    }
+                }
+                catch (Exception e) {
+                    LOGGER.warn("Exception while polling AggregateEventEntry, retrying next poll interval", e);
+                }
+
+                onAppendDetected.run();  // if this throws an exception, terminates the coordination
+            }
+
+            LOGGER.info("Exiting " + this);
+        });
+
+        pollingThread.start();
+
+        return new Handle() {
+
+            @Override
+            public void onEventsAppended(List<TaggedEventMessage<?>> events) {
+                if (events.size() > 0) {
+                    pollingThread.interrupt();
+                }
+            }
+
+            @Override
+            public void terminate() {
+                terminated.set(true);
+                pollingThread.interrupt();
+            }
+        };
+    }
+
+    private long countEvents() {
+        try (EntityManager entityManager = entityManagerProvider.getEntityManager()) {
+            return entityManager.createQuery(COUNT_EVENTS, Long.class).getSingleResult();
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -52,11 +52,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -597,6 +599,24 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     @Test
     void tokenAtShouldReturnNonNullForEmptyStore() throws InterruptedException, ExecutionException {
         assertThat(testSubject.tokenAt(Instant.now(), processingContext()).get()).isNotNull();
+    }
+
+    @Test
+    @Disabled("Fails for both JPA and Axon on the last await")  // TODO #3855 - When a sourcing completes, the callback should be called per MessageStream contract
+    void callbackShouldBeCalledWhenSourcingCompletes() {
+        AtomicBoolean called = new AtomicBoolean();
+        MessageStream<EventMessage> stream = testSubject.source(SourcingCondition.conditionFor(EventCriteria.havingTags("unknown", "non-existing")), processingContext());
+
+        stream.setCallback(() -> called.set(true));
+
+        called.set(false);  // on set, it is called immediately, so clear flag again
+
+        assertThat(stream.isCompleted()).isFalse();
+
+        stream.next();  // this seems required
+
+        await().untilAsserted(() -> assertThat(stream.isCompleted()).isTrue());
+        await().untilAsserted(() -> assertThat(called).isTrue());
     }
 
     private void assertTrackedEntry(Entry<EventMessage> actual, EventMessage expected, long eventNumber) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStreamTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStreamTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.MessageStream;
+import org.axonframework.messaging.MessageStream.Empty;
+import org.axonframework.messaging.MessageStream.Single;
+import org.axonframework.messaging.MessageStreamTest;
+import org.axonframework.messaging.MessageType;
+import org.axonframework.messaging.SimpleEntry;
+import org.junit.jupiter.api.Assumptions;
+
+import java.util.List;
+import java.util.UUID;
+
+public class ContinuousMessageStreamTest extends MessageStreamTest<EventMessage> {
+
+    @Override
+    protected MessageStream<EventMessage> completedTestSubject(List<EventMessage> messages) {
+        return new ContinuousMessageStream<EventMessage>(
+            last -> last == null ? messages : List.of(),
+            m -> new SimpleEntry<>(m),
+            (ms, r) -> () -> true
+        );
+    }
+
+    @Override
+    protected Single<EventMessage> completedSingleStreamTestSubject(EventMessage message) {
+        Assumptions.abort("doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    protected Empty<EventMessage> completedEmptyStreamTestSubject() {
+        Assumptions.abort("doesn't support explicitly empty streams");
+        return null;
+    }
+
+    @Override
+    protected MessageStream<EventMessage> failingTestSubject(List<EventMessage> messages, RuntimeException failure) {
+        return new ContinuousMessageStream<EventMessage>(
+            last -> {
+                if (last == null && !messages.isEmpty()) {
+                    return messages;
+                }
+
+                throw failure;
+            },
+            m -> new SimpleEntry<>(m),
+            (ms, r) -> () -> true
+        );
+    }
+
+    @Override
+    protected EventMessage createRandomMessage() {
+        return new GenericEventMessage(new MessageType("message"), UUID.randomUUID().toString());
+    }
+
+    @Override
+    protected boolean isBoundedStream() {
+        return false;
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationProperties.java
@@ -34,6 +34,7 @@ public class JpaEventStorageEngineConfigurationProperties {
     private int gapTimeout = 10_000;
     private long lowestGlobalSequence = 1;
     private int maxGapOffset = 60_000;
+    private long pollingInterval = 1000;
 
     /**
      * Batch size to retrieve events from the storage.
@@ -78,6 +79,15 @@ public class JpaEventStorageEngineConfigurationProperties {
      */
     public int maxGapOffset() {
         return maxGapOffset;
+    }
+
+    /**
+     * Retries the polling interval in milliseconds to detect new appended events.
+     *
+     * @return The polling interval. Defaults to 1000 ms.
+     */
+    public long pollingInterval() {
+        return pollingInterval;
     }
 
     /**
@@ -128,6 +138,15 @@ public class JpaEventStorageEngineConfigurationProperties {
      */
     public void maxGapOffset(int maxGapOffset) {
         this.maxGapOffset = maxGapOffset;
+    }
+
+    /**
+     * Sets the polling interval to detect new appended events.
+     *
+     * @param pollingInterval The polling interval in milliseconds.
+     */
+    public void pollingInterval(long pollingInterval) {
+        this.pollingInterval = pollingInterval;
     }
 }
 

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngineConfiguration;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaPollingEventCoordinator;
 import org.axonframework.extension.springboot.JpaEventStorageEngineConfigurationProperties;
 import org.axonframework.extension.springboot.util.RegisterDefaultEntities;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -39,6 +40,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.time.Duration;
 import java.util.function.UnaryOperator;
 
 /**
@@ -105,7 +107,13 @@ public class JpaEventStoreAutoConfiguration {
                             .gapTimeout(properties.gapTimeout())
                             .lowestGlobalSequence(properties.lowestGlobalSequence())
                             .maxGapOffset(properties.maxGapOffset())
-                            .persistenceExceptionResolver(persistenceExceptionResolver);
+                            .persistenceExceptionResolver(persistenceExceptionResolver)
+                            .eventCoordinator(
+                                new JpaPollingEventCoordinator(
+                                    entityManagerProvider,
+                                    Duration.ofMillis(properties.pollingInterval())
+                                )
+                            );
 
             registry.registerIfNotPresent(EventStorageEngine.class,
                                           (configuration)

--- a/messaging/src/test/java/org/axonframework/messaging/CloseCallbackMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/CloseCallbackMessageStreamTest.java
@@ -29,28 +29,28 @@ import static org.junit.jupiter.api.Assertions.*;
 class CloseCallbackMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(
+    protected MessageStream<Message> completedTestSubject(
             List<Message> messages) {
         return new CloseCallbackMessageStream<>(MessageStream.fromIterable(messages), () -> {
         });
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(
             Message message) {
         return CloseCallbackMessageStream.single(MessageStream.just(message), () -> {
         });
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         return CloseCallbackMessageStream.empty(MessageStream.empty(), () -> {
         });
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(
-            List<Message> messages, Exception failure) {
+    protected MessageStream<Message> failingTestSubject(
+            List<Message> messages, RuntimeException failure) {
         return new CloseCallbackMessageStream<>(MessageStream.fromIterable(messages)
                                                              .concatWith(MessageStream.failed(failure)),
                                                 () -> {
@@ -58,7 +58,7 @@ class CloseCallbackMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
             return new GenericMessage(new MessageType("message"),
                                       "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/CompletionCallbackMessageStreamTest.java
@@ -33,32 +33,32 @@ class CompletionCallbackMessageStreamTest extends MessageStreamTest<Message> {
     };
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(messages), NO_OP_COMPLETION_CALLBACK);
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("CompletionCallbackMessageStream does not support explicit single-item streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("CompletionCallbackMessageStream does not support explicit zero-item streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         return new CompletionCallbackMessageStream<>(MessageStream.fromIterable(messages)
                                                                   .concatWith(MessageStream.failed(failure)),
                                                      NO_OP_COMPLETION_CALLBACK);
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/ConcatenatingMessageStreamTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
 class ConcatenatingMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         if (messages.isEmpty()) {
             return new ConcatenatingMessageStream<>(MessageStream.empty().cast(), MessageStream.empty().cast());
         } else if (messages.size() == 1) {
@@ -51,25 +51,25 @@ class ConcatenatingMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("ConcatenatingMessageStream doesn't support explicit single-value streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("ConcatenatingMessageStream doesn't support explicitly empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                              Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         return completedTestSubject(messages).concatWith(MessageStream.failed(failure));
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                   "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/DelayedMessageStreamTest.java
@@ -39,24 +39,24 @@ import static org.mockito.Mockito.*;
 class DelayedMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         MessageStream<Message> testStream = MessageStream.fromIterable(messages);
         return DelayedMessageStream.create(CompletableFuture.completedFuture(testStream));
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         return DelayedMessageStream.createSingle(CompletableFuture.completedFuture(MessageStream.just(message)));
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         return new DelayedMessageStream.Empty<>(CompletableFuture.completedFuture(MessageStream.empty().cast()));
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         return DelayedMessageStream.create(CompletableFuture.completedFuture(
                 MessageStream.fromIterable(messages)
                              .concatWith(MessageStream.failed(failure)))
@@ -64,7 +64,7 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/EmptyMessageStreamTest.java
@@ -34,31 +34,31 @@ import static org.junit.jupiter.api.Assertions.*;
 class EmptyMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         Assumptions.assumeTrue(messages.isEmpty(), "EmptyMessageStream doesn't support content");
         return MessageStream.empty();
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("EmptyMessageStream doesn't support content");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         return MessageStream.empty();
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                    Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         Assumptions.abort("EmptyMessageStream doesn't support failed streams");
         return MessageStream.empty();
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         Assumptions.abort("EmptyMessageStream doesn't support content");
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FailedMessageStreamTest.java
@@ -31,32 +31,32 @@ import static org.junit.jupiter.api.Assertions.*;
 class FailedMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         Assumptions.abort("FailedMessageStream doesn't support successful streams");
         return null;
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("FailedMessageStream doesn't support successful streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("FailedMessageStream doesn't support successful streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                    Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         Assumptions.assumeTrue(messages.isEmpty(), "FailedMessageStream doesn't support content");
         return MessageStream.failed(failure);
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         Assumptions.abort("FailedMessageStream doesn't support content");
         return null;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/FilteringMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FilteringMessageStreamTest.java
@@ -33,28 +33,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FilteringMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return new FilteringMessageStream<>(MessageStream.fromIterable(messages), entry -> true);
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         return new FilteringMessageStream.Single<>(MessageStream.just(message), entry -> true);
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("ConcatenatingMessageStream doesn't support explicitly empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages, Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages, RuntimeException failure) {
         return completedTestSubject(messages).concatWith(MessageStream.failed(failure));
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/FluxMessageStreamTest.java
@@ -36,18 +36,18 @@ import static org.junit.jupiter.api.Assertions.*;
 class FluxMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return FluxUtils.asMessageStream(Flux.fromIterable(messages));
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("FluxMessageStream doesn't support explicit single-value streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("FluxMessageStream doesn't support explicitly empty streams");
         return null;
     }
@@ -55,7 +55,7 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
     protected MessageStream<Message> uncompletedTestSubject(List<Message> messages,
-                                                                    CompletableFuture<Void> completionMarker) {
+                                                            CompletableFuture<Void> completionMarker) {
         return FluxUtils.asMessageStream(Flux.fromIterable(messages).concatWith(
                 Flux.create(emitter -> completionMarker.whenComplete(
                         (v, e) -> {
@@ -69,12 +69,12 @@ class FluxMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages, Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages, RuntimeException failure) {
         return FluxUtils.asMessageStream(Flux.fromIterable(messages).concatWith(Mono.error(failure)));
     }
 
     @Override
-    Message createRandomMessage() {
+    protected  Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/IgnoredEntriesMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/IgnoredEntriesMessageStreamTest.java
@@ -34,30 +34,30 @@ import static org.junit.jupiter.api.Assertions.*;
 class IgnoredEntriesMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         Assumptions.assumeTrue(messages.isEmpty(), "EmptyMessageStream ignores entries");
         return MessageStream.fromIterable(messages).ignoreEntries();
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("IgnoredEntriesMessageStream ignores entries");
         return MessageStream.just(message).ignoreEntries();
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         return MessageStream.empty().ignoreEntries().cast();
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages, Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages, RuntimeException failure) {
         Assumptions.abort("IgnoredEntriesMessageStream ignores entries");
         return MessageStream.fromIterable(messages).concatWith(MessageStream.failed(failure)).ignoreEntries();
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }
@@ -76,6 +76,7 @@ class IgnoredEntriesMessageStreamTest extends MessageStreamTest<Message> {
         assertFalse(processed.get());
     }
 
+    @Override
     @Test
     void shouldEmitOriginalExceptionAsFailure() {
         var testSubject = MessageStream.failed(new MockException()).ignoreEntries();

--- a/messaging/src/test/java/org/axonframework/messaging/IteratorMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/IteratorMessageStreamTest.java
@@ -30,31 +30,31 @@ import java.util.concurrent.ThreadLocalRandom;
 class IteratorMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return MessageStream.fromIterable(messages);
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("IteratorMessageStream doesn't support explicit single-value streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("IteratorMessageStream doesn't support explicitly empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         Assumptions.abort("IterableMessageStream doesn't support failures");
         return null;
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/MappedMessageStreamTest.java
@@ -34,7 +34,7 @@ class MappedMessageStreamTest extends MessageStreamTest<Message> {
     private static final Function<Entry<Message>, Entry<Message>> NO_OP_MAPPER = entry -> entry;
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         if (messages.size() == 1) {
             return new MappedMessageStream.Single<>(MessageStream.just(messages.getFirst()), NO_OP_MAPPER);
         }
@@ -42,24 +42,24 @@ class MappedMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         return new MappedMessageStream.Single<>(MessageStream.just(message), NO_OP_MAPPER);
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("MappedMessageStream does not support empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> entries, Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> entries, RuntimeException failure) {
         return new MappedMessageStream<>(MessageStream.fromIterable(entries)
                                                       .concatWith(MessageStream.failed(failure)), NO_OP_MAPPER);
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnErrorContinueMessageStreamTest.java
@@ -30,26 +30,26 @@ import java.util.concurrent.ThreadLocalRandom;
 class OnErrorContinueMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages),
                                                   error -> MessageStream.empty().cast());
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("OnErrorContinueMessageStream doesn't support explicit single-value streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("OnErrorContinueMessageStream doesn't support explicitly empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         return new OnErrorContinueMessageStream<>(MessageStream.fromIterable(messages)
                                                                .concatWith(MessageStream.failed(new RuntimeException(
                                                                        "Wrong failure"))),
@@ -57,7 +57,7 @@ class OnErrorContinueMessageStreamTest extends MessageStreamTest<Message> {
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/OnNextMessageStreamTest.java
@@ -41,31 +41,31 @@ class OnNextMessageStreamTest extends MessageStreamTest<Message> {
     };
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return new OnNextMessageStream<>(MessageStream.fromIterable(messages), NO_OP_ON_NEXT);
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         return new OnNextMessageStream.Single<>(MessageStream.just(message), NO_OP_ON_NEXT);
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("OnNextMessageStream does not support empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         return new OnNextMessageStream<>(MessageStream.fromIterable(messages)
                                                       .concatWith(MessageStream.failed(failure)),
                                          NO_OP_ON_NEXT);
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/QueueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/QueueMessageStreamTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class QueueMessageStreamTest extends MessageStreamTest<EventMessage> {
 
     @Override
-    MessageStream<EventMessage> completedTestSubject(List<EventMessage> messages) {
+    protected MessageStream<EventMessage> completedTestSubject(List<EventMessage> messages) {
         QueueMessageStream<EventMessage> testSubject = new QueueMessageStream<>();
         messages.forEach(m -> testSubject.offer(m, Context.empty()));
         testSubject.complete();
@@ -39,13 +39,13 @@ class QueueMessageStreamTest extends MessageStreamTest<EventMessage> {
     }
 
     @Override
-    MessageStream.Single<EventMessage> completedSingleStreamTestSubject(EventMessage message) {
+    protected MessageStream.Single<EventMessage> completedSingleStreamTestSubject(EventMessage message) {
         Assumptions.abort("QueueMessageStream does not support explicit single-item streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<EventMessage> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<EventMessage> completedEmptyStreamTestSubject() {
         Assumptions.abort("QueueMessageStream does not support explicit zero-item streams");
         return null;
     }
@@ -73,7 +73,7 @@ class QueueMessageStreamTest extends MessageStreamTest<EventMessage> {
     }
 
     @Override
-    MessageStream<EventMessage> failingTestSubject(List<EventMessage> messages, Exception failure) {
+    protected MessageStream<EventMessage> failingTestSubject(List<EventMessage> messages, RuntimeException failure) {
         QueueMessageStream<EventMessage> testSubject = new QueueMessageStream<>();
         messages.forEach(m -> testSubject.offer(m, Context.empty()));
         testSubject.completeExceptionally(failure);
@@ -81,7 +81,7 @@ class QueueMessageStreamTest extends MessageStreamTest<EventMessage> {
     }
 
     @Override
-    EventMessage createRandomMessage() {
+    protected EventMessage createRandomMessage() {
         return new GenericEventMessage(new MessageType("message"),
                                          "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/SingleValueMessageStreamTest.java
@@ -34,32 +34,32 @@ import static org.junit.jupiter.api.Assertions.*;
 class SingleValueMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         Assumptions.assumeTrue(messages.size() == 1, "SingleValueMessageStream only supports a single value");
         return MessageStream.just(messages.getFirst());
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         return MessageStream.just(message);
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("DelayedMessageStream does not support empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                              Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         Assumptions.assumeTrue(messages.isEmpty(),
                                "SingleValueMessageStream only supports failures without regular values");
         return MessageStream.fromFuture(CompletableFuture.failedFuture(failure));
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                   "test-" + ThreadLocalRandom.current().nextInt(10000));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/StreamMessageStreamTest.java
@@ -31,31 +31,31 @@ import java.util.stream.Stream;
 class StreamMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
-    MessageStream<Message> completedTestSubject(List<Message> messages) {
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
         return MessageStream.fromStream(messages.stream());
     }
 
     @Override
-    MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
         Assumptions.abort("StreamMessageStream doesn't support explicit single-value streams");
         return null;
     }
 
     @Override
-    MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
         Assumptions.abort("StreamMessageStream doesn't support explicitly empty streams");
         return null;
     }
 
     @Override
-    MessageStream<Message> failingTestSubject(List<Message> messages,
-                                                      Exception failure) {
+    protected MessageStream<Message> failingTestSubject(List<Message> messages,
+                                                        RuntimeException failure) {
         Assumptions.abort("StreamMessageStream doesn't support failures");
         return null;
     }
 
     @Override
-    Message createRandomMessage() {
+    protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
     }


### PR DESCRIPTION
Contains a new (internal) interface to define custom event coordination between multiple instances of an event storage engine (across processes), with a default implementation for JPA that does polling.

Also updated gaps in MessageStream documentation, and improvided MessageStreamTest to be able to test unbounded streams.