### PR TITLE
[#4111] Register event processors as interface types for decorator support

### DIFF
--- a/examples/university-java-springboot/src/main/java/org/axonframework/examples/university/FacultyInitializer.java
+++ b/examples/university-java-springboot/src/main/java/org/axonframework/examples/university/FacultyInitializer.java
@@ -27,7 +27,7 @@ import org.axonframework.examples.university.shared.CourseId;
 import org.axonframework.examples.university.write.changecoursecapacity.ChangeCourseCapacity;
 import org.axonframework.examples.university.write.createcourse.CreateCourse;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -66,7 +66,7 @@ public class FacultyInitializer implements ApplicationRunner {
     }
 
     private void waitUntilReady() {
-        var processor = axonConfiguration.getComponents(PooledStreamingEventProcessor.class).get(
+        var processor = axonConfiguration.getComponents(StreamingEventProcessor.class).get(
                 "EventProcessor[" + PROCESSOR_NAME + "]");
         log.info("[FACULTY] Waiting for course statistics projection replay to finish...");
         executeUntilTrue(

--- a/examples/university-java/src/main/java/org/axonframework/examples/university/UniversityExampleApplication.java
+++ b/examples/university-java/src/main/java/org/axonframework/examples/university/UniversityExampleApplication.java
@@ -23,7 +23,7 @@ import org.axonframework.common.infra.FilesystemStyleComponentDescriptor;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.examples.university.read.coursestats.projection.CourseStatsConfiguration;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +53,7 @@ public class UniversityExampleApplication {
                     configuration.getComponent(QueryGateway.class)
             );
 
-            var processor = configuration.getComponents(PooledStreamingEventProcessor.class).get(CourseStatsConfiguration.NAME);
+            var processor = configuration.getComponents(StreamingEventProcessor.class).get(CourseStatsConfiguration.NAME);
             logger.info("Waiting for course statistics projection replay to finish...");
             executeUntilTrue(
                     () -> !processor.isReplaying(),

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorConfigurationTest.java
@@ -30,11 +30,10 @@ import org.axonframework.messaging.core.MessageHandlerInterceptorChain;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
-import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
-import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorConfiguration;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
@@ -168,13 +167,13 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig1 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY1 + "]").orElseThrow();
             assertThat(eventProcessorConfig1.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig1.getOptionalComponent(PooledStreamingEventProcessor.class,
+            assertThat(eventProcessorConfig1.getOptionalComponent(StreamingEventProcessor.class,
                                                                   "EventProcessor[" + KEY1 + "]")).isPresent();
 
             Configuration eventProcessorConfig2 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY2 + "]").orElseThrow();
             assertThat(eventProcessorConfig2.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessor.class,
+            assertThat(eventProcessorConfig2.getOptionalComponent(StreamingEventProcessor.class,
                                                                   "EventProcessor[" + KEY2 + "]")).isPresent();
         }
     }
@@ -276,13 +275,13 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig1 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY1 + "]").orElseThrow();
             assertThat(eventProcessorConfig1.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig1.getOptionalComponent(SubscribingEventProcessor.class,
+            assertThat(eventProcessorConfig1.getOptionalComponent(EventProcessor.class,
                                                                   "EventProcessor[" + KEY1 + "]")).isPresent();
 
             Configuration eventProcessorConfig2 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY2 + "]").orElseThrow();
             assertThat(eventProcessorConfig2.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessor.class,
+            assertThat(eventProcessorConfig2.getOptionalComponent(StreamingEventProcessor.class,
                                                                   "EventProcessor[" + KEY2 + "]")).isPresent();
         }
     }
@@ -315,7 +314,7 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig1 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY1 + "]").orElseThrow();
             assertThat(eventProcessorConfig1.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig1.getOptionalComponent(SubscribingEventProcessor.class,
+            assertThat(eventProcessorConfig1.getOptionalComponent(EventProcessor.class,
                                                                   "EventProcessor[" + KEY1 + "]")).isPresent();
             assertThat(eventProcessorConfig1.getOptionalComponent(SubscribingEventProcessorConfiguration.class)).hasValueSatisfying(
                     // there is an additional custom interceptor
@@ -325,7 +324,7 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig2 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY2 + "]").orElseThrow();
             assertThat(eventProcessorConfig2.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessor.class,
+            assertThat(eventProcessorConfig2.getOptionalComponent(StreamingEventProcessor.class,
                                                                   "EventProcessor[" + KEY2 + "]")).isPresent();
             assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessorConfiguration.class)).hasValueSatisfying(
                     // we should not see the custom interceptor here
@@ -363,7 +362,7 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig1 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY1 + "]").orElseThrow();
             assertThat(eventProcessorConfig1.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig1.getOptionalComponent(SubscribingEventProcessor.class,
+            assertThat(eventProcessorConfig1.getOptionalComponent(EventProcessor.class,
                                                                   "EventProcessor[" + KEY1 + "]")).isPresent();
             assertThat(eventProcessorConfig1.getOptionalComponent(SubscribingEventProcessorConfiguration.class)).hasValueSatisfying(
                     // there is an additional custom interceptor
@@ -373,7 +372,7 @@ class EventProcessorConfigurationTest {
             Configuration eventProcessorConfig2 = axonApplication.getModuleConfiguration(
                     "EventProcessor[" + KEY2 + "]").orElseThrow();
             assertThat(eventProcessorConfig2.getComponents(EventProcessor.class)).isNotEmpty();
-            assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessor.class,
+            assertThat(eventProcessorConfig2.getOptionalComponent(StreamingEventProcessor.class,
                                                                   "EventProcessor[" + KEY2 + "]")).isPresent();
             assertThat(eventProcessorConfig2.getOptionalComponent(PooledStreamingEventProcessorConfiguration.class)).hasValueSatisfying(
                     // we should not see the custom interceptor here

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
@@ -39,6 +39,7 @@ import org.axonframework.messaging.eventhandling.deadletter.SequencedDeadLetterQ
 import org.axonframework.messaging.eventhandling.interception.InterceptingEventHandlingComponent;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterProcessor;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequenceCachingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.common.lifecycle.Phase;
@@ -206,7 +207,7 @@ public class PooledStreamingEventProcessorModule extends BaseModule<PooledStream
 
     private void registerEventProcessor() {
         var processorComponentDefinition = ComponentDefinition
-                .ofTypeAndName(PooledStreamingEventProcessor.class, processorName)
+                .ofTypeAndName(StreamingEventProcessor.class, processorName)
                 .withBuilder(cfg -> new PooledStreamingEventProcessor(
                         processorName,
                         getEventHandlingComponents(cfg),

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModule.java
@@ -30,6 +30,7 @@ import org.axonframework.messaging.eventhandling.configuration.EventProcessorCon
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorCustomization;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
 import org.axonframework.messaging.eventhandling.interception.InterceptingEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.processing.EventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequenceCachingEventHandlingComponent;
 import org.axonframework.common.lifecycle.Phase;
 
@@ -100,7 +101,7 @@ public class SubscribingEventProcessorModule extends BaseModule<SubscribingEvent
 
     private void registerEventProcessor() {
         var processorComponentDefinition = ComponentDefinition
-                .ofTypeAndName(SubscribingEventProcessor.class, processorName)
+                .ofTypeAndName(EventProcessor.class, processorName)
                 .withBuilder(cfg -> new SubscribingEventProcessor(
                         processorName,
                         getEventHandlingComponents(cfg),

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
@@ -38,6 +38,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.configuration.EventHandlingComponentsConfigurer;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.ErrorHandler;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.PropagatingErrorHandler;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
@@ -1140,7 +1141,9 @@ class PooledStreamingEventProcessorModuleTest {
             String processorName
     ) {
         return configuration.getModuleConfiguration(processorName)
-                            .flatMap(m -> m.getOptionalComponent(PooledStreamingEventProcessor.class, processorName));
+                            .flatMap(m -> m.getOptionalComponent(StreamingEventProcessor.class, processorName))
+                            .filter(PooledStreamingEventProcessor.class::isInstance)
+                            .map(PooledStreamingEventProcessor.class::cast);
     }
 
     @Nullable

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
@@ -40,6 +40,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.configuration.EventHandlingComponentsConfigurer;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.EventProcessor;
 import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.ErrorHandler;
@@ -666,7 +667,9 @@ class SubscribingEventProcessorModuleTest {
             String processorName
     ) {
         return configuration.getModuleConfiguration(processorName)
-                            .flatMap(m -> m.getOptionalComponent(SubscribingEventProcessor.class, processorName));
+                            .flatMap(m -> m.getOptionalComponent(EventProcessor.class, processorName))
+                            .filter(SubscribingEventProcessor.class::isInstance)
+                            .map(SubscribingEventProcessor.class::cast);
     }
 
     @Nullable


### PR DESCRIPTION
 ## Summary

  This PR enables the decorator pattern for event processors by registering them under their interface types instead of concrete types. This aligns event processors with the existing pattern used by `CommandBus`, `QueryBus`, and `EventStore`.

  ## Changes

  ### New Interface: `SubscribingEventProcessor`
  - Extracted interface from the existing `SubscribingEventProcessor` class
  - Creates symmetry with `StreamingEventProcessor` interface

  ### Renamed Class: `SimpleSubscribingEventProcessor`
  - The original `SubscribingEventProcessor` class is now `SimpleSubscribingEventProcessor`
  - Follows the naming convention used by `SimpleCommandBus`, `SimpleQueryBus`, etc.

  ### Registration Changes
  | Processor | Before | After |
  |-----------|--------|-------|
  | `PooledStreamingEventProcessor` | `PooledStreamingEventProcessor.class` | `StreamingEventProcessor.class` |
  | `SimpleSubscribingEventProcessor` | `SubscribingEventProcessor.class` (concrete) | `SubscribingEventProcessor.class` (interface) |

  ## Benefits

  1. **Decorator Support**: Extensions can now register decorators for event processors:
     ```java
     componentRegistry.registerDecorator(
         EventProcessor.class,  // or StreamingEventProcessor.class, SubscribingEventProcessor.class
         (config, name, delegate) -> new DecoratedEventProcessor(delegate)
     );

  2. Clean Lookups:
    - getComponents(EventProcessor.class) → all processors
    - getComponents(StreamingEventProcessor.class) → only streaming
    - getComponents(SubscribingEventProcessor.class) → only subscribing
  3. Improved Extensibility: Enables cross-cutting concerns like multi-tenancy, monitoring, and tracing to be applied via decoration.

  Breaking Changes

  Code using getComponents(PooledStreamingEventProcessor.class) should be updated to use getComponents(StreamingEventProcessor.class), this change is unlikely to effect end users.

  Related

  - Closes #4111
  - Enables decorator pattern for multitenancy extension event processors