### PR TITLE
Spring Autoconfiguration files need to be ordered

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -16,9 +16,14 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.EntityManagerFactory;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.axonframework.common.configuration.SearchScope;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurationDefaults;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
@@ -58,55 +63,68 @@ import java.util.function.UnaryOperator;
 public class JpaEventStoreAutoConfiguration {
 
     /**
-     * Defines the default configuration for the {@link AggregateBasedJpaEventStorageEngine}.
-     * @param entityManagerProvider  The provider for the EntityManager to use
-     * @param persistenceExceptionResolver The resolver to convert exceptions from the underlying persistence layer
-     * @param properties properties defining the configuration of the event storage engine
-     * @return a unary operator adding the defined properties to the configuration
+     * Creates an aggregate-based JPA event storage engine enhancer.
+     *
+     * @param entityManagerProvider                        An entity manager provide to access the underlying DB.
+     * @param persistenceExceptionResolver                 A persistence exception resolver on duplicate errors.
+     * @param jpaEventStorageEngineConfigurationProperties Spring properties to configure the JPA Event store Engine.
+     * @return A configuration enhancer registering JPA Storage Engine ordered between Axon Server and In-Memory Storage
+     * Engine.
      */
-    @ConditionalOnMissingBean
     @Bean
-    public UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> jpaEventStorageEngineConfigurationCustomizer(
+    public ConfigurationEnhancer aggregateBasedJpaEventStorageEngine(
             EntityManagerProvider entityManagerProvider,
             PersistenceExceptionResolver persistenceExceptionResolver,
-            JpaEventStorageEngineConfigurationProperties properties
+            JpaEventStorageEngineConfigurationProperties jpaEventStorageEngineConfigurationProperties
     ) {
-        return config ->
-                config
-                        .batchSize(properties.batchSize())
-                        .gapCleaningThreshold(properties.gapCleaningThreshold())
-                        .gapTimeout(properties.gapTimeout())
-                        .lowestGlobalSequence(properties.lowestGlobalSequence())
-                        .maxGapOffset(properties.maxGapOffset())
-                        .persistenceExceptionResolver(persistenceExceptionResolver)
-                        .eventCoordinator(
-                                new JpaPollingEventCoordinator(
-                                        entityManagerProvider,
-                                        Duration.ofMillis(properties.pollingInterval())
-                                )
-                        );
+        return new AggregateBasedJpaEventStorageEngineConfigurationEnhancer(
+                jpaEventStorageEngineConfigurationProperties,
+                entityManagerProvider,
+                persistenceExceptionResolver
+        );
     }
 
     /**
-     * Defines an AggregateBasedJpaEventStorageEngine bean.
-     *
-     * @param entityManagerProvider The provider for the EntityManager to use
-     * @param transactionManager    The transaction manager that manages the database transactions
-     * @param eventConverter        The converter to convert events to persistence format
-     * @param configurer            The operator setting required configuration
-     * @return an AggregateBasedJpaEventStorageEngine bean
+     * Enhancer for registration of a bean definition creating a JPA Storage Engine.
      */
-    @ConditionalOnMissingBean
-    @Bean
-    public EventStorageEngine jpaEventStorageEngine(EntityManagerProvider entityManagerProvider,
-                                                    TransactionManager transactionManager,
-                                                    EventConverter eventConverter,
-                                                    UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> configurer) {
-        return new AggregateBasedJpaEventStorageEngine(
-                entityManagerProvider,
-                transactionManager,
-                eventConverter,
-                configurer
-        );
+    public record AggregateBasedJpaEventStorageEngineConfigurationEnhancer(
+            JpaEventStorageEngineConfigurationProperties properties,
+            EntityManagerProvider entityManagerProvider,
+            PersistenceExceptionResolver persistenceExceptionResolver
+    ) implements ConfigurationEnhancer {
+
+        @Override
+        public void enhance(@Nonnull ComponentRegistry registry) {
+            UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> configurer = config ->
+                    config
+                            .batchSize(properties.batchSize())
+                            .gapCleaningThreshold(properties.gapCleaningThreshold())
+                            .gapTimeout(properties.gapTimeout())
+                            .lowestGlobalSequence(properties.lowestGlobalSequence())
+                            .maxGapOffset(properties.maxGapOffset())
+                            .persistenceExceptionResolver(persistenceExceptionResolver)
+                            .eventCoordinator(
+                                new JpaPollingEventCoordinator(
+                                    entityManagerProvider,
+                                    Duration.ofMillis(properties.pollingInterval())
+                                )
+                            );
+
+            registry.registerIfNotPresent(EventStorageEngine.class,
+                                          (configuration)
+                                                  -> new AggregateBasedJpaEventStorageEngine(
+                                                  entityManagerProvider,
+                                                  configuration.getComponent(TransactionManager.class),
+                                                  configuration.getComponent(EventConverter.class),
+                                                  configurer
+                                          ),
+                                          SearchScope.ALL);
+        }
+
+        @Override
+        public int order() {
+            // we must be lower than the defaults in order to win.
+            return EventSourcingConfigurationDefaults.ENHANCER_ORDER - 500;
+        }
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventSourcingConfigurationDefaultsAutoconfigTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventSourcingConfigurationDefaultsAutoconfigTest.java
@@ -57,6 +57,7 @@ class EventSourcingConfigurationDefaultsAutoconfigTest {
             assertThat(context).hasSingleBean(TagResolver.class);
             assertThat(context).hasBean(TagResolver.class.getName());
             assertThat(context).hasSingleBean(EventStorageEngine.class);
+            assertThat(context).hasBean(EventStorageEngine.class.getName());
             assertThat(context).hasSingleBean(EventStore.class);
             assertThat(context).hasSingleBean(EventSink.class);
             assertThat(context).hasBean(EventStore.class.getName());


### PR DESCRIPTION
The JpaAutoConfiguration and JpaEventStoreAutoConfiguration need to be properly ordered, to ensure Spring's Jpa Autoconfiguration is processed before. Also, the AxonServer Event Store must take precedence over the JPA based implementation.