### PR TITLE
Fix: Maven Central badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 </p>
 
 # Axon Framework
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.axonframework/axon/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.axonframework/axon)
+
+[![Maven Central](https://img.shields.io/maven-central/v/org.axonframework/axon-framework-bom)](https://central.sonatype.com/artifact/org.axonframework/axon-framework-bom)
 ![Build Status](https://github.com/AxonFramework/AxonFramework/workflows/Axon%20Framework/badge.svg?branch=master)
 [![SonarCloud Status](https://sonarcloud.io/api/project_badges/measure?project=AxonFramework_AxonFramework&metric=alert_status)](https://sonarcloud.io/dashboard?id=AxonFramework_AxonFramework)
 


### PR DESCRIPTION
The maven-central badge was not working correclty, still showing the M1 release to be latest. 
Fixed by switching to `img.shields.io/maven-central`.

Also: the link behind the badge leads to the `axon-framework-bom` artifact, so when you click the badge, you get something you can directly c&p to your app.