### PR TITLE
fix(messaging): `ResourceOverridingProcessingContext` run lifecycle hooks with the overridden resources

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContext.java
@@ -80,87 +80,105 @@ public class ResourceOverridingProcessingContext<R> implements ProcessingContext
 
     @Override
     public ProcessingLifecycle on(@Nonnull Phase phase, @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.on(phase, action);
+        delegate.on(phase, ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOn(@Nonnull Phase phase, @Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOn(phase, action);
+        delegate.runOn(phase, ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onPreInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onPreInvocation(action);
+        delegate.onPreInvocation(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnPreInvocation(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnPreInvocation(action);
+        delegate.runOnPreInvocation(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onInvocation(action);
+        delegate.onInvocation(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnInvocation(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnInvocation(action);
+        delegate.runOnInvocation(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onPostInvocation(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onPostInvocation(action);
+        delegate.onPostInvocation(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnPostInvocation(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnPostInvocation(action);
+        delegate.runOnPostInvocation(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onPrepareCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onPrepareCommit(action);
+        delegate.onPrepareCommit(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnPrepareCommit(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnPrepareCommit(action);
+        delegate.runOnPrepareCommit(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onCommit(action);
+        delegate.onCommit(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnCommit(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnCommit(action);
+        delegate.runOnCommit(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onAfterCommit(@Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
-        return delegate.onAfterCommit(action);
+        delegate.onAfterCommit(ignoredContext -> action.apply(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle runOnAfterCommit(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.runOnAfterCommit(action);
+        delegate.runOnAfterCommit(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle onError(@Nonnull ErrorHandler action) {
-        return delegate.onError(action);
+        delegate.onError((ignoredContext, phase, error) -> action.handle(this, phase, error));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.whenComplete(action);
+        delegate.whenComplete(ignoredContext -> action.accept(this));
+        return this;
     }
 
     @Override
     public ProcessingLifecycle doFinally(@Nonnull Consumer<ProcessingContext> action) {
-        return delegate.doFinally(action);
+        onError((context, phase, error) -> action.accept(context));
+        whenComplete(action);
+        return this;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContextTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ResourceOverridingProcessingContextTest.java
@@ -16,11 +16,24 @@
 
 package org.axonframework.messaging.core.unitofwork;
 
+import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.core.Context;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
+import static org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases.COMMIT;
+import static org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases.INVOCATION;
+import static org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases.PRE_INVOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -48,5 +61,158 @@ class ResourceOverridingProcessingContextTest {
         assertThat(result).containsValue(testResourceValue);
         assertThat(result).containsKey(testOverrideKey);
         assertThat(result).containsValue(testOverrideValue);
+    }
+
+    @Nested
+    class LifecycleCallbackContextOverrideTests {
+
+        private final Context.ResourceKey<String> testResourceKey = Context.ResourceKey.withLabel("test-resource");
+        private final Context.ResourceKey<String> testOverrideKey = Context.ResourceKey.withLabel("overriding-resource");
+        private final String delegateResourceValue = "delegate-resource-value";
+        private final String overriddenResourceValue = "overridden-resource-value";
+        private LifecycleAwareStubProcessingContext delegate;
+        private ResourceOverridingProcessingContext<String> testSubject;
+
+        @BeforeEach
+        void setUp() {
+            delegate = new LifecycleAwareStubProcessingContext();
+            delegate.putResource(testResourceKey, delegateResourceValue);
+            delegate.putResource(testOverrideKey, "delegate-overridden-value");
+            testSubject = new ResourceOverridingProcessingContext<>(delegate, testOverrideKey, overriddenResourceValue);
+        }
+
+        @Test
+        void onCallbackReceivesOverridingContext() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+
+            testSubject.on(INVOCATION, context -> {
+                contextRef.set(context);
+                return CompletableFuture.completedFuture(null);
+            });
+
+            delegate.triggerPhase(INVOCATION);
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void onPreInvocationCallbackReceivesOverridingContext() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+
+            testSubject.onPreInvocation(context -> {
+                contextRef.set(context);
+                return CompletableFuture.completedFuture(null);
+            });
+
+            delegate.triggerPhase(PRE_INVOCATION);
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void runOnPreInvocationCallbackReceivesOverridingContext() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+
+            testSubject.runOnPreInvocation(contextRef::set);
+
+            delegate.triggerPhase(PRE_INVOCATION);
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void onErrorCallbackReceivesOverridingContext() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+            IllegalStateException expectedException = new IllegalStateException("simulated");
+
+            testSubject.onError((context, phase, error) -> {
+                contextRef.set(context);
+                assertThat(phase).isEqualTo(COMMIT);
+                assertThat(error).isSameAs(expectedException);
+            });
+
+            delegate.triggerError(COMMIT, expectedException);
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void whenCompleteCallbackReceivesOverridingContext() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+
+            testSubject.whenComplete(contextRef::set);
+
+            delegate.triggerComplete();
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void doFinallyCallbackReceivesOverridingContextOnCompletion() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+
+            testSubject.doFinally(contextRef::set);
+
+            delegate.triggerComplete();
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        @Test
+        void doFinallyCallbackReceivesOverridingContextOnError() {
+            AtomicReference<ProcessingContext> contextRef = new AtomicReference<>();
+            IllegalStateException expectedException = new IllegalStateException("simulated");
+
+            testSubject.doFinally(contextRef::set);
+
+            delegate.triggerError(COMMIT, expectedException);
+
+            assertContextContainsOverride(contextRef.get());
+        }
+
+        private void assertContextContainsOverride(ProcessingContext context) {
+            assertThat(context).isSameAs(testSubject);
+            assertThat(context.getResource(testResourceKey)).isEqualTo(delegateResourceValue);
+            assertThat(context.getResource(testOverrideKey)).isEqualTo(overriddenResourceValue);
+        }
+    }
+
+    private static class LifecycleAwareStubProcessingContext extends StubProcessingContext {
+
+        private final Map<ProcessingLifecycle.Phase, List<Function<ProcessingContext, CompletableFuture<?>>>> phaseActions =
+                new HashMap<>();
+        private final List<ProcessingLifecycle.ErrorHandler> errorHandlers = new ArrayList<>();
+        private final List<Consumer<ProcessingContext>> completionHandlers = new ArrayList<>();
+
+        @Override
+        public ProcessingLifecycle on(@Nonnull ProcessingLifecycle.Phase phase,
+                                      @Nonnull Function<ProcessingContext, CompletableFuture<?>> action) {
+            phaseActions.computeIfAbsent(phase, p -> new ArrayList<>()).add(action);
+            return this;
+        }
+
+        @Override
+        public ProcessingLifecycle onError(@Nonnull ProcessingLifecycle.ErrorHandler action) {
+            errorHandlers.add(action);
+            return this;
+        }
+
+        @Override
+        public ProcessingLifecycle whenComplete(@Nonnull Consumer<ProcessingContext> action) {
+            completionHandlers.add(action);
+            return this;
+        }
+
+        void triggerPhase(ProcessingLifecycle.Phase phase) {
+            phaseActions.getOrDefault(phase, List.of()).forEach(action -> action.apply(this).join());
+        }
+
+        void triggerError(ProcessingLifecycle.Phase phase, Throwable error) {
+            errorHandlers.forEach(handler -> handler.handle(this, phase, error));
+        }
+
+        void triggerComplete() {
+            completionHandlers.forEach(handler -> handler.accept(this));
+        }
     }
 }


### PR DESCRIPTION
Before: every on phase method returns delegate and execute the hook without the override. 