### PR TITLE
Adjust indent of Migration Paths section

### DIFF
--- a/docs/reference-guide/modules/migration/partials/nav.adoc
+++ b/docs/reference-guide/modules/migration/partials/nav.adoc
@@ -4,5 +4,5 @@
 ** xref:migration:prerequisites.adoc[]
 ** xref:migration:solved-architecture-choices.adoc[]
 ** xref:migration:understanding-architecture-principles.adoc[]
-* xref:migration:paths/index.adoc[]
+** xref:migration:paths/index.adoc[]
 //** xref:migration:paths/message-changes.adoc[] - shows how sub pages are added to nav


### PR DESCRIPTION
This PR adjust the indentation of the "Migration Paths" section. 
I earlier suggested (wrongfully) that we should keep it on top level. 
In doing so, the "Migration Paths" link aligns with the "Migration Guide" link in the navigation window, which is incorrect. 
By moving it down one step, we place it under the "Migration Guide" where it belongs.