### PR TITLE
add AbstractAnnotatedMessageHandlerEnhancerDefinition

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AbstractAnnotatedMessageHandlerEnhancerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AbstractAnnotatedMessageHandlerEnhancerDefinition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.annotation;
+
+import org.axonframework.common.annotation.AnnotationUtils;
+import org.axonframework.messaging.core.MessageTypeResolver;
+
+import java.util.Optional;
+
+public abstract class AbstractAnnotatedMessageHandlerEnhancerDefinition implements HandlerEnhancerDefinition {
+
+    private final MessageTypeResolver messageTypeResolver = new AnnotationMessageTypeResolver();
+
+    protected Optional<String> resolveMessageNameFromPayloadType(
+            MessageHandlingMember<?> original,
+            String attributeName,
+            Class<? extends org.axonframework.messaging.core.Message> messageType
+    ) {
+        return original.<String>attribute(attributeName)
+                       .filter(s -> !s.isEmpty())
+                       .or(() -> AnnotationUtils
+                               .<Class<? extends org.axonframework.messaging.core.Message>>findAnnotationAttribute(
+                                       original.payloadType(),
+                                       org.axonframework.messaging.core.annotation.Message.class,
+                                       "messageType"
+                               )
+                               .filter(messageType::isAssignableFrom)
+                               .map(mt -> messageTypeResolver
+                                       .resolveOrThrow(original.payloadType())
+                                       .qualifiedName()
+                                       .toString()
+                               ));
+    }
+}


### PR DESCRIPTION
I'm not too sure about this one, but here's an idea. It appears the *HandlerDefinition files are supposed to be command/event/query but for me they weren't so because they wouldn't read the `@Message` annotation to build the name. Also there was a semi-intentional feature in all 3 where it would take an optional of the message name out of the top-level annotation like `CommandHandler#commandName` but it would count the empty string as "present", in which case it would create the definition (not return the original) but inside of the definition it'd compare to empty string and set it to `null`. 

I'm a bit confused as some time has passed since I'd started trying to make spring boot work, but either this or #3894 was blocking me by using class name instead of the actual message name (I define custom `MessageType` on each message via annotation but nothing on the handler annotations) - so I'd get errors like command handler is not found. 

Btw, I see the package name has "annotation" but the classes don't, a bit inconsistent. And also there's a confusion about `HandlerEnhancerDefinition` and `HandlerDefinition` - you have both classes but in this PR the classes have suffix of `HandlerDefinition` even though they implement `HandlerEnhancerDefinition`.

Sorry, no unit tests, low on time and out of AI credits, feel free to take over