### PR TITLE
Micronaut Support

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -92,6 +92,8 @@
         <db-scheduler.version>16.12.0</db-scheduler.version>
         <jobrunr.version>8.6.1</jobrunr.version>
         <quartz.version>2.5.2</quartz.version>
+        <!-- Micronaut -->
+        <micronaut.version>5.0.2</micronaut.version>
         <!-- Spring -->
         <spring.version>6.2.18</spring.version>
         <spring.boot.version>3.5.14</spring.boot.version>
@@ -314,6 +316,14 @@
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Micronaut -->
+            <dependency>
+                <groupId>io.micronaut.platform</groupId>
+                <artifactId>micronaut-platform</artifactId>
+                <version>${micronaut.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/common/src/test/java/org/axonframework/common/configuration/ApplicationConfigurerTestSuite.java
+++ b/common/src/test/java/org/axonframework/common/configuration/ApplicationConfigurerTestSuite.java
@@ -1939,12 +1939,12 @@ public abstract class ApplicationConfigurerTestSuite<C extends ApplicationConfig
             List<Configuration> levelOneConfigurations = rootConfig.getModuleConfigurations();
             assertEquals(2, levelOneConfigurations.size());
             // Left module can access own components and parent, not its siblings.
-            Configuration leftConfig = levelOneConfigurations.getFirst();
+            Configuration leftConfig = rootConfig.getModuleConfiguration("left").orElseThrow();
             assertTrue(leftConfig.getOptionalComponent(TestComponent.class, "root").isPresent());
             assertEquals(leftModuleComponent, leftConfig.getComponent(TestComponent.class, "left"));
             assertFalse(leftConfig.getOptionalComponent(TestComponent.class, "right").isPresent());
             // Right module can access own components and parent, not its siblings,
-            Configuration rightConfig = levelOneConfigurations.get(1);
+            Configuration rightConfig = rootConfig.getModuleConfiguration("right").orElseThrow();
             assertTrue(rightConfig.getOptionalComponent(TestComponent.class, "root").isPresent());
             assertEquals(rightModuleComponent, rightConfig.getComponent(TestComponent.class, "right"));
             assertFalse(rightConfig.getOptionalComponent(TestComponent.class, "left").isPresent());

--- a/extensions/micronaut/micronaut/pom.xml
+++ b/extensions/micronaut/micronaut/pom.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.micronaut</groupId>
+        <artifactId>axon-micronaut-extension</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>axon-micronaut</artifactId>
+
+    <name>Axon Extension - Micronaut - Core</name>
+    <description>
+        Module providing Micronaut specific helper functionality to ease configuration / set-up of an Axon application,
+        as
+        well as some Micronaut specific infrastructure components.
+    </description>
+
+    <dependencies>
+        <!-- Axon -->
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-conversion</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-eventsourcing</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- explicitly define transitive dependencies to increase version priority -->
+        <!-- see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies -->
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-eventsourcing</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-modelling</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Micronaut -->
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.security</groupId>
+            <artifactId>micronaut-security</artifactId>
+        </dependency>
+        <!--        <dependency>-->
+        <!--            <groupId>io.micronaut.security</groupId>-->
+        <!--            <artifactId>micronaut-security-annotations</artifactId>-->
+        <!--        </dependency>-->
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-model</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-tx-hibernate</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-tx</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Serialization -->
+        <dependency>
+            <groupId>io.micronaut.serde</groupId>
+            <artifactId>micronaut-serde-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Validation -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Annotations -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- Database -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-connection</artifactId>
+<!--            <scope>test</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-connection-hibernate</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Caching -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Scheduling -->
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Project Reactor -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Other -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.eaio.uuid</groupId>
+            <artifactId>uuid</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>c3p0</groupId>
+            <artifactId>c3p0</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.micronaut.maven</groupId>
+                <artifactId>micronaut-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Uncomment to enable incremental compilation -->
+                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                    <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-inject-java</artifactId>
+                        </path>
+                        <path>
+                            <groupId>io.micronaut.serde</groupId>
+                            <artifactId>micronaut-serde-processor</artifactId>
+                            <exclusions>
+                                <exclusion>
+                                    <groupId>io.micronaut</groupId>
+                                    <artifactId>micronaut-inject</artifactId>
+                                </exclusion>
+                            </exclusions>
+                        </path>
+                    </annotationProcessorPaths>
+                    <verbose>true</verbose>
+                    <compilerArgs>
+                        <arg>-Amicronaut.processing.annotations= org.axonframework.extension.micronaut.messaging.*</arg>
+                        <arg>-Amicronaut.processing.group=org.axonframework.extension.micronaut.messaging</arg>
+                        <arg>-Amicronaut.processing.module=micronaut</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.axonframework.extension.micronaut</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/AxonConfigurationProperties.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/AxonConfigurationProperties.java
@@ -1,0 +1,21 @@
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+
+import static io.micronaut.core.util.StringUtils.TRUE;
+
+
+/**
+ * Configuration properties for altering Axons behavior
+ *
+ * @param enhancerScanning sets whether classpath scanning of
+ *                         {@link org.axonframework.common.configuration.ConfigurationEnhancer} is enabled
+ */
+@ConfigurationProperties(AxonConfigurationProperties.PREFIX)
+public record AxonConfigurationProperties(
+        @Bindable(defaultValue = TRUE)
+        boolean enhancerScanning) {
+
+    public static final String PREFIX = "axon";
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautAxonApplication.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautAxonApplication.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.ApplicationConfigurer;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.LifecycleRegistry;
+
+import java.util.function.Consumer;
+
+/**
+ * A singleton {@link ApplicationConfigurer} implementation using the application contexts {@link ComponentRegistry} and
+ * {@link LifecycleRegistry}.
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+@Singleton
+public class MicronautAxonApplication implements ApplicationConfigurer {
+
+    private final LifecycleRegistry lifecycleRegistry;
+    private final ComponentRegistry componentRegistry;
+    private final Provider<AxonConfiguration> axonConfigurationProvider;
+
+
+    /**
+     * @param componentRegistry         The {@link ComponentRegistry} used for
+     *                                  {@link #componentRegistry(Consumer)} operation.
+     * @param lifecycleRegistry         The {@link ComponentRegistry} used for
+     *                                  {@link #lifecycleRegistry(Consumer)} operation.
+     * @param axonConfigurationProvider For providing the {@link AxonConfiguration} {@link #build() built} needs.
+     */
+    @Internal
+    public MicronautAxonApplication(LifecycleRegistry lifecycleRegistry,
+                                    ComponentRegistry componentRegistry,
+                                    Provider<AxonConfiguration> axonConfigurationProvider
+    ) {
+        this.componentRegistry = componentRegistry;
+        this.lifecycleRegistry = lifecycleRegistry;
+        this.axonConfigurationProvider = axonConfigurationProvider;
+    }
+
+    @Override
+    public ApplicationConfigurer componentRegistry(Consumer<ComponentRegistry> componentRegistrar) {
+        componentRegistrar.accept(componentRegistry);
+        return this;
+    }
+
+    @Override
+    public ApplicationConfigurer lifecycleRegistry(Consumer<LifecycleRegistry> lifecycleRegistrar) {
+        lifecycleRegistrar.accept(lifecycleRegistry);
+        return this;
+    }
+
+    @Override
+    public AxonConfiguration build() {
+        return axonConfigurationProvider.get();
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautAxonConfiguration.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautAxonConfiguration.java
@@ -1,0 +1,94 @@
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.axonframework.common.TypeReference;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * An {@link AxonConfiguration} implementation which uses the built
+ * {@link org.axonframework.extension.micronaut.config.MicronautComponentRegistry.MicronautConfiguration} as a
+ * delegate.
+ * <p>
+ * This Singleton is marked as {@link Primary} so that when a {@link Configuration} is injected anywhere, this candidate
+ * will be injected instead of
+ * {@link org.axonframework.extension.micronaut.config.MicronautComponentRegistry.MicronautConfiguration} which is also
+ * a supertype of {@link Configuration}
+ */
+@Primary
+@Context
+@Requires(bean = MicronautComponentRegistry.MicronautConfiguration.class)
+class MicronautAxonConfiguration implements AxonConfiguration {
+
+    private final Configuration delegate;
+
+    @Internal
+    public MicronautAxonConfiguration(MicronautComponentRegistry.MicronautConfiguration delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void start() {
+        // ignore, connected to Micronaut lifecycle
+    }
+
+    @Override
+    public void shutdown() {
+        // ignore, connected to Micronaut Lifecycle
+    }
+
+    @Override
+    public <C> Optional<C> getOptionalComponent(Class<C> type, @Nullable String name) {
+        return delegate.getOptionalComponent(type, name);
+    }
+
+    @Override
+    public <C> Optional<C> getOptionalComponent(TypeReference<C> typeReference,
+                                                @Nullable String name) {
+        return delegate.getOptionalComponent(typeReference, name);
+    }
+
+    @Override
+    public <C> C getComponent(Class<C> type,
+                              @Nullable String name,
+                              Supplier<C> defaultImpl) {
+        return delegate.getComponent(type, name, defaultImpl);
+    }
+
+    @Override
+    public List<Configuration> getModuleConfigurations() {
+        return delegate.getModuleConfigurations();
+    }
+
+    @Override
+    public Optional<Configuration> getModuleConfiguration(String name) {
+        return delegate.getModuleConfiguration(name);
+    }
+
+    @Nullable
+    @Override
+    public Configuration getParent() {
+        return delegate.getParent();
+    }
+
+    @Override
+    public <C> Map<String, C> getComponents(Class<C> type) {
+        return delegate.getComponents(type);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("configuration", delegate);
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautComponentRegistry.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautComponentRegistry.java
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.RuntimeBeanDefinition;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.NonUniqueBeanException;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import org.axonframework.common.TypeReference;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.AmbiguousComponentMatchException;
+import org.axonframework.common.configuration.Component;
+import org.axonframework.common.configuration.ComponentDefinition;
+import org.axonframework.common.configuration.ComponentFactory;
+import org.axonframework.common.configuration.ComponentOverrideException;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.Components;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.axonframework.common.configuration.DecoratorDefinition;
+import org.axonframework.common.configuration.DefaultComponentRegistry;
+import org.axonframework.common.configuration.DuplicateModuleRegistrationException;
+import org.axonframework.common.configuration.HierarchicalLifecycleRegistry;
+import org.axonframework.common.configuration.LifecycleRegistry;
+import org.axonframework.common.configuration.Module;
+import org.axonframework.common.configuration.OverridePolicy;
+import org.axonframework.common.configuration.SearchScope;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link ComponentRegistry} implementation that connects into Micronaut's ecosystem
+ * By using the {@link BeanContext}, this {@link ComponentRegistry} can return any component, regardless of whether it
+ * was registered with this {@link ComponentRegistry}, through a {@link ConfigurationEnhancer}, or coming from
+ * Micronaut's Application Context directly. The latter integration ensures that <b>any</b> Axon Framework component
+ * using the {@link Configuration} resulting from this {@link ComponentRegistry} can retrieve <b>any</b> bean that's
+ * available.
+ * <p>
+ * Currently missing features: Decoration of Micronaut Beans outside manually registered components.
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+@Singleton
+@Requires(missingBeans = ComponentRegistry.class)
+public class MicronautComponentRegistry implements ComponentRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final LifecycleRegistry lifecycleRegistry;
+
+    private final Components localComponents = new Components();
+
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final MicronautConfiguration configuration;
+    private final BeanContext beanContext;
+    private final AxonConfigurationProperties axonConfigurationProperties;
+
+    private final List<Class<? extends ConfigurationEnhancer>> disabledEnhancers = new CopyOnWriteArrayList<>();
+    private final List<Class<? extends ConfigurationEnhancer>> invokedEnhancers = new CopyOnWriteArrayList<>();
+
+
+    /**
+     * @param beanContext                 The {@link BeanContext} for registering and retrieving components.
+     * @param lifecycleRegistry           The {@link LifecycleRegistry} used to initializes.
+     *                                    {@link #registerModule(Module) registered modules} and
+     *                                    {@link #registerFactory(ComponentFactory) registered factories}.
+     * @param axonConfigurationProperties The {@link AxonConfigurationProperties} used for configuring axon's behavior.
+     */
+    @Internal
+    public MicronautComponentRegistry(BeanContext beanContext,
+                                      LifecycleRegistry lifecycleRegistry,
+                                      AxonConfigurationProperties axonConfigurationProperties
+    ) {
+        this.beanContext = beanContext;
+        this.lifecycleRegistry = lifecycleRegistry;
+        this.axonConfigurationProperties = axonConfigurationProperties;
+        this.configuration = new MicronautConfiguration(beanContext);
+    }
+
+    /**
+     * Scans ConfigurationEnhancers if applicable, can happen immediately as it is not configurable after bean
+     * initializationpringsprin
+     */
+    @PostConstruct
+    void postConstruct() {
+        if (axonConfigurationProperties.enhancerScanning()) {
+            scanForConfigurationEnhancers();
+        }
+    }
+
+    /**
+     * This method builds the final {@link MicronautConfiguration} It does these things in order:
+     * <ol>
+     *     <li>Invoke {@link ConfigurationEnhancer#enhance(ComponentRegistry)} on all registered enhancers.</li>
+     *     <li>Decorate all registered {@code Components} by invoking all {@link #registerDecorator(DecoratorDefinition) registered decorators}.</li>
+     *     <li>Registers <b>all</b> {@link Component Components} with the Application Context.</li>
+     *     <li>Looks for any {@link Module Modules} and {@link #registerModule(Module) registers} them.</li>
+     *     <li>Builds all registered {@code Modules} so that they become available to {@link Configuration#getModuleConfigurations()}.</li>
+     *     <li>{@link ComponentFactory#registerShutdownHandlers(LifecycleRegistry) Registers} all {@code ComponentFactory} shutdown handlers with in the {@link LifecycleRegistry}.</li>
+     * </ol>
+     *
+     * @return Built {@link MicronautConfiguration}
+     */
+    public MicronautConfiguration build() {
+        if (initialized.getAndSet(true)) {
+            return configuration;
+        }
+        invokeEnhancers();
+        decorateComponents();
+        registerLocalComponentsWithApplicationContext();
+        buildModuleConfigurations();
+        registerFactoryLifecycleHooks();
+        return configuration;
+    }
+
+    @Override
+    public <C> ComponentRegistry registerComponent(ComponentDefinition<? extends C> definition) {
+        if (!(definition instanceof ComponentDefinition.ComponentCreator<? extends C> creator)) {
+            // The compiler should avoid this from happening.
+            throw new IllegalArgumentException("Unsupported component definition type: " + definition);
+        }
+
+        // We need to buffer these components, because they may depend on components that aren't
+        // registered yet. We will register these in the application context just-in-time.
+        Component<? extends C> component = creator.createComponent();
+        if (localComponents.contains(component.identifier())) {
+            throw new ComponentOverrideException(creator.rawType(), creator.name());
+        }
+
+        localComponents.put(component);
+        return this;
+    }
+
+    @Override
+    public <C> ComponentRegistry registerDecorator(DecoratorDefinition<C, ? extends C> definition) {
+        if (!(definition instanceof DecoratorDefinition.CompletedDecoratorDefinition<C, ? extends C> decoratorRegistration)) {
+            // The compiler should avoid this from happening.
+            throw new IllegalArgumentException("Unsupported decorator definition type: " + definition);
+        }
+        logger.debug("Registering decorator definition: [{}]", definition);
+
+        var annotationMetadata = new MutableAnnotationMetadata();
+        annotationMetadata.addDeclaredAnnotation(Order.class.getName(),
+                                                 Collections.singletonMap(AnnotationMetadata.VALUE_MEMBER,
+                                                                          decoratorRegistration.order()));
+        beanContext.registerBeanDefinition(
+                RuntimeBeanDefinition
+                        .builder(definition)
+                        .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(
+                                decoratorRegistration.getClass()).toArray(Class[]::new))
+                        .annotationMetadata(annotationMetadata)
+                        .singleton(true)
+                        // Because every DecoratorDefinition can be the same type (for example: DefaultDecoratorDefinition)
+                        // We need every Singleton BeanDefinition to be uniquely qualified, as without it decorators will override one another.
+                        // Therefore, we use the Objects toString method to Name this BeanDefinition uniqely.
+                        .named(definition.toString())
+                        .build());
+        return this;
+    }
+
+    @Override
+    public boolean hasComponent(Class<?> type, @Nullable String name, SearchScope searchScope) {
+        var identifier = new Component.Identifier<>(type, name);
+        // Checks both the local Components as the BeanFactory,
+        //  since the ConfigurationEnhancers act before component registration with the Application Context.
+        return switch (searchScope) {
+            case ALL -> localComponents.contains(identifier) || contextHasComponent(identifier);
+            case CURRENT -> localComponents.contains(identifier);
+            case ANCESTORS -> contextHasComponent(identifier);
+        };
+    }
+
+
+    @Override
+    public ComponentRegistry registerEnhancer(ConfigurationEnhancer enhancer) {
+        logger.debug("Registering enhancer [{}].", enhancer.getClass().getSimpleName());
+        var annotationMetadata = new MutableAnnotationMetadata();
+        annotationMetadata.addDeclaredAnnotation(Order.class.getName(),
+                                                 Collections.singletonMap(AnnotationMetadata.VALUE_MEMBER,
+                                                                          enhancer.order()));
+        var runtimeBeanDefinitionBuilder = RuntimeBeanDefinition.builder(enhancer)
+                                                                .named(String.valueOf(enhancer.hashCode()))
+                                                                .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(
+                                                                        enhancer.getClass()).toArray(Class[]::new))
+                                                                .singleton(true);
+        var beanDefinition = beanContext.findBeanDefinition(enhancer.getClass());
+        if (beanDefinition.isPresent()) {
+            logger.warn("Duplicate Configuration Enhancer registration detected. Replaced enhancer of type [{}].",
+                        enhancer.getClass().getSimpleName());
+            annotationMetadata.addDeclaredAnnotation(
+                    Replaces.class.getName(),
+                    Map.of(AnnotationMetadata.VALUE_MEMBER,
+                           new AnnotationClassValue<>(beanDefinition.get().getBeanType()),
+                           "named",
+                           Objects.requireNonNull(Qualifiers.findName(beanDefinition.get().getDeclaredQualifier()))));
+        }
+        runtimeBeanDefinitionBuilder.annotationMetadata(annotationMetadata);
+
+        beanContext.registerBeanDefinition(runtimeBeanDefinitionBuilder.build());
+        return this;
+    }
+
+    @Override
+    public ComponentRegistry registerModule(Module module) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Registering module [{}].", module.name());
+        }
+        Qualifier<Module> moduleQualifier = Qualifiers.byName(module.name());
+        if (beanContext.findBeanDefinition(Module.class, moduleQualifier).isPresent()) {
+            throw new DuplicateModuleRegistrationException(module);
+        }
+        beanContext.registerBeanDefinition(
+                RuntimeBeanDefinition.
+                        builder(module)
+                        .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(module.getClass()).toArray(Class[]::new))
+                        .qualifier(moduleQualifier)
+                        .singleton(true)
+                        .build());
+        return this;
+    }
+
+    @Override
+    public <C> ComponentRegistry registerFactory(ComponentFactory<C> factory) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Registering component factory [{}].", factory.getClass().getSimpleName());
+        }
+        this.beanContext.registerSingleton(factory);
+        return this;
+    }
+
+    @Override
+    public ComponentRegistry setOverridePolicy(OverridePolicy overridePolicy) {
+        if (overridePolicy != OverridePolicy.REJECT) {
+            logger.warn("Enabling Component overriding on a Micronaut-based ComponentRegistry is not supported. "
+                                + "Please use Micronaut \"Bean Replacement\" instead.");
+        }
+        return this;
+    }
+
+    @Override
+    public ComponentRegistry disableEnhancerScanning() {
+        logger.warn("Disabling enhancer scanning on a Micronaut-based Component-Registry is not supported"
+                            + "Please set the micronaut property \"" + AxonConfigurationProperties.PREFIX
+                            + ".enhancer-scanning" + "\" to false instead.");
+        return this;
+    }
+
+    @Override
+    public ComponentRegistry disableEnhancer(String fullyQualifiedClassName) {
+        try {
+            var enhancerClass = Class.forName(fullyQualifiedClassName);
+            if (!ConfigurationEnhancer.class.isAssignableFrom(enhancerClass)) {
+                throw new IllegalArgumentException(String.format("Class %s is not a ConfigurationEnhancer",
+                                                                 fullyQualifiedClassName));
+            }
+            //noinspection unchecked
+            return disableEnhancer((Class<? extends ConfigurationEnhancer>) enhancerClass);
+        } catch (ClassNotFoundException e) {
+            logger.warn(
+                    "Disabling Configuration Enhancer [{}] won't take effect as the enhancer class could not be found.",
+                    fullyQualifiedClassName);
+        }
+        return this;
+    }
+
+    @Override
+    public ComponentRegistry disableEnhancer(Class<? extends ConfigurationEnhancer> enhancerClass) {
+        if (invokedEnhancers.contains(enhancerClass)) {
+            logger.warn("Disabling Configuration Enhancer [{}] won't take effect as it has already been invoked. "
+                                + "We recommend to invoke disabling of this enhancer before it takes effect.",
+                        enhancerClass.getSimpleName());
+            return this;
+        }
+//        beanContext.registerBeanConfiguration(ConditionalBean);
+        disabledEnhancers.add(enhancerClass);
+        return this;
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("initialized", initialized.get());
+        descriptor.describeProperty("components", localComponents);
+        descriptor.describeProperty("decorators", getDecorators());
+        descriptor.describeProperty("configurerEnhancers", getConfigurationEnhancerMap());
+        descriptor.describeProperty("modules", getModules());
+        descriptor.describeProperty("factories", getFactories());
+    }
+
+
+    public <T> boolean isLocalComponent(Component.Identifier<T> beanComponentId) {
+        if (localComponents.contains(beanComponentId)) {
+            return true;
+        }
+        if (beanComponentId.areTypeAndNameEqual()) {
+            return localComponents.contains(new Component.Identifier<>(beanComponentId.type(), null));
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the {@link BeanContext} contains a {@link io.micronaut.inject.BeanDefinition} for this
+     * {@link org.axonframework.common.configuration.Component.Identifier}
+     */
+    @SuppressWarnings("unchecked")
+    private <C> boolean contextHasComponent(Component.Identifier<C> identifier) {
+        return beanContext
+                .findBeanDefinition(
+                        (Argument<C>) Argument.of(identifier.type().getType()),
+                        identifier.name() == null ? Qualifiers.none() : Qualifiers.byName(identifier.name())
+                )
+                .isPresent();
+    }
+
+    /**
+     * Registers all {@link ComponentFactory} ShutdownHandlers with in the {@link LifecycleRegistry}
+     */
+    private void registerFactoryLifecycleHooks() {
+        getFactories().forEach(factory -> factory.registerShutdownHandlers(lifecycleRegistry));
+    }
+
+    /**
+     * Scans for additional {@link ConfigurationEnhancer ConfigurationEnhancers} through means of a
+     * {@link SoftServiceLoader}.
+     * <p>
+     */
+    private void scanForConfigurationEnhancers() {
+        SoftServiceLoader<ConfigurationEnhancer> enhancerLoader = SoftServiceLoader.load(ConfigurationEnhancer.class,
+                                                                                         getClass().getClassLoader());
+        var collectedEnhancers = new ArrayList<ConfigurationEnhancer>();
+        var beanEnhancers = new HashSet<>(getConfigurationEnhancers());
+        enhancerLoader.collectAll(collectedEnhancers,
+                                  (enhancer) -> !beanEnhancers.contains(enhancer) && !disabledEnhancers.contains(
+                                          enhancer.getClass()));
+        collectedEnhancers.forEach(this::registerEnhancer);
+    }
+
+
+    /**
+     * Invoke all the {@link #registerEnhancer(ConfigurationEnhancer) registered}
+     * {@link ConfigurationEnhancer enhancers} on this {@link ComponentRegistry} implementation in their
+     * {@link ConfigurationEnhancer#order()}.
+     * <p>
+     * This will ensure all sensible default components and decorators are in place from these enhancers.
+     * <p>
+     * This method supports dynamic enhancer registration - if an enhancer registers another enhancer during its
+     * {@link ConfigurationEnhancer#enhance(ComponentRegistry)} call, the newly registered enhancer will be processed in
+     * the correct order based on its {@link ConfigurationEnhancer#order()} value relative to all unprocessed enhancers.
+     * Each enhancer is processed one at a time to ensure proper ordering when new enhancers are registered
+     * dynamically.
+     */
+    private void invokeEnhancers() {
+
+        Set<ConfigurationEnhancer> processedEnhancerKeys = new HashSet<>();
+
+        Collection<ConfigurationEnhancer> configurationEnhancers = getConfigurationEnhancers();
+        do {
+            // Find the next unprocessed enhancer with the lowest order value
+            Optional<ConfigurationEnhancer> nextEnhancer = configurationEnhancers
+                    .stream()
+                    .filter(entry ->
+                                    !processedEnhancerKeys.contains(entry))
+                    .findFirst();
+            if (nextEnhancer.isEmpty()) {
+                break; // No more enhancers to process
+            }
+            ConfigurationEnhancer enhancer = nextEnhancer.get();
+            if (!disabledEnhancers.contains(enhancer.getClass())) {
+                enhancer.enhance(this);
+                invokedEnhancers.add(enhancer.getClass());
+            }
+            processedEnhancerKeys.add(enhancer);
+
+            // Refresh ConfigurationEnhancers in case new ones were added
+            configurationEnhancers = getConfigurationEnhancers();
+        } while (processedEnhancerKeys.size() < getConfigurationEnhancers().size());
+    }
+
+    /**
+     * Decorate all components that have been {@link #registerComponent(ComponentDefinition) registered directly} or
+     * registered through a {@link ConfigurationEnhancer}.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void decorateComponents() {
+        for (DecoratorDefinition.CompletedDecoratorDefinition decorator : getDecorators()) {
+            for (Component.Identifier id : localComponents.identifiers()) {
+                if (decorator.matches(id)) {
+                    localComponents.replace(id, decorator::decorate);
+                }
+            }
+        }
+    }
+
+    /**
+     * Registers all {@link Component Components} that are present in the {@link Components} collection with the
+     * Micronaut's Application Context. The registration of {@code Components} should occur
+     * <b>after</b> all {@link ConfigurationEnhancer ConfigurationEnhancers} have enhanced the configuration. By doing
+     * so, we ensure that any defaults or overrides are present in the Application Context too.
+     **/
+    private void registerLocalComponentsWithApplicationContext() {
+        localComponents.postProcessComponents(this::registerLocalComponent);
+    }
+
+    /**
+     * Register a component in the {@link BeanContext} This creates a {@link RuntimeBeanDefinition} with the component's
+     * name as it {@link Qualifiers} if it exists.
+     * <p>
+     * TODO: Fix limitation where registering DecoratedComponents doesn't register the newly decorated type, only the
+     * original components type. See TODO in MicronautComponentRegistryTest.validateDecoratorDefinitionsAreInvoked
+     */
+    private <T> void registerLocalComponent(Component<T> component) {
+        String name = component.identifier().name();
+        Class<T> componentClass = component.identifier().type().getTypeAsClass();
+        if (beanContext.findBeanDefinition(componentClass, name != null ? Qualifiers.byName(name) : Qualifiers.none())
+                       .isPresent()) {
+            logger.info("Component with type [{}], name [{}] is already available. Skipping registration.",
+                        component.getClass().getName(),
+                        name);
+            return;
+        }
+        //noinspection unchecked
+        beanContext.registerBeanDefinition(
+                RuntimeBeanDefinition
+                        .builder((Argument<? super T>) Argument.of(component.identifier().type().getType()),
+                                 () -> component.resolve(configuration))
+                        .named(name)
+                        .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(componentClass).toArray(Class[]::new))
+                        .singleton(true)
+                        .build());
+        component.initLifecycle(configuration, lifecycleRegistry);
+    }
+
+    private DefaultComponentRegistry copyWithDecoratorsAndEnhancers() {
+        return DefaultComponentRegistry.create(getDecorators(), getConfigurationEnhancers(), disabledEnhancers);
+    }
+
+    /**
+     * Retrieve and thus Eagerly Init all {@link Module modules} and build their {@link Configuration configurations}
+     */
+    private void buildModuleConfigurations() {
+        getModules().forEach(this::buildModuleConfig);
+    }
+
+    /**
+     * Build a modules {@link Configuration} and registers it in the {@link BeanContext} with a name {@link Qualifiers}
+     * where the name is the {@link Module modules} name
+     */
+    private void buildModuleConfig(Module module) {
+        var moduleRegistry = copyWithDecoratorsAndEnhancers();
+        var moduleConfig = HierarchicalLifecycleRegistry.build(
+                lifecycleRegistry,
+                childLifecycleRegistry -> {
+                    var local = moduleRegistry.createLocalConfiguration(configuration);
+                    var moduleConfiguration = module.build(local, childLifecycleRegistry);
+                    return moduleRegistry.buildNested(moduleConfiguration, childLifecycleRegistry);
+                });
+        beanContext.registerBeanDefinition(
+                RuntimeBeanDefinition
+                        .builder(moduleConfig)
+                        .exposedTypes(ReflectionUtils.getAllClassesInHierarchy(moduleConfig.getClass())
+                                                     .toArray(Class[]::new))
+                        .named(module.name())
+                        .singleton(true)
+                        .build()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public Collection<DecoratorDefinition.CompletedDecoratorDefinition<?, ?>> getDecorators() {
+        return (Collection<DecoratorDefinition.CompletedDecoratorDefinition<?, ?>>) (Collection<?>) beanContext.getBeansOfType(
+                DecoratorDefinition.class);
+    }
+
+    private Collection<Module> getModules() {
+        return beanContext.getBeansOfType(Module.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Collection<ComponentFactory> getFactories() {
+        return beanContext.getBeansOfType(ComponentFactory.class);
+    }
+
+    private Collection<ConfigurationEnhancer> getConfigurationEnhancers() {
+        return beanContext.getBeansOfType(ConfigurationEnhancer.class);
+    }
+
+    private Map<String, ConfigurationEnhancer> getConfigurationEnhancerMap() {
+        return beanContext.mapOfType(ConfigurationEnhancer.class);
+    }
+
+    /**
+     * A Micronaut integrated {@link Configuration} implementation. Resolves {@link Component}s and Module
+     * {@link Configuration}s using the {@link BeanContext}
+     */
+    public static class MicronautConfiguration implements Configuration {
+
+        private final BeanContext beanContext;
+
+        /**
+         * @param beanContext The {@link BeanContext} used for retrieving the {@link Component components} and
+         *                    {@link Module module} {@link Configuration configurations}.
+         */
+        @Internal
+        public MicronautConfiguration(BeanContext beanContext) {
+            this.beanContext = beanContext;
+        }
+
+        @Override
+        public <C> Optional<C> getOptionalComponent(Class<C> type, @Nullable String name) {
+            Qualifier<C> qualifier = name == null ? Qualifiers.none() : Qualifiers.byName(name);
+            try {
+                return beanContext.findBean(type, qualifier);
+            } catch (NonUniqueBeanException e) {
+                throw new AmbiguousComponentMatchException(new Component.Identifier<>(type, name));
+            }
+        }
+
+        @Override
+        public <C> Optional<C> getOptionalComponent(TypeReference<C> typeReference, @Nullable String name) {
+            Qualifier<C> qualifier = name == null ? Qualifiers.none() : Qualifiers.byName(name);
+            try {
+                //noinspection unchecked
+                return beanContext.findBean((Argument<C>) Argument.of(typeReference.getType()), qualifier);
+            } catch (NonUniqueBeanException e) {
+                throw new AmbiguousComponentMatchException(new Component.Identifier<>(typeReference, name));
+            }
+        }
+
+        @Override
+        public <C> C getComponent(Class<C> type, @Nullable String name, Supplier<C> defaultImpl) {
+            return getOptionalComponent(type, name).orElseGet(defaultImpl);
+        }
+
+        @Override
+        public List<Configuration> getModuleConfigurations() {
+            return beanContext.getBeanDefinitions(Configuration.class).stream()
+                              .filter(a -> Qualifiers.findName(a.getDeclaredQualifier()) != null).map(
+                            beanContext::getBean).toList();
+        }
+
+        @Override
+        public Optional<Configuration> getModuleConfiguration(String name) {
+            return beanContext.findBean(Configuration.class, Qualifiers.byName(name));
+        }
+
+        @Nullable
+        @Override
+        public Configuration getParent() {
+            return null;
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            descriptor.describeProperty("modules", getModuleConfigurations());
+        }
+
+        @Override
+        public <C> Map<String, C> getComponents(Class<C> type) {
+            var beanDefinitions = beanContext.getBeanDefinitions(type);
+            Map<String, C> result = new LinkedHashMap<>(beanDefinitions.size());
+            //noinspection NullableProblems
+            result.putAll(beanDefinitions
+                                  .stream()
+                                  .collect(
+                                          Collectors.toMap(
+                                                  bd -> Qualifiers.findName(bd.getDeclaredQualifier()),
+                                                  beanContext::getBean
+                                          )
+                                  ));
+            for (Configuration moduleConfig : getModuleConfigurations()) {
+                Map<String, C> moduleComponents = moduleConfig.getComponents(type);
+                result.putAll(moduleComponents);
+            }
+            return Collections.unmodifiableMap(result);
+        }
+    }
+
+    public record MicronautComponent<T>(Identifier<T> identifier, T bean) implements Component<T> {
+
+        @Override
+        public T resolve(Configuration configuration) {
+            return bean;
+        }
+
+        @Override
+        public boolean isInstantiated() {
+            return true;
+        }
+
+        @Override
+        public void initLifecycle(Configuration configuration, LifecycleRegistry lifecycleRegistry) {
+            // Unimplemented since Micronaut manages the lifecycle of all beans.
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            descriptor.describeProperty("identifier", identifier);
+            descriptor.describeProperty("bean", bean);
+        }
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautConfigurationFactory.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautConfigurationFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+/**
+ * Builds the {@link org.axonframework.extension.micronaut.config.MicronautComponentRegistry.MicronautConfiguration}
+ * from the {@link MicronautComponentRegistry}
+ */
+@Requires(bean = MicronautComponentRegistry.class)
+@Factory
+public class MicronautConfigurationFactory {
+
+    @Singleton
+    MicronautComponentRegistry.MicronautConfiguration buildConfiguration(MicronautComponentRegistry registry) {
+        return registry.build();
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleHandler.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Provider;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.LifecycleHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A wrapper for {@link LifecycleHandler start-specific lifecycle handler} for usage with Micronaut. This class
+ * implements {@link Ordered} which corresponds to the {@link LifecycleHandler}'s phase This allows it to be ordered
+ * correctly when ingesting a collection of this class.
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+public abstract class MicronautLifecycleHandler implements Ordered {
+
+    private final Provider<Configuration> configurationProvider;
+    private final LifecycleHandler lifecycleHandler;
+    private final int phase;
+
+    /**
+     * @param configurationProvider A provider for {@link Configuration} which is given to the {@param lifecycleHandler}
+     *                              as an argument during invocation.
+     * @param phase                 The phase to register the Lifecycle Handler in.
+     * @param lifecycleHandler      The {@link LifecycleHandler} to invoke.
+     */
+    @Internal
+    public MicronautLifecycleHandler(
+            Provider<Configuration> configurationProvider,
+            int phase,
+            LifecycleHandler lifecycleHandler) {
+        this.configurationProvider = configurationProvider;
+        this.lifecycleHandler = lifecycleHandler;
+        this.phase = phase;
+    }
+
+    @Override
+    public int getOrder() {
+        return phase;
+    }
+
+    /**
+     * Invokes the {@link LifecycleHandler} with the provided {@link Configuration}
+     *
+     * @return The {@link LifecycleHandler#run} future.
+     */
+    protected CompletableFuture<?> run() {
+        return this.lifecycleHandler.run(configurationProvider.get());
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleRegistry.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleRegistry.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.runtime.graceful.GracefulShutdownConfiguration;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.LifecycleHandler;
+import org.axonframework.common.configuration.LifecycleRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+import static io.micronaut.core.util.StringUtils.FALSE;
+
+/**
+ * A {@link LifecycleRegistry} implementation that registers all lifecycle handlers as {@link MicronautLifecycleHandler}
+ * Singletons
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+@Requires(missingBeans = LifecycleRegistry.class)
+@Singleton
+public class MicronautLifecycleRegistry implements LifecycleRegistry {
+
+    private final BeanContext beanContext;
+    private final boolean gracefulShutdownEnabled;
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final Provider<Configuration> configurationProvider;
+
+    /**
+     * @param beanContext             The {@link BeanContext} used for registering the {@link LifecycleHandler}'s.
+     * @param gracefulShutdownEnabled The state of {@link io.micronaut.runtime.graceful.GracefulShutdownConfiguration}
+     *                                which sets whether registered {@link MicronautLifecycleShutdownHandler}'s support
+     *                                graceful shutdown.
+     * @param configurationProvider   The {@link Configuration} provider that is used by the {@link LifecycleHandler}'s
+     *                                on invocation.
+     */
+    @Internal
+    public MicronautLifecycleRegistry(BeanContext beanContext,
+                                      @Property(name = GracefulShutdownConfiguration.ENABLED, defaultValue = FALSE) boolean gracefulShutdownEnabled,
+                                      Provider<Configuration> configurationProvider
+    ) {
+        this.beanContext = beanContext;
+        this.gracefulShutdownEnabled = gracefulShutdownEnabled;
+        this.configurationProvider = configurationProvider;
+    }
+
+    @Override
+    public LifecycleRegistry registerLifecyclePhaseTimeout(long timeout, TimeUnit timeUnit) {
+        logger.warn("Registering lifecycle phase timeout on a Micronaut-based LifecycleRegistry is not supported.");
+        return this;
+    }
+
+
+    @Override
+    public LifecycleRegistry onStart(int phase, LifecycleHandler startHandler) {
+        beanContext.registerSingleton(
+                MicronautLifecycleStartHandler.class,
+                new MicronautLifecycleStartHandler(configurationProvider, phase, startHandler)
+        );
+        return this;
+    }
+
+    @Override
+    public LifecycleRegistry onShutdown(int phase, LifecycleHandler shutdownHandler) {
+        beanContext.registerSingleton(
+                MicronautLifecycleShutdownHandler.class,
+                new MicronautLifecycleShutdownHandler(
+                        configurationProvider,
+                        gracefulShutdownEnabled,
+                        phase,
+                        shutdownHandler
+                )
+        );
+        return this;
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleShutdownHandler.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleShutdownHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.ShutdownEvent;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
+import jakarta.inject.Provider;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.LifecycleHandler;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A {@link MicronautLifecycleHandler} implementation for {@link LifecycleHandler shutdown-specific lifecycle handler}
+ * Integrates with micronaut by being a {@link ApplicationEventListener<ShutdownEvent> ShutdownEvent listener} which
+ * runs the LifecycleHandler on shutdown, or with {@link io.micronaut.runtime.graceful.GracefulShutdownManager} which
+ * can shut down the application gracefully.
+ * <p>
+ * This class is designed to be registered as a singleton to participate in Micronaut's ApplicationContext Lifecycle,
+ * therefore it must be annotated with {@link Introspected}
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+@Introspected
+public final class MicronautLifecycleShutdownHandler extends MicronautLifecycleHandler
+        implements GracefulShutdownCapable,
+        ApplicationEventListener<ShutdownEvent> {
+
+    private final boolean gracefulShutdownEnabled;
+
+    /**
+     * @param configurationProvider   A provider for {@link Configuration} which is given to the
+     *                                {@param lifecycleHandler} as an argument during invocation.
+     * @param gracefulShutdownEnabled The state of {@link io.micronaut.runtime.graceful.GracefulShutdownConfiguration}
+     *                                which sets whether this bean supports GracefulShutdown or not.
+     * @param phase                   The phase to register the Lifecycle Handler in.
+     * @param lifecycleHandler        The {@link LifecycleHandler} to invoke.
+     */
+    @Internal
+    public MicronautLifecycleShutdownHandler(
+            Provider<Configuration> configurationProvider,
+            boolean gracefulShutdownEnabled,
+            int phase,
+            LifecycleHandler lifecycleHandler
+    ) {
+        super(configurationProvider, phase, lifecycleHandler);
+        this.gracefulShutdownEnabled = gracefulShutdownEnabled;
+    }
+
+    @Override
+    public CompletionStage<?> shutdownGracefully() {
+        return this.run();
+    }
+
+    /**
+     * if graceful shutdown is enabled, we want to use it to control the shut-down instead of relying on the
+     * ShutdownEvent
+     */
+    @Override
+    public boolean supports(ShutdownEvent event) {
+        return !gracefulShutdownEnabled;
+    }
+
+    @Override
+    public void onApplicationEvent(ShutdownEvent event) {
+        try {
+            this.run().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleStartHandler.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/MicronautLifecycleStartHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Provider;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.LifecycleHandler;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A {@link MicronautLifecycleHandler} implementation for {@link LifecycleHandler start-specific lifecycle handler}
+ * Integrates with micronaut by being a {@link ApplicationEventListener<StartupEvent> StartupEvent listener} which runs
+ * the LifecycleHandler on startup
+ * <p>
+ * This class is designed to be registered as a singleton to participate in Micronaut's ApplicationContext Lifecycle,
+ * therefore it must be annotated with {@link Introspected}
+ *
+ * @author Daniel Karapishchenko
+ * @since 5.1.0
+ */
+@Introspected public final class MicronautLifecycleStartHandler
+        extends MicronautLifecycleHandler implements ApplicationEventListener<StartupEvent> {
+
+    /**
+     * @param configurationProvider A provider for {@link Configuration} which is given to the {@param lifecycleHandler}
+     *                              as an argument during invocation.
+     * @param phase                 The phase to register the Lifecycle Handler in.
+     * @param lifecycleHandler      The {@link LifecycleHandler} to invoke.
+     */
+    @Internal
+    public MicronautLifecycleStartHandler(Provider<Configuration> configurationProvider,
+                                          int phase,
+                                          LifecycleHandler lifecycleHandler) {
+        super(configurationProvider, phase, lifecycleHandler);
+    }
+
+    @Override
+    public void onApplicationEvent(StartupEvent event) {
+        try {
+            this.run().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/package-info.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/config/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.axonframework.extension.micronaut.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/package-info.java
+++ b/extensions/micronaut/micronaut/src/main/java/org/axonframework/extension/micronaut/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Configuration
+@Requires(property = AxonConfigurationProperties.PREFIX + ".enabled", notEquals = FALSE)
+@NullMarked
+package org.axonframework.extension.micronaut;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import org.axonframework.extension.micronaut.config.AxonConfigurationProperties;
+import org.jspecify.annotations.NullMarked;
+
+import static io.micronaut.core.util.StringUtils.FALSE;
+import static io.micronaut.core.util.StringUtils.TRUE;

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/DisableAxonTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/DisableAxonTest.java
@@ -1,0 +1,32 @@
+package org.axonframework.extension.micronaut;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import org.axonframework.extension.micronaut.config.AxonConfigurationProperties;
+import org.axonframework.extension.micronaut.config.MicronautAxonApplication;
+import org.axonframework.extension.micronaut.config.MicronautComponentRegistry;
+import org.axonframework.extension.micronaut.config.MicronautLifecycleRegistry;
+import org.junit.jupiter.api.*;
+
+import java.util.Map;
+
+import static io.micronaut.core.util.StringUtils.FALSE;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DisableAxonTest {
+
+    @AutoClose
+    BeanContext applicationContext = ApplicationContext
+            .builder(
+                    Map.of(AxonConfigurationProperties.PREFIX + ".enabled", FALSE))
+            .eagerBeansEnabled(false)
+            .start();
+
+    @Test
+    void settingAxonEnabledToFalseDisablesAllAxonBeans() {
+        assertFalse(applicationContext.containsBean(MicronautAxonApplication.class));
+        assertFalse(applicationContext.containsBean(MicronautComponentRegistry.class));
+        assertFalse(applicationContext.containsBean(MicronautLifecycleRegistry.class));
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/AxonConfigurationPropertiesTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/AxonConfigurationPropertiesTest.java
@@ -1,0 +1,27 @@
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.*;
+
+import static io.micronaut.core.util.StringUtils.FALSE;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest(rebuildContext = true)
+class AxonConfigurationPropertiesTest {
+
+    @Inject
+    AxonConfigurationProperties configurationProperties;
+
+    @Property(name = AxonConfigurationProperties.PREFIX + ".enhancer-scanning", value = FALSE)
+    @Test
+    void canDisableEnhancerScanning() {
+        assertFalse(configurationProperties.enhancerScanning());
+    }
+
+    @Test
+    void enhancerScanningDefaultsToTrue() {
+        assertTrue(configurationProperties.enhancerScanning());
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautAxonApplicationTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautAxonApplicationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
+import org.axonframework.common.configuration.ApplicationConfigurerTestSuite;
+
+class MicronautAxonApplicationTest extends ApplicationConfigurerTestSuite<MicronautAxonApplication> {
+
+    BeanContext beanContext = ApplicationContext.builder().eagerBeansEnabled(false).start();
+
+    @Override
+    public MicronautAxonApplication createConfigurer() {
+        return beanContext.getBean(MicronautAxonApplication.class);
+    }
+
+    @Override
+    protected void initialize(MicronautAxonApplication testSubject) {
+        beanContext.getBean(MicronautComponentRegistry.class).build();
+    }
+
+    @Override
+    public boolean supportsOverriding() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsComponentFactories() {
+        return false;
+    }
+
+    @Override
+    public boolean doesOwnLifecycleManagement() {
+        return false;
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautComponentRegistryTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautComponentRegistryTest.java
@@ -1,0 +1,448 @@
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.axonframework.common.TypeReference;
+import org.axonframework.common.configuration.BaseModule;
+import org.axonframework.common.configuration.Component;
+import org.axonframework.common.configuration.ComponentDecorator;
+import org.axonframework.common.configuration.ComponentDefinition;
+import org.axonframework.common.configuration.ComponentFactory;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.axonframework.common.configuration.DecoratorDefinition;
+import org.axonframework.common.configuration.DefaultComponentRegistry;
+import org.axonframework.common.configuration.InstantiatedComponentDefinition;
+import org.axonframework.common.configuration.LifecycleRegistry;
+import org.axonframework.common.configuration.Module;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.commandhandling.CommandBus;
+import org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus;
+import org.junit.jupiter.api.*;
+import org.mockito.internal.util.*;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.micronaut.core.util.StringUtils.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest(rebuildContext = true)
+class MicronautComponentRegistryTest {
+
+    private static final String CUSTOM_COMPONENT_REGISTRY_ENABLED_PROPERTY = "spec.MicronautComponentRegistryTest.customComponentRegistry";
+
+    @Inject
+    private BeanContext beanContext;
+
+    @Test
+    void expectToBeAvailableInContext() {
+        assertThat(beanContext.getBean(ComponentRegistry.class) instanceof MicronautComponentRegistry).isTrue();
+    }
+
+    @Property(name = CUSTOM_COMPONENT_REGISTRY_ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void expectToBeOverridable() {
+        assertTrue(beanContext.getBean(ComponentRegistry.class) instanceof DefaultComponentRegistry);
+    }
+
+    @Property(name = DecoratorDefinitionContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void validateDecoratorDefinitionsAreInvoked() {
+        assertTrue(beanContext.containsBean(CommandBus.class));
+        // TODO: can't be implemented until DecoratedComponent type is exposed before `component.resolve` is ran
+        // assertTrue(beanContext.containsBean(InterceptingCommandBus.class));
+        var decoratorStarted = beanContext.findBean(AtomicBoolean.class,
+                                                    Qualifiers.byName(DecoratorDefinitionContext.DECORATOR_STARTED_NAME));
+        assertTrue(decoratorStarted.isPresent());
+        await().pollDelay(Duration.ofMillis(50))
+               .atMost(Duration.ofSeconds(1))
+               .untilTrue(decoratorStarted.get());
+    }
+
+    @Property(name = ModuleContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void validateModuleBeanCreationMethodAddsModuleToAxonConfiguration() {
+        var module = beanContext.findBean(Module.class);
+        assertThat(module.isPresent()).isTrue();
+        assertThat(module.get().name()).isEqualTo(ModuleContext.MODULE_NAME);
+
+        Configuration axonConfiguration = beanContext.getBean(Configuration.class);
+        assertThat(axonConfiguration.getModuleConfigurations()).hasSize(1);
+        Optional<Configuration> testModuleConfig =
+                axonConfiguration.getModuleConfiguration(ModuleContext.MODULE_NAME);
+        assertThat(testModuleConfig).isNotEmpty();
+        // Validate if the MODULE_SPECIFIC_STRING, that is only registered by the TestModule internally,
+        //  is not in the Application Context.
+        assertThat(testModuleConfig.get().getComponent(Object.class, ModuleContext.MODULE_SPECIFIC_STRING))
+                .isEqualTo(ModuleContext.MODULE_SPECIFIC_STRING);
+        assertThat(beanContext.containsBean(Object.class,
+                                            Qualifiers.byName(ModuleContext.MODULE_SPECIFIC_STRING))).isFalse();
+
+        // We expect a Module-specific bean to be registered for both a start and shutdown handler.
+        Collection<MicronautLifecycleStartHandler> startHandlers = beanContext.getBeansOfType(
+                MicronautLifecycleStartHandler.class);
+        Collection<MicronautLifecycleShutdownHandler> shutdownHandlers = beanContext.getBeansOfType(
+                MicronautLifecycleShutdownHandler.class);
+
+
+        assertTrue(startHandlers.stream().anyMatch(h -> h.getOrder() == ModuleContext.START_PHASE));
+        assertTrue(shutdownHandlers.stream().anyMatch(h -> h.getOrder() == ModuleContext.SHUTDOWN_PHASE));
+
+
+        assertThat(beanContext.getBean(AtomicBoolean.class,
+                                       Qualifiers.byName(ModuleContext.LIFECYCLE_START_NAME))).isTrue();
+        AtomicBoolean moduleSpecificShutdownHandlerInvoked = beanContext.getBean(AtomicBoolean.class,
+                                                                                 Qualifiers.byName(ModuleContext.LIFECYCLE_SHUTDOWN_NAME));
+        assertThat(moduleSpecificShutdownHandlerInvoked).isFalse();
+
+        beanContext.stop();
+        assertThat(moduleSpecificShutdownHandlerInvoked).isTrue();
+        // don't break @MicronautTest
+        beanContext.start();
+    }
+
+    @Property(name = ComponentFactoryContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void validateComponentFactoryBeanUsage() {
+        var shutdownHandlers = beanContext.getBeansOfType(MicronautLifecycleShutdownHandler.class);
+        assertTrue(shutdownHandlers.stream().anyMatch(h -> h.getOrder() == ComponentFactoryContext.SHUTDOWN_PHASE));
+        AtomicBoolean factoryShutdownHandlerInvoked = beanContext.getBean(AtomicBoolean.class,
+                                                                          Qualifiers.byName(ComponentFactoryContext.FACTORY_SHUTDOWN_HANDLER_INVOKED_NAME));
+        assertThat(factoryShutdownHandlerInvoked).isFalse();
+        beanContext.stop();
+        assertThat(factoryShutdownHandlerInvoked).isTrue();
+        // don't break @MicronautTest
+        beanContext.start();
+    }
+
+    @Property(name = GenericComponentRegistrationContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void configurationEnhancerRegisteredGenericComponentsAreCorrectlyRegisteredInApplicationContext() {
+        var myDependentBean = beanContext.getBean(GenericComponentRegistrationContext.MyDependentBean.class);
+
+        assertThat(myDependentBean.beanOne().field()).isEqualTo("helloWorld");
+        assertThat(myDependentBean.beanTwo().field()).isEqualTo(42L);
+    }
+
+
+    @Property(name = LifecycleContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void componentDefinitionsIntegrateWithLifecycleRegistryThroughDedicatedLifecycleBeans() {
+        // We expect beans to be registered for lifecycle handlers.
+        Collection<MicronautLifecycleStartHandler> startHandlers = beanContext.getBeansOfType(
+                MicronautLifecycleStartHandler.class);
+        Collection<MicronautLifecycleShutdownHandler> shutdownHandlers = beanContext.getBeansOfType(
+                MicronautLifecycleShutdownHandler.class);
+
+        assertTrue(startHandlers.stream().anyMatch(h -> h.getOrder() == LifecycleContext.START_PHASE));
+        assertTrue(shutdownHandlers.stream().anyMatch(h -> h.getOrder() == LifecycleContext.SHUTDOWN_PHASE));
+
+        assertThat(beanContext.getBean(AtomicBoolean.class,
+                                       Qualifiers.byName(LifecycleContext.LIFECYCLE_START_NAME))).isTrue();
+        AtomicBoolean shutdownHandlerInvoked = beanContext.getBean(AtomicBoolean.class,
+                                                                   Qualifiers.byName(LifecycleContext.LIFECYCLE_SHUTDOWN_NAME));
+        assertThat(shutdownHandlerInvoked).isFalse();
+
+        beanContext.stop();
+        assertThat(shutdownHandlerInvoked).isTrue();
+        // don't break @MicronautTest
+        beanContext.start();
+    }
+
+
+    @Property(name = BeanDecoratorDefinitionContext.ENABLED_PROPERTY, value = TRUE)
+    @Disabled("Unsupported yet")
+    @Test
+    void validateDecoratorDefinitionsAreInvokedOnMicronautBeans() {
+        assertThat(beanContext.getBean(String.class)).isEqualTo(BeanDecoratorDefinitionContext.CUSTOM_BEAN_OVERRIDE);
+        var decoratorStarted = beanContext.findBean(AtomicBoolean.class,
+                                                    Qualifiers.byName(BeanDecoratorDefinitionContext.DECORATOR_STARTED_NAME));
+        assertThat(decoratorStarted.isPresent()).isTrue();
+        await().pollDelay(Duration.ofMillis(50))
+               .atMost(Duration.ofSeconds(1))
+               .untilTrue(decoratorStarted.get());
+    }
+
+    @Factory
+    @Requires(property = BeanDecoratorDefinitionContext.ENABLED_PROPERTY, value = TRUE)
+    public static class BeanDecoratorDefinitionContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.BeanDecoratorDefinitionContext";
+        private static final String DECORATOR_STARTED_NAME = "spec.MicronautComponentRegistry.BeanDecoratorDefinitionContext.decoratorStarted";
+        private static final String CUSTOM_BEAN_OVERRIDE = "override";
+
+        @Singleton
+        @Named(DECORATOR_STARTED_NAME)
+        AtomicBoolean decoratorStarted() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        String customBeam() {
+            return "custom";
+        }
+
+        @Singleton
+        DecoratorDefinition<String, String> interceptingDecorator(
+                @Named(DECORATOR_STARTED_NAME) AtomicBoolean decoratorStarted) {
+            return DecoratorDefinition.forType(String.class)
+                                      .with((config, name, delegate) ->
+                                                    CUSTOM_BEAN_OVERRIDE
+                                      )
+                                      .order(0)
+                                      .onStart(0, component -> decoratorStarted.set(true));
+        }
+    }
+
+    @Factory
+    @Requires(property = DecoratorDefinitionContext.ENABLED_PROPERTY, value = TRUE)
+    public static class DecoratorDefinitionContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.DecoratorDefinitionContext";
+        private static final String DECORATOR_STARTED_NAME = "spec.MicronautComponentRegistry.DecoratorDefinitionContext.decoratorStarted";
+
+        @Singleton
+        @Named(DECORATOR_STARTED_NAME)
+        AtomicBoolean decoratorStarted() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        DecoratorDefinition<CommandBus, InterceptingCommandBus> interceptingDecorator(
+                @Named(DECORATOR_STARTED_NAME) AtomicBoolean decoratorStarted) {
+            return DecoratorDefinition.forType(CommandBus.class)
+                                      .with((config, name, delegate) ->
+                                                    new InterceptingCommandBus(delegate, List.of(), List.of()))
+                                      .order(0)
+                                      .onStart(0, component -> decoratorStarted.set(true));
+        }
+    }
+
+    @Factory
+    @Requires(property = ConfigurationEnhancerContext.ENABLED_PROPERTY, value = TRUE)
+    public static class ConfigurationEnhancerContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.ConfigurationEnhancerContext";
+
+        @Singleton
+        ConfigurationEnhancer configurationEnhancer() {
+            return registry -> registry.registerDecorator(
+                    CommandBus.class, 0,
+                    (ComponentDecorator<CommandBus, CommandBus>) (config, name, delegate) ->
+                            new InterceptingCommandBus(delegate, List.of(), List.of())
+            );
+        }
+    }
+
+    @Factory
+    @Requires(property = ModuleContext.ENABLED_PROPERTY, value = TRUE)
+    public static class ModuleContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.ModuleContext";
+        private static final String LIFECYCLE_START_NAME = "spec.MicronautComponentRegistry.ModuleContext.startHandlerInvoked";
+        private static final String MODULE_NAME = "testModule";
+        private static final String LIFECYCLE_SHUTDOWN_NAME = "spec.MicronautComponentRegistry.ModuleContext.shutdownHandlerInvoked";
+        private static final String MODULE_SPECIFIC_STRING = "Some String That Is Only Present Here!";
+        private static final int START_PHASE = 1337;
+        private static final int SHUTDOWN_PHASE = 7331;
+
+        @Singleton
+        @Named(LIFECYCLE_START_NAME)
+        AtomicBoolean startHandlerInvoked() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        @Named(LIFECYCLE_SHUTDOWN_NAME)
+        AtomicBoolean shutdownHandlerInvoked() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        <S extends BaseModule<S>> BaseModule<S> testModule(
+                @Named(LIFECYCLE_START_NAME) AtomicBoolean moduleSpecificStartHandlerInvoked,
+                @Named(LIFECYCLE_SHUTDOWN_NAME) AtomicBoolean moduleSpecificShutdownHandlerInvoked) {
+            return new BaseModule<>(MODULE_NAME) {
+                @Override
+                public Configuration build(
+                        Configuration parent,
+                        LifecycleRegistry lifecycleRegistry
+                ) {
+                    lifecycleRegistry.onStart(START_PHASE, () -> moduleSpecificStartHandlerInvoked.set(true));
+                    lifecycleRegistry.onShutdown(SHUTDOWN_PHASE, () -> moduleSpecificShutdownHandlerInvoked.set(true));
+                    componentRegistry(registry -> registry.registerComponent(
+                            Object.class, MODULE_SPECIFIC_STRING, c -> MODULE_SPECIFIC_STRING
+                    ));
+                    return super.build(parent, lifecycleRegistry);
+                }
+            };
+        }
+    }
+
+    @Factory
+    @Requires(property = ComponentFactoryContext.ENABLED_PROPERTY, value = TRUE)
+    public static class ComponentFactoryContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.ComponentFactoryContext";
+        private static final String FACTORY_SHUTDOWN_HANDLER_INVOKED_NAME = "spec.MicronautComponentRegistry.ComponentFactoryContext.factoryShutdownHandlerInvoked";
+        private static final String FACTORY_SPECIFIC_STRING = "Some Factory Made String.";
+        private static final int SHUTDOWN_PHASE = 9001;
+
+
+        @Singleton
+        @Named(FACTORY_SHUTDOWN_HANDLER_INVOKED_NAME)
+        AtomicBoolean factoryShutdownHandlerInvoked() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        ComponentFactory<String> testComponentFactory(@Named(FACTORY_SHUTDOWN_HANDLER_INVOKED_NAME)
+                                                      AtomicBoolean factoryShutdownHandlerInvoked) {
+            return new ComponentFactory<>() {
+                @Override
+                public void describeTo(ComponentDescriptor descriptor) {
+                    // Not implemented as not important.
+                }
+
+                @Override
+                public Class<String> forType() {
+                    return String.class;
+                }
+
+                @Override
+                public Optional<Component<String>> construct(
+                        String name,
+                        Configuration config
+                ) {
+                    return Optional.of(new InstantiatedComponentDefinition<>(
+                            new Component.Identifier<>(forType(), name),
+                            name + FACTORY_SPECIFIC_STRING
+                    ));
+                }
+
+                @Override
+                public void registerShutdownHandlers(LifecycleRegistry registry) {
+                    registry.onShutdown(9001, () -> factoryShutdownHandlerInvoked.set(true));
+                }
+            };
+        }
+    }
+
+    @Factory
+    @Requires(property = GenericComponentRegistrationContext.ENABLED_PROPERTY, value = TRUE)
+    public static class GenericComponentRegistrationContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.GenericComponentRegistrationContext";
+
+        @Singleton
+        ConfigurationEnhancer genericComponentRegistrationEnhancer() {
+            return registry -> {
+                ComponentDefinition<MyGenericBean<String>> genericStringBeanDefinition =
+                        ComponentDefinition.ofTypeAndName(new TypeReference<MyGenericBean<String>>() {
+                                           }, "stringBean")
+                                           .withInstance(new MyGenericBean<>("helloWorld"));
+                registry.registerComponent(genericStringBeanDefinition);
+
+                ComponentDefinition<MyGenericBean<Integer>> genericIntegerBeanDefinition =
+                        ComponentDefinition.ofTypeAndName(new TypeReference<MyGenericBean<Integer>>() {
+                                           }, "intBean")
+                                           .withInstance(new MyGenericBean<>(1337));
+                registry.registerComponent(genericIntegerBeanDefinition);
+
+                ComponentDefinition<MyGenericBean<Long>> genericLongBeanDefinition =
+                        ComponentDefinition.ofTypeAndName(new TypeReference<MyGenericBean<Long>>() {
+                                           }, "longBean")
+                                           .withInstance(new MyGenericBean<>(42L));
+                registry.registerComponent(genericLongBeanDefinition);
+            };
+        }
+
+        @Singleton
+        MyDependentBean<String, Long> myDependentBean(MyGenericBean<String> stringBean,
+                                                      MyGenericBean<Long> longBean) {
+            return new MyDependentBean<>(stringBean, longBean);
+        }
+
+
+        private record MyGenericBean<T>(T field) {
+
+        }
+
+        private record MyDependentBean<T, S>(MyGenericBean<T> beanOne, MyGenericBean<S> beanTwo) {
+
+        }
+    }
+
+
+    @Factory
+    @Requires(property = LifecycleContext.ENABLED_PROPERTY, value = TRUE)
+    public static class LifecycleContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautComponentRegistry.LifecycleContext";
+
+        private static final String LIFECYCLE_START_NAME = "spec.MicronautComponentRegistry.LifecycleContext.startHandlerInvoked";
+        private static final String LIFECYCLE_SHUTDOWN_NAME = "spec.MicronautComponentRegistry.LifecycleContext.shutdownHandlerInvoked";
+        private static final int START_PHASE = 1337;
+        private static final int SHUTDOWN_PHASE = 7331;
+
+
+        @Singleton
+        @Named(LIFECYCLE_START_NAME)
+        AtomicBoolean startHandlerInvoked() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        @Named(LIFECYCLE_SHUTDOWN_NAME)
+        AtomicBoolean shutdownHandlerInvoked() {
+            return new AtomicBoolean(false);
+        }
+
+        @Singleton
+        ConfigurationEnhancer lifecycleBeanAdder(
+                @Named(LIFECYCLE_START_NAME) AtomicBoolean componentSpecificStartHandlerInvoked,
+                @Named(LIFECYCLE_SHUTDOWN_NAME) AtomicBoolean componentSpecificShutdownHandlerInvoked) {
+            return registry -> registry.registerComponent(
+                    ComponentDefinition.ofType(TestComponent.class)
+                                       .withBuilder(c -> new TestComponent(componentSpecificStartHandlerInvoked,
+                                                                           componentSpecificShutdownHandlerInvoked))
+                                       .onStart(START_PHASE, TestComponent::start)
+                                       .onShutdown(SHUTDOWN_PHASE, TestComponent::shutdown)
+            );
+        }
+
+        private record TestComponent(AtomicBoolean started,
+                                     AtomicBoolean stopped) {
+
+            public void start() {
+                started.set(true);
+            }
+
+            public void shutdown() {
+                stopped.set(true);
+            }
+        }
+    }
+
+    @Requires(property = CUSTOM_COMPONENT_REGISTRY_ENABLED_PROPERTY, value = TRUE)
+    @Singleton
+    ComponentRegistry customComponentRegistry() {
+        return new DefaultComponentRegistry();
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleRegistryTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleRegistryTest.java
@@ -1,0 +1,76 @@
+package org.axonframework.extension.micronaut.config;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.LifecycleHandler;
+import org.axonframework.common.configuration.LifecycleRegistry;
+import org.axonframework.common.configuration.StubLifecycleRegistry;
+import org.junit.jupiter.api.*;
+
+import static io.micronaut.core.util.StringUtils.TRUE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@MicronautTest(rebuildContext = true)
+class MicronautLifecycleRegistryTest {
+
+    @Inject
+    BeanContext beanContext;
+    @Inject
+    LifecycleRegistry lifecycleRegistry;
+
+    @Property(name = CustomLifecycleRegistryContext.ENABLED_PROPERTY, value = TRUE)
+    @Test
+    void shouldBeOverridable() {
+        assertTrue(lifecycleRegistry instanceof StubLifecycleRegistry);
+    }
+
+    @Test
+    void onStartRegistersMicronautLifecycleStartHandlerWithBeanContext() {
+        assertFalse(beanContext.containsBean(MicronautLifecycleStartHandler.class));
+        lifecycleRegistry.onStart(1, mock(LifecycleHandler.class));
+        lifecycleRegistry.onStart(2, mock(LifecycleHandler.class));
+        assertEquals(2, beanContext.getBeansOfType(MicronautLifecycleStartHandler.class).size());
+    }
+
+
+    @Test
+    void onShutdownRegistersMicronautLifecycleShutdownHandlerWithBeanContext() {
+        assertFalse(beanContext.containsBean(MicronautLifecycleShutdownHandler.class));
+        lifecycleRegistry.onShutdown(1, mock(LifecycleHandler.class));
+        lifecycleRegistry.onShutdown(2, mock(LifecycleHandler.class));
+        assertEquals(2, beanContext.getBeansOfType(MicronautLifecycleShutdownHandler.class).size());
+    }
+
+
+    @Test
+    void expectToBeAvailableInContext() {
+        assertTrue(beanContext.containsBean(LifecycleRegistry.class));
+    }
+
+
+    @Factory
+    @Requires(property = CustomLifecycleRegistryContext.ENABLED_PROPERTY, value = TRUE)
+    public static class CustomLifecycleRegistryContext {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronuatLifecycleRegistryTest.CustomLifecycleRegistryContext";
+
+        @Singleton
+        LifecycleRegistry stubLifecycleRegistry() {
+            return new StubLifecycleRegistry();
+        }
+    }
+
+    @MockBean(Configuration.class)
+    Configuration configuration() {
+        return mock();
+    }
+}
+

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleShutdownHandlerTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleShutdownHandlerTest.java
@@ -1,0 +1,88 @@
+package org.axonframework.extension.micronaut.config;
+
+import com.google.common.primitives.Ints;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.runtime.graceful.GracefulShutdownConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static io.micronaut.core.util.StringUtils.FALSE;
+import static io.micronaut.core.util.StringUtils.TRUE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Property(name = "expected-invocations", value = "3,2,1,9,5")
+@Property(name = MicronautLifecycleShutdownHandlerTest.TestLifecycleShutdownHandlerFactory.ENABLED_PROPERTY, value = TRUE)
+@Property(name = GracefulShutdownConfiguration.ENABLED, value = TRUE)
+@MicronautTest(rebuildContext = true)
+class MicronautLifecycleShutdownHandlerTest {
+
+    @Inject
+    private BeanContext beanContext;
+
+    @Inject
+    TestLifecycleShutdownHandlerFactory lifecycleStartHandlerFactory;
+
+    @Property(name = "expected-invocations")
+    private int[] expectedInvocations;
+
+    /**
+     * We are stopping the BeanContext for our tests to simulate application shutdown, new tests with throw an error if
+     * the beanContext is stopped, therefore we are ensuring the context is up after each test
+     */
+    @AfterEach
+    void afterEach() {
+        beanContext.start();
+    }
+
+    @Test
+    void shouldCallShutdownHandlersInPhaseOrder() {
+        beanContext.stop();
+        assertEquals(expectedInvocations.length,
+                     lifecycleStartHandlerFactory.invocations.size());
+        assertArrayEquals(Arrays.stream(expectedInvocations).sorted().toArray(),
+                          Ints.toArray(lifecycleStartHandlerFactory.invocations));
+    }
+
+    @Test
+    void shouldInvokeShutdownHandlersAfterContextStop() {
+        assertEquals(0, lifecycleStartHandlerFactory.invocations.size());
+        beanContext.stop();
+        assertNotEquals(0, lifecycleStartHandlerFactory.invocations.size());
+    }
+
+    @Context
+    @Requires(property = TestLifecycleShutdownHandlerFactory.ENABLED_PROPERTY, value = TRUE)
+    public static class TestLifecycleShutdownHandlerFactory {
+
+        protected static final String ENABLED_PROPERTY = "spec.MicronautLifecycleShutdownHandlerTest.TestLifecycleShutdownHandlerFactory.enabled";
+
+        public ArrayList<Integer> invocations = new ArrayList<>();
+
+        public TestLifecycleShutdownHandlerFactory(
+                BeanContext beanContext,
+                @Property(name = GracefulShutdownConfiguration.ENABLED,defaultValue = FALSE) boolean gracefulShutdownEnabled,
+                @Property(name = "expected-invocations") int[] expectedInvocations
+        ) {
+            for (var i : expectedInvocations) {
+                beanContext.registerSingleton(
+                        MicronautLifecycleShutdownHandler.class,
+                        new MicronautLifecycleShutdownHandler(mock(), gracefulShutdownEnabled, i, (c) -> {
+                            invocations.add(i);
+                            return CompletableFuture.completedFuture(null);
+                        }),
+                        Qualifiers.byName(String.valueOf(i))
+                );
+            }
+        }
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleStartHandlerTest.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/MicronautLifecycleStartHandlerTest.java
@@ -1,0 +1,59 @@
+package org.axonframework.extension.micronaut.config;
+
+import com.google.common.primitives.Ints;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static io.micronaut.core.util.StringUtils.TRUE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@MicronautTest(rebuildContext = true)
+class MicronautLifecycleStartHandlerTest {
+
+    @Property(name = TestLifecycleStartHandlerFactory.ENABLED_PROPERTY, value = TRUE)
+    @Property(name = "expected-invocations", value = "3,2,1,9,5")
+    @Test
+    void tests(
+            TestLifecycleStartHandlerFactory lifecycleStartHandlerFactory,
+            @Property(name = "expected-invocations") int[] expectedInvocations
+    ) {
+        assertEquals(expectedInvocations.length,
+                     lifecycleStartHandlerFactory.invocations.size());
+        assertArrayEquals(Arrays.stream(expectedInvocations).sorted().toArray(),
+                          Ints.toArray(lifecycleStartHandlerFactory.invocations));
+    }
+
+    @Context
+    @Requires(property = TestLifecycleStartHandlerFactory.ENABLED_PROPERTY, value = TRUE)
+    static class TestLifecycleStartHandlerFactory {
+
+        private static final String ENABLED_PROPERTY = "spec.MicronautLifecycleStartHandlerTest.TestLifecycleStartHandlerFactory";
+
+        public ArrayList<Integer> invocations = new ArrayList<>();
+
+        public TestLifecycleStartHandlerFactory(
+                BeanContext beanContext,
+                @Property(name = "expected-invocations") int[] expectedInvocations
+        ) {
+            for (var i : expectedInvocations) {
+
+                beanContext.registerSingleton(
+                        MicronautLifecycleStartHandler.class,
+                        new MicronautLifecycleStartHandler(mock(), i, (c) -> {
+                            invocations.add(i);
+                            return CompletableFuture.completedFuture(null);
+                        })
+                );
+            }
+        }
+    }
+}

--- a/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/package-info.java
+++ b/extensions/micronaut/micronaut/src/test/java/org/axonframework/extension/micronaut/config/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.axonframework.extension.micronaut.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/extensions/micronaut/pom.xml
+++ b/extensions/micronaut/pom.xml
@@ -18,25 +18,29 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.axonframework</groupId>
-        <artifactId>axon-parent</artifactId>
+        <groupId>org.axonframework.extensions</groupId>
+        <artifactId>axon-extensions</artifactId>
         <version>${revision}</version>
-        <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 
-    <groupId>org.axonframework.extensions</groupId>
-    <artifactId>axon-extensions</artifactId>
+    <groupId>org.axonframework.extensions.micronaut</groupId>
+    <artifactId>axon-micronaut-extension</artifactId>
     <packaging>pom</packaging>
 
-    <name>Axon Extension - Parent</name>
-    <description>Module providing parent for Axon Framework Extensions.</description>
+    <name>Axon Extension - Micronaut - Parent</name>
+    <description>Module providing parent for Axon Framework Micronaut Extension.</description>
 
     <modules>
-        <module>kotlin</module>
-        <module>metrics</module>
-        <module>reactor</module>
-        <module>spring</module>
         <module>micronaut</module>
-        <module>tracing</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.axonframework.extensions.micronaut</groupId>
+                <artifactId>axon-micronaut</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
Initial implementation of micronaut-extension

This introduces implementations for:
- LifecycleRegistry
- ComponentRegistry
- AxonConfiguation
- AxonApplication

The only thing currently missing in this implementation is decoration of non-manually registered beans.
Implementhing this is a bit problematic and really goes againts Micronauts Reflection-less appraoch to stuff.
Therefore I left it as unimplemented for now.
