### PR TITLE
Add missing `@Nonnull` annotations in processing lifecycle

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/LegacyMessageSupportingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/LegacyMessageSupportingContext.java
@@ -20,7 +20,6 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.configuration.ComponentNotFoundException;
 import org.axonframework.messaging.core.Message;
-import org.axonframework.messaging.core.Message;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -77,17 +76,17 @@ public class LegacyMessageSupportingContext implements ProcessingContext {
     }
 
     @Override
-    public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 
     @Override
-    public ProcessingLifecycle onError(ErrorHandler action) {
+    public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 
     @Override
-    public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.core.unitofwork;
 
+import jakarta.annotation.Nonnull;
 import org.axonframework.common.FutureUtils;
 
 import java.util.concurrent.CompletableFuture;
@@ -91,7 +92,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action);
+    ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action);
 
     /**
      * Registers the provided {@code action} to be executed in the given {@code phase}.
@@ -102,7 +103,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOn(Phase phase, Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOn(@Nonnull Phase phase, @Nonnull Consumer<ProcessingContext> action) {
         return on(phase, c -> {
             action.accept(c);
             return FutureUtils.emptyCompletedFuture();
@@ -119,7 +120,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onPreInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onPreInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PRE_INVOCATION, action);
     }
 
@@ -132,7 +133,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnPreInvocation(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnPreInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PRE_INVOCATION, action);
     }
 
@@ -145,7 +146,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.INVOCATION, action);
     }
 
@@ -157,7 +158,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnInvocation(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.INVOCATION, action);
     }
 
@@ -171,7 +172,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onPostInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onPostInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.POST_INVOCATION, action);
     }
 
@@ -184,7 +185,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnPostInvocation(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnPostInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.POST_INVOCATION, action);
     }
 
@@ -198,7 +199,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onPrepareCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onPrepareCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PREPARE_COMMIT, action);
     }
 
@@ -211,7 +212,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnPrepareCommit(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnPrepareCommit(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PREPARE_COMMIT, action);
     }
 
@@ -224,7 +225,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.COMMIT, action);
     }
 
@@ -236,7 +237,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnCommit(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnCommit(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.COMMIT, action);
     }
 
@@ -250,7 +251,7 @@ public interface ProcessingLifecycle {
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle onAfterCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    default ProcessingLifecycle onAfterCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.AFTER_COMMIT, action);
     }
 
@@ -263,7 +264,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle runOnAfterCommit(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle runOnAfterCommit(@Nonnull Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.AFTER_COMMIT, action);
     }
 
@@ -279,7 +280,7 @@ public interface ProcessingLifecycle {
      *               execution.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    ProcessingLifecycle onError(ErrorHandler action);
+    ProcessingLifecycle onError(@Nonnull ErrorHandler action);
 
     /**
      * Registers the provided {@code action} to be executed when this {@link ProcessingLifecycle} completes <b>all</b>
@@ -288,7 +289,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action);
+    ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action);
 
     /**
      * Registers the provided {@code action} to be executed {@link #onError(ErrorHandler) on error} of <b>and</b>
@@ -300,7 +301,7 @@ public interface ProcessingLifecycle {
      * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
      */
-    default ProcessingLifecycle doFinally(Consumer<ProcessingContext> action) {
+    default ProcessingLifecycle doFinally(@Nonnull Consumer<ProcessingContext> action) {
         onError((c, p, e) -> action.accept(c));
         whenComplete(action);
         return this;
@@ -332,7 +333,7 @@ public interface ProcessingLifecycle {
          *                          to fail.
          * @param error             The exception or error describing the cause.
          */
-        void handle(ProcessingContext processingContext, Phase phase, Throwable error);
+        void handle(@Nonnull ProcessingContext processingContext, @Nonnull Phase phase, @Nonnull Throwable error);
     }
 
     /**
@@ -368,7 +369,7 @@ public interface ProcessingLifecycle {
          * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>smaller</b> than the order of
          * the {@code other Phase}.
          */
-        default boolean isBefore(Phase other) {
+        default boolean isBefore(@Nonnull Phase other) {
             return this.order() < other.order();
         }
 
@@ -381,7 +382,7 @@ public interface ProcessingLifecycle {
          * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>larger</b> than the order of
          * the {@code other Phase}.
          */
-        default boolean isAfter(Phase other) {
+        default boolean isAfter(@Nonnull Phase other) {
             return this.order() > other.order();
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
@@ -78,87 +78,87 @@ public class ResourceOverridingProcessingContext<R> implements ProcessingContext
     }
 
     @Override
-    public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.on(phase, action);
     }
 
     @Override
-    public ProcessingLifecycle runOn(Phase phase, Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOn(@Nonnull Phase phase, @Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOn(phase, action);
     }
 
     @Override
-    public ProcessingLifecycle onPreInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onPreInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onPreInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnPreInvocation(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnPreInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnPreInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle onInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnInvocation(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle onPostInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onPostInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onPostInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnPostInvocation(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnPostInvocation(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnPostInvocation(action);
     }
 
     @Override
-    public ProcessingLifecycle onPrepareCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onPrepareCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onPrepareCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnPrepareCommit(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnPrepareCommit(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnPrepareCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle onCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnCommit(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnCommit(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle onAfterCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle onAfterCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         return delegate.onAfterCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle runOnAfterCommit(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle runOnAfterCommit(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.runOnAfterCommit(action);
     }
 
     @Override
-    public ProcessingLifecycle onError(ErrorHandler action) {
+    public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
         return delegate.onError(action);
     }
 
     @Override
-    public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.whenComplete(action);
     }
 
     @Override
-    public ProcessingLifecycle doFinally(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle doFinally(@Nonnull Consumer<ProcessingContext> action) {
         return delegate.doFinally(action);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
@@ -117,18 +117,18 @@ public class UnitOfWork implements ProcessingLifecycle {
     }
 
     @Override
-    public UnitOfWork on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+    public UnitOfWork on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         context.on(phase, action);
         return this;
     }
 
     @Override
-    public ProcessingLifecycle onError(ErrorHandler action) {
+    public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
         return context.onError(action);
     }
 
     @Override
-    public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
         return context.whenComplete(action);
     }
 
@@ -158,7 +158,7 @@ public class UnitOfWork implements ProcessingLifecycle {
      * the Unit Of Work has been committed. Or, an exceptionally completed future with the exception that caused this
      * Unit of Work to fail.
      */
-    public <R> CompletableFuture<R> executeWithResult(Function<ProcessingContext, CompletableFuture<R>> action) {
+    public <R> CompletableFuture<R> executeWithResult(@Nonnull Function<ProcessingContext, CompletableFuture<R>> action) {
         CompletableFuture<R> result = new CompletableFuture<>();
         onInvocation(processingContext -> safe(() -> action.apply(processingContext))
                 .whenComplete(FutureUtils.alsoComplete(result)));
@@ -173,7 +173,7 @@ public class UnitOfWork implements ProcessingLifecycle {
      * @return A {@link CompletableFuture} wrapping both the successful and exceptional result of the given
      * {@code action}.
      */
-    private <R> CompletableFuture<R> safe(Callable<CompletableFuture<R>> action) {
+    private <R> CompletableFuture<R> safe(@Nonnull Callable<CompletableFuture<R>> action) {
         try {
             CompletableFuture<R> result = action.call();
             if (result == null) {
@@ -243,7 +243,7 @@ public class UnitOfWork implements ProcessingLifecycle {
         }
 
         @Override
-        public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+        public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
             var current = currentPhase.get();
             if (current != null && phase.order() <= current.order()) {
                 throw new IllegalStateException(
@@ -267,7 +267,7 @@ public class UnitOfWork implements ProcessingLifecycle {
          * {@code action}.
          */
         private Function<ProcessingContext, CompletableFuture<?>> safe(
-                Phase phase, Function<ProcessingContext, CompletableFuture<?>> action
+                @Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action
         ) {
             return processingContext -> {
                 CompletableFuture<?> result;
@@ -287,7 +287,7 @@ public class UnitOfWork implements ProcessingLifecycle {
         }
 
         @Override
-        public ProcessingLifecycle onError(ErrorHandler action) {
+        public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
             ErrorHandler silentAction = failSilently(action);
             this.errorHandlers.add(silentAction);
             var currentStatus = status.get();
@@ -302,7 +302,7 @@ public class UnitOfWork implements ProcessingLifecycle {
             return this;
         }
 
-        private ErrorHandler failSilently(ErrorHandler action) {
+        private ErrorHandler failSilently(@Nonnull ErrorHandler action) {
             return (context, phase, exception) -> {
                 try {
                     action.handle(context, phase, exception);
@@ -313,7 +313,7 @@ public class UnitOfWork implements ProcessingLifecycle {
         }
 
         @Override
-        public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+        public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
             Consumer<ProcessingContext> silentAction = completeSilently(action);
             this.completeHandlers.add(silentAction);
             var currentStatus = status.get();
@@ -327,7 +327,7 @@ public class UnitOfWork implements ProcessingLifecycle {
             return this;
         }
 
-        private Consumer<ProcessingContext> completeSilently(Consumer<ProcessingContext> action) {
+        private Consumer<ProcessingContext> completeSilently(@Nonnull Consumer<ProcessingContext> action) {
             return processingContext -> {
                 try {
                     action.accept(processingContext);
@@ -391,7 +391,7 @@ public class UnitOfWork implements ProcessingLifecycle {
             }
         }
 
-        private CompletableFuture<Void> runErrorHandlers(Throwable e) {
+        private CompletableFuture<Void> runErrorHandlers(@Nonnull Throwable e) {
             status.set(Status.COMPLETED_ERROR);
             CauseAndPhase recordedCause = errorCause.get();
 
@@ -527,7 +527,7 @@ public class UnitOfWork implements ProcessingLifecycle {
          *              {@code cause} was thrown.
          * @param cause The {@link Throwable} thrown in an action executed in the given {@code phase}.
          */
-        private record CauseAndPhase(Phase phase, Throwable cause) {
+        private record CauseAndPhase(@Nonnull Phase phase, @Nonnull Throwable cause) {
 
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/EventSchedulingProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/EventSchedulingProcessingContext.java
@@ -76,17 +76,17 @@ class EventSchedulingProcessingContext implements ProcessingContext {
     }
 
     @Override
-    public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 
     @Override
-    public ProcessingLifecycle onError(ErrorHandler action) {
+    public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 
     @Override
-    public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
@@ -98,7 +98,7 @@ public class StubProcessingContext implements ProcessingContext {
         return false;
     }
 
-    public CompletableFuture<Object> moveToPhase(ProcessingLifecycle.Phase phase) {
+    public CompletableFuture<Object> moveToPhase(@Nonnull ProcessingLifecycle.Phase phase) {
         if (phase.isBefore(currentPhase)) {
             throw new IllegalArgumentException("Cannot move to a phase before the current phase");
         }
@@ -118,7 +118,7 @@ public class StubProcessingContext implements ProcessingContext {
     }
 
     @Override
-    public ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action) {
+    public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
         if (phase.order() <= currentPhase.order()) {
             throw new IllegalArgumentException("Cannot register an action for a phase that has already passed");
         }
@@ -127,13 +127,13 @@ public class StubProcessingContext implements ProcessingContext {
     }
 
     @Override
-    public ProcessingLifecycle onError(ErrorHandler action) {
+    public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
         logger.warn("Error handler is not yet supported in the StubProcessingContext");
         return this;
     }
 
     @Override
-    public ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action) {
+    public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
         logger.warn("Completion action is not yet supported in the StubProcessingContext");
         return this;
     }


### PR DESCRIPTION
There is a lot of code that relies on the various methods of `ProcessingLifecycle` to not accept `null`, so let's make that official.