### PR TITLE
Make initial callback execution for InMemory engine unconditional

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -322,9 +322,7 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
         @Override
         public void setCallback(@Nonnull Runnable callback) {
             this.callback.set(callback);
-            if (eventStorage.isEmpty() || eventStorage.containsKey(Math.max(0, this.position.get()))) {
-                callback.run();
-            }
+            callback.run();
         }
 
         @Override


### PR DESCRIPTION
This solves a problem when `reduce` is called on a message stream provided by the InMemoryEventStorageEngine. When `reduce` is called on a stream that has zero events (due to using high start `Position`), `reduce` will block indefinitely.