### PR TITLE
4.10: Rename doc references to Axoniq Platform

### DIFF
--- a/docs/dead-letter-queue-guide/modules/ROOT/pages/retrying.adoc
+++ b/docs/dead-letter-queue-guide/modules/ROOT/pages/retrying.adoc
@@ -3,7 +3,7 @@
 
 The dead letter queue is a stop-gap. It's important to strive to have the queue empty as soon as possible. Ideally by retrying the events, and removing them from the queue.
 You can retrieve a `SequencedDeadLetterProcessor` from the `EventProcessingConfiguration` based on a processing group name.
-Additionally, it's also possible to use AxonIQ Console and process a queue manually.
+Additionally, it's also possible to use Axoniq Platform and process a queue manually.
 
 To schedule processing dead letter sequences you can do something like:
 

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -5,12 +5,12 @@ This section of the reference guide intends to cover in detail the capabilities 
 
 [[console]]
 == New: Easy monitoring and management
-AxonIQ Console is the platform to monitor and manage your Axon Framework applications. It provides insights into the performance and behavior of your application, and allows you to manage your application's event processors.
+Axoniq Platform makes it easy to monitor and manage your Axon Framework applications. It provides insights into the performance and behavior of your application, and allows you to manage your application's event processors.
 You can also get scalable xref:axon-server-reference::index.adoc[Axon Server] licenses with scalable pricing, and manage your Axon Server instances.
 
-image::axoniq-console-teaser.png[alt="Statistics measured in AxonIQ Console"]
+image::axoniq-console-teaser.png[alt="Statistics measured on Axoniq Platform"]
 
-For more information, see the xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console Reference Guide] or link:https://console.axoniq.io[sign up directly].
+For more information, see the xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform Reference] or link:https://platform.axoniq.io[sign up directly].
 
 == Reference sections
 A summary of the various subsections is given below.

--- a/docs/old-reference-guide/modules/events/pages/event-processors/dead-letter-queue.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/dead-letter-queue.adoc
@@ -6,9 +6,9 @@ Instead of either logging the error and continuing, or infinitely retrying the c
 
 [TIP]
 .Insight and Management
-xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console] provides insight into the Dead-Letter Queue and tools for its management.
+xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform] provides insight into the Dead-Letter Queue and tools for its management.
 It's straightforward to see the dead letters in the queue and decide to retry them or remove them from the queue.
-You can find more information on the xref:axoniq-console-reference:ROOT:features/dlq.adoc[Dead-Letter Queue page of AxonIQ Console].
+You can find more information on the xref:axoniq-platform-reference:ROOT:features/dlq.adoc[Dead-Letter Queue page of Axoniq Platform].
 
 Note that you _cannot_ share a dead-letter queue between different processing groups.
 Hence, each processing group you want to enable this behavior for should receive a unique dead-letter queue instance.

--- a/docs/old-reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -1515,8 +1515,8 @@ To change the number of segments at runtime, the _split and merge_ operations sh
 Splitting and merging allow you to control the number of segments dynamically.
 There are roughly three approaches to do this.
 
-==== 1. AxonIQ Console
-Through xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console]'s processor detail page, where you can scale the segments manually, or configure your segments to scale automatically with the number of your application's replicas. It's the easiest to set up and use.
+==== 1. Axoniq Platform
+Through xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform]'s processor detail page, where you can scale the segments manually, or configure your segments to scale automatically with the number of your application's replicas. It's the easiest to set up and use.
 
 ==== 2. Axon Server
 The xref:axon-server-reference:ROOT:index.adoc[Axon Server] Dashboard contains split and merge buttons to adjust the number of segments. While it's straightforward to use as well, it does not support automatic scaling based on the number of replicas.
@@ -1571,7 +1571,7 @@ We can calculate the segment identifier the provided `segmentId will be merged w
 [NOTE]
 .Segment Selection Considerations
 ====
-When splitting or merging through AxonIQ Console and Axon Server, it chooses the most appropriate segment to split or merge for you.
+When splitting or merging through Axoniq Platform and Axon Server, it chooses the most appropriate segment to split or merge for you.
 When using the Axon Framework API directly, the developer should deduce the segment to split or segments to merge by themselves:
 
 * Split: for fair balancing, a split is ideally performed on the largest segment
@@ -1584,25 +1584,25 @@ When using the Axon Framework API directly, the developer should deduce the segm
 A benefit of streaming events is that we can reopen the stream at any point in time.
 Whenever some event handling components misbehaved, and the view models they update or actions they triggered should happen again, starting anew can be useful.
 Handling events again by adjusting the position on the stream is what's called "a replay," a feature supported by the `StreamingEventProcessor`.
-You can trigger a reset using xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console], or programmatically through the Axon Framework API.
+You can trigger a reset using xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform], or programmatically through the Axon Framework API.
 
 [#reset-console]
 === Triggering a reset with Console
 
-Triggering a reset through the xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console] is straightforward.
+Triggering a reset through the xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform] is straightforward.
 It will make sure all processors are stopped, the tokens reset, and the replay is started, without any need for manual intervention.
 
 Go to the detail page of the processor you would like to reset. On the left side, under the configuration details, is a "Reset Processor" button.
 
-image::console-processor-detail-page-reset.png[alt="AxonIQ Console processor detail page with underlined 'Reset Processor' button"]
+image::console-processor-detail-page-reset.png[alt="Axoniq Platform processor detail page with underlined 'Reset Processor' button"]
 
 Clicking this button will open a dialog in which you can choose the desired position in the event store to replay from. You can choose of resetting to the tail, head, or a custom date.
 
-image::console-processor-reset-dialog.png[alt="AxonIQ Console reset dialog", width=65%, align="center"]
+image::console-processor-reset-dialog.png[alt="Axoniq Platform reset dialog", width=65%, align="center"]
 
 After resetting the processor, the replay will start immediately. You can track its progress under the "Segments" tab. During a replay, each segment has its own pace.
 
-image::console-processor-replaying-segments.png[alt="AxonIQ Console segments view during a replay"]
+image::console-processor-replaying-segments.png[alt="Axoniq Platform segments view during a replay"]
 
 During this time, it's normal to see the latency of the processor at a high value, because it's processing events from a long time ago. This will slowly decrease until it's back at the head position.
 
@@ -1693,8 +1693,8 @@ class StreamingProcessorController {
 If you are in a <<Multi-node processing,multi-node>> scenario, that means _all_ nodes should shut down the `StreamingEventProcessor`.
 Otherwise, another node will pick up the segments released by the inactive processor instance.
 
-Being able to shut down or start up all streaming processor instances is most easily achieved through the xref:axon-server-reference:ROOT:index.adoc[Axon Server] Dashboard or xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console].
-They both provide a "start" and "stop" button, which will start/stop the processor on every node. With AxonIQ Console you can also reset the processor.
+Being able to shut down or start up all streaming processor instances is most easily achieved through the xref:axon-server-reference:ROOT:index.adoc[Axon Server] Dashboard or xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform].
+They both provide a "start" and "stop" button, which will start/stop the processor on every node. With Axoniq Platform you can also reset the processor.
 
 When Axon Server is not used, you should construct a custom endpoint in your application.
 The `StreamingProcessorService` sample shared above would be ideal for adding a start and stop method.

--- a/docs/old-reference-guide/modules/messaging-concepts/pages/index.adoc
+++ b/docs/old-reference-guide/modules/messaging-concepts/pages/index.adoc
@@ -108,9 +108,9 @@ Commands are sent to the Command Bus, which dispatches them to the appropriate C
 The command handler will apply events that will be published and handled by Event Handlers.
 These handlers can update the read model, which can be queried using Query Messages.
 
-Using xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console],
+Using xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform],
 you can monitor the flow of messages in your application as you can see in the image below.
 
-image::axoniq-console-flow.gif[alt="Animated graphic of message flow in AxonIQ Console"]
+image::axoniq-console-flow.gif[alt="Animated graphic of message flow in Axoniq Platform"]
 
-Besides seeing the flow, every message handler is individually monitored, providing deep insight into the performance and behavior of your application. For more information, see the xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console Reference Guide] or link:https://console.axoniq.io[sign up directly].
+Besides seeing the flow, every message handler is individually monitored, providing deep insight into the performance and behavior of your application. For more information, see the xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform Reference Guide] or link:https://console.axoniq.io[sign up directly].

--- a/docs/old-reference-guide/modules/monitoring/pages/index.adoc
+++ b/docs/old-reference-guide/modules/monitoring/pages/index.adoc
@@ -6,12 +6,12 @@ This section contains all information regarding metrics, tracing and monitoring 
 
 == New: Easy monitoring and management
 
-AxonIQ Console is the platform to monitor and manage your Axon Framework applications in great detail.
+Axoniq Platform is the platform to monitor and manage your Axon Framework applications in great detail.
 It provides insights into each handler, event processor and aggregate with almost zero configuration. You can set alerts on these metrics and get notified when something goes wrong, so you can act before it becomes a problem
 
-image::axoniq-console-teaser.png[alt="Statistics measured in AxonIQ Console"]
+image::axoniq-console-teaser.png[alt="Statistics measured in Axoniq Platform"]
 
-For more information, see the xref:axoniq-console-reference:ROOT:index.adoc[AxonIQ Console Reference Guide] or link:https://console.axoniq.io[sign up directly].
+For more information, see the xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform Reference Guide] or link:https://console.axoniq.io[sign up directly].
 
 
 == Reference sections

--- a/docs/old-reference-guide/modules/release-notes/pages/major-releases.adoc
+++ b/docs/old-reference-guide/modules/release-notes/pages/major-releases.adoc
@@ -57,7 +57,7 @@ As such, the default `ReplayToken` should be regarded as a behavioral breaking c
 
 * Add suppressible log message when console client is not on the classpath. https://github.com/AxonFramework/AxonFramework/pull/2868[#2868]
 * Instruct compiler to include parameter names metadata https://github.com/AxonFramework/AxonFramework/pull/2835[#2835]
-* Log notification about AxonIQ console, if console-framework-client is not there https://github.com/AxonFramework/AxonFramework/issues/2819[#2819]
+* Log notification about Axoniq Platform, if console-framework-client is not there https://github.com/AxonFramework/AxonFramework/issues/2819[#2819]
 * Add additional Axon Server connector configuration to the `AxonServerConfiguration` https://github.com/AxonFramework/AxonFramework/pull/2815[#2815]
 * Introduce the `AxonServerEventStoreFactory` https://github.com/AxonFramework/AxonFramework/pull/2807[#2807]
 * Claim segments operation for Streaming Event Processors https://github.com/AxonFramework/AxonFramework/issues/2803[#2803]

--- a/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/event-snapshots.adoc
@@ -9,7 +9,7 @@ For example, items in stock tend to change quite often. Each time an item is sol
 [TIP]
 .To measure it to know!
 ====
-xref:axoniq-console-reference:ROOT:features/metrics.adoc#aggregate_metrics[AxonIQ Console] can measure the number of events that were loaded during command handling, so you know if you need to create snapshots or not. It's also able to track many more interesting metrics, such as the load time of the aggregate, and the time it took to store the events.
+xref:axoniq-platform-reference:ROOT:features/metrics.adoc#aggregate_metrics[Axoniq Platform] can measure the number of events that were loaded during command handling, so you know if you need to create snapshots or not. It's also able to track many more interesting metrics, such as the load time of the aggregate, and the time it took to store the events.
 ====
 
 === Creating a snapshot


### PR DESCRIPTION
Renames all references in the docs to Axoniq Platform instead of AxonIQ Console. These will be the new coordinates for Antora, as the product has been renamed.


There have been no docs changes to these sections in 4.11 and 4.12, so these changes can be merged into those branches as well. 