### PR TITLE
Add position method to consistency marker

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedEventStorageEngineUtils.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedEventStorageEngineUtils.java
@@ -19,11 +19,8 @@ package org.axonframework.eventsourcing.eventstore;
 import jakarta.annotation.Nullable;
 import org.axonframework.messaging.eventstreaming.Tag;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import static org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException.conflictingEventsDetected;
@@ -122,69 +119,6 @@ public final class AggregateBasedEventStorageEngineUtils {
             }
         }
         return e;
-    }
-
-    /**
-     * Helper class that tracks the sequence of events for different aggregates and manages the consistency marker for
-     * the aggregates.
-     */
-    public static final class AggregateSequencer {
-
-        private final Map<String, AtomicLong> aggregateSequences;
-        private AggregateBasedConsistencyMarker consistencyMarker;
-
-        /**
-         * Constructs a new {@code AggregateSequencer} with the specified aggregate sequences and consistency marker.
-         *
-         * @param aggregateSequences A map of aggregate identifiers to atomic sequences.
-         * @param consistencyMarker  The consistency marker for this sequencer.
-         */
-        private AggregateSequencer(Map<String, AtomicLong> aggregateSequences,
-                                   AggregateBasedConsistencyMarker consistencyMarker) {
-            this.aggregateSequences = aggregateSequences;
-            this.consistencyMarker = consistencyMarker;
-        }
-
-        /**
-         * Creates a new {@code AggregateSequencer} with the provided consistency marker.
-         *
-         * @param consistencyMarker The consistency marker for the new sequencer.
-         * @return A new {@code AggregateSequencer}.
-         */
-        public static AggregateSequencer with(AggregateBasedConsistencyMarker consistencyMarker) {
-            return new AggregateSequencer(new HashMap<>(), consistencyMarker);
-        }
-
-        /**
-         * Forwarded the consistency marker by the state of aggregate sequences.
-         *
-         * @return The new consistency marker after forwarding
-         * @see AggregateBasedConsistencyMarker#forwarded(String, long)
-         */
-        public AggregateBasedConsistencyMarker forwarded() {
-            var newConsistencyMarker = consistencyMarker;
-            for (var aggSeq : aggregateSequences.entrySet()) {
-                newConsistencyMarker = newConsistencyMarker
-                        .forwarded(aggSeq.getKey(), aggSeq.getValue().get());
-            }
-            consistencyMarker = newConsistencyMarker;
-            return newConsistencyMarker;
-        }
-
-        /**
-         * Get and increment the sequence for the given aggregate identifier. If the aggregate does not exist, it is
-         * initialized with the consistency marker's position for that identifier.
-         *
-         * @param aggregateIdentifier The identifier of the aggregate to get and increment the sequence for
-         * @return The atomic long sequence for the aggregate
-         */
-        public long incrementAndGetSequenceOf(String aggregateIdentifier) {
-            var aggregateSequence = aggregateSequences.computeIfAbsent(
-                    aggregateIdentifier,
-                    i -> new AtomicLong(consistencyMarker.positionOf(i))
-            );
-            return aggregateSequence.incrementAndGet();
-        }
     }
 
     private AggregateBasedEventStorageEngineUtils() {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
@@ -77,6 +77,14 @@ public interface ConsistencyMarker {
     ConsistencyMarker upperBound(@Nonnull ConsistencyMarker other);
 
     /**
+     * Reduces this consistency marker to a single position if possible. 
+     * 
+     * @return a {@link Position}, never {@code null}
+     * @throws IllegalStateException if the marker could not be reduced to a single position
+     */
+    Position position();
+
+    /**
      * Adds the given {@code consistencyMarker} to the given {@code context} using the {@link #RESOURCE_KEY}.
      *
      * @param context           The {@code Context} to add the given {@code token} to.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarkers.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarkers.java
@@ -49,6 +49,11 @@ abstract class ConsistencyMarkers {
         }
 
         @Override
+        public Position position() {
+            return Position.START;
+        }
+
+        @Override
         public String toString() {
             return "ORIGIN";
         }
@@ -69,6 +74,11 @@ abstract class ConsistencyMarkers {
         @Override
         public ConsistencyMarker upperBound(@Nonnull ConsistencyMarker other) {
             return this;
+        }
+
+        @Override
+        public Position position() {
+            throw new UnsupportedOperationException("Not yet implemented");  // not implemented because there are no use cases
         }
 
         @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/GlobalIndexConsistencyMarker.java
@@ -64,13 +64,9 @@ public class GlobalIndexConsistencyMarker extends AbstractConsistencyMarker<Glob
         return other.position > this.position ? other : this;
     }
 
-    /**
-     * Returns the position of this global index consistency marker.
-     *
-     * @return The position of this global index consistency marker.
-     */
-    public long position() {
-        return this.position;
+    @Override
+    public Position position() {
+        return new GlobalIndexPosition(position);
     }
 
     @Override


### PR DESCRIPTION
This allows to extract a position from a consistency marker for resuming a sourcing at a later time.