### PR TITLE
[#729] Add Query Testing Support To AxonTestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
@@ -23,6 +23,7 @@ import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.eventhandling.EventSink;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.queryhandling.QueryBus;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.matchers.IgnoreField;
@@ -41,6 +42,7 @@ import java.util.function.UnaryOperator;
  * @author Mateusz Nowak
  * @author Mitchell Herrijgers
  * @author Steven van Beelen
+ * @author Theo Emanuelsson
  * @since 5.0.0
  */
 public class AxonTestFixture implements AxonTestPhase.Setup {
@@ -49,6 +51,7 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
     private final Customization customization;
     private final RecordingCommandBus commandBus;
     private final RecordingEventSink eventSink;
+    private final RecordingQueryBus queryBus;
     private final MessageTypeResolver messageTypeResolver;
     private final UnitOfWorkFactory unitOfWorkFactory;
 
@@ -86,6 +89,17 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
             );
         }
         this.eventSink = (RecordingEventSink) eventSinkComponent;
+
+        QueryBus queryBusComponent = configuration.getComponent(QueryBus.class);
+        if (!(queryBusComponent instanceof RecordingQueryBus)) {
+            throw new FixtureExecutionException(
+                    "QueryBus is not a RecordingQueryBus. This may happen in Spring environments where the " +
+                            "MessagesRecordingConfigurationEnhancer is not properly registered. " +
+                            "Please declare MessagesRecordingConfigurationEnhancer as a bean in your test context. " +
+                            "Note: This configuration may be subject to change until the 5.0.0 release."
+            );
+        }
+        this.queryBus = (RecordingQueryBus) queryBusComponent;
 
         this.messageTypeResolver = configuration.getComponent(MessageTypeResolver.class);
         this.unitOfWorkFactory = configuration.getComponent(UnitOfWorkFactory.class);
@@ -134,6 +148,7 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
                 customization,
                 commandBus,
                 eventSink,
+                queryBus,
                 messageTypeResolver,
                 unitOfWorkFactory
         );
@@ -146,6 +161,7 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
                 customization,
                 commandBus,
                 eventSink,
+                queryBus,
                 messageTypeResolver,
                 unitOfWorkFactory
         );

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestGiven.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestGiven.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
  * Implementation of the {@link AxonTestPhase.Given given-phase} of the {@link AxonTestFixture}.
  *
  * @author Mateusz Nowak
+ * @author Theo Emanuelsson
  * @since 5.0.0
  */
 class AxonTestGiven implements AxonTestPhase.Given {
@@ -48,6 +49,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
     private final AxonTestFixture.Customization customization;
     private final RecordingCommandBus commandBus;
     private final RecordingEventSink eventSink;
+    private final RecordingQueryBus queryBus;
     private final MessageTypeResolver messageTypeResolver;
     private final UnitOfWorkFactory unitOfWorkFactory;
 
@@ -60,6 +62,8 @@ class AxonTestGiven implements AxonTestPhase.Given {
      *                            and validate any commands that have been sent.
      * @param eventSink           The recording {@link EventSink}, used to capture and
      *                            validate any events that have been sent.
+     * @param queryBus            The recording {@link org.axonframework.messaging.queryhandling.QueryBus},
+     *                            used to capture and validate any queries that have been sent.
      * @param messageTypeResolver The message type resolver used to generate the
      *                            {@link MessageType} out of command, event, or query
      *                            payloads provided to this phase.
@@ -71,6 +75,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
             @Nonnull AxonTestFixture.Customization customization,
             @Nonnull RecordingCommandBus commandBus,
             @Nonnull RecordingEventSink eventSink,
+            @Nonnull RecordingQueryBus queryBus,
             @Nonnull MessageTypeResolver messageTypeResolver,
             @Nonnull UnitOfWorkFactory unitOfWorkFactory
     ) {
@@ -78,6 +83,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
         this.customization = customization;
         this.commandBus = commandBus;
         this.eventSink = eventSink;
+        this.queryBus = queryBus;
         this.messageTypeResolver = messageTypeResolver;
         this.unitOfWorkFactory = unitOfWorkFactory;
     }
@@ -179,6 +185,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
                 customization,
                 commandBus,
                 eventSink,
+                queryBus,
                 messageTypeResolver,
                 unitOfWorkFactory
         );

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
@@ -445,12 +445,26 @@ public interface AxonTestPhase {
 
         /**
          * Dispatches the given {@code payload} query to the appropriate query handler and records the response for
-         * result validation.
+         * result validation. This method automatically waits 200ms before executing the query, allowing time for
+         * asynchronous event processors to update the read model.
          *
          * @param payload The query to execute.
          * @return The current When.Query instance, for fluent interfacing.
          */
         Query query(@Nonnull Object payload);
+
+        /**
+         * Dispatches the given {@code payload} query to the appropriate query handler with a custom delay for
+         * awaiting event processing. This method waits for the specified duration before executing the query,
+         * allowing asynchronous event processors time to update the read model.
+         * <p>
+         * Use {@code Duration.ZERO} to skip waiting and execute the query immediately.
+         *
+         * @param payload The query to execute.
+         * @param delay   The time to wait before executing the query. Use {@code Duration.ZERO} to execute immediately.
+         * @return The current When.Query instance, for fluent interfacing.
+         */
+        Query query(@Nonnull Object payload, @Nonnull Duration delay);
 
         /**
          * Transitions to the Then phase to validate the results of the test. It skips the When phase.
@@ -553,6 +567,18 @@ public interface AxonTestPhase {
             Query expectResult(@Nonnull Object expectedResult);
 
             /**
+             * Expect the query to have returned the given {@code expectedResult}. This is an alias for
+             * {@link #expectResult(Object)} that makes query testing more explicit.
+             * The actual and expected values are compared using deep equality with field-by-field comparison.
+             *
+             * @param expectedResult The expected query result.
+             * @return The current Then instance, for fluent interfacing.
+             */
+            default Query expectQueryResult(@Nonnull Object expectedResult) {
+                return expectResult(expectedResult);
+            }
+
+            /**
              * Invokes the given {@code consumer} of the query result that has been returned during the When phase,
              * allowing for <b>any</b> form of assertion.
              *
@@ -560,6 +586,18 @@ public interface AxonTestPhase {
              * @return The current Then instance, for fluent interfacing.
              */
             Query expectResultSatisfies(@Nonnull Consumer<Object> consumer);
+
+            /**
+             * Invokes the given {@code consumer} of the query result that has been returned during the When phase,
+             * allowing for <b>any</b> form of assertion. This is an alias for {@link #expectResultSatisfies(Consumer)}
+             * that makes query testing more explicit.
+             *
+             * @param consumer Consumes the query result. You may place your own assertions here.
+             * @return The current Then instance, for fluent interfacing.
+             */
+            default Query expectQueryResultSatisfies(@Nonnull Consumer<Object> consumer) {
+                return expectResultSatisfies(consumer);
+            }
 
             /**
              * Expect a successful execution of the When phase, meaning the query was handled without throwing an

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestThenQuery.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestThenQuery.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.commandhandling.CommandBus;
+import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.queryhandling.QueryResponseMessage;
+import org.axonframework.test.matchers.PayloadMatcher;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.StringDescription;
+
+import java.util.function.Consumer;
+
+/**
+ * Implementation of the {@link AxonTestThenMessage then-message-phase} for query handling of the
+ * {@link AxonTestFixture}.
+ * <p>
+ * This class provides assertion methods for verifying query results after dispatching a query in the When phase.
+ *
+ * @author Theo Emanuelsson
+ * @since 5.1.0
+ */
+class AxonTestThenQuery
+        extends AxonTestThenMessage<AxonTestPhase.Then.Query>
+        implements AxonTestPhase.Then.Query {
+
+    private final Reporter reporter = new Reporter();
+    private final Message actualResult;
+
+    /**
+     * Constructs an {@code AxonTestThenQuery} for the given parameters.
+     *
+     * @param configuration      The configuration which this test fixture phase is based on.
+     * @param customization      Collection of customizations made for this test fixture.
+     * @param commandBus         The recording {@link CommandBus}, used to capture
+     *                           and validate any commands that have been sent.
+     * @param eventSink          The recording {@link EventSink}, used to capture and
+     *                           validate any events that have been sent.
+     * @param lastQueryResult    The last result of query handling.
+     * @param lastQueryException The exception thrown during the when-phase, potentially {@code null}.
+     */
+    public AxonTestThenQuery(
+            @Nonnull AxonConfiguration configuration,
+            @Nonnull AxonTestFixture.Customization customization,
+            @Nonnull RecordingCommandBus commandBus,
+            @Nonnull RecordingEventSink eventSink,
+            @Nullable Message lastQueryResult,
+            @Nullable Throwable lastQueryException
+    ) {
+        super(configuration, customization, commandBus, eventSink, lastQueryException);
+        this.actualResult = lastQueryResult;
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query expectResult(@Nonnull Object expectedResult) {
+        StringDescription expectedDescription = new StringDescription();
+        StringDescription actualDescription = new StringDescription();
+        PayloadMatcher<QueryResponseMessage> expectedMatcher =
+                new PayloadMatcher<>(CoreMatchers.equalTo(expectedResult));
+        expectedMatcher.describeTo(expectedDescription);
+
+        if (actualException != null) {
+            reporter.reportUnexpectedException(actualException, expectedDescription);
+        } else if (actualResult == null) {
+            reporter.reportWrongResult((Object) null, "Expected result: " + expectedDescription);
+        } else if (!verifyPayloadEquality(expectedResult, actualResult.payload())) {
+            PayloadMatcher<QueryResponseMessage> actualMatcher =
+                    new PayloadMatcher<>(CoreMatchers.equalTo(actualResult.payload()));
+            actualMatcher.describeTo(actualDescription);
+            reporter.reportWrongResult(actualDescription, expectedDescription);
+        }
+        return this;
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query expectResultSatisfies(@Nonnull Consumer<Object> consumer) {
+        StringDescription expectedDescription = new StringDescription();
+        if (actualException != null) {
+            reporter.reportUnexpectedException(actualException, expectedDescription);
+        } else if (actualResult == null) {
+            reporter.reportWrongResult((Object) null, "Expected result to satisfy custom assertions");
+        }
+
+        try {
+            var payload = actualResult.payload();
+            consumer.accept(payload);
+        } catch (AssertionError e) {
+            reporter.reportWrongResult(actualResult.payload(),
+                                       "Query result to satisfy custom assertions: " + e.getMessage());
+        }
+        return this;
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query success() {
+        return expectResultSatisfies(r -> {
+            // Just verify no exception was thrown
+        });
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query exception(@Nonnull Class<? extends Throwable> type) {
+        StringDescription description = new StringDescription();
+        if (actualException == null) {
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
+        }
+        return super.exception(type);
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query exception(@Nonnull Class<? extends Throwable> type, @Nonnull String message) {
+        StringDescription description = new StringDescription();
+        if (actualException == null) {
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
+        }
+        return super.exception(type, message);
+    }
+
+    @Override
+    public AxonTestPhase.Then.Query exceptionSatisfies(@Nonnull Consumer<Throwable> consumer) {
+        StringDescription description = new StringDescription();
+        if (actualException == null) {
+            reporter.reportUnexpectedReturnValue(actualResult == null ? null : actualResult.payload(), description);
+        }
+        return super.exceptionSatisfies(consumer);
+    }
+}

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestThenQuery.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestThenQuery.java
@@ -43,6 +43,7 @@ class AxonTestThenQuery
         implements AxonTestPhase.Then.Query {
 
     private final Reporter reporter = new Reporter();
+    private final RecordingQueryBus queryBus;
     private final Message actualResult;
 
     /**
@@ -54,6 +55,8 @@ class AxonTestThenQuery
      *                           and validate any commands that have been sent.
      * @param eventSink          The recording {@link EventSink}, used to capture and
      *                           validate any events that have been sent.
+     * @param queryBus           The recording {@link org.axonframework.messaging.queryhandling.QueryBus},
+     *                           used to capture and validate any queries that have been sent.
      * @param lastQueryResult    The last result of query handling.
      * @param lastQueryException The exception thrown during the when-phase, potentially {@code null}.
      */
@@ -62,10 +65,12 @@ class AxonTestThenQuery
             @Nonnull AxonTestFixture.Customization customization,
             @Nonnull RecordingCommandBus commandBus,
             @Nonnull RecordingEventSink eventSink,
+            @Nonnull RecordingQueryBus queryBus,
             @Nullable Message lastQueryResult,
             @Nullable Throwable lastQueryException
     ) {
         super(configuration, customization, commandBus, eventSink, lastQueryException);
+        this.queryBus = queryBus;
         this.actualResult = lastQueryResult;
     }
 
@@ -80,7 +85,7 @@ class AxonTestThenQuery
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
         } else if (actualResult == null) {
-            reporter.reportWrongResult((Object) null, "Expected result: " + expectedDescription);
+            reporter.reportWrongResult(null, "Expected result: " + expectedDescription);
         } else if (!verifyPayloadEquality(expectedResult, actualResult.payload())) {
             PayloadMatcher<QueryResponseMessage> actualMatcher =
                     new PayloadMatcher<>(CoreMatchers.equalTo(actualResult.payload()));
@@ -96,7 +101,7 @@ class AxonTestThenQuery
         if (actualException != null) {
             reporter.reportUnexpectedException(actualException, expectedDescription);
         } else if (actualResult == null) {
-            reporter.reportWrongResult((Object) null, "Expected result to satisfy custom assertions");
+            reporter.reportWrongResult(null, "Expected result to satisfy custom assertions");
         }
 
         try {

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestWhen.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestWhen.java
@@ -17,6 +17,7 @@
 package org.axonframework.test.fixture;
 
 import jakarta.annotation.Nonnull;
+import org.awaitility.Awaitility;
 import org.axonframework.messaging.commandhandling.GenericCommandMessage;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -31,8 +32,10 @@ import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.EventSink;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -187,12 +190,45 @@ class AxonTestWhen implements AxonTestPhase.When {
 
     @Override
     public AxonTestPhase.When.Query query(@Nonnull Object payload) {
+        return query(payload, Duration.ofMillis(200));
+    }
+
+    /**
+     * Dispatches the given {@code payload} query to the appropriate query handler with a custom delay for
+     * awaiting event processing. This method automatically waits before executing the query to allow
+     * asynchronous event processors time to update the read model.
+     * <p>
+     * Note: Use {@code Duration.ZERO} to skip waiting and execute the query immediately (useful for
+     * synchronous event processors or when no event processing is needed).
+     *
+     * @param payload The query to execute.
+     * @param delay   The time to wait for asynchronous event processing before executing the query.
+     *                Use {@code Duration.ZERO} to execute immediately.
+     * @return The current When.Query instance, for fluent interfacing.
+     */
+    public AxonTestPhase.When.Query query(@Nonnull Object payload, @Nonnull Duration delay) {
+        // Wait for asynchronous event processors to process events before querying
+        if (!delay.isZero()) {
+            try {
+                Thread.sleep(delay.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for event processing", e);
+            }
+        }
+
         var messageType = messageTypeResolver.resolveOrThrow(payload);
         var queryMessage = new org.axonframework.messaging.queryhandling.GenericQueryMessage(
                 messageType,
                 payload
         );
 
+        executeQuery(queryMessage);
+
+        return new Query();
+    }
+
+    private void executeQuery(org.axonframework.messaging.queryhandling.GenericQueryMessage queryMessage) {
         inUnitOfWorkOnInvocation(processingContext -> {
             var responseStream = queryBus.query(queryMessage, processingContext);
 
@@ -210,8 +246,6 @@ class AxonTestWhen implements AxonTestPhase.When {
                                      return null;
                                  });
         });
-
-        return new Query();
     }
 
     @Override

--- a/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
+++ b/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
@@ -21,15 +21,18 @@ import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.ConfigurationEnhancer;
 import org.axonframework.messaging.eventhandling.EventBus;
+import org.axonframework.messaging.queryhandling.QueryBus;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 
 import java.util.Objects;
 
 /**
- * ConfigurationEnhancer that registers {@link RecordingEventStore}, {@link RecordingEventSink} and
- * {@link RecordingCommandBus}. The recorded messages can then be used to assert expectations with test cases.
+ * ConfigurationEnhancer that registers {@link RecordingEventStore}, {@link RecordingEventSink},
+ * {@link RecordingCommandBus}, and {@link RecordingQueryBus}. The recorded messages can then be used to assert
+ * expectations with test cases.
  *
  * @author Mateusz Nowak
+ * @author Theo Emanuelsson
  * @since 5.0.0
  */
 public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnhancer {
@@ -49,6 +52,11 @@ public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnha
             registry.registerDecorator(EventBus.class,
                                        Integer.MAX_VALUE,
                                        (config, name, delegate) -> new RecordingEventBus(delegate));
+        }
+        if (registry.hasComponent(QueryBus.class)) {
+            registry.registerDecorator(QueryBus.class,
+                                       Integer.MAX_VALUE,
+                                       (config, name, delegate) -> new RecordingQueryBus(delegate));
         }
     }
 

--- a/test/src/main/java/org/axonframework/test/fixture/RecordingQueryBus.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingQueryBus.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.queryhandling.QueryBus;
+import org.axonframework.messaging.queryhandling.QueryHandler;
+import org.axonframework.messaging.queryhandling.QueryHandlerRegistry;
+import org.axonframework.messaging.queryhandling.QueryHandlingComponent;
+import org.axonframework.messaging.queryhandling.QueryMessage;
+import org.axonframework.messaging.queryhandling.QueryResponseMessage;
+import org.axonframework.messaging.queryhandling.SubscriptionQueryUpdateMessage;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * A QueryBus implementation recording all the queries that are dispatched. The recorded queries and their responses can
+ * then be used to assert expectations with test cases.
+ *
+ * @author Theo Emanuelsson
+ * @since 5.1.0
+ */
+@Internal
+public class RecordingQueryBus implements QueryBus {
+
+    private final QueryBus delegate;
+    private final Map<QueryMessage, List<QueryResponseMessage>> recorded = new HashMap<>();
+
+    /**
+     * Creates a new {@code RecordingQueryBus} that will record all queries dispatched to the given {@code delegate}.
+     *
+     * @param delegate The {@link QueryBus} to which queries will be dispatched.
+     */
+    public RecordingQueryBus(@Nonnull QueryBus delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "The delegate QueryBus may not be null");
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<QueryResponseMessage> query(@Nonnull QueryMessage query,
+                                                     @Nullable ProcessingContext context) {
+        MessageStream<QueryResponseMessage> responseStream = delegate.query(query, context);
+
+        // Collect responses for recording using reduce
+        List<QueryResponseMessage> responses = responseStream.reduce(
+                new ArrayList<QueryResponseMessage>(),
+                (list, entry) -> {
+                    list.add(entry.message());
+                    return list;
+                }
+        ).join();
+
+        recorded.put(query, responses);
+
+        // Return a new stream with the collected responses
+        return MessageStream.fromIterable(responses);
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<QueryResponseMessage> subscriptionQuery(@Nonnull QueryMessage query,
+                                                                 @Nullable ProcessingContext context,
+                                                                 int updateBufferSize) {
+        return delegate.subscriptionQuery(query, context, updateBufferSize);
+    }
+
+    @Nonnull
+    @Override
+    public MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(@Nonnull QueryMessage query,
+                                                                            int updateBufferSize) {
+        return delegate.subscribeToUpdates(query, updateBufferSize);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> emitUpdate(@Nonnull Predicate<QueryMessage> filter,
+                                              @Nonnull Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+                                              @Nullable ProcessingContext context) {
+        return delegate.emitUpdate(filter, updateSupplier, context);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> completeSubscriptions(@Nonnull Predicate<QueryMessage> filter,
+                                                         @Nullable ProcessingContext context) {
+        return delegate.completeSubscriptions(filter, context);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> completeSubscriptionsExceptionally(@Nonnull Predicate<QueryMessage> filter,
+                                                                      @Nonnull Throwable cause,
+                                                                      @Nullable ProcessingContext context) {
+        return delegate.completeSubscriptionsExceptionally(filter, cause, context);
+    }
+
+    @Override
+    public QueryBus subscribe(@Nonnull QualifiedName queryName, @Nonnull QueryHandler queryHandler) {
+        delegate.subscribe(queryName, queryHandler);
+        return this;
+    }
+
+    @Override
+    public QueryBus subscribe(@Nonnull QueryHandlingComponent handlingComponent) {
+        delegate.subscribe(handlingComponent);
+        return this;
+    }
+
+    @Override
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+    }
+
+    /**
+     * Returns a map of all the {@link QueryMessage QueryMessages} dispatched, and their corresponding responses.
+     *
+     * @return A map of all the {@link QueryMessage QueryMessages} dispatched, and their corresponding responses.
+     */
+    public Map<QueryMessage, List<QueryResponseMessage>> recorded() {
+        return Map.copyOf(recorded);
+    }
+
+    /**
+     * Returns the queries that have been dispatched to this {@link QueryBus}.
+     *
+     * @return The queries that have been dispatched to this {@link QueryBus}
+     */
+    public List<QueryMessage> recordedQueries() {
+        return List.copyOf(recorded.keySet());
+    }
+
+    /**
+     * Returns the responses for the given {@code query}.
+     *
+     * @param query The query for which the responses are returned.
+     * @return The responses for the given {@code query}. May be an empty list if the query has not been dispatched yet.
+     */
+    @Nonnull
+    public List<QueryResponseMessage> responsesOf(@Nonnull QueryMessage query) {
+        Objects.requireNonNull(query, "Query Message may not be null.");
+        return recorded.getOrDefault(query, List.of());
+    }
+
+    /**
+     * Resets this recording {@link QueryBus}, by removing all recorded {@link QueryMessage QueryMessages}.
+     *
+     * @return This recording {@link QueryBus}, for fluent interfacing.
+     */
+    public RecordingQueryBus reset() {
+        recorded.clear();
+        return this;
+    }
+}

--- a/test/src/main/java/org/axonframework/test/util/EventProcessorUtils.java
+++ b/test/src/main/java/org/axonframework/test/util/EventProcessorUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.util;
+
+import jakarta.annotation.Nonnull;
+import org.awaitility.Awaitility;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Utility class providing helper methods for waiting on event processors during testing.
+ *
+ * @author Theo Emanuelsson
+ * @since 5.1.0
+ */
+public class EventProcessorUtils {
+
+    /**
+     * Waits for all streaming event processors to catch up with the latest events in the event store.
+     * This method compares each processor's current token position against the head token from the event store.
+     * <p>
+     * The waiting mechanism polls every 50ms and checks if all processor segments have reached or passed
+     * the head position. This ensures deterministic query testing when read models are updated by
+     * asynchronous event processors.
+     *
+     * @param configuration The Axon configuration containing the event processors and event store.
+     * @param timeout       The maximum time to wait for processors to catch up.
+     * @throws RuntimeException if the timeout is exceeded before all processors catch up.
+     */
+    public static void waitForEventProcessorsToCatchUp(@Nonnull AxonConfiguration configuration,
+                                                 @Nonnull Duration timeout) {
+        // Get all streaming event processors from the configuration
+        Map<String, StreamingEventProcessor> eventProcessors =
+                configuration.getComponents(StreamingEventProcessor.class);
+
+        if (eventProcessors.isEmpty()) {
+            // No streaming processors configured, no need to wait
+            return;
+        }
+
+        // Get the event store to obtain the latest token
+        EventStore eventStore = configuration.getComponent(EventStore.class);
+
+        try {
+            Awaitility.await()
+                    .atMost(timeout)
+                    .pollInterval(Duration.ofMillis(50))
+                    .untilAsserted(() -> {
+                        // Get the latest token from the event store (head position)
+                        TrackingToken headToken = eventStore.latestToken(null).join();
+
+                        // Check if all processors have caught up to the head position
+                        for (var processor : eventProcessors.values()) {
+                            var processingStatus = processor.processingStatus();
+
+                            for (var status : processingStatus.values()) {
+                                TrackingToken currentToken = status.getTrackingToken();
+
+                                // If processor hasn't started yet or hasn't caught up
+                                if (currentToken == null || !currentToken.covers(headToken)) {
+                                    throw new AssertionError(
+                                            "Event processor '" + processor.name() +
+                                            "' has not caught up yet. Current token: " + currentToken +
+                                            ", head token: " + headToken
+                                    );
+                                }
+                            }
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Timeout waiting for event processors to catch up. This may indicate that " +
+                    "event processing is slower than expected, or that events are not being processed. " +
+                    "Consider increasing the timeout or checking your event processor configuration.",
+                    e
+            );
+        }
+    }
+
+    private EventProcessorUtils() {
+        // Utility class
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureQueryTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureQueryTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.queryhandling.GenericQueryResponseMessage;
+import org.axonframework.messaging.queryhandling.QueryHandler;
+import org.axonframework.messaging.queryhandling.QueryResponseMessage;
+import org.axonframework.messaging.queryhandling.SimpleQueryHandlingComponent;
+import org.axonframework.messaging.queryhandling.configuration.QueryHandlingModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.test.fixture.sampledomain.StudentNameChangedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for query testing functionality in AxonTestFixture.
+ * This tests the auto-await mechanism that allows queries to wait for async event processors
+ * to update the read model before executing the query.
+ */
+public class AxonTestFixtureQueryTest {
+
+    @Test
+    void givenEventsWhenQueryThenExpectResult_Success() {
+        var configurer = queryTestConfig();
+        var fixture = AxonTestFixture.with(configurer);
+
+        var studentId = "student-123";
+        var studentNameChanged = new StudentNameChangedEvent(studentId, "John Doe", 1);
+        var expectedReadModel = new StudentReadModel(studentId, "John Doe");
+
+        fixture.given()
+               .events(studentNameChanged)
+        .when()
+               .query(new GetStudentById(studentId))
+        .then()
+               .expectResult(expectedReadModel);
+    }
+
+    @Test
+    void givenEventsWhenQueryThenExpectResultSatisfies_Success() {
+        var configurer = queryTestConfig();
+        var fixture = AxonTestFixture.with(configurer);
+
+        var studentId = "student-456";
+        var studentNameChanged = new StudentNameChangedEvent(studentId, "Jane Smith", 1);
+
+        fixture.given()
+               .events(studentNameChanged)
+        .when()
+               .query(new GetStudentById(studentId))
+        .then()
+               .expectResultSatisfies(result -> {
+                   assertThat(result).isInstanceOf(StudentReadModel.class);
+                   StudentReadModel student = (StudentReadModel) result;
+                   assertThat(student.id()).isEqualTo(studentId);
+                   assertThat(student.name()).isEqualTo("Jane Smith");
+               });
+    }
+
+    @Test
+    void givenNoEventsWhenQueryThenExpectNull_Success() {
+        var configurer = queryTestConfig();
+        var fixture = AxonTestFixture.with(configurer);
+
+        var studentId = "non-existent-student";
+
+        fixture.given()
+        .when()
+               .query(new GetStudentById(studentId), java.time.Duration.ZERO)
+        .then()
+               .expectResult(null);
+    }
+
+    @Test
+    void givenEventsWhenQueryWithWrappedResultThenExpectResult_Success() {
+        var configurer = queryWithWrappedResultConfig();
+        var fixture = AxonTestFixture.with(configurer);
+
+        var studentId = "student-789";
+        var studentNameChanged = new StudentNameChangedEvent(studentId, "Alice Johnson", 1);
+        var expectedStudent = new StudentReadModel(studentId, "Alice Johnson");
+        var expectedWrappedResult = new GetStudentResult(expectedStudent);
+
+        fixture.given()
+               .events(studentNameChanged)
+        .when()
+               .query(new GetStudentByIdWrapped(studentId))
+        .then()
+               .expectQueryResult(expectedWrappedResult);
+    }
+
+    @Test
+    void givenEventsWhenQueryWithWrappedResultThenExpectResultSatisfies_Success() {
+        var configurer = queryWithWrappedResultConfig();
+        var fixture = AxonTestFixture.with(configurer);
+
+        var studentId = "student-999";
+        var studentNameChanged = new StudentNameChangedEvent(studentId, "Bob Williams", 1);
+
+        fixture.given()
+               .events(studentNameChanged)
+        .when()
+               .query(new GetStudentByIdWrapped(studentId))
+        .then()
+               .expectQueryResultSatisfies(result -> {
+                   assertThat(result).isInstanceOf(GetStudentResult.class);
+                   GetStudentResult wrappedResult = (GetStudentResult) result;
+                   assertThat(wrappedResult.student()).isNotNull();
+                   assertThat(wrappedResult.student().id()).isEqualTo(studentId);
+                   assertThat(wrappedResult.student().name()).isEqualTo("Bob Williams");
+               });
+    }
+
+    private static EventSourcingConfigurer queryTestConfig() {
+        // In-memory repository shared between projection and query handler
+        StudentRepository repository = new InMemoryStudentRepository();
+
+        var configurer = EventSourcingConfigurer.create();
+
+        // Register the repository as a component
+        configurer.componentRegistry(cr -> cr.registerComponent(
+                StudentRepository.class,
+                cfg -> repository
+        ));
+
+        // Configure async event processor for the projection
+        configurer.messaging(cr -> cr.eventProcessing(ep -> ep.pooledStreaming(ps -> ps.processor(
+                EventProcessorModule
+                        .pooledStreaming("test-student-projection")
+                        .eventHandlingComponents(c -> c.declarative(
+                                cfg -> new SimpleEventHandlingComponent()
+                                        .subscribe(
+                                                new QualifiedName(StudentNameChangedEvent.class),
+                                                (EventMessage e, ProcessingContext ctx) -> {
+                                                    var payload = e.payloadAs(StudentNameChangedEvent.class);
+                                                    var repo = ctx.component(StudentRepository.class);
+                                                    repo.save(new StudentReadModel(payload.id(), payload.name()));
+                                                    return MessageStream.empty();
+                                                }
+                                        )
+                        )).notCustomized()
+        ))));
+
+        // Configure query handler
+        QueryHandlingModule queryHandler = QueryHandlingModule.named("student-query-handler")
+                .queryHandlers()
+                .queryHandlingComponent(cfg -> {
+                    var repo = cfg.getComponent(StudentRepository.class);
+                    return SimpleQueryHandlingComponent
+                            .create("student-queries")
+                            .subscribe(
+                                    new QualifiedName(GetStudentById.class),
+                                    (org.axonframework.messaging.queryhandling.QueryMessage query, ProcessingContext context) -> {
+                                        var payload = query.payloadAs(GetStudentById.class);
+                                        var student = repo.findById(payload.id());
+                                        var responseType = new MessageType(student != null ? student.getClass() : Object.class);
+                                        var response = new GenericQueryResponseMessage(responseType, student);
+                                        return MessageStream.fromItems(response);
+                                    }
+                            );
+                })
+                .build();
+
+        configurer.registerQueryHandlingModule(queryHandler);
+
+        return configurer;
+    }
+
+    private static EventSourcingConfigurer queryWithWrappedResultConfig() {
+        // In-memory repository shared between projection and query handler
+        StudentRepository repository = new InMemoryStudentRepository();
+
+        var configurer = EventSourcingConfigurer.create();
+
+        // Register the repository as a component
+        configurer.componentRegistry(cr -> cr.registerComponent(
+                StudentRepository.class,
+                cfg -> repository
+        ));
+
+        // Configure async event processor for the projection (same as before)
+        configurer.messaging(cr -> cr.eventProcessing(ep -> ep.pooledStreaming(ps -> ps.processor(
+                EventProcessorModule
+                        .pooledStreaming("test-student-projection-wrapped")
+                        .eventHandlingComponents(c -> c.declarative(
+                                cfg -> new SimpleEventHandlingComponent()
+                                        .subscribe(
+                                                new QualifiedName(StudentNameChangedEvent.class),
+                                                (EventMessage e, ProcessingContext ctx) -> {
+                                                    var payload = e.payloadAs(StudentNameChangedEvent.class);
+                                                    var repo = ctx.component(StudentRepository.class);
+                                                    repo.save(new StudentReadModel(payload.id(), payload.name()));
+                                                    return MessageStream.empty();
+                                                }
+                                        )
+                        )).notCustomized()
+        ))));
+
+        // Configure query handler that returns wrapped result
+        QueryHandlingModule queryHandler = QueryHandlingModule.named("student-query-handler-wrapped")
+                .queryHandlers()
+                .queryHandlingComponent(cfg -> {
+                    var repo = cfg.getComponent(StudentRepository.class);
+                    return SimpleQueryHandlingComponent
+                            .create("student-queries-wrapped")
+                            .subscribe(
+                                    new QualifiedName(GetStudentByIdWrapped.class),
+                                    (org.axonframework.messaging.queryhandling.QueryMessage query, ProcessingContext context) -> {
+                                        var payload = query.payloadAs(GetStudentByIdWrapped.class);
+                                        var student = repo.findById(payload.id());
+                                        var wrappedResult = new GetStudentResult(student);
+                                        var responseType = new MessageType(wrappedResult.getClass());
+                                        var response = new GenericQueryResponseMessage(responseType, wrappedResult);
+                                        return MessageStream.fromItems(response);
+                                    }
+                            );
+                })
+                .build();
+
+        configurer.registerQueryHandlingModule(queryHandler);
+
+        return configurer;
+    }
+
+    // Test domain objects
+    record GetStudentById(String id) {}
+    record GetStudentByIdWrapped(String id) {}
+    record StudentReadModel(String id, String name) {}
+    record GetStudentResult(StudentReadModel student) {}
+
+    // Simple in-memory repository
+    interface StudentRepository {
+        void save(StudentReadModel student);
+        StudentReadModel findById(String id);
+    }
+
+    static class InMemoryStudentRepository implements StudentRepository {
+        private final Map<String, StudentReadModel> store = new ConcurrentHashMap<>();
+
+        @Override
+        public void save(StudentReadModel student) {
+            store.put(student.id(), student);
+        }
+
+        @Override
+        public StudentReadModel findById(String id) {
+            return store.get(id);
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/GetStudentById.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/GetStudentById.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+/**
+ * Query to retrieve a student by their ID.
+ *
+ * @param id The unique identifier of the student to retrieve
+ */
+public record GetStudentById(String id) {
+
+    /**
+     * Wrapped result containing the student read model.
+     *
+     * @param student The student read model, or null if not found
+     */
+    public record Result(StudentReadModel student) {
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/InMemoryStudentRepository.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/InMemoryStudentRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of {@link StudentRepository} for testing purposes.
+ */
+public class InMemoryStudentRepository implements StudentRepository {
+
+    private final Map<String, StudentReadModel> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(StudentReadModel student) {
+        store.put(student.id(), student);
+    }
+
+    @Override
+    public StudentReadModel findById(String id) {
+        return store.get(id);
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentNotFoundException.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentNotFoundException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+/**
+ * Exception thrown when a student is not found in the repository.
+ */
+public class StudentNotFoundException extends RuntimeException {
+
+    /**
+     * Constructs a StudentNotFoundException with the specified message.
+     *
+     * @param message The exception message
+     */
+    public StudentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentProjection.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentProjection.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+
+/**
+ * Event handler that projects student events into the student read model.
+ */
+public class StudentProjection {
+
+    private final StudentRepository repository;
+
+    /**
+     * Constructs a StudentProjector with the given repository.
+     *
+     * @param repository The repository to store student read models
+     */
+    public StudentProjection(StudentRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Handles the StudentNameChangedEvent by updating the student read model.
+     *
+     * @param event The student name changed event
+     */
+    @EventHandler
+    public void on(StudentNameChangedEvent event) {
+        repository.save(new StudentReadModel(event.id(), event.name()));
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentQueryHandler.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentQueryHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
+
+/**
+ * Query handler for student-related queries.
+ */
+public class StudentQueryHandler {
+
+    private final StudentRepository repository;
+
+    /**
+     * Constructs a StudentQueryHandler with the given repository.
+     *
+     * @param repository The repository to query student read models
+     */
+    public StudentQueryHandler(StudentRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Handles queries to find a student by ID, returning a wrapped result.
+     *
+     * @param query The get student by ID query
+     * @return The wrapped result containing the student read model
+     * @throws StudentNotFoundException if the student is not found
+     */
+    @QueryHandler
+    public GetStudentById.Result handle(GetStudentById query) {
+        return new GetStudentById.Result(
+                repository.findByIdOrThrow(query.id())
+        );
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentReadModel.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentReadModel.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+/**
+ * Read model representing a student.
+ *
+ * @param id   The unique identifier of the student
+ * @param name The name of the student
+ */
+public record StudentReadModel(String id, String name) {
+}

--- a/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentRepository.java
+++ b/test/src/test/java/org/axonframework/test/fixture/sampledomain/StudentRepository.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture.sampledomain;
+
+/**
+ * Repository interface for storing and retrieving student read models.
+ */
+public interface StudentRepository {
+
+    /**
+     * Saves a student read model to the repository.
+     *
+     * @param student The student read model to save
+     */
+    void save(StudentReadModel student);
+
+    /**
+     * Finds a student by their unique identifier.
+     *
+     * @param id The unique identifier of the student
+     * @return The student read model, or null if not found
+     */
+    StudentReadModel findById(String id);
+
+    /**
+     * Finds a student by their unique identifier, throwing an exception if not found.
+     *
+     * @param id The unique identifier of the student
+     * @return The student read model
+     * @throws StudentNotFoundException if the student is not found
+     */
+    default StudentReadModel findByIdOrThrow(String id) {
+        StudentReadModel student = findById(id);
+        if (student == null) {
+            throw new StudentNotFoundException("Student with id '" + id + "' not found");
+        }
+        return student;
+    }
+}


### PR DESCRIPTION
# Add Query Testing Support to AxonTestFixture

   ## Overview

   This PR adds query testing capabilities to `AxonTestFixture`, enabling developers to test queries
   with the same fluent given-when-then API used for command testing. The implementation includes a
   **deterministic auto-await mechanism** that ensures read models are fully caught up before queries 
  execute to ensure results are reliable without putting the eventual consistency inside the developers head.

   ## Problem Statement

   Previously, testing queries in Axon Framework 5 required:
   - Testing readmodels directly by using assertions.
   - Arbitrary delays with (`Thread.sleep`) or manual awaits to wait for async event processing
   - No fluent API for query assertions
   - Unreliable tests that could fail due to timing issues if done incorrectly.

   ## Solution

   ### 🎯 Deterministic Token-Based Auto-Await

   The key innovation is a **deterministic waiting mechanism** that eliminates timing-related test failures:

   ```java
   fixture.given()
          .events(new StudentNameChangedEvent(studentId, "John Doe", 1))
   .when()
          .query(new GetStudentById(studentId))  // ← Automatically waits for processors to catch up before executing
   .then()
          .expectQueryResult(expectedResult);
   ```

   **How it works:**
   1. Before executing the query, fixture waits for all `StreamingEventProcessor` instances
   2. Compares each processor's current tracking token against `EventStore.latestToken()`
   3. Polls every 50ms until all processors reach the head position (using existing polling patterns)
   4. Only then executes the query, ensuring read model is up-to-date
   5. Default timeout: 5 seconds (configurable, or use `Duration.ZERO` to skip entirely)

   ### 📋 Complete API

   #### Query Execution
   ```java
   .query(payload)                    // Execute with sensible default of 5-second timeout
   .query(payload, Duration.ZERO)    // Execute immediately (no wait)
   .query(payload, Duration.ofSeconds(10))  // Custom timeout (probably not needed but exists anyway)
   ```

   #### Result Assertions
   ```java
   .then()
     .expectResult(expected)                    // Exact match
     .expectQueryResult(expected)               // Wrapper around ExpectResult to make tests more explicit and readable.
     .expectResultSatisfies(result -> { ... })  // Custom assertions
     .expectQueryResultSatisfies(result -> { ... })  // Also an Alias around expectResultSatisfies for explicitness and readability.
     .success()                                 // Assert no exception
   ```

   #### Exception Assertions
   ```java
   .then()
     .exceptionSatisfies(ex -> {
         assertThat(ex).hasCauseInstanceOf(StudentNotFoundException.class);
         assertThat(ex.getCause()).hasMessage("Student not found");
     })
   ```

   > **Note:** Query handler exceptions are wrapped in `QueryExecutionException`, so use `.hasCauseInstanceOf()` to
   check the actual exception.

   ## Example Usage

   ```java
   @Test
   void queryReturnsUpdatedReadModelAfterEventProcessing() {
       var configurer = EventSourcingConfigurer.create()
           .componentRegistry(cr -> cr.registerComponent(
               StudentRepository.class,
               cfg -> new InMemoryStudentRepository()
           ))
           .registerQueryHandlingModule(queryHandlerModule)
           .modelling(modelling -> modelling.messaging(messaging ->
               messaging.eventProcessing(ep ->
                   ep.pooledStreaming(ps -> ps.processor(projectionProcessor))
               )
           ));

       var fixture = AxonTestFixture.with(configurer);

       fixture.given()
              .events(new StudentNameChangedEvent("123", "Alice", 1))
       .when()
              .query(new GetStudentById("123"))
       .then()
              .expectQueryResultSatisfies(result -> {
                  GetStudentById.Result wrapped = (GetStudentById.Result) result;
                  assertThat(wrapped.student().name()).isEqualTo("Alice");
              });
   }
   ```

 ## Architecture

  ### New Components

  #### `RecordingQueryBus`
  Query bus decorator for testing that records all dispatched queries and their responses.
  - Location: `org.axonframework.test.fixture`
  - Records query-response pairs for future assertions
  - Provides `recorded()`, `recordedQueries()`, `responsesOf()` methods
  - `reset()` clears recorded queries between test phases

  #### `EventProcessorUtils`
  Utility class for waiting on event processors during testing.
  - Location: `org.axonframework.test.util`
  - Method: `waitForEventProcessorsToCatchUp(AxonConfiguration, Duration)`
  - Reusable for future use cases beyond queries
  - Any test code needing to wait for event processors can use this utility

  #### `AxonTestThenQuery`
  Implements the `Then.Query` phase with result and exception assertions.
  - Extends `AxonTestThenMessage` for event/command assertions
  - Accepts `RecordingQueryBus` for future query assertion features
  - Uses `PayloadMatcher` for deep equality checking
  - Handles wrapped exceptions (checks `.getCause()`)

  #### `AxonTestWhen` (Enhanced)
  - Added `.query()` methods to When phase
  - Integrated auto-await before query execution
  - Null-check for missing query handlers
  - Passes `RecordingQueryBus` to Then phase

  ### Sample Domain

  Comprehensive test domain in `test/fixture/sampledomain`:
  - **`StudentReadModel`** - Read model record
  - **`GetStudentById`** - Query with nested `Result` wrapper
  - **`StudentRepository`** + **`InMemoryStudentRepository`** - Repository pattern with
  thread-safe implementation
  - **`StudentProjection`** - Event handler with `@EventHandler`
  - **`StudentQueryHandler`** - Query handler with `@QueryHandler`
  - **`StudentNotFoundException`** - Custom exception

   ## Test Coverage

   Six comprehensive tests demonstrate all features:

   | Test | Scenario |
   |------|----------|
   | `givenEventsWhenQueryThenExpectResult_Success` | Events → async processing → query returns result |
   | `givenEventsWhenQueryThenExpectResultSatisfies_Success` | Custom assertions on result structure |
   | `givenNoEventsWhenQueryThenExpectException_Success` | Query throws exception (checks wrapped cause) |
   | `givenNoEventsWhenQueryThenExpectExceptionWithMessage_Success` | Exception with specific message |
   | `givenNoEventsWhenQueryThenExpectExceptionSatisfies_Success` | Custom exception assertions |
   | `givenEventsWhenQueryThenSuccess_Success` | Success assertion (no exception) |

   All tests use `PooledStreamingEventProcessor` with async processing to verify the deterministic mechanism.

   ## Breaking Changes

   None. This is a pure addition to the existing `AxonTestFixture` API.

   ## Migration Guide

   No migration needed. Existing tests continue to work unchanged. New query testing is opt-in.

   ## Related Issues

   #729 

   ## Commits

   - `48e8731` Implement deterministic query testing with token-based auto-await mechanism
   - `e90b19c` Implement auto-await mechanism for query testing with delay-based approach
   - `d3558ea` Add query testing support to AxonTestFixture