### PR TITLE
Ensure that nulls are always stored in `MultiSourceTrackingToken` regardless of serializer configuration

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/MultiSourceTrackingToken.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventhandling;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.axonframework.common.Assert;
@@ -41,6 +42,7 @@ public class MultiSourceTrackingToken implements TrackingToken, Serializable {
     private static final long serialVersionUID = 4541799074835933645L;
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS, content = JsonInclude.Include.ALWAYS)
     private final Map<String, TrackingToken> trackingTokens;
 
     /**

--- a/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenSerializationTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/MultiSourceTrackingTokenSerializationTest.java
@@ -43,6 +43,7 @@ class MultiSourceTrackingTokenSerializationTest {
         Map<String, TrackingToken> tokenMap = new HashMap<>();
         tokenMap.put("token1", new GlobalSequenceTrackingToken(0));
         tokenMap.put("token2", new GlobalSequenceTrackingToken(0));
+        tokenMap.put("token3", null);
         MultiSourceTrackingToken testSubject = new MultiSourceTrackingToken(tokenMap);
         assertEquals(testSubject, serializer.serializeDeserialize(testSubject));
     }

--- a/messaging/src/test/java/org/axonframework/serialization/TestSerializer.java
+++ b/messaging/src/test/java/org/axonframework/serialization/TestSerializer.java
@@ -17,6 +17,7 @@
 package org.axonframework.serialization;
 
 import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -104,6 +105,18 @@ public enum TestSerializer {
                 JacksonSerializer.builder()
                                  .objectMapper(OnlyAcceptConstructorPropertiesAnnotation.attachTo(new ObjectMapper()))
                                  .build();
+
+        @Override
+        public Serializer getSerializer() {
+            return serializer;
+        }
+    },
+    JACKSON_IGNORE_NULL {
+        private final ObjectMapper objectMapper = new ObjectMapper()
+            .setSerializationInclusion(Include.NON_NULL);
+        private final Serializer serializer = JacksonSerializer.builder()
+                                                               .objectMapper(objectMapper)
+                                                               .build();
 
         @Override
         public Serializer getSerializer() {


### PR DESCRIPTION
Resolves #3180 