### PR TITLE
Default to the `AnnotationMessageTypeResolver` in annotation-specific components

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
@@ -24,13 +24,13 @@ import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
 import org.axonframework.messaging.commandhandling.SimpleCommandHandlingComponent;
-import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
@@ -92,7 +92,7 @@ public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComp
         this(annotatedCommandHandler,
              parameterResolverFactory,
              ClasspathHandlerDefinition.forClass(annotatedCommandHandler.getClass()),
-             new ClassBasedMessageTypeResolver(),
+             new AnnotationMessageTypeResolver(),
              converter);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
@@ -213,7 +213,7 @@ public class AnnotatedHandlerInspector<T> {
             handlerDefinition.createHandler(inspectedType,
                                             method,
                                             parameterResolverFactory,
-                                            result -> resolveToStream(result, new ClassBasedMessageTypeResolver()))
+                                            result -> resolveToStream(result, new AnnotationMessageTypeResolver()))
                              .ifPresent(h -> registerHandler(inspectedType, h));
         }
 

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -18,6 +18,10 @@ package org.axonframework.modelling.command;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ObjectUtils;
+import org.axonframework.common.ReflectionUtils;
+import org.axonframework.messaging.LegacyMessageHandler;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.commandhandling.CommandHandler;
 import org.axonframework.messaging.commandhandling.CommandHandlingComponent;
@@ -27,16 +31,13 @@ import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
 import org.axonframework.messaging.commandhandling.NoHandlerForCommandException;
 import org.axonframework.messaging.commandhandling.annotation.AnnotatedCommandHandlingComponent;
 import org.axonframework.messaging.commandhandling.annotation.CommandHandlingMember;
-import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.common.ObjectUtils;
-import org.axonframework.common.ReflectionUtils;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
-import org.axonframework.messaging.LegacyMessageHandler;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
@@ -289,7 +290,7 @@ public class AggregateAnnotationCommandHandler<T> implements CommandHandlingComp
         private HandlerDefinition handlerDefinition;
         private AggregateModel<T> aggregateModel;
         private CreationPolicyAggregateFactory<T> creationPolicyAggregateFactory;
-        private MessageTypeResolver messageTypeResolver = new ClassBasedMessageTypeResolver();
+        private MessageTypeResolver messageTypeResolver = new AnnotationMessageTypeResolver();
 
         /**
          * Sets the {@link Repository} used to add and load Aggregate instances of generic type {@code T} upon

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlerInvoker.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlerInvoker.java
@@ -19,19 +19,20 @@ package org.axonframework.messaging.eventhandling;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.messaging.eventhandling.annotation.AnnotationEventHandlerAdapter;
-import org.axonframework.messaging.eventhandling.processing.errorhandling.ListenerInvocationErrorHandler;
-import org.axonframework.messaging.eventhandling.processing.errorhandling.LoggingErrorHandler;
-import org.axonframework.messaging.eventhandling.sequencing.SequencingPolicy;
-import org.axonframework.messaging.eventhandling.sequencing.SequentialPerAggregatePolicy;
-import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
-import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentMatcher;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.annotation.AnnotationEventHandlerAdapter;
+import org.axonframework.messaging.eventhandling.processing.errorhandling.ListenerInvocationErrorHandler;
+import org.axonframework.messaging.eventhandling.processing.errorhandling.LoggingErrorHandler;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentMatcher;
+import org.axonframework.messaging.eventhandling.sequencing.SequencingPolicy;
+import org.axonframework.messaging.eventhandling.sequencing.SequentialPerAggregatePolicy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -220,7 +221,7 @@ public class SimpleEventHandlerInvoker implements EventHandlerInvoker {
         private HandlerDefinition handlerDefinition;
         private ListenerInvocationErrorHandler listenerInvocationErrorHandler = new LoggingErrorHandler();
         private SequencingPolicy sequencingPolicy = SequentialPerAggregatePolicy.instance();
-        private MessageTypeResolver messageTypeResolver = new ClassBasedMessageTypeResolver();
+        private MessageTypeResolver messageTypeResolver = new AnnotationMessageTypeResolver();
 
         /**
          * Sets the {@code eventHandlers} this {@link EventHandlerInvoker} will forward all its events to. If an event

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotationEventHandlerAdapter.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotationEventHandlerAdapter.java
@@ -17,24 +17,24 @@
 package org.axonframework.messaging.eventhandling.annotation;
 
 import jakarta.annotation.Nonnull;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.EventMessageHandler;
-import org.axonframework.messaging.eventhandling.replay.ResetNotSupportedException;
-import org.axonframework.messaging.eventhandling.replay.GenericResetContext;
-import org.axonframework.messaging.eventhandling.replay.ResetContext;
-import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
-import org.axonframework.messaging.core.MessageType;
-import org.axonframework.messaging.core.annotation.HandlerAttributes;
 import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.HandlerAttributes;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
-import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventMessageHandler;
+import org.axonframework.messaging.eventhandling.replay.GenericResetContext;
+import org.axonframework.messaging.eventhandling.replay.ResetContext;
+import org.axonframework.messaging.eventhandling.replay.ResetNotSupportedException;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -65,7 +65,7 @@ public class AnnotationEventHandlerAdapter implements EventMessageHandler {
     public AnnotationEventHandlerAdapter(Object annotatedEventListener) {
         this(annotatedEventListener,
              ClasspathParameterResolverFactory.forClass(annotatedEventListener.getClass()),
-             new ClassBasedMessageTypeResolver());
+             new AnnotationMessageTypeResolver());
     }
 
     /**

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/java/SimpleEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/java/SimpleEventScheduler.java
@@ -18,6 +18,10 @@ package org.axonframework.messaging.eventhandling.scheduling.java;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.IdentifierFactory;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventBus;
@@ -25,9 +29,6 @@ import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.scheduling.EventScheduler;
 import org.axonframework.messaging.eventhandling.scheduling.ScheduleToken;
-import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
-import org.axonframework.messaging.core.MessageTypeResolver;
-import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.eventhandling.scheduling.quartz.QuartzEventScheduler;
 import org.axonframework.messaging.unitofwork.LegacyDefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.LegacyUnitOfWork;
@@ -140,7 +141,7 @@ public class SimpleEventScheduler implements EventScheduler {
         private ScheduledExecutorService scheduledExecutorService;
         private EventBus eventBus;
         private TransactionManager transactionManager = NoTransactionManager.INSTANCE;
-        private MessageTypeResolver messageTypeResolver = new ClassBasedMessageTypeResolver();
+        private MessageTypeResolver messageTypeResolver = new AnnotationMessageTypeResolver();
 
         /**
          * Sets the {@link EventBus} used to publish events on to, once the schedule has been met.


### PR DESCRIPTION
Inside of all the Annotation* classes you should use the annotations to build up the data but for some reason you only take fqdn from the handler payload. Let's use this annotation resolver by default instead, it falls back on the fqdn anyway, so should be no harm.

I have a bunch of meta-annotations with `@Message` where I define common namespace for certain domains and also defined custom names for each, e.g. class name is `com.domain.a.DomainASomethingHappenedV1` but the name is `domain.a.SomethingHappened#1.0`. I don't want to repeat that on every handler annotation, let these classes scan the payload class instead.

Btw, why use semver for event version? Can't really see myself incrementing a patch version, feel like it's either major or minor for adding/removing/renaming fields. Whoever consumes an event wouldn't want to create another handler for some internal logic change, but changing version basically means a separate event and needs an upcaster, right? My default is `1.0`.

Also btw, would be good to use message type namespace for grouping together event handlers instead of package names. But to consider, I can't see which event/command handler failed in the exception logs, I can only see the package name right now. And stack trace has only axon files in it.

Sorry, no unit tests, low on time and out of AI credits, feel free to take over