### PR TITLE
Adjustments to StorageEngineTestSuite for transactional executors

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStorageEngineIT.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/AxonServerEventStorageEngineIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.axonframework.eventsourcing.eventstore.StorageEngineTestSuite;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.conversion.ChainingContentTypeConverter;
 import org.axonframework.test.server.AxonServerContainer;
-import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -61,7 +60,7 @@ class AxonServerEventStorageEngineIT extends StorageEngineTestSuite<AxonServerEv
     }
 
     @Override
-    protected AxonServerEventStorageEngine buildStorageEngine() throws IOException {
+    protected AxonServerEventStorageEngine createStorageEngine() throws IOException {
         container.start();
         ServerAddress address = new ServerAddress(container.getHost(), container.getGrpcPort());
         connection = AxonServerConnectionFactory.forClient("AxonServerEventStorageEngineTest")

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 class InMemoryEventStorageEngineTest extends StorageEngineTestSuite<InMemoryEventStorageEngine> {
 
     @Override
-    protected InMemoryEventStorageEngine buildStorageEngine() {
+    protected InMemoryEventStorageEngine createStorageEngine() {
         return new InMemoryEventStorageEngine();
     }
 


### PR DESCRIPTION
Adjustments to StorageEngineTestSuite for transactional executors.

The adjustments give more control to subclasses that need to provide a
processing context to know when they should commit or rollback the
executor associated with the context.

The test also contains adjustments to avoid blocking the main thread, as
`appendEvents` may block if a concurrent transaction is trying to update
the same tags.

For a more high level test that needs to dig less deep into these
internals see `StorageEngineBackedEventStoreTestSuite`