### PR TITLE
Resolve Token table deadlock opportunity

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/tokenstore/jpa/JpaTokenStore.java
@@ -30,6 +30,7 @@ import org.axonframework.eventhandling.tokenstore.UnableToRetrieveIdentifierExce
 import org.axonframework.serialization.SerializedObject;
 import org.axonframework.serialization.SerializedType;
 import org.axonframework.serialization.Serializer;
+import org.hibernate.LockMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -335,8 +336,10 @@ public class JpaTokenStore implements TokenStore {
      * @param segment       the segment of the processor to load or insert a token entry for
      */
     private void validateSegment(String processorName, Segment segment, EntityManager entityManager) {
-        TokenEntry mergeableSegment = entityManager //This segment should exist
-                .find(TokenEntry.class, new TokenEntry.PK(processorName, segment.mergeableSegmentId()), loadingLockMode);
+        // This segment should exist
+        TokenEntry mergeableSegment = entityManager.find(
+                TokenEntry.class, new TokenEntry.PK(processorName, segment.mergeableSegmentId()), LockModeType.NONE
+        );
         if (mergeableSegment == null) {
             throw new UnableToClaimTokenException(format("Unable to claim token '%s[%s]'. It has been merged with another segment",
                                                          processorName, segment.getSegmentId()));


### PR DESCRIPTION
This pull request adjusts the lock mode for finding a "mergeable" segment. 
This search is done to validate we're not accidentally loading a segment that's recently been split or merged, as part of the loading a token through `JpaTokenStore#fetchToken`.
This operation is, in turn, used by the `Coordinator` of the Pooled Streaming Event Processor during **every** run of the coordination thread.

As finding the mergeable segment used the configured `LockModeType` of the `JpaTokenStore`, defaulting to `LockModeType.PESSIMISTIC_WRITE`.
This makes it so that there's a high chance this flow causes dead locks, especially given the frequency the PSEP will trigger this activity.