### PR TITLE
Ensure `ResourceOverridingProcessingContext#resources()` does not throw an Unsupported Operation Exception

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.messaging.core.unitofwork;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -175,9 +176,9 @@ public class ResourceOverridingProcessingContext<R> implements ProcessingContext
 
     @Override
     public Map<ResourceKey<?>, Object> resources() {
-        var allResources = delegate.resources();
-        allResources.put(key, resource.get());
-        return allResources;
+        Map<ResourceKey<?>, Object> all = new HashMap<>(delegate.resources());
+        all.put(key, resource.get());
+        return Map.copyOf(all);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContextTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContextTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.unitofwork;
+
+import org.axonframework.messaging.core.Context;
+import org.junit.jupiter.api.*;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link ResourceOverridingProcessingContext}.
+ *
+ * @author Steven van Beelen
+ */
+class ResourceOverridingProcessingContextTest {
+
+    @Test
+    void resourcesReturnsCollectionOfAllResources() {
+        Context.ResourceKey<String> testResourceKey = Context.ResourceKey.withLabel("my-resource");
+        String testResourceValue = "my-resource";
+        Context.ResourceKey<String> testOverrideKey = Context.ResourceKey.withLabel("overriding-resource");
+        String testOverrideValue = "overriding-resource";
+
+        ResourceOverridingProcessingContext<String> testSubject = new ResourceOverridingProcessingContext<>(
+                new StubProcessingContext().withResource(testResourceKey, testResourceValue),
+                testOverrideKey, testOverrideValue
+        );
+
+        Map<Context.ResourceKey<?>, Object> result = testSubject.resources();
+
+        assertThat(result).containsKey(testResourceKey);
+        assertThat(result).containsValue(testResourceValue);
+        assertThat(result).containsKey(testOverrideKey);
+        assertThat(result).containsValue(testOverrideValue);
+    }
+}


### PR DESCRIPTION
This PR ensures that the `ResourceOverridingProcessingContext` `resources()` method does not throw an `UnsupportedOperationException`. 
To that end, we should ensure we have a mutable map from the delegate so that we can add the override separately for the resources we return. 
This holds, as all other `ProcessingContext#resources` method returns an immutable map. Hence, the adding of the overridden resource failed.
Furthermore, I have added a test that validates this work.