### PR TITLE
Show failed message handler in logs

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MethodInvokingMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MethodInvokingMessageHandlingMember.java
@@ -176,19 +176,21 @@ public class MethodInvokingMessageHandlingMember<T> implements MessageHandlingMe
 
         CompletableFuture<MessageStream<?>> invocationFuture = parametersFuture.handle((params, throwable) -> {
             if (throwable != null) {
-                return MessageStream.failed(throwable);
+                return MessageStream.failed(new MessageHandlerInvocationException(
+                        String.format("Error handling %s", method), throwable));
             }
             try {
                 Object result = method.invoke(target, params);
                 return returnTypeConverter.apply(result);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 if (e.getCause() instanceof Exception) {
-                    return MessageStream.failed(e.getCause());
+                    return MessageStream.failed(new MessageHandlerInvocationException(
+                            String.format("Error handling %s", method), e.getCause()));
                 } else if (e.getCause() instanceof Error) {
                     return MessageStream.failed(e.getCause());
                 }
                 return MessageStream.failed(new MessageHandlerInvocationException(
-                        String.format("Error handling an object of type [%s]", messageType), e));
+                        String.format("Error handling %s", method), e));
             }
         });
 


### PR DESCRIPTION
Before (can't tell where the error is coming from):
```
37:29.190 [ WARN] Error while processing batch in Work Package [8]-[EventProcessor[my.package]]. Aborting Work Package... - [anking.plaid]-0] org.axonframework.messaging.eventhandling.processing.streaming.pooled.WorkPackage 

org.axonframework.common.AxonConfigurationException: No suitable @EntityCreator found for id: [20b33d2e-3f01-4b4c-802b-c9e0746fd5fc] and event message [null]. Candidates were:
 - public my.package.MyStateEntity(my,package.MyEvent)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:687) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$5(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.loadOrCreate(EventSourcingRepository.java:137) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.SimpleStateManager.loadManagedEntity(SimpleStateManager.java:80) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.StateManager.loadEntity(StateManager.java:101) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.annotation.InjectEntityParameterResolver.resolveParameterValue(InjectEntityParameterResolver.java:93) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.tryResolveParameterValue(MethodInvokingMessageHandlingMember.java:231) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.lambda$resolveParameterValues$1(MethodInvokingMessageHandlingMember.java:218) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.resolveParameterValues(MethodInvokingMessageHandlingMember.java:219) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.handle(MethodInvokingMessageHandlingMember.java:175) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	... 51 more
Caused by: org.axonframework.common.AxonConfigurationException: No suitable @EntityCreator found for id: [20b33d2e-3f01-4b4c-802b-c9e0746fd5fc] and event message [null]. Candidates were:
 - public my.package.MyState(my.package.MyEvent)
	at org.axonframework.eventsourcing.annotation.reflection.AnnotationBasedEventSourcedEntityFactory.findMostSpecificMethod(AnnotationBasedEventSourcedEntityFactory.java:278) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.annotation.reflection.AnnotationBasedEventSourcedEntityFactory.create(AnnotationBasedEventSourcedEntityFactory.java:315) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.EventSourcingRepository.createEntityIfNullFromLoad(EventSourcingRepository.java:148) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$3(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$5(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.loadOrCreate(EventSourcingRepository.java:137) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.SimpleStateManager.loadManagedEntity(SimpleStateManager.java:80) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.StateManager.loadEntity(StateManager.java:101) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.annotation.InjectEntityParameterResolver.resolveParameterValue(InjectEntityParameterResolver.java:93) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.tryResolveParameterValue(MethodInvokingMessageHandlingMember.java:231) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.lambda$resolveParameterValues$1(MethodInvokingMessageHandlingMember.java:218) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.resolveParameterValues(MethodInvokingMessageHandlingMember.java:219) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.handle(MethodInvokingMessageHandlingMember.java:175) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	... 51 more
```

After (can see the actual event handler):
```
37:29.190 [ WARN] Error while processing batch in Work Package [8]-[EventProcessor[my.package]]. Aborting Work Package... - [anking.plaid]-0] org.axonframework.messaging.eventhandling.processing.streaming.pooled.WorkPackage 

org.axonframework.messaging.core.annotation.MessageHandlerInvocationException: Error handling public void my.package.MyService.onHandleThis(my.package.MyEvent,my.package.MyState,org.axonframework.messaging.eventhandling.gateway.EventAppender)
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.lambda$handle$0(MethodInvokingMessageHandlingMember.java:180) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniHandleStage(CompletableFuture.java:950) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.handle(CompletableFuture.java:2372) ~[?:?]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.handle(MethodInvokingMessageHandlingMember.java:177) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.WrappedMessageHandlingMember.handle(WrappedMessageHandlingMember.java:72) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.interception.annotation.NoMoreInterceptors.handle(NoMoreInterceptors.java:60) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.annotation.AnnotatedEventHandlingComponent.lambda$interceptedEventHandler$3(AnnotatedEventHandlingComponent.java:178) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent.handle(SimpleEventHandlingComponent.java:84) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.annotation.AnnotatedEventHandlingComponent.handle(AnnotatedEventHandlingComponent.java:203) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.DelegatingEventHandlingComponent.handle(DelegatingEventHandlingComponent.java:54) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.interception.EventMessageHandlerInterceptorChain$InterceptingHandler.proceed(EventMessageHandlerInterceptorChain.java:92) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.interception.EventMessageHandlerInterceptorChain$InterceptingHandler.proceed(EventMessageHandlerInterceptorChain.java:76) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.interception.DefaultHandlerInterceptorRegistry.lambda$registerInterceptor$3(DefaultHandlerInterceptorRegistry.java:83) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.interception.CorrelationDataInterceptor.interceptOnHandle(CorrelationDataInterceptor.java:115) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.interception.DefaultHandlerInterceptorRegistry.lambda$registerInterceptor$4(DefaultHandlerInterceptorRegistry.java:80) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.interception.EventMessageHandlerInterceptorChain$InterceptingHandler.handle(EventMessageHandlerInterceptorChain.java:85) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.interception.EventMessageHandlerInterceptorChain.proceed(EventMessageHandlerInterceptorChain.java:70) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.interception.InterceptingEventHandlingComponent.handle(InterceptingEventHandlingComponent.java:82) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent.chainedSequenceInvocations(SequencingEventHandlingComponent.java:103) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent.lambda$handle$0(SequencingEventHandlingComponent.java:85) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916) ~[?:?]
	at org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent.handle(SequencingEventHandlingComponent.java:83) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.ProcessorEventHandlingComponents.handle(ProcessorEventHandlingComponents.java:106) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.ProcessorEventHandlingComponents.handle(ProcessorEventHandlingComponents.java:91) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor.processWithErrorHandling(PooledStreamingEventProcessor.java:352) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor.lambda$spawnWorker$3(PooledStreamingEventProcessor.java:327) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.pooled.WorkPackage.lambda$processEvents$9(WorkPackage.java:382) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.lambda$safe$2(UnitOfWork.java:269) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.lambda$runNextPhase$8(UnitOfWork.java:409) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
	at org.axonframework.common.DirectExecutor.execute(DirectExecutor.java:54) ~[axon-common-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1184) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenComposeAsync(CompletableFuture.java:2352) ~[?:?]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.lambda$runNextPhase$9(UnitOfWork.java:409) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.concurrent.ConcurrentLinkedQueue.forEachFrom(ConcurrentLinkedQueue.java:1037) ~[?:?]
	at java.base/java.util.concurrent.ConcurrentLinkedQueue$CLQSpliterator.forEachRemaining(ConcurrentLinkedQueue.java:894) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:662) ~[?:?]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.runNextPhase(UnitOfWork.java:411) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.executeAllPhaseHandlers(UnitOfWork.java:359) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork$UnitOfWorkProcessingContext.commit(UnitOfWork.java:342) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.unitofwork.UnitOfWork.execute(UnitOfWork.java:140) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.pooled.WorkPackage.processEvents(WorkPackage.java:393) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.eventhandling.processing.streaming.pooled.WorkPackage.lambda$scheduleWorker$7(WorkPackage.java:345) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.util.concurrent.CompletionException: org.axonframework.common.AxonConfigurationException: No suitable @EntityCreator found for id: [20b33d2e-3f01-4b4c-802b-c9e0746fd5fc] and event message [null]. Candidates were:
 - public my.package.MyState(my.package.MyEvent)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:687) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$5(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.loadOrCreate(EventSourcingRepository.java:137) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.SimpleStateManager.loadManagedEntity(SimpleStateManager.java:80) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.StateManager.loadEntity(StateManager.java:101) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.annotation.InjectEntityParameterResolver.resolveParameterValue(InjectEntityParameterResolver.java:93) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.tryResolveParameterValue(MethodInvokingMessageHandlingMember.java:231) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.lambda$resolveParameterValues$1(MethodInvokingMessageHandlingMember.java:218) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.resolveParameterValues(MethodInvokingMessageHandlingMember.java:219) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.handle(MethodInvokingMessageHandlingMember.java:175) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	... 51 more
Caused by: org.axonframework.common.AxonConfigurationException: No suitable @EntityCreator found for id: [20b33d2e-3f01-4b4c-802b-c9e0746fd5fc] and event message [null]. Candidates were:
 - public my.package.MyState(my.package.MyEvent)
	at org.axonframework.eventsourcing.annotation.reflection.AnnotationBasedEventSourcedEntityFactory.findMostSpecificMethod(AnnotationBasedEventSourcedEntityFactory.java:278) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.annotation.reflection.AnnotationBasedEventSourcedEntityFactory.create(AnnotationBasedEventSourcedEntityFactory.java:315) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.EventSourcingRepository.createEntityIfNullFromLoad(EventSourcingRepository.java:148) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$3(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.lambda$loadOrCreate$5(EventSourcingRepository.java:140) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at org.axonframework.eventsourcing.EventSourcingRepository.loadOrCreate(EventSourcingRepository.java:137) ~[axon-eventsourcing-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.SimpleStateManager.loadManagedEntity(SimpleStateManager.java:80) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.StateManager.loadEntity(StateManager.java:101) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.modelling.annotation.InjectEntityParameterResolver.resolveParameterValue(InjectEntityParameterResolver.java:93) ~[axon-modelling-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.tryResolveParameterValue(MethodInvokingMessageHandlingMember.java:231) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.lambda$resolveParameterValues$1(MethodInvokingMessageHandlingMember.java:218) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?]
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?]
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.resolveParameterValues(MethodInvokingMessageHandlingMember.java:219) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	at org.axonframework.messaging.core.annotation.MethodInvokingMessageHandlingMember.handle(MethodInvokingMessageHandlingMember.java:175) ~[axon-messaging-5.0.0-SNAPSHOT.jar:5.0.0-SNAPSHOT]
	... 51 more
```

Just noticed the `AxonConfigurationException` is mentioned twice but not sure if I should've unwrapped it on line 179 or it shouldn't have been wrapped in the first place. Just FYI

Also, IMO that should be logged under `ERROR`

low on time, feel free to take over