### PR TITLE
Adjust JavaDoc generation plugin settings

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2025. Axon Framework
+  ~ Copyright (c) 2010-2026. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -675,49 +675,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>javadoc</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadoc</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <doclint>none</doclint>
-                            <!-- These parameters are in preparation for resolution of this issue: -->
-                            <!-- https://bugs.openjdk.java.net/browse/JDK-8068562 -->
-                            <tags>
-                                <tag>
-                                    <name>apiNote</name>
-                                    <placement>a</placement>
-                                    <head>API Note:</head>
-                                </tag>
-                                <tag>
-                                    <name>implSpec</name>
-                                    <placement>a</placement>
-                                    <head>Implementation Requirements:</head>
-                                </tag>
-                                <tag>
-                                    <name>implNote</name>
-                                    <placement>a</placement>
-                                    <head>Implementation Note:</head>
-                                </tag>
-                            </tags>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2025. Axon Framework
+  ~ Copyright (c) 2010-2026. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -189,6 +189,7 @@
                 <module>build/coverage-report</module>
             </modules>
         </profile>
+
         <profile>
             <id>examples</id>
             <activation>
@@ -200,6 +201,51 @@
             <modules>
                 <module>examples</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>javadoc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <doclint>none</doclint>
+                            <legacyMode>true</legacyMode>
+                            <skippedModules>axon-todo,axon-legacy,axon-legacy-aggregate,axon-legacy-saga,axon-migration,axon-integrationtests</skippedModules>
+                            <!-- These parameters are in preparation for resolution of this issue: -->
+                            <!-- https://bugs.openjdk.java.net/browse/JDK-8068562 -->
+                            <tags>
+                                <tag>
+                                    <name>apiNote</name>
+                                    <placement>a</placement>
+                                    <head>API Note:</head>
+                                </tag>
+                                <tag>
+                                    <name>implSpec</name>
+                                    <placement>a</placement>
+                                    <head>Implementation Requirements:</head>
+                                </tag>
+                                <tag>
+                                    <name>implNote</name>
+                                    <placement>a</placement>
+                                    <head>Implementation Note:</head>
+                                </tag>
+                            </tags>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
As of the current status of Axon Framework, our typical JavaDoc/Apidocs creation flow stopped working.
The simple operation we ran normally was:

`mvn clean package javadoc:aggregate-jar -Dmaven.test.skip`

We run this call against a released tag, after which we publish the [apidocs](https://apidocs.axoniq.io/latest/).
This, however, ceased to work. This PR changes a number of things to get it to work again, which are:

- Moving the `javadoc` profile from `./build/parent/pom.xml` to the `./pom.xml`. This is done as we aggregate the apidocs into a single page, which is invoked from the root of the Axon Framework project.
- I enabled the `legacyMode` setting in the configuration. Although real documentation here was scarce (or at least, I couldn't find it), this was recommended to me as Axon Framework does not use `module-info.java` files at this point in time.
- Exclude the modules `axon-todo`, `axon-legacy`, `axon-legacy-aggregate`, `axon-legacy-saga`, `axon-migration`, and `axon-integrationtests`, as we do not require JavaDoc/Apidocs from these. Furthermore, I have a hunch that the `axon-todo` module might be the reason we need the `legacyMode` setting, as **it** has overlapping packages with the modules we **do** want JavaDoc from (simply because it contains todos for AF5).

By doing the above, we should be in the right place to get JavaDoc / Apidocs out the door again as we used to.