### PR TITLE
Upgrade Axon Server Connector version to 2025.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <!-- Axon Server -->
-        <axonserver-connector-java.version>2024.2.5</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2025.2.1</axonserver-connector-java.version>
         <!-- Caching -->
         <ehcache.version>2.10.9.2</ehcache.version>
         <ehcache3.version>3.10.8</ehcache3.version>


### PR DESCRIPTION
This pull request upgrades the `axonserver-connector-java` version to 2025.2.1.
We couldn't do this before, as the 2025 connector is build with JDK11. 
As 4.13.0 will be JDK17, we can thus upgrade to this version.

Furthermore, this upgrade is a required stepping stone #4153.