### PR TITLE
Unify pom names and descriptions for consistency

### DIFF
--- a/extensions/metrics/metrics-dropwizard/pom.xml
+++ b/extensions/metrics/metrics-dropwizard/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>axon-metrics-dropwizard</artifactId>
 
-    <name>Axon Framework - Dropwizard Metrics</name>
+    <name>Axon Extension - Metrics - Dropwizard</name>
     <description>
         This module contains components that provide metrics for standard Axon components using the Dropwizard metrics
         library.

--- a/extensions/metrics/metrics-micrometer/pom.xml
+++ b/extensions/metrics/metrics-micrometer/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>axon-metrics-micrometer</artifactId>
 
-    <name>Axon Framework - Micrometer Metrics</name>
+    <name>Axon Extension - Metrics - Micrometer</name>
     <description>
         This module contains components that provide metrics for standard Axon components using the Micrometer library.
     </description>

--- a/extensions/metrics/pom.xml
+++ b/extensions/metrics/pom.xml
@@ -25,11 +25,13 @@
 
     <groupId>org.axonframework.extensions.metrics</groupId>
     <artifactId>axon-metrics-extension</artifactId>
+
+    <name>Axon Extension - Metrics - Parent</name>
+    <description>
+        Module providing parent for Axon Framework Metrics Extension.
+    </description>
+
     <packaging>pom</packaging>
-
-    <name>Axon Framework - Metrics Extension Parent</name>
-    <description>Module providing parent for Axon Framework Metrics Extension.</description>
-
     <modules>
         <module>metrics-dropwizard</module>
         <module>metrics-micrometer</module>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -25,10 +25,13 @@
 
     <groupId>org.axonframework.extensions</groupId>
     <artifactId>axon-extensions</artifactId>
-    <packaging>pom</packaging>
 
-    <name>Axon Framework - Extensions Parent</name>
-    <description>Module providing root for Axon Framework Extensions.</description>
+    <name>Axon Extension - Parent</name>
+    <description>
+        Module providing parent for Axon Framework Extensions.
+    </description>
+
+    <packaging>pom</packaging>
     <modules>
         <module>spring</module>
         <module>metrics</module>

--- a/extensions/spring/pom.xml
+++ b/extensions/spring/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>axon-spring-extension</artifactId>
     <packaging>pom</packaging>
 
-    <name>Axon Framework - Spring Extension Parent</name>
+    <name>Axon Extension - Spring - Parent</name>
     <description>Module providing parent for Axon Framework Spring Extension.</description>
 
     <modules>

--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -24,12 +24,11 @@
     </parent>
 
     <artifactId>axon-spring-boot-autoconfigure</artifactId>
-    <name>Axon Framework - Spring Boot Support</name>
 
+    <name>Axon Extension - Spring - SpringBoot Autoconfigure</name>
     <description>
         Module providing support for autoconfiguration of Axon Framework through Spring Boot.
     </description>
-
 
     <dependencies>
 

--- a/extensions/spring/spring-boot-starter/pom.xml
+++ b/extensions/spring/spring-boot-starter/pom.xml
@@ -26,8 +26,10 @@
     <artifactId>axon-spring-boot-starter</artifactId>
     <version>5.0.0-SNAPSHOT</version>
 
-    <name>Spring Boot Starter module for Axon Framework</name>
-
+    <name>Axon Extension - Spring - SpringBoot Starter</name>
+    <description>
+        Bundling axon-spring and axon-spring-boot-autoconfigure as a starter.
+    </description>
 
     <dependencies>
         <dependency>

--- a/extensions/spring/spring/pom.xml
+++ b/extensions/spring/spring/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>axon-spring</artifactId>
 
-    <name>Axon Framework - Spring Support</name>
+    <name>Axon Extension - Spring - Core</name>
     <description>
         Module providing Spring specific helper functionality to ease configuration / set-up of an Axon application, as
         well as some Spring specific infrastructure components.

--- a/extensions/tracing/pom.xml
+++ b/extensions/tracing/pom.xml
@@ -25,11 +25,13 @@
 
     <groupId>org.axonframework.extensions.tracing</groupId>
     <artifactId>axon-tracing-extension</artifactId>
+
+    <name>Axon Extension - Tracing - Parent</name>
+    <description>
+        Module providing parent for Axon Framework Tracing Extension.
+    </description>
+
     <packaging>pom</packaging>
-
-    <name>Axon Framework - Tracing Extension Parent</name>
-    <description>Module providing parent for Axon Framework Tracing Extension.</description>
-
     <modules>
         <module>tracing-opentelemetry</module>
     </modules>

--- a/extensions/tracing/tracing-opentelemetry/pom.xml
+++ b/extensions/tracing/tracing-opentelemetry/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>axon-tracing-opentelemetry</artifactId>
 
-    <name>Axon Framework - OpenTelemetry Tracing</name>
+    <name>Axon Extension - Tracing - OpenTelemetry</name>
     <description>
         This module contains components that provide tracing support specifically for OpenTelemetry.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,7 @@
     </modules>
     <packaging>pom</packaging>
 
-
-    <name>Axon Framework</name>
+    <name>Axon Framework - Parent</name>
     <description>
         The Axon framework supports developers with the plumbing and wiring required to build a CQRS architecture, by
         providing (abstract) implementations of common CQRS building blocks.


### PR DESCRIPTION
I went through all poms and updated their `<name>`s to follow one consistent style:

 (`Axon [Framework|Extension] ( - <Context>) - <Name>`)

In the end, this turns this:

```
[INFO] Axon Framework ..................................... SUCCESS
[INFO] Axon Framework - Common ............................ SUCCESS
[INFO] Axon Framework - Conversion ........................ SUCCESS
[INFO] Axon Framework - Messaging ......................... SUCCESS
[INFO] Axon Framework - Modelling ......................... SUCCESS
[INFO] Axon Framework - Event Sourcing .................... SUCCESS
[INFO] Axon Framework - Test Fixtures ..................... SUCCESS
[INFO] Axon Framework - Axon Server Connector ............. SUCCESS
[INFO] Axon Framework - Extensions Parent ................. SUCCESS
[INFO] Axon Framework - Spring Extension Parent ........... SUCCESS
[INFO] Axon Framework - Spring Support .................... SUCCESS
[INFO] Axon Framework - Metrics Extension Parent .......... SUCCESS
[INFO] Axon Framework - Dropwizard Metrics ................ SUCCESS
[INFO] Axon Framework - Tracing Extension Parent .......... SUCCESS
[INFO] Axon Framework - OpenTelemetry Tracing ............. SUCCESS
[INFO] Axon Framework - Micrometer Metrics ................ SUCCESS
[INFO] Axon Framework - Spring Boot Support ............... SUCCESS
[INFO] Spring Boot Starter module for Axon Framework ...... SUCCESS
[INFO] Axon Framework - Integration Tests ................. SUCCESS
[INFO] Axon Framework - Legacy Components ................. SUCCESS
[INFO] Axon Framework - Legacy Aggregate .................. SUCCESS
[INFO] Axon Framework - Legacy Saga ....................... SUCCESS
[INFO] Axon Framework - Migration ......................... SUCCESS
[INFO] Axon Framework - TODO .............................. SUCCESS
[INFO] Axon Framework - Update ............................ SUCCESS
[INFO] ------------------------------------------------------------
```

into this:

```
[INFO] Axon Framework - Parent ............................ SUCCESS
[INFO] Axon Framework - Common ............................ SUCCESS
[INFO] Axon Framework - Conversion ........................ SUCCESS
[INFO] Axon Framework - Messaging ......................... SUCCESS
[INFO] Axon Framework - Modelling ......................... SUCCESS
[INFO] Axon Framework - Event Sourcing .................... SUCCESS
[INFO] Axon Framework - Test Fixtures ..................... SUCCESS
[INFO] Axon Framework - Axon Server Connector ............. SUCCESS
[INFO] Axon Extension - Parent ............................ SUCCESS
[INFO] Axon Extension - Spring - Parent ................... SUCCESS
[INFO] Axon Extension - Spring - Core ..................... SUCCESS
[INFO] Axon Extension - Metrics - Parent .................. SUCCESS
[INFO] Axon Extension - Metrics - Dropwizard .............. SUCCESS
[INFO] Axon Extension - Tracing - Parent .................. SUCCESS
[INFO] Axon Extension - Tracing - OpenTelemetry ........... SUCCESS
[INFO] Axon Extension - Metrics - Micrometer .............. SUCCESS
[INFO] Axon Extension - Spring - SpringBoot Autoconfigure . SUCCESS
[INFO] Axon Extension - Spring - SpringBoot Starter ....... SUCCESS
[INFO] Axon Framework - Integration Tests ................. SUCCESS
[INFO] Axon Framework - Legacy Components ................. SUCCESS
[INFO] Axon Framework - Legacy Aggregate .................. SUCCESS
[INFO] Axon Framework - Legacy Saga ....................... SUCCESS
[INFO] Axon Framework - Migration ......................... SUCCESS
[INFO] Axon Framework - TODO .............................. SUCCESS
[INFO] Axon Framework - Update ............................ SUCCESS
[INFO] ------------------------------------------------------------
```

Contains no code changes.

Notes:

* Using the prefix `Axon Framework - Extensions - ...` made the lines so long that they did't align and looked cluttered. But in the end, we moved those modules to `extensions` because they are _not_ part of the framework, so this won't hurt.
* Using the "context" `Extensions` was one char too long, while `Extension` perfectly aligns with `Framework`