### PR TITLE
Fix flaky tests in InterceptorAutoConfigurationTest by lowering ConfigurationParameterResolverFactory priority

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/configuration/reflection/ConfigurationParameterResolverFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/configuration/reflection/ConfigurationParameterResolverFactory.java
@@ -28,7 +28,7 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.util.Objects;
 
-import static org.axonframework.common.Priority.LOW;
+import static org.axonframework.common.Priority.LOWER;
 
 /**
  * A {@code ParameterResolverFactory} implementation that resolves parameters from available components in the
@@ -39,7 +39,7 @@ import static org.axonframework.common.Priority.LOW;
  * @author Allard Buijze
  * @since 3.0.2
  */
-@Priority(LOW)
+@Priority(LOWER)
 public class ConfigurationParameterResolverFactory implements ParameterResolverFactory {
 
     private final Configuration configuration;


### PR DESCRIPTION
### Description
Lowered the priority of 'ConfigurationParameterResolverFactory' from 'Priority.LOW' to 'Priority.LOWER'. This ensures that 'DefaultParameterResolverFactory' with 'Priority.LOW' takes precedence during parameter resolution.

### Motivation
NonDex detected test flakiness in:

- `org.axonframework.extension.springboot.autoconfig.InterceptorAutoConfigurationTest.commandDispatchInterceptorsAreRegisteredInCorrectOrder`
- `org.axonframework.extension.springboot.autoconfig.InterceptorAutoConfigurationTest.eventDispatchInterceptorsAreRegisteredInCorrectOrder`
- `org.axonframework.extension.springboot.autoconfig.InterceptorAutoConfigurationTest.queryDispatchInterceptorsAreRegisteredInCorrectOrder`

The flakiness was caused by a race condition between `ConfigurationParameterResolverFactory` and `DefaultParameterResolverFactory`, which both shared the same priority as `Priority.LOW`. When `ConfigurationParameterResolverFactory` was loaded first, it attempted to resolve the command message payload of type `Object` by looking it up in Spring `ApplicationContext`. Since multiple beans exist in the context, this resulted in a `NoUniqueBeanDefinitionException`. Lowering the priority of `ConfigurationParameterResolverFactory` to `Priority.LOWER`, makes sure that `DefaultParameterResolverFactory` is always consulted first. NonDex output with the original error attached.
[nondex_output_.txt](https://github.com/user-attachments/files/24108950/nondex_output_.txt)

