### PR TITLE
Unmark 4.12 as pre-release

### DIFF
--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -3,7 +3,7 @@ title: Axon Framework
 version:
   axon-(?<version>+({0..9}).+({0..9})).*: $<version>
   master: development
-prerelease: true
+prerelease: false
 start_page: ROOT:index.adoc
 
 asciidoc:


### PR DESCRIPTION
4.12 is marked as pre-release in the antora yaml, causing it to not be the latest version in the menus and links. This PR sets it to false, and 4.12 will become the latest version.