### PR TITLE
Filter out empty events list in `EventGateway`

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/AbstractEventGateway.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/AbstractEventGateway.java
@@ -33,8 +33,8 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 
 /**
- * Abstract implementation of an EventGateway, which handles the dispatch interceptors. The
- * actual publishing of events is left to the subclasses.
+ * Abstract implementation of an EventGateway, which handles the dispatch interceptors. The actual publishing of events
+ * is left to the subclasses.
  *
  * @author Bert Laverman
  * @since 4.1
@@ -47,8 +47,8 @@ public abstract class AbstractEventGateway {
     /**
      * Instantiate an {@link AbstractEventGateway} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link EventBus} is not {@code null} and throws an {@link AxonConfigurationException}
-     * if it is.
+     * Will assert that the {@link EventBus} is not {@code null} and throws an {@link AxonConfigurationException} if it
+     * is.
      *
      * @param builder the {@link Builder} used to instantiate a {@link AbstractEventGateway} instance
      */
@@ -77,6 +77,9 @@ public abstract class AbstractEventGateway {
                                                         .map(GenericEventMessage::asEventMessage)
                                                         .map(this::processInterceptors)
                                                         .collect(Collectors.toList());
+        if (interceptedEvents.isEmpty()) {
+            return;
+        }
         this.eventBus.publish(interceptedEvents);
     }
 
@@ -119,8 +122,8 @@ public abstract class AbstractEventGateway {
     /**
      * Abstract Builder class to instantiate {@link AbstractEventGateway} implementations.
      * <p>
-     * The {@code dispatchInterceptors} are defaulted to an empty list.
-     * The {@link EventBus} is a <b>hard requirement</b> and as such should be provided.
+     * The {@code dispatchInterceptors} are defaulted to an empty list. The {@link EventBus} is a <b>hard
+     * requirement</b> and as such should be provided.
      */
     public abstract static class Builder {
 
@@ -141,8 +144,8 @@ public abstract class AbstractEventGateway {
         }
 
         /**
-         * Sets the {@link List} of {@link MessageDispatchInterceptor}s for {@link EventMessage}s.
-         * Are invoked when an event is being dispatched.
+         * Sets the {@link List} of {@link MessageDispatchInterceptor}s for {@link EventMessage}s. Are invoked when an
+         * event is being dispatched.
          *
          * @param dispatchInterceptors which are invoked when an event is being dispatched
          * @return the current Builder instance, for fluent interfacing
@@ -153,8 +156,8 @@ public abstract class AbstractEventGateway {
         }
 
         /**
-         * Sets the {@link List} of {@link MessageDispatchInterceptor}s for {@link EventMessage}s.
-         * Are invoked when an event is being dispatched.
+         * Sets the {@link List} of {@link MessageDispatchInterceptor}s for {@link EventMessage}s. Are invoked when an
+         * event is being dispatched.
          *
          * @param dispatchInterceptors which are invoked when an event is being dispatched
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventGateway.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/gateway/EventGateway.java
@@ -51,7 +51,7 @@ public interface EventGateway extends MessageDispatchInterceptorSupport<EventMes
      * listeners.
      * <p>
      * Implementations may treat the given {@code events} as a single batch and distribute the events as such to all
-     * subscribed EventListeners.
+     * subscribed EventListeners. When the given {@code events} is an empty list, nothing happens.
      *
      * @param events The collection of events to publish
      */

--- a/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/gateway/DefaultEventGatewayTest.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.MessageDispatchInterceptor;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -96,5 +97,18 @@ class DefaultEventGatewayTest {
         assertEquals(2, interceptedResult.size());
         assertEquals("Event2", interceptedResult.get(0).getPayload());
         assertEquals("Event3", interceptedResult.get(1).getPayload());
+    }
+
+    @Test
+    void publishNoEvents() {
+        //Given
+        ArrayList<Object> noEvents = new ArrayList<>();
+
+        //When
+        testSubject.publish(noEvents);
+
+        //Then
+        verifyNoInteractions(mockEventBus);
+        verifyNoInteractions(mockEventMessageTransformer);
     }
 }


### PR DESCRIPTION
This pull request filters on an empty list of events in the `EventGateway`. 
If we do not, exceptions may occur further down the line when the empty list is given to the `EventBus`.
Noted by a user as a behavioral change introduced by #3241.