### PR TITLE
Document `jobrunr.background-job-server.enabled` setting for JobRunr

### DIFF
--- a/docs/old-reference-guide/modules/deadlines/pages/deadline-managers.adoc
+++ b/docs/old-reference-guide/modules/deadlines/pages/deadline-managers.adoc
@@ -155,8 +155,9 @@ If handlers only need to rely on the timestamp the event was published, they can
 
 Spring Boot users will need to define a `DeadlineManager` bean using one of the available implementations.
 
-Spring Boot users who want to use the JobRunr deadline manager can add either https://mvnrepository.com/artifact/org.jobrunr/jobrunr-spring-boot-2-starter[`jobrunr-spring-boot-2-starter`] or https://mvnrepository.com/artifact/org.jobrunr/jobrunr-spring-boot-3-starter[`jobrunr-spring-boot-3-starter`] as a dependency. Depending on which version of Spring Boot is used.
-Doing so will make a `JobScheduler` bean available, which the auto-configuration can use to create a `JobRunrDeadlineManager`.
+Spring Boot users who want to use the JobRunr deadline manager can add either https://mvnrepository.com/artifact/org.jobrunr/jobrunr-spring-boot-2-starter[`jobrunr-spring-boot-2-starter`] if they are below version 8 of JobRunr, or https://mvnrepository.com/artifact/org.jobrunr/jobrunr-spring-boot-3-starter[`jobrunr-spring-boot-3-starter`] as a dependency. Depending on which version of Spring Boot is used.
+Doing so will make a `JobScheduler` bean available, which the auto-configuration can use to create a `JobRunrDeadlineManager`. When taking the Spring Boot approach, be mindful to set the `jobrunr.background-job-server.enabled` to `true`! This is required to ensure scheduled deadlines are executed as expected.
+
 Alternatively. the bean can be configured like this:
 
 [source,java]

--- a/docs/old-reference-guide/modules/deadlines/pages/event-schedulers.adoc
+++ b/docs/old-reference-guide/modules/deadlines/pages/event-schedulers.adoc
@@ -91,6 +91,7 @@ Spring Boot users which rely on Axon Server do not have to define anything.
 The auto-configuration will automatically create a `AxonServerEventScheduler` for them.
 
 Spring Boot users who want to use the JobRunr event scheduler can add https://mvnrepository.com/artifact/org.jobrunr/jobrunr-spring-boot-starter[`jobrunr-spring-boot-starter`] as a dependency.
+When taking the Spring Boot route with JobRunr, be sure to set the `jobrunr.background-job-server.enabled` property to `true` to ensure scheduled events are published as expected.
 In addition, an `EventScheduler` bean configuration needs to be added.
 This should look like:
 


### PR DESCRIPTION
This PR addresses a caveat when using JobRunr as described for Axon when configuring it through Spring Boot.
The `jobrunr.background-job-server.enabled` should be set to `true` to get expected behavior.
Added a one liner to describe this for `EventSchedulers` and `DeadlineManager`.