### PR TITLE
Update event publishing methods to accept lists of EventMessage subtypes

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
@@ -145,7 +145,7 @@ public class InterceptingEventStore implements EventStore {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         return delegateBus.publish(context, events);
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
@@ -90,7 +90,7 @@ public class StorageEngineBackedEventStore implements EventStore {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         if (context == null) {
             AppendCondition none = AppendCondition.none();
             List<TaggedEventMessage<?>> taggedEvents = new ArrayList<>();
@@ -115,7 +115,7 @@ public class StorageEngineBackedEventStore implements EventStore {
     }
 
     private void appendToTransaction(ProcessingContext context,
-                                     List<EventMessage> events) {
+                                     List<? extends EventMessage> events) {
         EventStoreTransaction transaction = transaction(context);
         for (EventMessage event : events) {
             transaction.appendEvent(event);

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/DelegatingEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/DelegatingEventBus.java
@@ -50,7 +50,7 @@ public abstract class DelegatingEventBus implements EventBus {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         return delegate.publish(context, events);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSink.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSink.java
@@ -78,5 +78,5 @@ public interface EventSink extends DescribableComponent {
      * successful completion of this future means the {@code events} where published.
      */
     CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                    @Nonnull List<EventMessage> events);
+                                    @Nonnull List<? extends EventMessage> events);
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventBus.java
@@ -82,7 +82,7 @@ public class InterceptingEventBus implements EventBus {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         return delegateSink.publish(context, events);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventSink.java
@@ -82,7 +82,7 @@ public class InterceptingEventSink implements EventSink {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         return interceptingPublisher.interceptAndPublish(events, context);
     }
 
@@ -110,7 +110,7 @@ public class InterceptingEventSink implements EventSink {
         }
 
         private CompletableFuture<Void> interceptAndPublish(
-                @Nonnull List<EventMessage> events,
+                @Nonnull List<? extends EventMessage> events,
                 @Nullable ProcessingContext context
         ) {
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
@@ -105,7 +105,7 @@ public class SimpleEventBus implements EventBus {
     }
 
     @Override
-    public CompletableFuture<Void> publish(@Nullable ProcessingContext context, @Nonnull List<EventMessage> events) {
+    public CompletableFuture<Void> publish(@Nullable ProcessingContext context, @Nonnull List<? extends EventMessage> events) {
         if (context == null) {
             // No processing context, publish immediately
             eventSubscribers.notifySubscribers(events, context);
@@ -116,7 +116,7 @@ public class SimpleEventBus implements EventBus {
         return FutureUtils.emptyCompletedFuture();
     }
 
-    private void registerEventPublishingHooks(@Nonnull ProcessingContext context, @Nonnull List<EventMessage> events) {
+    private void registerEventPublishingHooks(@Nonnull ProcessingContext context, @Nonnull List<? extends EventMessage> events) {
         // Check if we're already in or past the commit phase - publishing is forbidden at this point
         if (context.isCommitted()) {
             throw new IllegalStateException(

--- a/messaging/src/test/java/org/axonframework/messaging/core/configuration/MessagingConfigurerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/configuration/MessagingConfigurerTest.java
@@ -177,7 +177,7 @@ class MessagingConfigurerTest extends ApplicationConfigurerTestSuite<MessagingCo
         EventSink expected = new EventSink() {
             @Override
             public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                                   @Nonnull List<EventMessage> events) {
+                                                   @Nonnull List<? extends EventMessage> events) {
                 return FutureUtils.emptyCompletedFuture();
             }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/gateway/ProcessingContextEventAppenderTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/gateway/ProcessingContextEventAppenderTest.java
@@ -41,7 +41,7 @@ class ProcessingContextEventAppenderTest {
     private final EventSink mockEventSink = spy(new EventSink() {
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -1086,7 +1086,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
 
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             return null;
         }
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/modelling/command/GenericJpaRepositoryTest.java
@@ -346,7 +346,7 @@ class GenericJpaRepositoryTest {
 
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             publishedEvents.addAll(events);
             return super.publish(context, events);
         }

--- a/stash/todo/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
+++ b/stash/todo/src/test/java/org/axonframework/integrationtests/modelling/command/CommandHandlingTest.java
@@ -98,7 +98,7 @@ class CommandHandlingTest {
 
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             if (context == null) {
                 storeEvents(events);
             } else {
@@ -107,7 +107,7 @@ class CommandHandlingTest {
             return super.publish(context, events);
         }
 
-        private void storeEvents(@Nonnull List<EventMessage> events) {
+        private void storeEvents(@Nonnull List<? extends EventMessage> events) {
             storedEvents.addAll(
                     events.stream()
                           .map(StubEventStore::asDomainEventMessage)

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/AbstractDbSchedulerEventSchedulerTest.java
@@ -235,7 +235,7 @@ abstract class AbstractDbSchedulerEventSchedulerTest {
 
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             publishedMessages.addAll(events);
             return FutureUtils.emptyCompletedFuture();
         }

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventSchedulerTest.java
@@ -221,7 +221,7 @@ class JobRunrEventSchedulerTest {
 
         @Override
         public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                               @Nonnull List<EventMessage> events) {
+                                               @Nonnull List<? extends EventMessage> events) {
             publishedMessages.addAll(events);
             return FutureUtils.emptyCompletedFuture();
         }

--- a/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
@@ -55,7 +55,7 @@ public class RecordingEventSink implements EventSink {
 
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
-                                           @Nonnull List<EventMessage> events) {
+                                           @Nonnull List<? extends EventMessage> events) {
         return delegate.publish(context, events)
                        .thenRun(() -> recorded.addAll(events));
     }


### PR DESCRIPTION
This change allows this to compile:

```java
eventStore.publish(
    null, 
    Arrays.stream(events)
        .map(e -> new GenericEventMessage(new MessageType(e.getClass()), e))
        .toList()
);
```

Without this change, the list must be cast to `List<EventMessage>`.