### PR TITLE
Depend on `axon-update` in `axon-messaging`

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>axon-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-update</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Conversion -->
         <dependency>


### PR DESCRIPTION
This PR adds a dependency on `axon-update`. 
If we don't, the Update Checker is not automatically loaded, and we thus wouldn't get any update metrics in without it.