### PR TITLE
[#3982] fix(test): `Event events(@Nonnull List<?>... events)` - invalid usage of varargs

### DIFF
--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestGiven.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestGiven.java
@@ -90,7 +90,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
     @Override
     public AxonTestPhase.Given event(@Nonnull Object payload, @Nonnull Metadata metadata) {
         if (payload instanceof EventMessage message) {
-            return events(message);
+            return events(message.andMetadata(metadata));
         }
         var eventMessage = toGenericEventMessage(payload, metadata);
         return events(eventMessage);
@@ -132,7 +132,7 @@ class AxonTestGiven implements AxonTestPhase.Given {
     @Override
     public AxonTestPhase.Given command(@Nonnull Object payload, @Nonnull Metadata metadata) {
         if (payload instanceof CommandMessage message) {
-            return commands(message);
+            return commands(message.andMetadata(metadata));
         }
         var commandMessage = toGenericCommandMessage(payload, metadata);
         return commands(commandMessage);

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestPhase.java
@@ -145,10 +145,12 @@ public interface AxonTestPhase {
         Given noPriorActivity();
 
         /**
-         * Configures a single event with the given {@code payload} as part of the "given" state. This event will be
-         * published with empty metadata.
+         * Configures a single event as part of the "given" state. This event will be published with empty metadata.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, it will be used directly.
          *
-         * @param payload The payload of the event to publish.
+         * @param payload The event payload or {@link EventMessage} to publish.
          * @return The current Given instance, for fluent interfacing.
          */
         default Given event(@Nonnull Object payload) {
@@ -156,11 +158,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Configures a single event with the given {@code payload} and {@code metadata} as part of the "given" state.
+         * Configures a single event with the given {@code metadata} as part of the "given" state.
          * This event will be published.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link EventMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The payload of the event to publish.
-         * @param metadata The metadata to attach to the event.
+         * @param payload  The event payload or {@link EventMessage} to publish.
+         * @param metadata The metadata to attach to the event (merged if payload is an {@link EventMessage}).
          * @return The current Given instance, for fluent interfacing.
          */
         default Given event(@Nonnull Object payload, @Nonnull Map<String, String> metadata) {
@@ -168,11 +174,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Configures a single event with the given {@code payload} and {@code metadata} as part of the "given" state.
+         * Configures a single event with the given {@code metadata} as part of the "given" state.
          * This event will be published.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link EventMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The payload of the event to publish.
-         * @param metadata The metadata to attach to the event.
+         * @param payload  The event payload or {@link EventMessage} to publish.
+         * @param metadata The metadata to attach to the event (merged if payload is an {@link EventMessage}).
          * @return The current Given instance, for fluent interfacing.
          */
         Given event(@Nonnull Object payload, @Nonnull Metadata metadata);
@@ -216,10 +226,13 @@ public interface AxonTestPhase {
         Given events(@Nonnull List<?> events);
 
         /**
-         * Configures a single command with the given {@code payload} as part of the "given" state. This command will be
-         * dispatched to corresponding command handlers.
+         * Configures a single command as part of the "given" state. This command will be dispatched to corresponding
+         * command handlers with empty metadata.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, it will be used directly.
          *
-         * @param payload The payload of the command to dispatch.
+         * @param payload The command payload or {@link CommandMessage} to dispatch.
          * @return The current Given instance, for fluent interfacing.
          */
         default Given command(@Nonnull Object payload) {
@@ -227,11 +240,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Configures a single command with the given {@code payload} and {@code metadata} as part of the "given" state.
+         * Configures a single command with the given {@code metadata} as part of the "given" state.
          * This command will be dispatched to corresponding command handlers.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link CommandMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The payload of the command to dispatch.
-         * @param metadata The metadata to attach to the command.
+         * @param payload  The command payload or {@link CommandMessage} to dispatch.
+         * @param metadata The metadata to attach to the command (merged if payload is a {@link CommandMessage}).
          * @return The current Given instance, for fluent interfacing.
          */
         default Given command(@Nonnull Object payload, @Nonnull Map<String, String> metadata) {
@@ -239,11 +256,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Configures a single command with the given {@code payload} and {@code metadata} as part of the "given" state.
+         * Configures a single command with the given {@code metadata} as part of the "given" state.
          * This command will be dispatched to corresponding command handlers.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link CommandMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The payload of the command to dispatch.
-         * @param metadata The metadata to attach to the command.
+         * @param payload  The command payload or {@link CommandMessage} to dispatch.
+         * @param metadata The metadata to attach to the command (merged if payload is a {@link CommandMessage}).
          * @return The current Given instance, for fluent interfacing.
          */
         Given command(@Nonnull Object payload, @Nonnull Metadata metadata);
@@ -371,10 +392,13 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Dispatches the given {@code payload} command to the appropriate command handler and records all activity for
+         * Dispatches the given command to the appropriate command handler and records all activity for
          * result validation. The command will be dispatched with empty metadata.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, it will be used directly.
          *
-         * @param payload The command to execute.
+         * @param payload The command payload or {@link CommandMessage} to dispatch.
          * @return The current When instance, for fluent interfacing.
          */
         default Command command(@Nonnull Object payload) {
@@ -382,11 +406,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Dispatches the given {@code payload} command with the provided {@code metadata} to the appropriate command
+         * Dispatches the given command with the provided {@code metadata} to the appropriate command
          * handler and records all activity for result validation.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link CommandMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The command to execute.
-         * @param metadata The metadata to attach to the command.
+         * @param payload  The command payload or {@link CommandMessage} to dispatch.
+         * @param metadata The metadata to attach to the command (merged if payload is a {@link CommandMessage}).
          * @return The current When instance, for fluent interfacing.
          */
         default Command command(@Nonnull Object payload, @Nonnull Map<String, String> metadata) {
@@ -394,20 +422,27 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Dispatches the given {@code payload} command with the provided {@code metadata} to the appropriate command
+         * Dispatches the given command with the provided {@code metadata} to the appropriate command
          * handler and records all activity for result validation.
+         * <p>
+         * The {@code payload} parameter accepts either a command payload object or a {@link CommandMessage}.
+         * If a {@link CommandMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link CommandMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The command to execute.
-         * @param metadata The metadata to attach to the command.
+         * @param payload  The command payload or {@link CommandMessage} to dispatch.
+         * @param metadata The metadata to attach to the command (merged if payload is a {@link CommandMessage}).
          * @return The current When instance, for fluent interfacing.
          */
         Command command(@Nonnull Object payload, @Nonnull Metadata metadata);
 
         /**
-         * Publishes the given {@code payload} event with the provided {@code metadata} to the appropriate event handler
-         * and records all activity for result validation. The event will be published with empty metadata.
+         * Publishes the given event to the appropriate event handler and records all activity for result validation.
+         * The event will be published with empty metadata.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, it will be used directly.
          *
-         * @param payload The event to publish.
+         * @param payload The event payload or {@link EventMessage} to publish.
          * @return The current When instance, for fluent interfacing.
          */
         default Event event(@Nonnull Object payload) {
@@ -415,11 +450,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Publishes the given {@code payload} event with the provided {@code metadata} to the appropriate event handler
+         * Publishes the given event with the provided {@code metadata} to the appropriate event handler
          * and records all activity for result validation.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link EventMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The event to publish.
-         * @param metadata The metadata to attach to the event.
+         * @param payload  The event payload or {@link EventMessage} to publish.
+         * @param metadata The metadata to attach to the event (merged if payload is an {@link EventMessage}).
          * @return The current When instance, for fluent interfacing.
          */
         default Event event(@Nonnull Object payload, @Nonnull Map<String, String> metadata) {
@@ -427,11 +466,15 @@ public interface AxonTestPhase {
         }
 
         /**
-         * Publishes the given {@code payload} event with the provided {@code metadata} to the appropriate event handler
+         * Publishes the given event with the provided {@code metadata} to the appropriate event handler
          * and records all activity for result validation.
+         * <p>
+         * The {@code payload} parameter accepts either an event payload object or an {@link EventMessage}.
+         * If an {@link EventMessage} is provided, the given {@code metadata} will be merged with the message's
+         * existing metadata using {@link EventMessage#andMetadata(Metadata)}.
          *
-         * @param payload  The event to publish.
-         * @param metadata The metadata to attach to the event.
+         * @param payload  The event payload or {@link EventMessage} to publish.
+         * @param metadata The metadata to attach to the event (merged if payload is an {@link EventMessage}).
          * @return The current When instance, for fluent interfacing.
          */
         Event event(@Nonnull Object payload, @Nonnull Metadata metadata);

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestWhen.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestWhen.java
@@ -89,7 +89,7 @@ class AxonTestWhen implements AxonTestPhase.When {
     public Command command(@Nonnull Object payload, @Nonnull Metadata metadata) {
         CommandMessage message;
         if (payload instanceof CommandMessage commandMessage) {
-            message = commandMessage;
+            message = commandMessage.andMetadata(metadata);
         } else {
             var messageType = messageTypeResolver.resolveOrThrow(payload);
             message = new GenericCommandMessage(messageType, payload, metadata);
@@ -112,7 +112,7 @@ class AxonTestWhen implements AxonTestPhase.When {
     @Override
     public Event event(@Nonnull Object payload, @Nonnull Metadata metadata) {
         if (payload instanceof EventMessage message) {
-            return events(message);
+            return events(message.andMetadata(metadata));
         }
         var eventMessage = toGenericEventMessage(payload, metadata);
         return events(eventMessage);


### PR DESCRIPTION
+ merge Metadata if someone pass message as a payload along with Metadata. 

The fix made in this PR relates to #3982.