### PR TITLE
docs(messaging): clarify that `@Timestamp` annotation is required to inject event timestamp in `@EventHandler` and `@EventSourcingHandler` annotations

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingHandler.java
@@ -35,8 +35,9 @@ import java.lang.annotation.*;
  * not present.</li>
  * <li>Parameters of type {@link MetaData} will have the entire Meta Data of an Event Message
  * injected.</li>
- * <li>Parameters of type {@link java.time.Instant} will resolve to the timestamp of the EventMessage. This is the
- * time at which the Event was generated.</li>
+ * <li>Parameters of type {@link java.time.Instant} annotated with
+ * {@link org.axonframework.eventhandling.Timestamp @Timestamp} will resolve to the timestamp of
+ * the EventMessage. This is the time at which the Event was generated.</li>
  * <li>Parameters assignable to {@link Message} will have the entire {@link
  * org.axonframework.eventhandling.EventMessage} injected (if the message is assignable to that parameter). If the first
  * parameter is of type message, it effectively matches an Event of any type, even if generic parameters would suggest

--- a/messaging/src/main/java/org/axonframework/eventhandling/EventHandler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/EventHandler.java
@@ -35,8 +35,9 @@ import java.lang.annotation.*;
  * not present.</li>
  * <li>Parameters of type {@link MetaData} will have the entire Meta Data of an Event Message
  * injected.</li>
- * <li>Parameters of type {@link java.time.Instant} (or any of its super classes or implemented interfaces) will
- * resolve to the timestamp of the EventMessage. This is the time at which the Event was generated.</li>
+ * <li>Parameters of type {@link java.time.Instant} annotated with
+ * {@link org.axonframework.eventhandling.Timestamp @Timestamp} will resolve to the timestamp of
+ * the EventMessage. This is the time at which the Event was generated.</li>
  * <li>Parameters assignable to {@link Message} will have the entire {@link
  * EventMessage} injected (if the message is assignable to that parameter). If the first
  * parameter is of type message, it effectively matches an Event of any type, even if generic parameters would suggest


### PR DESCRIPTION
Same fix as https://github.com/AxonFramework/AxonFramework/pull/4106, but for AF4. 