### PR TITLE
When splitting and merging tokens, update both tokens involved

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
@@ -158,6 +158,17 @@ class SplitTask extends CoordinatorTask {
                                  splitStatuses[0].getSegment().getSegmentId(),
                                  context
                          ))
+                         .thenCompose(result -> tokenStore.deleteToken(
+                                 name,
+                                 splitStatuses[0].getSegment().getSegmentId(),
+                                 context
+                         ))
+                         .thenCompose(result -> tokenStore.initializeSegment(
+                                 splitStatuses[0].getTrackingToken(),
+                                 name,
+                                 splitStatuses[0].getSegment(),
+                                 context
+                         ))
                          .thenRun(() -> logger.info(
                                  "Processor [{}] successfully split {} into {} and {}.",
                                  name, segmentToSplit, splitStatuses[0].getSegment(), splitStatuses[1].getSegment()

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -117,6 +117,9 @@ class MergeTaskTest {
         when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(testTokenToBeMerged));
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+
         workPackages.put(SEGMENT_TO_BE_MERGED, workPackageTwo);
 
         ArgumentCaptor<TrackingToken> mergedTokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
@@ -126,10 +129,11 @@ class MergeTaskTest {
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO.getSegmentId()), any());
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ONE.getSegmentId()), any());
         verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any());
-        verify(tokenStore).storeToken(mergedTokenCaptor.capture(),
-                                      eq(PROCESSOR_NAME),
-                                      eq(SEGMENT_TO_MERGE),
-                                      any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore).initializeSegment(mergedTokenCaptor.capture(),
+                                             eq(PROCESSOR_NAME),
+                                             eq(new Segment(0, 0)),
+                                             any());
         TrackingToken resultToken = mergedTokenCaptor.getValue();
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
@@ -151,6 +155,8 @@ class MergeTaskTest {
                 .thenReturn(completedFuture(testTokenToMerge));
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(testTokenToBeMerged));
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
 
         ArgumentCaptor<TrackingToken> mergedTokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
 
@@ -159,10 +165,11 @@ class MergeTaskTest {
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO.getSegmentId()), any());
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ONE.getSegmentId()), any());
         verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any());
-        verify(tokenStore).storeToken(mergedTokenCaptor.capture(),
-                                      eq(PROCESSOR_NAME),
-                                      eq(SEGMENT_TO_MERGE),
-                                      any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore).initializeSegment(mergedTokenCaptor.capture(),
+                                             eq(PROCESSOR_NAME),
+                                             eq(new Segment(0, 0)),
+                                             any());
         TrackingToken resultToken = mergedTokenCaptor.getValue();
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
@@ -188,6 +195,8 @@ class MergeTaskTest {
         when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(testTokenToBeMerged));
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
 
         ArgumentCaptor<TrackingToken> mergedTokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
 
@@ -196,10 +205,11 @@ class MergeTaskTest {
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO.getSegmentId()), any());
         verify(tokenStore).fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ONE.getSegmentId()), any());
         verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any());
-        verify(tokenStore).storeToken(mergedTokenCaptor.capture(),
-                                      eq(PROCESSOR_NAME),
-                                      eq(SEGMENT_TO_MERGE),
-                                      any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore).initializeSegment(mergedTokenCaptor.capture(),
+                                             eq(PROCESSOR_NAME),
+                                             eq(new Segment(0, 0)),
+                                             any());
         TrackingToken resultToken = mergedTokenCaptor.getValue();
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
@@ -236,6 +246,9 @@ class MergeTaskTest {
         when(workPackageTwo.abort(null)).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+
         workPackages.put(SEGMENT_TO_BE_MERGED, workPackageTwo);
 
         doThrow(new UnableToClaimTokenException("some exception"))
@@ -263,6 +276,8 @@ class MergeTaskTest {
         when(workPackageTwo.abort(null)).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
         workPackages.put(SEGMENT_TO_BE_MERGED, workPackageTwo);
 
         doThrow(new IllegalStateException("some exception"))

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -1114,6 +1114,70 @@ class PooledStreamingEventProcessorTest {
                     () -> assertNotNull(testSubject.processingStatus().get(1))
             );
         }
+
+        @Test
+        void splitAndMergeSegmentOfGroupOf4() {
+            // given
+            int testSegmentId = 2;
+            int splitSegmentId = 6;  // splitting segment 2 when there are 4 segments results in a new segment 6/7
+            int testTokenClaimInterval = 500;
+
+            withTestSubject(
+                    List.of(),
+                    c -> c.initialSegmentCount(4).tokenClaimInterval(testTokenClaimInterval)
+            );
+
+            // when
+            startEventProcessor();
+
+            // wait until the segment we want to split is in use, and verify all segments are correct in the token store:
+            await().untilAsserted(() -> {
+                assertNotNull(testSubject.processingStatus().get(testSegmentId));
+                assertThat(tokenStore.fetchSegments(PROCESSOR_NAME, null).join())
+                    .containsExactlyInAnyOrder(
+                        new Segment(0, 3),
+                        new Segment(1, 3),
+                        new Segment(2, 3),
+                        new Segment(3, 3)
+                    );
+            });
+
+            // split segment:
+            boolean success = testSubject.splitSegment(testSegmentId).join();
+
+            assertThat(success).isTrue();
+
+            // wait until the two split segments are in use, and verify all segments are correct in the token store:
+            await().untilAsserted(() -> {
+                assertNotNull(testSubject.processingStatus().get(testSegmentId));
+                assertNotNull(testSubject.processingStatus().get(splitSegmentId));
+                assertThat(tokenStore.fetchSegments(PROCESSOR_NAME, null).join())
+                    .containsExactlyInAnyOrder(
+                        new Segment(0, 3),
+                        new Segment(1, 3),
+                        new Segment(3, 3),
+                        new Segment(2, 7),
+                        new Segment(6, 7)
+                    );
+            });
+
+            // merge segment:
+            success = testSubject.mergeSegment(1).join();
+
+            assertThat(success).isTrue();
+
+            // wait until the merged segments is in use, and verify all segments are correct in the token store:
+            await().untilAsserted(() -> {
+                assertNotNull(testSubject.processingStatus().get(1));
+                assertThat(tokenStore.fetchSegments(PROCESSOR_NAME, null).join())
+                    .containsExactlyInAnyOrder(
+                        new Segment(0, 3),
+                        new Segment(1, 1),
+                        new Segment(2, 7),
+                        new Segment(6, 7)
+                    );
+            });
+        }
     }
 
     @Nested

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
@@ -82,12 +82,24 @@ class SplitTaskTest {
         when(workPackage.abort(null)).thenReturn(emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
                 .thenReturn(completedFuture(testTokenToSplit));
-        when(tokenStore.initializeSegment(any(), anyString(), any(Segment.class), any())).thenReturn(emptyCompletedFuture());
-        when(tokenStore.releaseClaim(any(), anyInt(), any())).thenReturn(emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(1, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.releaseClaim(eq(PROCESSOR_NAME), anyInt(), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
+                .thenReturn(emptyCompletedFuture());
+
         workPackages.put(SEGMENT_ID, workPackage);
 
         testSubject.run();
 
+        // original token must be reinitialized (due to mask change):
+        verify(tokenStore).initializeSegment(eq(expectedOriginal.getTrackingToken()),
+                                             eq(PROCESSOR_NAME),
+                                             eq(expectedOriginal.getSegment()),
+                                             any());
         verify(tokenStore).initializeSegment(eq(expectedSplit.getTrackingToken()),
                                              eq(PROCESSOR_NAME),
                                              eq(expectedSplit.getSegment()),
@@ -112,11 +124,22 @@ class SplitTaskTest {
                 .thenReturn(completedFuture(Segment.ROOT_SEGMENT));
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
                 .thenReturn(completedFuture(testTokenToSplit));
-        when(tokenStore.initializeSegment(any(), anyString(), any(Segment.class), any())).thenReturn(emptyCompletedFuture());
-        when(tokenStore.releaseClaim(any(), anyInt(), any())).thenReturn(emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(1, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.releaseClaim(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
+                .thenReturn(emptyCompletedFuture());
 
         testSubject.run();
 
+        // original token must be reinitialized (due to mask change):
+        verify(tokenStore).initializeSegment(eq(expectedOriginal.getTrackingToken()),
+                                             eq(PROCESSOR_NAME),
+                                             eq(expectedOriginal.getSegment()),
+                                             any());
         verify(tokenStore).initializeSegment(eq(expectedSplit.getTrackingToken()),
                                              eq(PROCESSOR_NAME),
                                              eq(expectedSplit.getSegment()),


### PR DESCRIPTION
Before the introduction of persistent masks, split and merge tasks could focus only on the newly created or deleted segment. However, now that masks are persistent, the other segment involved must be persisted to store its modified mask.

**Note:** I used `deleteToken` + `initializeSegment` to "update" a segment, as there isn't a dedicated method for this.  This is less ideal, but not a huge issue IMHO (it's all transactional anyway).  However, this may affect things like the timestamp of the token.  If this is a problem, please let me know and I'll rework it.