### PR TITLE
[#4032] cleanup gitignore/idea/ setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ axon.iws
 
 # IntelliJ project files
 *.iml
-.idea/
 
 # Eclipse project files
 .classpath

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!copyright/
+!inspectionProfiles/
+!icon.svg


### PR DESCRIPTION
We no longer ignore the complete .idea/ folder as we need the copyright/ and inspectionProfiles/, instead the directory specific .gitignore keeps only the required files and ignores the rest.

fixes #4032