### PR TITLE
Upgrade to db-scheduler 16.2.0 and migrate to new TaskDescriptor API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,8 +38,6 @@ updates:
           - "minor"
           - "major"
     ignore:
-      - dependency-name: "com.github.kagkarlsson:db-scheduler"
-        versions: [ "[14.0.0,)" ]
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
         versions: [ "[2.18.0,)" ]
       - dependency-name: "com.lmax:disruptor"

--- a/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManager.java
+++ b/messaging/src/main/java/org/axonframework/deadline/dbscheduler/DbSchedulerDeadlineManager.java
@@ -21,6 +21,7 @@ import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerState;
 import com.github.kagkarlsson.scheduler.exceptions.TaskInstanceNotFoundException;
 import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
@@ -83,10 +84,10 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class DbSchedulerDeadlineManager extends AbstractDeadlineManager implements Lifecycle {
 
     private static final Logger logger = getLogger(DbSchedulerDeadlineManager.class);
-    private static final TaskWithDataDescriptor<DbSchedulerBinaryDeadlineDetails> binaryTaskDescriptor =
-            new TaskWithDataDescriptor<>(TASK_NAME, DbSchedulerBinaryDeadlineDetails.class);
-    private static final TaskWithDataDescriptor<DbSchedulerHumanReadableDeadlineDetails> humanReadableTaskDescriptor =
-            new TaskWithDataDescriptor<>(TASK_NAME, DbSchedulerHumanReadableDeadlineDetails.class);
+    private static final TaskDescriptor<DbSchedulerBinaryDeadlineDetails> binaryTaskDescriptor =
+            TaskDescriptor.of(TASK_NAME, DbSchedulerBinaryDeadlineDetails.class);
+    private static final TaskDescriptor<DbSchedulerHumanReadableDeadlineDetails> humanReadableTaskDescriptor =
+            TaskDescriptor.of(TASK_NAME, DbSchedulerHumanReadableDeadlineDetails.class);
 
     private final ScopeAwareProvider scopeAwareProvider;
     private final Scheduler scheduler;
@@ -171,7 +172,7 @@ public class DbSchedulerDeadlineManager extends AbstractDeadlineManager implemen
                 deadlineScope,
                 interceptedDeadlineMessage,
                 serializer);
-        return binaryTaskDescriptor.instance(taskInstanceId.getId(), details);
+        return binaryTaskDescriptor.instance(taskInstanceId.getId()).data(details).build();
     }
 
     private TaskInstance<?> humanReadableTask(
@@ -185,7 +186,7 @@ public class DbSchedulerDeadlineManager extends AbstractDeadlineManager implemen
                 deadlineScope,
                 interceptedDeadlineMessage,
                 serializer);
-        return humanReadableTaskDescriptor.instance(taskInstanceId.getId(), details);
+        return humanReadableTaskDescriptor.instance(taskInstanceId.getId()).data(details).build();
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
@@ -19,8 +19,8 @@ package org.axonframework.eventhandling.scheduling.dbscheduler;
 import com.github.kagkarlsson.scheduler.Scheduler;
 import com.github.kagkarlsson.scheduler.SchedulerState;
 import com.github.kagkarlsson.scheduler.task.Task;
+import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
-import com.github.kagkarlsson.scheduler.task.TaskWithDataDescriptor;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.IdentifierFactory;
@@ -64,10 +64,10 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class DbSchedulerEventScheduler implements EventScheduler, Lifecycle {
 
     private static final Logger logger = getLogger(DbSchedulerEventScheduler.class);
-    private static final TaskWithDataDescriptor<DbSchedulerHumanReadableEventData> humanReadableTaskDescriptor =
-            new TaskWithDataDescriptor<>(TASK_NAME, DbSchedulerHumanReadableEventData.class);
-    private static final TaskWithDataDescriptor<DbSchedulerBinaryEventData> binaryTaskDescriptor =
-            new TaskWithDataDescriptor<>(TASK_NAME, DbSchedulerBinaryEventData.class);
+    private static final TaskDescriptor<DbSchedulerHumanReadableEventData> humanReadableTaskDescriptor =
+            TaskDescriptor.of(TASK_NAME, DbSchedulerHumanReadableEventData.class);
+    private static final TaskDescriptor<DbSchedulerBinaryEventData> binaryTaskDescriptor =
+            TaskDescriptor.of(TASK_NAME, DbSchedulerBinaryEventData.class);
     private final Scheduler scheduler;
     private final Serializer serializer;
     private final TransactionManager transactionManager;
@@ -183,7 +183,7 @@ public class DbSchedulerEventScheduler implements EventScheduler, Lifecycle {
         } else {
             data = binaryDataFromObject(event);
         }
-        return binaryTaskDescriptor.instance(taskInstanceId.getId(), data);
+        return binaryTaskDescriptor.instance(taskInstanceId.getId()).data(data).build();
     }
 
     private DbSchedulerBinaryEventData binaryDataFromObject(Object event) {
@@ -210,7 +210,7 @@ public class DbSchedulerEventScheduler implements EventScheduler, Lifecycle {
         } else {
             data = humanReadableDataFromObject(event);
         }
-        return humanReadableTaskDescriptor.instance(taskInstanceId.getId(), data);
+        return humanReadableTaskDescriptor.instance(taskInstanceId.getId()).data(data).build();
     }
 
     private DbSchedulerHumanReadableEventData humanReadableDataFromObject(Object event) {

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <jackson.version>2.19.2</jackson.version>
         <xstream.version>1.4.21</xstream.version>
         <!-- Scheduling -->
-        <db-scheduler.version>13.0.0</db-scheduler.version><!-- Don't upgrade due to JDK8 -->
+        <db-scheduler.version>16.6.0</db-scheduler.version>
         <jobrunr.version>8.0.1</jobrunr.version>
         <quartz.version>2.4.0</quartz.version>
         <!-- Spring -->


### PR DESCRIPTION
chore(db-scheduler): upgrade to 16.2.0 and migrate to new TaskDescriptor API

- Replace deprecated TaskWithDataDescriptor with TaskDescriptor.of(...)
- Adapt code to new builder pattern: instance(id).data(data).build()
- Remove Dependabot ignore rule for db-scheduler updates
- Verified existing component and integration tests
- No functional changes, purely API migration for db-scheduler 15+ compatibility

Cherry picked from commit 6759a08fce894d1e775dd569a2a285f7e70c7592 by @Kirboyyy, upon request of @nils-christian in #4073.
Changes are targeted towards the branch of PR #4136 to ensure the correct JDK version is in place.