### PR TITLE
chore: re-include springdoc openapi ui for example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,5 @@ updates:
       versions: [ "[7.0.0,)" ]
     - dependency-name: "org.springframework.boot:*"
       versions: [ "[4.0.0,)" ]
+    - dependency-name: "org.springdoc:*"
+      versions: [ "[3.0.0,)" ]

--- a/examples/university-java-springboot/pom.xml
+++ b/examples/university-java-springboot/pom.xml
@@ -77,6 +77,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-docker-compose</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+            <version>2.8.13</version>
+        </dependency>
+
 
         <!-- Axon -->
         <dependency>


### PR DESCRIPTION
- it's nice to have for the example application
- version 3.0.0 excluded via dependabot, will require spring boot 4