### PR TITLE
[#3847] Logging warn message for included streaming event criteria

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -25,10 +25,10 @@ import org.axonframework.common.TypeReference;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker.AggregateSequencer;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils;
-import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
@@ -52,6 +52,7 @@ import org.axonframework.messaging.eventhandling.TerminalEventMessage;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.EventCriterion;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
 import org.axonframework.messaging.eventstreaming.Tag;
@@ -372,6 +373,11 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     @Override
     public MessageStream<EventMessage> stream(@Nonnull StreamingCondition condition,
                                               @Nullable ProcessingContext processingContext) {
+        EventCriteria criteria = condition.criteria();
+        if (criteria.hasCriteria()) {
+            logger.warn("Ignoring streaming criteria. Reason: unsupported by this aggregate-based event store."
+                                + "Ignored criteria are: {}", criteria);
+        }
         GapAwareTrackingToken trackingToken = tokenOperations.assertGapAwareTrackingToken(condition.position());
 
         return new ContinuousMessageStream<TokenAndEvent>(


### PR DESCRIPTION
This PR adds a WARN-level log message when `EventCriteria` are present on an `AggregateBasedJpaEventStorageEngine#stream` invocation.

Throwing an exception may be preferred, but users typically do not choose the criteria at all for streaming, as they will never invoke this method.
Furthermore, the `EventCriteria` is automatically set on `PooledStreamingEventProcessor` creation to the set of known event types.
Hence, **any** application using the PSEP that uses the `AggregateBasedJpaEventStorageEngine` would get exceptions automatically if we throw exceptions.

Hence, I went for logging a WARN message. Still don't think this is ideal, though. Thoughts?

This PR intends to resolve #3847.