### PR TITLE
Refactor JPA event storage to use TransactionalExecutor

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngineIT.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngineIT.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.GapA
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
+import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.test.server.AxonServerContainer;
@@ -33,6 +34,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -103,5 +105,16 @@ class AggregateBasedAxonServerEventStorageEngineIT extends
     @Override
     protected EventMessage convertPayload(EventMessage original) {
         return original.withConvertedPayload(String.class, converter);
+    }
+
+    @Test
+    void transactionCanBeCommitedOnlyOnce() {
+        var tx =
+                testSubject.appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                                         processingContext(),
+                                         taggedEventMessage("event-0", TEST_AGGREGATE_TAGS)).join();
+
+        assertDoesNotThrow(() -> tx.commit(processingContext()).get(1, TimeUnit.SECONDS));
+        assertThrows(Exception.class, () -> tx.commit(processingContext()).get(1, TimeUnit.SECONDS));
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerStorageEngineBackedEventStoreIT.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerStorageEngineBackedEventStoreIT.java
@@ -21,7 +21,10 @@ import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
 import io.axoniq.axonserver.connector.impl.ServerAddress;
 import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStoreTestSuite;
-import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.axonframework.test.server.AxonServerContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -43,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Testcontainers
 class AxonServerStorageEngineBackedEventStoreIT extends StorageEngineBackedEventStoreTestSuite<AxonServerEventStorageEngine> {
 
+    private static final UnitOfWorkFactory FACTORY = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
     private static final String CONTEXT = "default";
 
     @SuppressWarnings("resource")
@@ -81,8 +85,8 @@ class AxonServerStorageEngineBackedEventStoreIT extends StorageEngineBackedEvent
     }
 
     @Override
-    protected void enhanceProcessingLifecycle(ProcessingLifecycle lifecycle) {
-        // No enhancement needed for Axon Server, it does its own transaction management
+    protected UnitOfWork unitOfWork() {
+        return FACTORY.create();
     }
 
     @Test

--- a/common/src/main/java/org/axonframework/common/function/ThrowingConsumer.java
+++ b/common/src/main/java/org/axonframework/common/function/ThrowingConsumer.java
@@ -1,0 +1,20 @@
+package org.axonframework.common.function;
+
+/**
+ * Functional interface for operations which may throw a checked exception.
+ *
+ * @param <T> the input type of the consumer
+ * @param <X> the exception type the consumer may throw
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+public interface ThrowingConsumer<T, X extends Exception> {
+
+    /**
+     * Accepts an input to perform an operation.
+     *
+     * @param input the input of type {@code T}
+     * @throws X when the consumer failed with an exception of type {@code X}
+     */
+    void accept(T input) throws X;
+}

--- a/common/src/main/java/org/axonframework/common/function/ThrowingFunction.java
+++ b/common/src/main/java/org/axonframework/common/function/ThrowingFunction.java
@@ -1,0 +1,22 @@
+package org.axonframework.common.function;
+
+/**
+ * Functional interface for operations which may throw a checked exception.
+ *
+ * @param <T> the input type of the function
+ * @param <R> the result type of the function
+ * @param <X> the exception type the function may throw
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+public interface ThrowingFunction<T, R, X extends Exception> {
+
+    /**
+     * Applies the function to the given {@code T}.
+     *
+     * @param input the input of type {@code T}
+     * @return the result of applying the function
+     * @throws X when the function failed with an exception of type {@code X}
+     */
+    R apply(T input) throws X;
+}

--- a/common/src/main/java/org/axonframework/common/jpa/EntityManagerExecutor.java
+++ b/common/src/main/java/org/axonframework/common/jpa/EntityManagerExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common.jpa;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.EntityManager;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.function.ThrowingFunction;
+import org.axonframework.common.tx.TransactionalExecutor;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link TransactionalExecutor} implementation for {@link EntityManager}s.
+ *
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+@Internal
+public class EntityManagerExecutor implements TransactionalExecutor<EntityManager> {
+    private final EntityManagerProvider provider;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param factory An {@link EntityManagerProvider}, cannot be {@code null}.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public EntityManagerExecutor(@Nonnull EntityManagerProvider factory) {
+        this.provider = Objects.requireNonNull(factory, "factory");
+    }
+
+    @Override
+    public <R> CompletableFuture<R> apply(ThrowingFunction<EntityManager, R, Exception> function) {
+        try {
+            return CompletableFuture.completedFuture(function.apply(provider.getEntityManager()));
+        }
+        catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/common/src/main/java/org/axonframework/common/jpa/FactoryBasedEntityManagerProvider.java
+++ b/common/src/main/java/org/axonframework/common/jpa/FactoryBasedEntityManagerProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common.jpa;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.Objects;
+
+/**
+ * An implementation of the {@link EntityManagerProvider} that returns a new {@link EntityManager} instance
+ * each time using the {@link EntityManagerFactory}.
+ *
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+public class FactoryBasedEntityManagerProvider implements EntityManagerProvider {
+    private final EntityManagerFactory entityManagerFactory;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param entityManagerFactory The {@link EntityManagerFactory} to use, cannot be {@code null}.
+     */
+    public FactoryBasedEntityManagerProvider(@Nonnull EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = Objects.requireNonNull(entityManagerFactory, "entityManagerFactory");
+    }
+
+    @Override
+    public EntityManager getEntityManager() {
+        return entityManagerFactory.createEntityManager();
+    }
+}

--- a/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
+++ b/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common.tx;
+
+import jakarta.annotation.Nonnull;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.function.ThrowingConsumer;
+import org.axonframework.common.function.ThrowingFunction;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Executes transactional operations with automatic transaction management. The
+ * user of this interface will get (limited) access to a transactional resource,
+ * like a JDBC connection or an Entity Manager, with which to perform operations.
+ * <p>
+ * At the appropriate time in the lifecycle of this executor, commit or rollback
+ * is called on the transactional resource managed by it. Any (uncaught) exceptions
+ * will result in the resource to be rolled back, and any associated lifecycle to
+ * be put into an error state.
+ * <p>
+ * This interface provides convenience methods for both operations that return
+ * a result and operations that are purely side-effecting.
+ *
+ * @param <T> the type of the resource
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+@Internal
+public interface TransactionalExecutor<T> {
+
+    /**
+     * Executes a transactional operation that does not return a result.
+     * <p>
+     * Implementations are responsible for managing the lifecycle of the
+     * provided resource, including obtaining, closing, commit and rollback.
+     *
+     * @param consumer A consumer which accepts the transactional resource of type {@code T};
+     *     cannot be {@code null}.
+     * @return A {@link CompletableFuture} with a void result.
+     * @throws NullPointerException when {@code consumer} is {@code null}
+     */
+    default CompletableFuture<Void> accept(@Nonnull ThrowingConsumer<T, Exception> consumer) {
+        Objects.requireNonNull(consumer, "consumer");
+
+        return apply(r -> {
+            consumer.accept(r);
+
+            return null;
+        });
+    }
+
+    /**
+     * Executes a transactional operation that returns a result.
+     * <p>
+     * Implementations are responsible for managing the lifecycle of the
+     * provided resource, including obtaining, closing, commit and rollback.
+     *
+     * @param <R> the type of the result returned by the function
+     * @param function A function that accepts the transactional resource of type {@code T}
+     *     and produces a result of type {@code R}; cannot be {@code null}.
+     * @return A {@link CompletableFuture} which when it completes contains the result of
+     *     the provided function.
+     * @throws NullPointerException when {@code function} is {@code null}
+     */
+    <R> CompletableFuture<R> apply(@Nonnull ThrowingFunction<T, R, Exception> function);
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TransactionalExecutorProvider.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TransactionalExecutorProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.tx.TransactionalExecutor;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+
+/**
+ * Provides {@link TransactionalExecutor}s.
+ *
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+@Internal
+public interface TransactionalExecutorProvider<T> {
+
+    /**
+     * Provides a {@link TransactionalExecutor}, using the optional processing context.
+     *
+     * @param processingContext A {@link ProcessingContext}, can be {@code null}.
+     * @return A {@link TransactionalExecutor}, never {@code null}.
+     */
+    @Nonnull
+    TransactionalExecutor<T> getTransactionalExecutor(@Nullable ProcessingContext processingContext);
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -24,11 +24,11 @@ import org.axonframework.common.Assert;
 import org.axonframework.common.TypeReference;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
-import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.tx.TransactionalExecutor;
+import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker.AggregateSequencer;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils;
-import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
@@ -39,6 +39,7 @@ import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.StreamSpliterator;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
+import org.axonframework.eventsourcing.eventstore.TransactionalExecutorProvider;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.MessageStream;
@@ -46,7 +47,6 @@ import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
-import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.TerminalEventMessage;
@@ -70,7 +70,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -132,8 +131,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
             WHERE e.globalIndex >= :firstGapOffset \
             AND e.globalIndex <= :maxGlobalIndex""";
 
-    private final EntityManagerProvider entityManagerProvider;
-    private final TransactionManager transactionManager;
+    private final TransactionalExecutorProvider<EntityManager> transactionalExecutorProvider;
     private final EventConverter converter;
 
     private final PersistenceExceptionResolver persistenceExceptionResolver;
@@ -144,6 +142,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private final long lowestGlobalSequence;
 
     private final GapAwareTrackingTokenOperations tokenOperations;
+    private final Predicate<Throwable> isConflictException;
 
     /**
      * Tracks runnables for callbacks attached to streams for when new events may have become available.
@@ -155,21 +154,17 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     /**
      * Constructs an {@code AggregateBasedJpaEventStorageEngine} with the given parameters.
      *
-     * @param entityManagerProvider The {@link jakarta.persistence.EntityManager} provided for this storage solution.
-     * @param transactionManager    The transaction manager, ensuring all operations to the storage solution occur
-     *                              transactionally.
+     * @param transactionalExecutorProvider The transactional executor provider for this storage solution.
      * @param converter             The converter used to convert the {@link EventMessage#payload()} and
      *                              {@link EventMessage#metadata()} to a {@code byte[]}.
      * @param configurer            A unary operator of the {@link AggregateBasedJpaEventStorageEngineConfiguration}
      *                              that customizes the {@code AggregateBasedJpaEventStorageEngine} under construction.
      */
-    public AggregateBasedJpaEventStorageEngine(@Nonnull EntityManagerProvider entityManagerProvider,
-                                               @Nonnull TransactionManager transactionManager,
+    public AggregateBasedJpaEventStorageEngine(@Nonnull TransactionalExecutorProvider<EntityManager> transactionalExecutorProvider,
                                                @Nonnull EventConverter converter,
                                                @Nonnull UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> configurer) {
-        this.entityManagerProvider =
-                requireNonNull(entityManagerProvider, "The entityManagerProvider may not be null.");
-        this.transactionManager = requireNonNull(transactionManager, "The transactionManager may not be null.");
+        this.transactionalExecutorProvider =
+                requireNonNull(transactionalExecutorProvider, "The transactionalExecutorProvider may not be null.");
         this.converter = requireNonNull(converter, "The converter may not be null.");
 
         var config = requireNonNull(configurer, "The configurer may not be null.")
@@ -183,17 +178,9 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
         this.tokenOperations = new GapAwareTrackingTokenOperations(config.gapTimeout(), logger);
         this.eventCoordinatorHandle = config.eventCoordinator().startCoordination(this::onAppendDetected);
-    }
-
-    /**
-     * Returns an {@link EntityManager} from the {@link EntityManagerProvider}.
-     * <p>
-     * Internal use only.
-     *
-     * @return An {@link EntityManager} from the {@link EntityManagerProvider}.
-     */
-    private EntityManager entityManager() {
-        return entityManagerProvider.getEntityManager();
+        this.isConflictException = t -> persistenceExceptionResolver != null
+            && t instanceof Exception ex
+            && persistenceExceptionResolver.isDuplicateKeyViolation(ex);
     }
 
     @Override
@@ -209,67 +196,45 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
             return CompletableFuture.completedFuture(EmptyAppendTransaction.INSTANCE);
         }
 
-        return CompletableFuture.completedFuture(new AppendTransaction<AggregateBasedConsistencyMarker>() {
+        return entityManagerExecutor(processingContext).apply(em -> {
+            AggregateBasedConsistencyMarker preCommitConsistencyMarker = AggregateBasedConsistencyMarker.from(condition);
 
-            private final AtomicBoolean txFinished = new AtomicBoolean(false);
-            private final AggregateBasedConsistencyMarker preCommitConsistencyMarker =
-                    AggregateBasedConsistencyMarker.from(condition);
+            try {
+                AggregateSequencer sequencer = preCommitConsistencyMarker.createSequencer();
 
-            @Override
-            public CompletableFuture<AggregateBasedConsistencyMarker> commit(@Nullable ProcessingContext context) {
-                if (txFinished.getAndSet(true)) {
-                    return CompletableFuture.failedFuture(new IllegalStateException(
-                            "Already committed or rolled back"
-                    ));
-                }
-                var aggregateSequencer = preCommitConsistencyMarker.createSequencer();
+                events.stream()
+                    .map(taggedEvent -> mapToEntry(taggedEvent, sequencer, converter))
+                    .forEach(em::persist);
 
-                CompletableFuture<Void> txResult = new CompletableFuture<>();
-                var tx = transactionManager.startTransaction();
-                try {
-                    entityManagerPersistEvents(aggregateSequencer, events);
-                    tx.commit();
-                    eventCoordinatorHandle.onEventsAppended(events);
-                    txResult.complete(null);
-                } catch (Exception e) {
-                    tx.rollback();
-                    txResult.completeExceptionally(e);
-                }
+                em.flush();  // flush so violations occur here and now, instead of in the commit phase
 
-                return txResult.exceptionallyCompose(
-                                       e -> CompletableFuture.failedFuture(translateConflictException(e))
-                               )
-                               .thenApply(v -> aggregateSequencer.toMarker());
+                return new AppendTransaction<AggregateBasedConsistencyMarker>() {
+                    @Override
+                    public CompletableFuture<AggregateBasedConsistencyMarker> commit(ProcessingContext context) {
+                        // Transaction is in control of the entity manager executor, so do no work here
+                        return CompletableFuture.completedFuture(sequencer.toMarker());
+                    }
+
+                    @Override
+                    public void rollback(ProcessingContext context) {
+                        // Transaction is in control of the entity manager executor, so do no work here
+                    }
+
+                    @Override
+                    public CompletableFuture<ConsistencyMarker> afterCommit(
+                        AggregateBasedConsistencyMarker marker, ProcessingContext context
+                    ) {
+                        eventCoordinatorHandle.onEventsAppended(events);
+
+                        return CompletableFuture.completedFuture(marker);
+                    }
+                };
             }
-
-            @Override
-            public CompletableFuture<ConsistencyMarker> afterCommit(@Nonnull AggregateBasedConsistencyMarker marker,
-                                                                    @Nullable ProcessingContext context) {
-                return CompletableFuture.completedFuture(marker);
-            }
-
-            private Throwable translateConflictException(Throwable e) {
-                Predicate<Throwable> isConflictException = (t) -> persistenceExceptionResolver != null
-                        && t instanceof Exception ex
-                        && persistenceExceptionResolver.isDuplicateKeyViolation(ex);
-                return AggregateBasedEventStorageEngineUtils
-                        .translateConflictException(preCommitConsistencyMarker, e, isConflictException);
-            }
-
-            @Override
-            public void rollback(@Nullable ProcessingContext context) {
-                txFinished.set(true);
+            catch (Exception e) {
+                throw AggregateBasedEventStorageEngineUtils
+                    .translateConflictException(preCommitConsistencyMarker, e, isConflictException);
             }
         });
-    }
-
-    private void entityManagerPersistEvents(AggregateSequencer aggregateSequencer,
-                                            List<TaggedEventMessage<?>> events) {
-        try (EntityManager entityManager = entityManager()) {
-            events.stream()
-                  .map(taggedEvent -> mapToEntry(taggedEvent, aggregateSequencer, converter))
-                  .forEach(entityManager::persist);
-        }
     }
 
     private static AggregateEventEntry mapToEntry(TaggedEventMessage<?> taggedEvent,
@@ -299,7 +264,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                                                           .flatten()
                                                           .stream()
                                                           .map(criterion -> this.aggregateSourceForCriterion(
-                                                                  condition, criterion
+                                                                  condition, criterion, processingContext
                                                           ))
                                                           .toList();
 
@@ -316,18 +281,19 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                                ));
     }
 
-    private AggregateSource aggregateSourceForCriterion(SourcingCondition condition, EventCriterion criterion) {
+    private AggregateSource aggregateSourceForCriterion(SourcingCondition condition, EventCriterion criterion, ProcessingContext pc) {
         AtomicReference<AggregateBasedConsistencyMarker> markerReference = new AtomicReference<>();
         var aggregateIdentifier = resolveAggregateIdentifier(criterion.tags());
         long firstSequenceNumber = AggregateSequenceNumberPosition.toSequenceNumber(condition.start());
         //noinspection DataFlowIssue
         StreamSpliterator<? extends AggregateEventEntry> entrySpliterator = new StreamSpliterator<>(
-                lastEntry -> transactionManager.fetchInTransaction(() -> queryEventsBy(
+                lastEntry -> queryEventsBy(
                         aggregateIdentifier,
                         lastEntry != null && lastEntry.aggregateSequenceNumber() != null
                                 ? lastEntry.aggregateSequenceNumber() + 1
-                                : firstSequenceNumber
-                )),
+                                : firstSequenceNumber,
+                        pc
+                ),
                 finalBatchPredicate
         );
 
@@ -343,14 +309,14 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         return new AggregateSource(markerReference, source);
     }
 
-    List<AggregateEventEntry> queryEventsBy(String aggregateIdentifier, long firstSequenceNumber) {
-        try (EntityManager entityManager = entityManager()) {
-            return entityManager.createQuery(EVENTS_BY_AGGREGATE_QUERY, AggregateEventEntry.class)
-                                .setParameter("id", aggregateIdentifier)
-                                .setParameter("seq", firstSequenceNumber)
-                                .setMaxResults(batchSize)
-                                .getResultList();
-        }
+    private List<AggregateEventEntry> queryEventsBy(String aggregateIdentifier, long firstSequenceNumber, ProcessingContext processingContext) {
+        return entityManagerExecutor(processingContext).apply(em ->
+            em.createQuery(EVENTS_BY_AGGREGATE_QUERY, AggregateEventEntry.class)
+                .setParameter("id", aggregateIdentifier)
+                .setParameter("seq", firstSequenceNumber)
+                .setMaxResults(batchSize)
+                .getResultList()
+        ).join();
     }
 
     private static Context setMarkerAndBuildContext(AggregateEventEntry entry,
@@ -392,57 +358,53 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                 () -> String.format("Token [%s] is of the wrong type. Expected [%s]",
                                     start, GapAwareTrackingToken.class.getSimpleName())
         );
-        List<TokenAndEvent> result = new ArrayList<>();
-        GapAwareTrackingToken cleanedToken = cleanedToken((GapAwareTrackingToken) start);
-        List<AggregateEventEntry> events =
-                transactionManager.fetchInTransaction(() -> queryEventsBy(cleanedToken));
 
-        GapAwareTrackingToken token = cleanedToken;
-        Instant gapTimeoutThreshold = tokenOperations.gapTimeoutThreshold();
-        for (AggregateEventEntry event : events) {
-            String type = event.aggregateType();
-            String identifier = event.aggregateIdentifier();
+        return entityManagerExecutor(null).apply(em -> {
+            List<TokenAndEvent> result = new ArrayList<>();
+            GapAwareTrackingToken cleanedToken = cleanedToken(em, (GapAwareTrackingToken) start);
+            List<AggregateEventEntry> events = queryEventsBy(em, cleanedToken);
 
-            // A null type or identifier is allowed, but those cannot form a valid tag:
-            Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
+            GapAwareTrackingToken token = cleanedToken;
+            Instant gapTimeoutThreshold = tokenOperations.gapTimeoutThreshold();
+            for (AggregateEventEntry event : events) {
+                String type = event.aggregateType();
+                String identifier = event.aggregateIdentifier();
 
-            if (condition.matches(new QualifiedName(event.type()), tags)) {
-                token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
-                result.add(new TokenAndEvent(token, event));
+                // A null type or identifier is allowed, but those cannot form a valid tag:
+                Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
+
+                if (condition.matches(new QualifiedName(event.type()), tags)) {
+                    token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
+                    result.add(new TokenAndEvent(token, event));
+                }
             }
-        }
-        return result;
+            return result;
+        }).join();
     }
 
-    private GapAwareTrackingToken cleanedToken(GapAwareTrackingToken lastToken) {
+    private GapAwareTrackingToken cleanedToken(EntityManager entityManager, GapAwareTrackingToken lastToken) {
         return lastToken != null && lastToken.getGaps().size() > gapCleaningThreshold
-                ? tokenOperations.withGapsCleaned(lastToken, indexAndTimestampBetweenGaps(lastToken))
+                ? tokenOperations.withGapsCleaned(lastToken, indexAndTimestampBetweenGaps(entityManager, lastToken))
                 : lastToken;
     }
 
-    private List<Object[]> indexAndTimestampBetweenGaps(GapAwareTrackingToken token) {
-        return transactionManager.fetchInTransaction(() -> {
-            try (EntityManager entityManager = entityManager()) {
-                return entityManager.createQuery(INDEX_AND_TIMESTAMP_QUERY, Object[].class)
-                                    .setParameter("firstGapOffset", token.getGaps().first())
-                                    .setParameter("maxGlobalIndex", token.getGaps().last() + 1L)
-                                    .getResultList();
-            }
-        });
+    private List<Object[]> indexAndTimestampBetweenGaps(EntityManager entityManager, GapAwareTrackingToken token) {
+        return entityManager.createQuery(INDEX_AND_TIMESTAMP_QUERY, Object[].class)
+                            .setParameter("firstGapOffset", token.getGaps().first())
+                            .setParameter("maxGlobalIndex", token.getGaps().last() + 1L)
+                            .getResultList();
     }
 
-    private List<AggregateEventEntry> queryEventsBy(GapAwareTrackingToken token) {
-        try (EntityManager entityManager = entityManager()) {
-            TypedQuery<AggregateEventEntry> eventsByTokenQuery =
-                    token == null || token.getGaps().isEmpty()
-                            ? entityManager.createQuery(EVENTS_BY_TOKEN_QUERY, AggregateEventEntry.class)
-                            : entityManager.createQuery(EVENTS_BY_GAPPED_TOKEN, AggregateEventEntry.class)
-                                           .setParameter("gaps", token.getGaps());
+    private List<AggregateEventEntry> queryEventsBy(EntityManager entityManager, GapAwareTrackingToken token) {
+        TypedQuery<AggregateEventEntry> eventsByTokenQuery =
+                token == null || token.getGaps().isEmpty()
+                        ? entityManager.createQuery(EVENTS_BY_TOKEN_QUERY, AggregateEventEntry.class)
+                        : entityManager.createQuery(EVENTS_BY_GAPPED_TOKEN, AggregateEventEntry.class)
+                                       .setParameter("gaps", token.getGaps());
 
-            return eventsByTokenQuery.setParameter("token", token == null ? -1L : token.getIndex())
-                                     .setMaxResults(batchSize)
-                                     .getResultList();
-        }
+        return eventsByTokenQuery.setParameter("token", token == null ? -1L : token.getIndex())
+                                 .setMaxResults(batchSize)
+                                 .getResultList();
     }
 
     private GapAwareTrackingToken calculateToken(@Nullable GapAwareTrackingToken token,
@@ -492,37 +454,36 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     @Override
     public CompletableFuture<TrackingToken> firstToken(@Nullable ProcessingContext processingContext) {
-        return queryToken(FIRST_TOKEN_QUERY);
+        return queryToken(FIRST_TOKEN_QUERY, processingContext);
     }
 
     @Override
     public CompletableFuture<TrackingToken> latestToken(@Nullable ProcessingContext processingContext) {
-        return queryToken(LATEST_TOKEN_QUERY);
+        return queryToken(LATEST_TOKEN_QUERY, processingContext);
     }
 
     @Nonnull
-    private CompletableFuture<TrackingToken> queryToken(String firstTokenQuery) {
-        try (EntityManager entityManager = entityManager()) {
-            long position = entityManager.createQuery(firstTokenQuery, Long.class).getSingleResult();
-            return CompletableFuture.completedFuture(new GapAwareTrackingToken(position, Set.of()));
-        }
+    private CompletableFuture<TrackingToken> queryToken(String firstTokenQuery, ProcessingContext processingContext) {
+        return entityManagerExecutor(processingContext).apply(entityManager -> new GapAwareTrackingToken(
+            entityManager.createQuery(firstTokenQuery, Long.class).getSingleResult(),
+            Set.of()
+        ));
     }
 
     @Override
     public CompletableFuture<TrackingToken> tokenAt(@Nonnull Instant at,
                                                     @Nullable ProcessingContext processingContext) {
-        try (EntityManager entityManager = entityManager()) {
-            long position = entityManager.createQuery(TOKEN_AT_QUERY, Long.class)
-                                         .setParameter("dateTime", formatInstant(at))
-                                         .getSingleResult();
-            return CompletableFuture.completedFuture(new GapAwareTrackingToken(position, Set.of()));
-        }
+        return entityManagerExecutor(processingContext).apply(entityManager -> new GapAwareTrackingToken(
+            entityManager.createQuery(TOKEN_AT_QUERY, Long.class)
+                         .setParameter("dateTime", formatInstant(at))
+                         .getSingleResult(),
+            Set.of()
+        ));
     }
 
     @Override
     public void describeTo(@Nonnull ComponentDescriptor descriptor) {
-        descriptor.describeProperty("entityManagerProvider", entityManagerProvider);
-        descriptor.describeProperty("transactionManager", transactionManager);
+        descriptor.describeProperty("transactionalExecutorProvider", transactionalExecutorProvider);
         descriptor.describeProperty("converter", converter);
         descriptor.describeProperty("persistenceExceptionResolver", persistenceExceptionResolver);
         descriptor.describeProperty("tokenOperations", tokenOperations);
@@ -551,6 +512,10 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         for (Runnable callback : streamCallbacks.values()) {
             callback.run();
         }
+    }
+
+    private TransactionalExecutor<EntityManager> entityManagerExecutor(ProcessingContext processingContext) {
+        return transactionalExecutorProvider.getTransactionalExecutor(processingContext);
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaTransactionalExecutorProvider.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaTransactionalExecutorProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.function.ThrowingFunction;
+import org.axonframework.common.jpa.EntityManagerExecutor;
+import org.axonframework.common.tx.TransactionalExecutor;
+import org.axonframework.eventsourcing.eventstore.TransactionalExecutorProvider;
+import org.axonframework.messaging.core.Context.ResourceKey;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * A {@link TransactionalExecutorProvider} implementation for JPA {@link EntityManager}s which
+ * provides a {@link TransactionalExecutor}.
+ * <p>
+ * When a processing context is supplied, supplies the {@link TransactionalExecutor} it must contain.
+ * If no processing context is supplied, creates an executor that executes the supplied functions
+ * in their own transaction.
+ *
+ * @author John Hendrikx
+ * @since 5.1.0
+ */
+@Internal
+public class JpaTransactionalExecutorProvider implements TransactionalExecutorProvider<EntityManager> {
+
+    /**
+     * The resource key for the {@link EntityManagerExecutor} supplier.
+     */
+    public static final ResourceKey<Supplier<EntityManagerExecutor>> SUPPLIER_KEY = ResourceKey.withLabel(EntityManagerExecutor.class.getSimpleName());
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param entityManagerFactory an {@link EntityManager} used when no processing context is supplied.
+     */
+    public JpaTransactionalExecutorProvider(@Nonnull EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = Objects.requireNonNull(entityManagerFactory, "entityManagerFactory");
+    }
+
+    @Override
+    public TransactionalExecutor<EntityManager> getTransactionalExecutor(ProcessingContext processingContext) {
+        if (processingContext != null) {
+            Supplier<EntityManagerExecutor> executorSupplier = processingContext.getResource(SUPPLIER_KEY);
+
+            if (executorSupplier == null) {
+                throw new IllegalStateException("an entity manager executor must be present in the processing context");
+            }
+
+            return executorSupplier.get();
+        }
+
+        return new TransactionalExecutor<>() {
+            @Override
+            public <R> CompletableFuture<R> apply(ThrowingFunction<EntityManager, R, Exception> function) {
+                // This uses the entity manager factory directly, so this always runs in its own transaction:
+                EntityManager entityManager = entityManagerFactory.createEntityManager();
+                EntityTransaction tx = entityManager.getTransaction();
+
+                try {
+                    tx.begin();
+
+                    R result = function.apply(entityManager);
+
+                    tx.commit();
+
+                    return CompletableFuture.completedFuture(result);
+                }
+                catch (Exception e) {
+                    if (tx.isActive()) {
+                        tx.rollback();
+                    }
+
+                    return CompletableFuture.failedFuture(e);
+                }
+                finally {
+                    entityManager.close();
+                }
+            }
+        };
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryStorageEngineBackedEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryStorageEngineBackedEventStoreTest.java
@@ -16,8 +16,12 @@
 
 package org.axonframework.eventsourcing.eventstore.inmemory;
 
+import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStore;
 import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStoreTestSuite;
-import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -27,6 +31,8 @@ import org.junit.jupiter.api.BeforeAll;
  * @author John Hendrikx
  */
 class InMemoryStorageEngineBackedEventStoreTest extends StorageEngineBackedEventStoreTestSuite<InMemoryEventStorageEngine> {
+
+    private static final UnitOfWorkFactory FACTORY = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
 
     private static InMemoryEventStorageEngine engine;
 
@@ -41,7 +47,7 @@ class InMemoryStorageEngineBackedEventStoreTest extends StorageEngineBackedEvent
     }
 
     @Override
-    protected void enhanceProcessingLifecycle(ProcessingLifecycle lifecycle) {
-        // no enhancement needed
+    protected UnitOfWork unitOfWork() {
+        return FACTORY.create();
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -145,6 +145,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring.boot.version}</version>

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -22,7 +22,7 @@ import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.ConfigurationEnhancer;
 import org.axonframework.common.configuration.SearchScope;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
-import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.FactoryBasedEntityManagerProvider;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurationDefaults;
 import org.axonframework.eventsourcing.eventstore.EventCoordinator;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
@@ -30,9 +30,9 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngineConfiguration;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaPollingEventCoordinator;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.extension.springboot.JpaEventStorageEngineConfigurationProperties;
 import org.axonframework.extension.springboot.util.RegisterDefaultEntities;
-import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -64,7 +64,7 @@ public class JpaEventStoreAutoConfiguration {
     /**
      * Creates an aggregate-based JPA event storage engine enhancer.
      *
-     * @param entityManagerProvider                        An entity manager provide to access the underlying DB.
+     * @param entityManagerFactory                         An entity manager factory to provide to access the underlying DB.
      * @param persistenceExceptionResolver                 A persistence exception resolver on duplicate errors.
      * @param jpaEventStorageEngineConfigurationProperties Spring properties to configure the JPA Event store Engine.
      * @return A configuration enhancer registering JPA Storage Engine ordered between Axon Server and In-Memory Storage
@@ -72,13 +72,13 @@ public class JpaEventStoreAutoConfiguration {
      */
     @Bean
     public ConfigurationEnhancer aggregateBasedJpaEventStorageEngine(
-            EntityManagerProvider entityManagerProvider,
+            EntityManagerFactory entityManagerFactory,
             PersistenceExceptionResolver persistenceExceptionResolver,
             JpaEventStorageEngineConfigurationProperties jpaEventStorageEngineConfigurationProperties
     ) {
         return new AggregateBasedJpaEventStorageEngineConfigurationEnhancer(
                 jpaEventStorageEngineConfigurationProperties,
-                entityManagerProvider,
+                entityManagerFactory,
                 persistenceExceptionResolver
         );
     }
@@ -88,38 +88,39 @@ public class JpaEventStoreAutoConfiguration {
      */
     public record AggregateBasedJpaEventStorageEngineConfigurationEnhancer(
             JpaEventStorageEngineConfigurationProperties properties,
-            EntityManagerProvider entityManagerProvider,
+            EntityManagerFactory factory,
             PersistenceExceptionResolver persistenceExceptionResolver
     ) implements ConfigurationEnhancer {
 
         @Override
         public void enhance(@Nonnull ComponentRegistry registry) {
-            UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> configurer = config ->
-                    config
-                            .batchSize(properties.batchSize())
-                            .gapCleaningThreshold(properties.gapCleaningThreshold())
-                            .gapTimeout(properties.gapTimeout())
-                            .lowestGlobalSequence(properties.lowestGlobalSequence())
-                            .maxGapOffset(properties.maxGapOffset())
-                            .persistenceExceptionResolver(persistenceExceptionResolver)
-                            .eventCoordinator(
-                                properties.pollingInterval() == 0 ?
-                                    EventCoordinator.SIMPLE :
-                                    new JpaPollingEventCoordinator(
-                                        entityManagerProvider,
-                                        Duration.ofMillis(properties.pollingInterval())
-                                    )
-                            );
+            UnaryOperator<AggregateBasedJpaEventStorageEngineConfiguration> configurer = config -> {
+                return config
+                        .batchSize(properties.batchSize())
+                        .gapCleaningThreshold(properties.gapCleaningThreshold())
+                        .gapTimeout(properties.gapTimeout())
+                        .lowestGlobalSequence(properties.lowestGlobalSequence())
+                        .maxGapOffset(properties.maxGapOffset())
+                        .persistenceExceptionResolver(persistenceExceptionResolver)
+                        .eventCoordinator(
+                            properties.pollingInterval() == 0 ?
+                                EventCoordinator.SIMPLE :
+                                new JpaPollingEventCoordinator(
+                                    new FactoryBasedEntityManagerProvider(factory),
+                                    Duration.ofMillis(properties.pollingInterval())
+                                )
+                        );
+            };
 
-            registry.registerIfNotPresent(EventStorageEngine.class,
-                                          (configuration)
-                                                  -> new AggregateBasedJpaEventStorageEngine(
-                                                  entityManagerProvider,
-                                                  configuration.getComponent(TransactionManager.class),
-                                                  configuration.getComponent(EventConverter.class),
-                                                  configurer
-                                          ),
-                                          SearchScope.ALL);
+            registry.registerIfNotPresent(
+                EventStorageEngine.class,
+                configuration -> new AggregateBasedJpaEventStorageEngine(
+                    new JpaTransactionalExecutorProvider(factory),
+                    configuration.getComponent(EventConverter.class),
+                    configurer
+                ),
+                SearchScope.ALL
+            );
         }
 
         @Override

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/TransactionAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/TransactionAutoConfiguration.java
@@ -16,7 +16,9 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManagerFactory;
+import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.extension.spring.messaging.unitofwork.SpringTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -41,13 +43,14 @@ public class TransactionAutoConfiguration {
      * Bean creation method constructing a {@link SpringTransactionManager} based on the given
      * {@code transactionManager}.
      *
-     * @param transactionManager The {@code PlatformTransactionManager} used to construct a
-     *                           {@link SpringTransactionManager}.
+     * @param transactionManager    The {@code PlatformTransactionManager} used to construct a
+     *                              {@link SpringTransactionManager}.
+     * @param entityManagerProvider An optional entity manager provider.
      * @return The {@link TransactionManager} to be used by Axon Framework.
      */
     @Bean
     @ConditionalOnMissingBean
-    public TransactionManager axonTransactionManager(PlatformTransactionManager transactionManager) {
-        return new SpringTransactionManager(transactionManager);
+    public TransactionManager axonTransactionManager(PlatformTransactionManager transactionManager, @Nullable EntityManagerProvider entityManagerProvider) {
+        return new SpringTransactionManager(transactionManager, entityManagerProvider);
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -20,18 +20,24 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.axonframework.common.jpa.EntityManagerExecutor;
 import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.FactoryBasedEntityManagerProvider;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
+import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTransaction;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.jpa.JpaPollingEventCoordinator;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.extension.spring.messaging.unitofwork.SpringTransactionManager;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageStream.Entry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -42,8 +48,9 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.Trac
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
 import org.axonframework.messaging.eventstreaming.Tag;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -67,9 +74,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.LongStream;
+
 import javax.sql.DataSource;
 
 import static java.util.Collections.emptySet;
@@ -77,7 +86,6 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link AggregateBasedJpaEventStorageEngine}.
@@ -90,10 +98,14 @@ import static org.mockito.Mockito.*;
 class AggregateBasedJpaEventStorageEngineIT
         extends AggregateBasedStorageEngineTestSuite<AggregateBasedJpaEventStorageEngine> {
 
+    private final ThreadLocal<Transaction> transactionTL = new ThreadLocal<>();
+
     @Autowired
     private PlatformTransactionManager platformTransactionManager;
     @Autowired
     private EntityManagerProvider entityManagerProvider;
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     private TransactionManager transactionManager;
 
@@ -101,14 +113,13 @@ class AggregateBasedJpaEventStorageEngineIT
 
     @Override
     protected AggregateBasedJpaEventStorageEngine buildStorageEngine() {
-        transactionManager = spy(new SpringTransactionManager(platformTransactionManager));
+        transactionManager = new SpringTransactionManager(platformTransactionManager, entityManagerProvider);
 
         this.engine = new AggregateBasedJpaEventStorageEngine(
-                entityManagerProvider,
-                transactionManager,
+                new JpaTransactionalExecutorProvider(entityManagerFactory),
                 converter,
                 config -> config
-                        .eventCoordinator(new JpaPollingEventCoordinator(entityManagerProvider, Duration.ofMillis(500)))
+                        .eventCoordinator(new JpaPollingEventCoordinator(new FactoryBasedEntityManagerProvider(entityManagerFactory), Duration.ofMillis(500)))
                         .persistenceExceptionResolver(new PersistenceExceptionResolver() {
                             @Override
                             public boolean isDuplicateKeyViolation(Exception exception) {
@@ -135,8 +146,27 @@ class AggregateBasedJpaEventStorageEngineIT
     }
 
     @Override
-    protected ProcessingContext processingContext() {
-        return null;
+    protected CompletableFuture<ConsistencyMarker> finishTx(CompletableFuture<AppendTransaction<?>> future, ProcessingContext pc) {
+        return super.finishTx(future, pc).whenComplete((v, e) -> finishTx());
+    }
+
+    private void finishTx() {
+        Transaction transaction = transactionTL.get();
+
+        if (transaction != null) {
+            transaction.commit();
+        }
+    }
+
+    @Override
+    protected synchronized ProcessingContext processingContext() {
+        StubProcessingContext context = new StubProcessingContext();
+
+        context.putResource(JpaTransactionalExecutorProvider.SUPPLIER_KEY, () -> new EntityManagerExecutor(entityManagerProvider));
+
+        transactionTL.set(transactionManager.startTransaction());
+
+        return context;
     }
 
     @Override
@@ -182,9 +212,10 @@ class AggregateBasedJpaEventStorageEngineIT
         AtomicBoolean called = new AtomicBoolean();
         TrackingToken position = testSubject.firstToken(processingContext()).get();
 
+        finishTx();
+
         // Create stream that should get new events as they arrive:
-        MessageStream<EventMessage> stream = testSubject.stream(StreamingCondition.startingFrom(position),
-                                                                processingContext());
+        MessageStream<EventMessage> stream = testSubject.stream(StreamingCondition.startingFrom(position), null);
 
         stream.setCallback(() -> called.set(true));
 
@@ -200,11 +231,7 @@ class AggregateBasedJpaEventStorageEngineIT
         await().during(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(called).isFalse());
 
         // Add a new message:
-        testSubject.appendEvents(AppendCondition.none(),
-                                 processingContext(),
-                                 taggedEventMessage("event", Set.of(new Tag("k", "v"))))
-                   .get()
-                   .commit(processingContext());
+        appendEvents(AppendCondition.none(), taggedEventMessage("event", Set.of(new Tag("k", "v"))));
 
         // Expect to see a new message arrive:
         await().untilAsserted(() -> assertThat(called).isTrue());
@@ -219,21 +246,11 @@ class AggregateBasedJpaEventStorageEngineIT
     }
 
     @Test
-    void sourcingFromNonGapAwareTrackingTokenShouldThrowException() {
+    void streamingFromNonGapAwareTrackingTokenShouldThrowException() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> testSubject.stream(StreamingCondition.startingFrom(new GlobalSequenceTrackingToken(5)),
-                                         processingContext())
+                () -> testSubject.stream(StreamingCondition.startingFrom(new GlobalSequenceTrackingToken(5)), null)
         );
-    }
-
-    @Test
-    void appendEventsIsPerformedInATransaction() {
-        appendCommitAndWait(testSubject,
-                            AppendCondition.none(),
-                            AggregateBasedStorageEngineTestSuite.taggedEventMessage("event-2", emptySet()));
-
-        verify(transactionManager).startTransaction();
     }
 
     @Test
@@ -271,7 +288,7 @@ class AggregateBasedJpaEventStorageEngineIT
 
         MessageStream<EventMessage> stream = testSubject.stream(
                 StreamingCondition.startingFrom(new GapAwareTrackingToken(0, Collections.emptySet())),
-                processingContext()
+                null
         );
 
         List<GapAwareTrackingToken> tokens = new ArrayList<>();
@@ -293,8 +310,7 @@ class AggregateBasedJpaEventStorageEngineIT
     @Test
     void oldGapsAreRemovedFromProvidedTrackingToken() {
         AggregateBasedJpaEventStorageEngine gapConfigTestSubject = new AggregateBasedJpaEventStorageEngine(
-                entityManagerProvider,
-                transactionManager,
+                new JpaTransactionalExecutorProvider(entityManagerFactory),
                 converter,
                 config -> config.maxGapOffset(10000)
                                 .gapTimeout(50001)
@@ -341,7 +357,7 @@ class AggregateBasedJpaEventStorageEngineIT
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 5)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("4", Set.of(aggregateToKeep)));
 
-        // Let's create some gaps by removing all events where the aggregate identifier is not "remove"
+        // Let's create some gaps by removing all events where the aggregate identifier is "remove"
         transaction = transactionManager.startTransaction();
         entityManager.createQuery(
                              "DELETE FROM AggregateEventEntry entry WHERE entry.aggregateIdentifier = :aggregateIdentifier"
@@ -376,7 +392,7 @@ class AggregateBasedJpaEventStorageEngineIT
         GapAwareTrackingToken startPosition = GapAwareTrackingToken.newInstance(secondLastEventIndex, gaps);
 
         MessageStream<EventMessage> eventStream =
-                gapConfigTestSubject.stream(StreamingCondition.startingFrom(startPosition), processingContext());
+                gapConfigTestSubject.stream(StreamingCondition.startingFrom(startPosition), null);
         assertThat(eventStream.hasNextAvailable()).isTrue();
         TrackingToken token = eventStream.next()
                                          .flatMap(TrackingToken::fromContext)
@@ -398,11 +414,9 @@ class AggregateBasedJpaEventStorageEngineIT
     private void appendCommitAndWait(AggregateBasedJpaEventStorageEngine subject,
                                      AppendCondition condition,
                                      TaggedEventMessage<?>... events) {
-        subject.appendEvents(condition, processingContext(), events)
-               .thenApply(this::castTransaction)
-               .thenCompose(tx -> tx.commit(processingContext())
-                                    .thenCompose(v -> tx.afterCommit(v, processingContext())))
-               .join();
+        ProcessingContext processingContext = processingContext();
+
+        finishTx(subject.appendEvents(condition, processingContext, events), processingContext);
     }
 
     @Configuration
@@ -436,7 +450,6 @@ class AggregateBasedJpaEventStorageEngineIT
             entityManagerFactoryBean.setPersistenceUnitName("integrationtest");
 
             HibernateJpaVendorAdapter jpaVendorAdapter = new HibernateJpaVendorAdapter();
-            jpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.HSQLDialect");
             jpaVendorAdapter.setGenerateDdl(true);
             jpaVendorAdapter.setShowSql(false);
 

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaStorageEngineBackedEventStoreIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaStorageEngineBackedEventStoreIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.eventsourcing.eventstore.jpa;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import org.axonframework.common.jdbc.PersistenceExceptionResolver;
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.FactoryBasedEntityManagerProvider;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
+import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStoreTestSuite;
+import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaPollingEventCoordinator;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
+import org.axonframework.extension.spring.messaging.unitofwork.SpringTransactionManager;
+import org.axonframework.extension.springboot.autoconfig.TransactionAutoConfiguration;
+import org.axonframework.extension.springboot.eventsourcing.eventstore.jpa.AggregateBasedJpaStorageEngineBackedEventStoreIT.TestConfig;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.junit.jupiter.api.AfterAll;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import java.time.Duration;
+
+import javax.sql.DataSource;
+
+/**
+ * Test class validating the {@link AggregateBasedJpaEventStorageEngine}.
+ *
+ * @author John Hendrikx
+ */
+@SpringBootTest(classes = TestConfig.class)
+@ImportAutoConfiguration(TransactionAutoConfiguration.class)
+class AggregateBasedJpaStorageEngineBackedEventStoreIT extends StorageEngineBackedEventStoreTestSuite<AggregateBasedJpaEventStorageEngine> {
+
+    private static AggregateBasedJpaEventStorageEngine engine;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private SpringTransactionManager springTransactionManager;
+
+    @AfterAll
+    static void afterAll() {
+        if (engine != null) {
+            engine.close();
+            engine = null;
+        }
+    }
+
+    @Override
+    protected AggregateBasedJpaEventStorageEngine getStorageEngine(EventConverter converter) {
+        if(engine == null) {
+            FactoryBasedEntityManagerProvider entityManagerProvider = new FactoryBasedEntityManagerProvider(entityManagerFactory);
+
+            engine = new AggregateBasedJpaEventStorageEngine(
+                new JpaTransactionalExecutorProvider(entityManagerFactory),
+                converter,
+                config -> config
+                    .eventCoordinator(new JpaPollingEventCoordinator(entityManagerProvider, Duration.ofMillis(500)))
+                    .persistenceExceptionResolver(new PersistenceExceptionResolver() {
+                        @Override
+                        public boolean isDuplicateKeyViolation(Exception exception) {
+                            return causeIsEntityExistsException(exception);
+                        }
+
+                        private boolean causeIsEntityExistsException(Throwable exception) {
+                            return exception instanceof java.sql.SQLIntegrityConstraintViolationException
+                                || (exception.getCause() != null
+                                    && causeIsEntityExistsException(exception.getCause()));
+                        }
+                    })
+            );
+        }
+
+        return engine;
+    }
+
+    @Override
+    protected UnitOfWork unitOfWork() {
+        TransactionalUnitOfWorkFactory factory = new TransactionalUnitOfWorkFactory(
+            springTransactionManager,
+            new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE)
+        );
+
+        return factory.create();
+    }
+
+    @Configuration
+    public static class TestConfig {
+
+        @Configuration
+        public static class PersistenceConfig {
+
+            @PersistenceContext
+            private EntityManager entityManager;
+
+            @Bean
+            public EntityManagerProvider entityManagerProvider() {
+                return new SimpleEntityManagerProvider(entityManager);
+            }
+        }
+
+        @Bean
+        public DataSource dataSource() {
+            String uniqueDbName = "jdbc:hsqldb:mem:aggregatebasedjpaeventstorageenginetest-" + System.nanoTime();
+            DriverManagerDataSource driverManagerDataSource =
+                    new DriverManagerDataSource(uniqueDbName, "sa", "password");
+            driverManagerDataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+            return driverManagerDataSource;
+        }
+
+        @Bean
+        public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+            LocalContainerEntityManagerFactoryBean entityManagerFactoryBean =
+                    new LocalContainerEntityManagerFactoryBean();
+            entityManagerFactoryBean.setPersistenceUnitName("integrationtest");
+
+            HibernateJpaVendorAdapter jpaVendorAdapter = new HibernateJpaVendorAdapter();
+            jpaVendorAdapter.setGenerateDdl(true);
+            jpaVendorAdapter.setShowSql(false);
+
+            entityManagerFactoryBean.setJpaVendorAdapter(jpaVendorAdapter);
+            entityManagerFactoryBean.setDataSource(dataSource);
+
+            return entityManagerFactoryBean;
+        }
+
+        @Bean
+        public JpaTransactionManager transactionManager(EntityManagerFactory entityManagerFactory,
+                                                        DataSource dataSource) {
+            JpaTransactionManager jpaTransactionManager = new JpaTransactionManager(entityManagerFactory);
+            jpaTransactionManager.setDataSource(dataSource);
+            return jpaTransactionManager;
+        }
+
+        @Bean
+        public static PersistenceAnnotationBeanPostProcessor persistenceAnnotationBeanPostProcessor() {
+            return new PersistenceAnnotationBeanPostProcessor();
+        }
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/resources/META-INF/persistence.xml
@@ -25,7 +25,6 @@
         <class>org.axonframework.modelling.saga.repository.jpa.AssociationValueEntry</class>
         <class>org.axonframework.modelling.saga.repository.jpa.SagaEntry</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
             <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:axontest"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>
@@ -40,7 +39,6 @@
         <class>org.axonframework.integrationtests.polymorphic.Child2Aggregate</class>
         <class>org.axonframework.integrationtests.polymorphic.SimpleAggregate</class>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
             <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:axontest"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/messaging/unitofwork/SpringTransactionManager.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/messaging/unitofwork/SpringTransactionManager.java
@@ -16,7 +16,13 @@
 
 package org.axonframework.extension.spring.messaging.unitofwork;
 
-import org.axonframework.common.Assert;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.axonframework.common.jpa.EntityManagerExecutor;
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.conversion.CachingSupplier;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
 import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -24,7 +30,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
-import jakarta.annotation.Nonnull;
+import java.util.Objects;
 
 /**
  * TransactionManager implementation that uses a {@link org.springframework.transaction.PlatformTransactionManager} as
@@ -36,17 +42,33 @@ import jakarta.annotation.Nonnull;
 public class SpringTransactionManager implements TransactionManager {
 
     private final PlatformTransactionManager transactionManager;
+    private final EntityManagerProvider entityManagerProvider;
     private final TransactionDefinition transactionDefinition;
 
     /**
+     * Constructs a new instance.
+     *
+     * @param transactionManager    The transaction manager to use
+     * @param entityManagerProvider The entity manager provider to use
+     * @param transactionDefinition The definition for transactions to create
+     */
+    public SpringTransactionManager(@Nonnull PlatformTransactionManager transactionManager,
+                                    @Nullable EntityManagerProvider entityManagerProvider,
+                                    @Nullable TransactionDefinition transactionDefinition) {
+        this.transactionManager = Objects.requireNonNull(transactionManager, "transactionManager");
+        this.entityManagerProvider = entityManagerProvider;
+        this.transactionDefinition = transactionDefinition;
+    }
+
+    /**
+     * Constructs a new instance.
+     *
      * @param transactionManager    The transaction manager to use
      * @param transactionDefinition The definition for transactions to create
      */
-    public SpringTransactionManager(PlatformTransactionManager transactionManager,
-                                    TransactionDefinition transactionDefinition) {
-        Assert.notNull(transactionManager, () -> "transactionManager may not be null");
-        this.transactionManager = transactionManager;
-        this.transactionDefinition = transactionDefinition;
+    public SpringTransactionManager(@Nonnull PlatformTransactionManager transactionManager,
+                                    @Nullable TransactionDefinition transactionDefinition) {
+        this(transactionManager, null, transactionDefinition);
     }
 
     /**
@@ -54,9 +76,37 @@ public class SpringTransactionManager implements TransactionManager {
      * transaction definition.
      *
      * @param transactionManager the transaction manager to use
+     * @param entityManagerProvider The entity manager provider to use
      */
-    public SpringTransactionManager(PlatformTransactionManager transactionManager) {
-        this(transactionManager, new DefaultTransactionDefinition());
+    public SpringTransactionManager(@Nonnull PlatformTransactionManager transactionManager,
+                                    @Nullable EntityManagerProvider entityManagerProvider) {
+        this(transactionManager, entityManagerProvider, new DefaultTransactionDefinition());
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param transactionManager The transaction manager to use.
+     */
+    public SpringTransactionManager(@Nonnull PlatformTransactionManager transactionManager) {
+        this(transactionManager, null, new DefaultTransactionDefinition());
+    }
+
+    @Override
+    public void attachToProcessingLifecycle(ProcessingLifecycle processingLifecycle) {
+        processingLifecycle.runOnPreInvocation(pc -> {
+            Transaction transaction = startTransaction();
+
+            if (entityManagerProvider != null) {
+                pc.putResource(
+                    JpaTransactionalExecutorProvider.SUPPLIER_KEY,
+                    CachingSupplier.of(() -> new EntityManagerExecutor(entityManagerProvider))
+                );
+            }
+
+            pc.runOnCommit(p -> transaction.commit());
+            pc.onError((p, phase, e) -> transaction.rollback());
+        });
     }
 
     @Nonnull

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/TransactionManager.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/TransactionManager.java
@@ -59,7 +59,7 @@ public interface TransactionManager extends ProcessingLifecycleHandlerRegistrar 
         }
     }
 
-    default void attachToProcessingLifecycle(ProcessingLifecycle processingLifecycle) {
+    default void attachToProcessingLifecycle(@Nonnull ProcessingLifecycle processingLifecycle) {
         processingLifecycle.runOnPreInvocation(pc -> {
             Transaction transaction = startTransaction();
             pc.runOnCommit(p -> transaction.commit());
@@ -69,11 +69,7 @@ public interface TransactionManager extends ProcessingLifecycleHandlerRegistrar 
 
     @Override
     default void registerHandlers(@Nonnull ProcessingLifecycle processingLifecycle) {
-        processingLifecycle.runOnPreInvocation(pc -> {
-            Transaction transaction = startTransaction();
-            pc.runOnCommit(p -> transaction.commit());
-            pc.onError((p, phase, e) -> transaction.rollback());
-        });
+        attachToProcessingLifecycle(processingLifecycle);
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreMigration2Test.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreMigration2Test.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
+import org.axonframework.conversion.TestConverter;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.ConfigToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToRetrieveIdentifierException;
+import org.hibernate.exception.SQLGrammarException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test class validating migrations of the {@link JpaTokenStore}.
+ *
+ * @author John Hendrikx
+ */
+@Disabled
+class JpaTokenStoreMigration2Test {
+
+    private final EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("tokenstore_migration");
+    private final EntityManager entityManager = entityManagerFactory.createEntityManager();
+    private final EntityManagerProvider entityManagerProvider = new SimpleEntityManagerProvider(entityManager);
+
+    private final JpaTokenStore jpaTokenStore = getTokenStore("local");
+
+    @Nested
+    class WhenMaskColumnIsMissing {
+
+        {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            entityManager.createNativeQuery("DROP TABLE IF EXISTS TOKENENTRY").executeUpdate();
+
+            // Create a table with a missing mask column
+            entityManager.createNativeQuery(
+                """
+                CREATE TABLE TOKENENTRY (
+                    token LONGVARBINARY(10000),
+                    tokenType VARCHAR(255),
+                    timestamp VARCHAR(255) NOT NULL,
+                    owner VARCHAR(255),
+                    processorName VARCHAR(255) NOT NULL,
+                    segment INT NOT NULL,
+                    PRIMARY KEY (processorName, segment)
+                )
+                """
+            ).executeUpdate();
+
+            tx.commit();
+        }
+
+        @Test
+        void storeShouldNotRetrieveIdentifier() {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            try {
+                assertThatThrownBy(() -> jpaTokenStore.retrieveStorageIdentifier(null).join())
+                    .isInstanceOf(CompletionException.class)
+                    .cause()
+                    .isInstanceOf(UnableToRetrieveIdentifierException.class)
+                    .cause()
+                    .isInstanceOf(SQLGrammarException.class)
+                    .hasMessageContaining("object not found: TE1_0.MASK in statement");
+            }
+            finally {
+                tx.commit();
+            }
+        }
+
+        @Test
+        void storeShouldNotInitializeSegments() {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            try {
+                assertThatThrownBy(() -> jpaTokenStore.initializeTokenSegments("processor", 5, null, null).join())
+                    .isInstanceOf(CompletionException.class)
+                    .cause()
+                    .isInstanceOf(SQLGrammarException.class)
+                    .hasMessageContaining("object not found: TE1_0.MASK in statement");
+            }
+            finally {
+                tx.commit();
+            }
+        }
+
+        @Test
+        void storeShouldNotFetchToken() {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            try {
+                assertThatThrownBy(() -> jpaTokenStore.fetchToken("processor", 2, null).join())
+                    .isInstanceOf(CompletionException.class)
+                    .cause()
+                    .isInstanceOf(SQLGrammarException.class)
+                    .hasMessageContaining("object not found: TE1_0.MASK in statement");
+            }
+            finally {
+                tx.commit();
+            }
+        }
+    }
+
+    @Nested
+    class WhenMaskColumnIsPresentAndStoreIsEmpty {
+
+        {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            entityManager.createNativeQuery("DROP TABLE IF EXISTS TOKENENTRY").executeUpdate();
+
+            entityManager.createNativeQuery(
+                """
+                CREATE TABLE TOKENENTRY (
+                    token LONGVARBINARY(10000),
+                    tokenType VARCHAR(255),
+                    timestamp VARCHAR(255) NOT NULL,
+                    owner VARCHAR(255),
+                    processorName VARCHAR(255) NOT NULL,
+                    segment INT NOT NULL,
+                    mask INT NOT NULL,
+                    PRIMARY KEY (processorName, segment)
+                )
+                """
+            ).executeUpdate();
+
+            tx.commit();
+        }
+
+        @Test
+        void anyCallShouldInitializeAndMigrateStore() {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            try {
+                String identifier = jpaTokenStore.retrieveStorageIdentifier(null).join();
+
+                assertThat(identifier).isNotEmpty();
+
+                @SuppressWarnings("unchecked")
+                List<TokenEntry> resultList = entityManager.createNativeQuery(
+                    """
+                    SELECT * FROM TOKENENTRY
+                    """,
+                    TokenEntry.class
+                ).getResultList();
+
+                assertThat(resultList).hasSize(1);
+
+                // assert config token:
+                assertThat(resultList.getFirst().getProcessorName()).isEqualTo("__config");
+                assertThat(resultList.getFirst().getSegment()).isEqualTo(Segment.ROOT_SEGMENT);
+                assertThat(resultList.getFirst().getToken(jpaTokenStore.converter()))
+                    .isInstanceOfSatisfying(ConfigToken.class, configToken -> {
+                        assertThat(configToken.getConfig().get("id")).isEqualTo(identifier);
+                        assertThat(configToken.getConfig().get("version")).isEqualTo("2");
+                    });
+            }
+            finally {
+                tx.commit();
+            }
+        }
+    }
+
+    @Nested
+    class WhenMaskColumnIsPresentAndThereWerePreMaskTokens {
+
+        {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            entityManager.createNativeQuery("DROP TABLE IF EXISTS TOKENENTRY").executeUpdate();
+
+            entityManager.createNativeQuery(
+                """
+                CREATE TABLE TOKENENTRY (
+                    token LONGVARBINARY(10000),
+                    tokenType VARCHAR(255),
+                    timestamp VARCHAR(255) NOT NULL,
+                    owner VARCHAR(255),
+                    processorName VARCHAR(255) NOT NULL,
+                    segment INT NOT NULL,
+                    mask INT NOT NULL,
+                    PRIMARY KEY (processorName, segment)
+                )
+                """
+            ).executeUpdate();
+
+            entityManager.createNativeQuery(
+                """
+                INSERT INTO TOKENENTRY (processorName, segment, mask, timestamp) VALUES
+                    ('my-processor', 1, 0, '2011-11-11T11:11:11Z'),
+                    ('my-processor', 2, 0, '2011-11-11T11:11:11Z'),
+                    ('my-processor', 3, 0, '2011-11-11T11:11:11Z');
+                """
+            ).executeUpdate();
+
+            tx.commit();
+        }
+
+        @Test
+        void anyCallShouldInitializeAndMigrateStore() {
+            EntityTransaction tx = entityManager.getTransaction();
+
+            tx.begin();
+
+            try {
+                String identifier = jpaTokenStore.retrieveStorageIdentifier(null).join();
+
+                assertThat(identifier).isNotEmpty();
+
+                @SuppressWarnings("unchecked")
+                List<TokenEntry> resultList = entityManager.createNativeQuery(
+                    """
+                    SELECT * FROM TOKENENTRY ORDER BY processorName, segment
+                    """,
+                    TokenEntry.class
+                ).getResultList();
+
+                assertThat(resultList).hasSize(4);
+
+                // assert config token:
+                assertThat(resultList.getFirst().getProcessorName()).isEqualTo("__config");
+                assertThat(resultList.getFirst().getSegment()).isEqualTo(Segment.ROOT_SEGMENT);
+                assertThat(resultList.getFirst().getToken(jpaTokenStore.converter()))
+                    .isInstanceOfSatisfying(ConfigToken.class, configToken -> {
+                        assertThat(configToken.getConfig().get("id")).isEqualTo(identifier);
+                        assertThat(configToken.getConfig().get("version")).isEqualTo("2");
+                    });
+
+                // check if masks were migrated:
+                for (int i = 1; i <= 3; i++) {
+                    TokenEntry entry = resultList.get(i);
+
+                    assertThat(entry.getProcessorName()).isEqualTo("my-processor");
+                    assertThat(entry.getSegment()).isEqualTo(new Segment(i, 3));
+                }
+            }
+            finally {
+                tx.commit();
+            }
+        }
+    }
+
+    private JpaTokenStore getTokenStore(String nodeId) {
+        MessagingConfigurer.create()
+            .lifecycleRegistry(lr -> {
+
+            });
+
+        Object obj = new Object();
+
+//        EventProcessorModule.pooledStreaming("bla")
+//            .eventHandlingComponents(obj)
+//            ;
+
+
+
+        return new JpaTokenStore(entityManagerProvider, TestConverter.JACKSON.getConverter(), JpaTokenStoreConfiguration.DEFAULT.nodeId(nodeId));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -16,8 +16,7 @@
 package org.axonframework.messaging.queryhandling;
 
 import org.axonframework.common.infra.MockComponentDescriptor;
-import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
-import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
+import org.axonframework.common.util.MockException;
 import org.axonframework.messaging.core.FluxUtils;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
@@ -27,8 +26,10 @@ import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactor
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
-import org.axonframework.common.util.MockException;
-import org.junit.jupiter.api.*;
+import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
@@ -50,8 +51,12 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test class validating the {@link SimpleQueryBus}.
@@ -83,13 +88,11 @@ class SimpleQueryBusTest {
     private SimpleQueryBus testSubject;
 
     private TransactionManager transactionManager;
-    private Transaction testTransaction;
 
     @BeforeEach
     void setUp() {
         transactionManager = mock(TransactionManager.class);
-        testTransaction = mock(Transaction.class);
-        when(transactionManager.startTransaction()).thenReturn(testTransaction);
+
         UnitOfWorkFactory unitOfWorkFactory =
                 new TransactionalUnitOfWorkFactory(transactionManager, UnitOfWorkTestUtils.SIMPLE_FACTORY);
 
@@ -256,8 +259,7 @@ class SimpleQueryBusTest {
                                                           .thenApply(entry -> entry.message().payload());
             // then...
             assertEquals("query1234", result.get());
-            verify(transactionManager).startTransaction();
-            verify(testTransaction).commit();
+            verify(transactionManager).registerHandlers(any(UnitOfWork.class));
         }
 
         @Test
@@ -277,8 +279,7 @@ class SimpleQueryBusTest {
             List<String> completedResult = result.get();
             assertTrue(completedResult.contains("query1234"));
             assertTrue(completedResult.contains("query5678"));
-            verify(transactionManager).startTransaction();
-            verify(testTransaction).commit();
+            verify(transactionManager).registerHandlers(any(UnitOfWork.class));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-failsafe.version>3.5.4</maven-failsafe.version>
         <maven-gpg.version>3.2.8</maven-gpg.version>
         <maven-install.version>3.1.4</maven-install.version>
-        <maven-jar.version>3.5.0</maven-jar.version>
+        <maven-jar.version>3.4.2</maven-jar.version>
         <maven-javadoc.version>3.12.0</maven-javadoc.version>
         <maven-release.version>3.3.1</maven-release.version>
         <maven-source.version>3.4.0</maven-source.version>


### PR DESCRIPTION
Introduces TransactionalExecutor and related abstractions for transactional resource management, refactors AggregateBasedJpaEventStorageEngine to use TransactionalExecutorProvider, and adds supporting classes for JPA and function utilities. Updates tests and configuration to align with the new transaction management approach, improving consistency and extensibility for transactional operations.