### PR TITLE
Resolve `MessageType` for query handlers based on `MessageTypeResolver`

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryIT.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryIT.java
@@ -22,6 +22,9 @@ import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.common.TypeReference;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
 import org.axonframework.messaging.queryhandling.GenericQueryMessage;
 import org.axonframework.messaging.queryhandling.QueryBus;
@@ -120,8 +123,14 @@ class StreamingQueryIT {
         nonStreamingSenderQueryBus =
                 axonServerQueryBus(senderLocalSegment, nonStreamingAxonServerAddress);
 
-        QueryHandlingComponent queryHandlingComponent =
-                new AnnotatedQueryHandlingComponent<>(new MyQueryHandler(), new DelegatingMessageConverter(PassThroughConverter.INSTANCE));
+        MyQueryHandler handler = new MyQueryHandler();
+        QueryHandlingComponent queryHandlingComponent = new AnnotatedQueryHandlingComponent<>(
+                handler,
+                ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                ClasspathHandlerDefinition.forClass(handler.getClass()),
+                new AnnotationMessageTypeResolver(),
+                new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+        );
         handlerQueryBus.subscribe(queryHandlingComponent);
         nonStreamingHandlerQueryBus.subscribe(queryHandlingComponent);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
@@ -18,8 +18,11 @@ package org.axonframework.messaging.queryhandling.annotation;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
@@ -56,40 +59,8 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
     private final SimpleQueryHandlingComponent handlingComponent;
     private final T target;
     private final AnnotatedHandlerInspector<T> model;
+    private final MessageTypeResolver messageTypeResolver;
     private final MessageConverter converter;
-
-    /**
-     * Wraps the given {@code annotatedQueryHandler}, allowing it to be subscribed to a {@link QueryBus} as a
-     * {@link QueryHandlingComponent}.
-     *
-     * @param annotatedQueryHandler The object containing the {@link QueryHandler} annotated methods.
-     * @param converter             The converter to use for converting the payload of the query to the type expected by
-     *                              the handler method.
-     */
-    public AnnotatedQueryHandlingComponent(@Nonnull T annotatedQueryHandler,
-                                           @Nonnull MessageConverter converter) {
-        this(annotatedQueryHandler,
-             ClasspathParameterResolverFactory.forClass(annotatedQueryHandler.getClass()),
-             converter);
-    }
-
-    /**
-     * Wraps the given {@code annotatedQueryHandler}, allowing it to be subscribed to a {@link QueryBus} as a
-     * {@link QueryHandlingComponent}.
-     *
-     * @param annotatedQueryHandler    The object containing the {@link QueryHandler} annotated methods.
-     * @param parameterResolverFactory The parameter resolver factory to resolve handler parameters with.
-     * @param converter                The converter to use for converting the payload of the command to the type
-     *                                 expected by the handler method.
-     */
-    public AnnotatedQueryHandlingComponent(@Nonnull T annotatedQueryHandler,
-                                           @Nonnull ParameterResolverFactory parameterResolverFactory,
-                                           @Nonnull MessageConverter converter) {
-        this(annotatedQueryHandler,
-             parameterResolverFactory,
-             ClasspathHandlerDefinition.forClass(annotatedQueryHandler.getClass()),
-             converter);
-    }
 
     /**
      * Wraps the given {@code annotatedQueryHandler}, allowing it to be subscribed to a {@link QueryBus} as a
@@ -98,12 +69,16 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
      * @param annotatedQueryHandler    The object containing the {@link QueryHandler} annotated methods.
      * @param parameterResolverFactory The parameter resolver factory to resolve handler parameters with.
      * @param handlerDefinition        The handler definition used to create concrete handlers.
+     * @param messageTypeResolver      The {@link MessageTypeResolver} resolving the
+     *                                 {@link QualifiedName names} for
+     *                                 {@link QueryMessage QueryMessages}.
      * @param converter                The converter to use for converting the payload of the command to the type
      *                                 expected by the handler method.
      */
     public AnnotatedQueryHandlingComponent(@Nonnull T annotatedQueryHandler,
                                            @Nonnull ParameterResolverFactory parameterResolverFactory,
                                            @Nonnull HandlerDefinition handlerDefinition,
+                                           @Nonnull MessageTypeResolver messageTypeResolver,
                                            @Nonnull MessageConverter converter) {
         this.handlingComponent = SimpleQueryHandlingComponent.create(
                 "AnnotatedQueryHandlingComponent[%s]".formatted(annotatedQueryHandler.getClass().getName())
@@ -116,6 +91,7 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
         this.model = AnnotatedHandlerInspector.inspectType(cls,
                                                            parameterResolverFactory,
                                                            handlerDefinition);
+        this.messageTypeResolver = requireNonNull(messageTypeResolver, "The MessageTypeResolver may not be null.");
         this.converter = requireNonNull(converter, "The Converter may not be null.");
 
         initializeHandlersBasedOnModel();
@@ -128,8 +104,16 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
     }
 
     private void registerHandler(QueryHandlingMember<? super T> handler) {
-        QualifiedName queryName = new QualifiedName(handler.queryName());
-        handlingComponent.subscribe(queryName, constructQueryHandlerFor(handler));
+        Class<?> payloadType = handler.payloadType();
+        QualifiedName qualifiedName = handler.unwrap(QueryHandlingMember.class)
+                                             .map(QueryHandlingMember::queryName)
+                                             // Only use names as is that not match the fully qualified class name.
+                                             .filter(name -> !name.equals(payloadType.getName()))
+                                             .map(QualifiedName::new)
+                                             .orElseGet(() -> messageTypeResolver.resolve(payloadType)
+                                                                                 .orElse(new MessageType(payloadType))
+                                                                                 .qualifiedName());
+        handlingComponent.subscribe(qualifiedName, constructQueryHandlerFor(handler));
     }
 
     private org.axonframework.messaging.queryhandling.QueryHandler constructQueryHandlerFor(

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/configuration/QueryHandlingModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/configuration/QueryHandlingModule.java
@@ -22,6 +22,7 @@ import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.common.configuration.ModuleBuilder;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
@@ -201,6 +202,7 @@ public interface QueryHandlingModule extends Module, ModuleBuilder<QueryHandling
                     handlingComponentBuilder.build(c),
                     c.getComponent(ParameterResolverFactory.class),
                     ClasspathHandlerDefinition.forClass(c.getClass()),
+                    c.getComponent(MessageTypeResolver.class),
                     c.getComponent(MessageConverter.class)
             ));
         }

--- a/messaging/src/test/java/org/axonframework/messaging/core/AsyncMessageHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AsyncMessageHandlerTest.java
@@ -34,6 +34,9 @@ import org.axonframework.messaging.eventhandling.annotation.AnnotatedEventHandli
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.DefaultParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
@@ -179,8 +182,14 @@ class AsyncMessageHandlerTest {
             @Test
             void returningJustShouldUseResult() {
                 int echoInt = 1;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new JustQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                JustQueryHandler handler = new JustQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<Integer> result = queryGateway.query(new EchoValue(echoInt), Integer.class, null);
                 assertThat(result).isDone();
@@ -190,8 +199,14 @@ class AsyncMessageHandlerTest {
             @Test
             void returningPrimitiveShouldUseResult() {
                 int echoInt = 1;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new PrimitiveQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                PrimitiveQueryHandler handler = new PrimitiveQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<Integer> result = queryGateway.query(new EchoValue(echoInt), Integer.class, null);
                 assertThat(result).isDone();
@@ -201,8 +216,14 @@ class AsyncMessageHandlerTest {
             @Test
             void returningOptionalShouldUseResult() {
                 int echoInt = 1;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new OptionalQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                OptionalQueryHandler handler = new OptionalQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<Integer> result = queryGateway.query(new EchoValue(echoInt), Integer.class, null);
                 assertThat(result).isDone();
@@ -212,8 +233,14 @@ class AsyncMessageHandlerTest {
             @Test
             void returningCompletableFutureShouldUseItsResult() {
                 int echoInt = 1;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new CompletableFutureQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                CompletableFutureQueryHandler handler = new CompletableFutureQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<Integer> result = queryGateway.query(new EchoValue(echoInt), Integer.class, null);
                 assertThat(result).isDone();
@@ -223,8 +250,14 @@ class AsyncMessageHandlerTest {
             @Test
             void returningMonoShouldUseItsResult() {
                 int echoInt = 1;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new MonoQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                MonoQueryHandler handler = new MonoQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<Integer> result = queryGateway.query(new EchoValue(echoInt), Integer.class, null);
                 assertThat(result).isDone();
@@ -235,8 +268,14 @@ class AsyncMessageHandlerTest {
             void returningIterableShouldUseItsResult() {
                 int echoIntOne = 1;
                 int echoIntTwo = 2;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new IterableQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                IterableQueryHandler handler = new IterableQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<List<Integer>> result =
                         queryGateway.queryMany(new EchoValue(echoIntOne, echoIntTwo), Integer.class, null);
@@ -248,8 +287,14 @@ class AsyncMessageHandlerTest {
             void returningStreamShouldUseItsResult() {
                 int echoIntOne = 1;
                 int echoIntTwo = 2;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new StreamQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                StreamQueryHandler handler = new StreamQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<List<Integer>> result =
                         queryGateway.queryMany(new EchoValue(echoIntOne, echoIntTwo), Integer.class, null);
@@ -261,8 +306,14 @@ class AsyncMessageHandlerTest {
             void returningFluxShouldUseItsResult() {
                 int echoIntOne = 1;
                 int echoIntTwo = 2;
-                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(new FluxQueryHandler(),
-                                                                         new DelegatingMessageConverter(PassThroughConverter.INSTANCE)));
+                FluxQueryHandler handler = new FluxQueryHandler();
+                queryBus.subscribe(new AnnotatedQueryHandlingComponent<>(
+                        handler,
+                        ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                        ClasspathHandlerDefinition.forClass(handler.getClass()),
+                        new AnnotationMessageTypeResolver(),
+                        new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+                ));
 
                 CompletableFuture<List<Integer>> result =
                         queryGateway.queryMany(new EchoValue(echoIntOne, echoIntTwo), Integer.class, null);

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -25,6 +25,9 @@ import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
 import org.axonframework.messaging.queryhandling.annotation.AnnotatedQueryHandlingComponent;
 import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
 import org.axonframework.conversion.PassThroughConverter;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.junit.jupiter.api.*;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -61,8 +64,13 @@ class FutureAsResponseTypeToQueryHandlersTest {
         queryBus = QueryBusTestUtils.aQueryBus();
 
         MyQueryHandler myQueryHandler = new MyQueryHandler();
-        QueryHandlingComponent queryHandlingComponent =
-                new AnnotatedQueryHandlingComponent<>(myQueryHandler, new DelegatingMessageConverter(PassThroughConverter.INSTANCE));
+        QueryHandlingComponent queryHandlingComponent = new AnnotatedQueryHandlingComponent<>(
+                myQueryHandler,
+                ClasspathParameterResolverFactory.forClass(myQueryHandler.getClass()),
+                ClasspathHandlerDefinition.forClass(myQueryHandler.getClass()),
+                new AnnotationMessageTypeResolver(),
+                new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+        );
         queryBus.subscribe(queryHandlingComponent);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/StreamingQueryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/StreamingQueryTest.java
@@ -17,6 +17,9 @@
 package org.axonframework.messaging.queryhandling;
 
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
 import org.axonframework.messaging.queryhandling.annotation.AnnotatedQueryHandlingComponent;
 import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
@@ -55,8 +58,13 @@ class StreamingQueryTest {
     void setUp() {
 
         myQueryHandler = new MyQueryHandler();
-        QueryHandlingComponent queryHandlingComponent =
-                new AnnotatedQueryHandlingComponent<>(myQueryHandler, new DelegatingMessageConverter(PassThroughConverter.INSTANCE));
+        QueryHandlingComponent queryHandlingComponent = new AnnotatedQueryHandlingComponent<>(
+                myQueryHandler,
+                ClasspathParameterResolverFactory.forClass(myQueryHandler.getClass()),
+                ClasspathHandlerDefinition.forClass(myQueryHandler.getClass()),
+                new AnnotationMessageTypeResolver(),
+                new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+        );
         queryBus.subscribe(queryHandlingComponent);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/InterceptingAnnotatedQueryHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/InterceptingAnnotatedQueryHandlingComponentTest.java
@@ -18,6 +18,9 @@ package org.axonframework.messaging.queryhandling.annotation;
 import org.axonframework.messaging.core.MessageHandlerInterceptorChain;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
 import org.axonframework.messaging.core.interception.annotation.ExceptionHandler;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor;
@@ -53,8 +56,12 @@ class InterceptingAnnotatedQueryHandlingComponentTest {
         // given...
         List<QueryMessage> withInterceptor = new ArrayList<>();
         List<QueryMessage> withoutInterceptor = new ArrayList<>();
+        MyInterceptingQueryHandler handler = new MyInterceptingQueryHandler(withoutInterceptor, withInterceptor, new ArrayList<>());
         QueryHandlingComponent testSubject = new AnnotatedQueryHandlingComponent<>(
-                new MyInterceptingQueryHandler(withoutInterceptor, withInterceptor, new ArrayList<>()),
+                handler,
+                ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                ClasspathHandlerDefinition.forClass(handler.getClass()),
+                new AnnotationMessageTypeResolver(),
                 new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
         );
 
@@ -77,8 +84,12 @@ class InterceptingAnnotatedQueryHandlingComponentTest {
     void exceptionHandlerAnnotatedMethodsAreSupportedForQueryHandlingComponents() {
         // given...
         List<Exception> interceptedExceptions = new ArrayList<>();
+        MyInterceptingQueryHandler handler = new MyInterceptingQueryHandler(new ArrayList<>(), new ArrayList<>(), interceptedExceptions);
         QueryHandlingComponent testSubject = new AnnotatedQueryHandlingComponent<>(
-                new MyInterceptingQueryHandler(new ArrayList<>(), new ArrayList<>(), interceptedExceptions),
+                handler,
+                ClasspathParameterResolverFactory.forClass(handler.getClass()),
+                ClasspathHandlerDefinition.forClass(handler.getClass()),
+                new AnnotationMessageTypeResolver(),
                 new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
         );
 


### PR DESCRIPTION
The AnnotatedQueryHandlingComponent did not take into account the message-annotations (such as `Query`) when determining the message name for the registration. This causes a mismatch (No handler found for query), as the QueryGateway does this upon sending.

This PR introduces the MessageTypeResolver for the AnnotatedQueryHandlingComponent and uses it to determine the message type.