### PR TITLE
Fix transitive dependencies

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -159,15 +159,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-docker-compose</artifactId>
             <version>${spring.boot.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <version>${spring.boot.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
make dependencies optional for `testcontainers` and `spring-boot-docker-compose` 