### PR TITLE
Retrofit split/merge concurrency issue from 4.12.2

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/Coordinator.java
@@ -245,7 +245,14 @@ class Coordinator {
      */
     public CompletableFuture<Boolean> splitSegment(int segmentId) {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
-        coordinatorTasks.add(new SplitTask(result, name, segmentId, workPackages, tokenStore, unitOfWorkFactory));
+        coordinatorTasks.add(new SplitTask(result,
+                                           name,
+                                           segmentId,
+                                           workPackages,
+                                           releasesDeadlines,
+                                           tokenStore,
+                                           unitOfWorkFactory,
+                                           clock));
         scheduleCoordinator();
         return result;
     }
@@ -265,7 +272,14 @@ class Coordinator {
      */
     public CompletableFuture<Boolean> mergeSegment(int segmentId) {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
-        coordinatorTasks.add(new MergeTask(result, name, segmentId, workPackages, tokenStore, unitOfWorkFactory));
+        coordinatorTasks.add(new MergeTask(result,
+                                           name,
+                                           segmentId,
+                                           workPackages,
+                                           releasesDeadlines,
+                                           tokenStore,
+                                           unitOfWorkFactory,
+                                           clock));
         scheduleCoordinator();
         return result;
     }

--- a/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/processors/streaming/pooled/MergeTask.java
@@ -55,6 +55,8 @@ class MergeTask extends CoordinatorTask {
     private final Map<Integer, WorkPackage> workPackages;
     private final TokenStore tokenStore;
     private final UnitOfWorkFactory unitOfWorkFactory;
+    private final Map<Integer, java.time.Instant> releasesDeadlines;
+    private final java.time.Clock clock;
 
     /**
      * Constructs a {@code MergeTask}.
@@ -67,24 +69,30 @@ class MergeTask extends CoordinatorTask {
      * @param workPackages      The collection of {@link WorkPackage}s controlled by the {@link Coordinator}. Will be
      *                          queried for the presence of the given {@code segmentId} and the segment to merge it
      *                          with.
+     * @param releasesDeadlines  the map of segments that are blocked from claiming until a specified time
      * @param tokenStore        The storage solution for {@link TrackingToken}s. Used to claim the {@code segmentId} if
      *                          it is not present in the {@code workPackages}, to remove one of the segments and merge
      *                          the merged token.
      * @param unitOfWorkFactory The {@link UnitOfWorkFactory} that spawns {@link UnitOfWork UnitOfWorks} used to invoke
      *                          all {@link TokenStore} operations inside a unit of work.
+     * @param clock              the clock used for time-based operations
      */
     MergeTask(CompletableFuture<Boolean> result,
               String name,
               int segmentId,
               Map<Integer, WorkPackage> workPackages,
+              Map<Integer, java.time.Instant> releasesDeadlines,
               TokenStore tokenStore,
-              UnitOfWorkFactory unitOfWorkFactory) {
+              UnitOfWorkFactory unitOfWorkFactory,
+              java.time.Clock clock) {
         super(result, name);
         this.name = name;
         this.segmentId = segmentId;
         this.workPackages = workPackages;
+        this.releasesDeadlines = releasesDeadlines;
         this.unitOfWorkFactory = unitOfWorkFactory;
         this.tokenStore = tokenStore;
+        this.clock = clock;
     }
 
     /**
@@ -122,6 +130,11 @@ class MergeTask extends CoordinatorTask {
     }
 
     private CompletableFuture<TrackingToken> tokenFor(int segmentId) {
+        // Block the segment from being claimed by the Coordinator while we perform the merge.
+        // This prevents a race condition where the Coordinator might claim a segment that's being merged.
+        releasesDeadlines.put(segmentId,
+                              clock.instant().plusSeconds(60)); // Block for 1 minute (will be cleared after merge)
+
         // Remove WorkPackage so that the CoordinatorTask cannot find it to release its claim upon impending abortion.
         return workPackages.containsKey(segmentId)
                 ? workPackages.remove(segmentId)
@@ -138,27 +151,33 @@ class MergeTask extends CoordinatorTask {
 
     private Boolean mergeSegments(Segment thisSegment, TrackingToken thisToken,
                                   Segment thatSegment, TrackingToken thatToken) {
-        Segment mergedSegment = thisSegment.mergedWith(thatSegment);
-        // We want to keep the token with the segmentId obtained by the merge operation, and to delete the other
-        int tokenToDelete = mergedSegment.getSegmentId() == thisSegment.getSegmentId()
-                ? thatSegment.getSegmentId() : thisSegment.getSegmentId();
-        TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
-                ? MergedTrackingToken.merged(thatToken, thisToken)
-                : MergedTrackingToken.merged(thisToken, thatToken);
+        try {
+            Segment mergedSegment = thisSegment.mergedWith(thatSegment);
+            // We want to keep the token with the segmentId obtained by the merge operation, and to delete the other
+            int tokenToDelete = mergedSegment.getSegmentId() == thisSegment.getSegmentId()
+                    ? thatSegment.getSegmentId() : thisSegment.getSegmentId();
+            TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
+                    ? MergedTrackingToken.merged(thatToken, thisToken)
+                    : MergedTrackingToken.merged(thisToken, thatToken);
 
-        joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-                context -> tokenStore.deleteToken(name, tokenToDelete, context)
-                                     .thenCompose(result -> tokenStore.storeToken(mergedToken,
-                                                                                  name,
-                                                                                  mergedSegment.getSegmentId(),
-                                                                                  context))
-                                     .thenCompose(result -> tokenStore.releaseClaim(name,
-                                                                                    mergedSegment.getSegmentId(),
-                                                                                    context))
-        ));
+            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+                    context -> tokenStore.deleteToken(name, tokenToDelete, context)
+                                         .thenCompose(result -> tokenStore.storeToken(mergedToken,
+                                                                                      name,
+                                                                                      mergedSegment.getSegmentId(),
+                                                                                      context))
+                                         .thenCompose(result -> tokenStore.releaseClaim(name,
+                                                                                        mergedSegment.getSegmentId(),
+                                                                                        context))
+            ));
 
-        logger.info("Processor [{}] successfully merged {} with {} into {}.",
-                    name, thisSegment, thatSegment, mergedSegment);
+            logger.info("Processor [{}] successfully merged {} with {} into {}.",
+                        name, thisSegment, thatSegment, mergedSegment);
+        } finally {
+            // Remove both segments from the releases deadlines to allow the Coordinator to claim the merged segment
+            releasesDeadlines.remove(thisSegment.getSegmentId());
+            releasesDeadlines.remove(thatSegment.getSegmentId());
+        }
         return true;
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/MergeTaskTest.java
@@ -68,6 +68,9 @@ class MergeTaskTest {
     private CompletableFuture<Boolean> result;
     private MergeTask testSubject;
 
+    private final Map<Integer, java.time.Instant> releasesDeadlines = new HashMap<>();
+    private final java.time.Clock clock = java.time.Clock.systemUTC();
+
     @BeforeEach
     void setUp() {
         result = new CompletableFuture<>();
@@ -77,9 +80,11 @@ class MergeTaskTest {
         when(tokenStore.fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ONE.getSegmentId()), any()))
             .thenReturn(completedFuture(SEGMENT_ONE));
 
+        releasesDeadlines.clear();
+
         testSubject = new MergeTask(
-                result, PROCESSOR_NAME, SEGMENT_TO_MERGE, workPackages, tokenStore,
-                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE)
+                result, PROCESSOR_NAME, SEGMENT_TO_MERGE, workPackages, releasesDeadlines, tokenStore,
+                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE), clock
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/processors/streaming/pooled/SplitTaskTest.java
@@ -48,7 +48,9 @@ class SplitTaskTest {
     private final Map<Integer, WorkPackage> workPackages = new HashMap<>();
     private final TokenStore tokenStore = mock(TokenStore.class);
     private final WorkPackage workPackage = mock(WorkPackage.class);
+    private final Map<Integer, java.time.Instant> releasesDeadlines = new HashMap<>();
     private CompletableFuture<Boolean> result;
+    private final java.time.Clock clock = java.time.Clock.systemUTC();
     private SplitTask testSubject;
 
     @BeforeEach
@@ -56,7 +58,14 @@ class SplitTaskTest {
         result = new CompletableFuture<>();
 
         testSubject = new SplitTask(
-                result, PROCESSOR_NAME, SEGMENT_ID, workPackages, tokenStore, UnitOfWorkTestUtils.SIMPLE_FACTORY
+                result,
+                PROCESSOR_NAME,
+                SEGMENT_ID,
+                workPackages,
+                releasesDeadlines,
+                tokenStore,
+                UnitOfWorkTestUtils.SIMPLE_FACTORY,
+                clock
         );
     }
 


### PR DESCRIPTION
This addresses an issue in the Split and Merge tasks where the coordinator could still start a new work package to process events, although a segment is claimed for a split or merge operation.

Resolves #3862