### PR TITLE
Upgrade to Dropwizard 5

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -70,7 +70,7 @@
         <log4j.version>2.25.2</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
         <!-- Metrics -->
-        <dropwizard.metrics.version>4.2.37</dropwizard.metrics.version>
+        <dropwizard.metrics.version>5.0.5</dropwizard.metrics.version>
         <micrometer.version>1.16.0</micrometer.version>
         <!-- Other -->
         <byte-buddy.version>1.18.1</byte-buddy.version>

--- a/extensions/metrics/metrics-dropwizard/pom.xml
+++ b/extensions/metrics/metrics-dropwizard/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <!-- Dropwizard -->
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
+            <groupId>io.dropwizard.metrics5</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${dropwizard.metrics.version}</version>
         </dependency>

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/CapacityMonitor.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/CapacityMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.SlidingTimeWindowReservoir;
-import com.codahale.metrics.Snapshot;
+import io.dropwizard.metrics5.Clock;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Histogram;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricSet;
+import io.dropwizard.metrics5.SlidingTimeWindowReservoir;
+import io.dropwizard.metrics5.Snapshot;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.monitoring.MessageMonitor;
@@ -32,15 +33,14 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Calculates capacity by tracking, within the configured time window, the average message processing time
- * and multiplying that by the amount of messages processed.
- *
- * The capacity can be more than 1 if the monitored
- * message handler processes the messages in parallel. The capacity for a single threaded message handler will be
- * a value between 0 and 1.
- *
- * If the value for a single threaded message handler is 1 the component is active 100% of the time. This means
- * that messages will have to wait to be processed.
+ * Calculates capacity by tracking, within the configured time window, the average message processing time and
+ * multiplying that by the amount of messages processed.
+ * <p>
+ * The capacity can be more than 1 if the monitored message handler processes the messages in parallel. The capacity for
+ * a single threaded message handler will be a value between 0 and 1.
+ * <p>
+ * If the value for a single threaded message handler is 1 the component is active 100% of the time. This means that
+ * messages will have to wait to be processed.
  *
  * @author Marijn van Zelst
  * @since 3.0
@@ -63,7 +63,7 @@ public class CapacityMonitor implements MessageMonitor<Message>, MetricSet {
     /**
      * Creates a capacity monitor with the default time window 10 minutes
      *
-     * @param window The length of the window to measure the capacity over
+     * @param window   The length of the window to measure the capacity over
      * @param timeUnit The time unit of the time window
      */
     public CapacityMonitor(long window, TimeUnit timeUnit) {
@@ -71,12 +71,12 @@ public class CapacityMonitor implements MessageMonitor<Message>, MetricSet {
     }
 
     /**
-     * Creates a capacity monitor with the given time window. Uses the provided clock
-     * to measure process time per message.
+     * Creates a capacity monitor with the given time window. Uses the provided clock to measure process time per
+     * message.
      *
-     * @param window The length of the window to measure the capacity over
+     * @param window   The length of the window to measure the capacity over
      * @param timeUnit The time unit of the time window
-     * @param clock The clock used to measure the process time per message
+     * @param clock    The clock used to measure the process time per message
      */
     public CapacityMonitor(long window, TimeUnit timeUnit, Clock clock) {
         SlidingTimeWindowReservoir slidingTimeWindowReservoir = new SlidingTimeWindowReservoir(window, timeUnit, clock);
@@ -109,19 +109,20 @@ public class CapacityMonitor implements MessageMonitor<Message>, MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        Map<String, Metric> metrics = new HashMap<>();
-        metrics.put("capacity", capacity);
+    public Map<MetricName, Metric> getMetrics() {
+        Map<MetricName, Metric> metrics = new HashMap<>();
+        metrics.put(MetricName.build("capacity"), capacity);
         return metrics;
     }
 
     private class CapacityGauge implements Gauge<Double> {
+
         @Override
         public Double getValue() {
             Snapshot snapshot = processedDurationHistogram.getSnapshot();
             double meanProcessTime = snapshot.getMean();
             int numProcessed = snapshot.getValues().length;
-            return  (numProcessed * meanProcessTime) / timeUnit.toMillis(window);
+            return (numProcessed * meanProcessTime) / timeUnit.toMillis(window);
         }
     }
 }

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitor.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricSet;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
@@ -35,10 +36,9 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * A {@link MessageMonitor} implementation dedicated to {@link EventMessage EventMessages}.
  * <p>
- * This monitor defines the latency between the {@link EventMessage#timestamp()} and the {@link Clock#instant()}.
- * Doing so, it depicts the latency from when an event was published compared to when an
- * {@link EventProcessor} processes the event to clarify how far behind an
- * {@code EventProcessor} is.
+ * This monitor defines the latency between the {@link EventMessage#timestamp()} and the {@link Clock#instant()}. Doing
+ * so, it depicts the latency from when an event was published compared to when an {@link EventProcessor} processes the
+ * event to clarify how far behind an {@code EventProcessor} is.
  * <p>
  * Do note that a replay (as triggered through {@link StreamingEventProcessor#resetTokens()}, for example) will cause
  * this metric to bump up due to the processor handling old events.
@@ -78,9 +78,9 @@ public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        Map<String, Metric> metrics = new HashMap<>();
-        metrics.put("latency", (Gauge<Long>) processTime::get); // NOSONAR
+    public Map<MetricName, Metric> getMetrics() {
+        Map<MetricName, Metric> metrics = new HashMap<>();
+        metrics.put(MetricName.build("latency"), (Gauge<Long>) processTime::get); // NOSONAR
         return metrics;
     }
 }

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MessageCountingMonitor.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MessageCountingMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricSet;
 import jakarta.annotation.Nonnull;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.monitoring.MessageMonitor;
@@ -64,15 +65,13 @@ public class MessageCountingMonitor implements MessageMonitor<Message>, MetricSe
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        Map<String, Metric> metricSet = new HashMap<>();
-        metricSet.put("ingestedCounter", ingestedCounter);
-        metricSet.put("processedCounter", processedCounter);
-        metricSet.put("successCounter", successCounter);
-        metricSet.put("failureCounter", failureCounter);
-        metricSet.put("ignoredCounter", ignoredCounter);
+    public Map<MetricName, Metric> getMetrics() {
+        Map<MetricName, Metric> metricSet = new HashMap<>();
+        metricSet.put(MetricName.build("ingestedCounter"), ingestedCounter);
+        metricSet.put(MetricName.build("processedCounter"), processedCounter);
+        metricSet.put(MetricName.build("successCounter"), successCounter);
+        metricSet.put(MetricName.build("failureCounter"), failureCounter);
+        metricSet.put(MetricName.build("ignoredCounter"), ignoredCounter);
         return metricSet;
     }
-
-
 }

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MessageTimerMonitor.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MessageTimerMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.Reservoir;
-import com.codahale.metrics.Timer;
+import io.dropwizard.metrics5.Clock;
+import io.dropwizard.metrics5.ExponentiallyDecayingReservoir;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricSet;
+import io.dropwizard.metrics5.Reservoir;
+import io.dropwizard.metrics5.Timer;
 import jakarta.annotation.Nonnull;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.core.Message;
@@ -48,21 +49,21 @@ public class MessageTimerMonitor implements MessageMonitor<Message>, MetricSet {
     private final Timer ignoredTimer;
 
     /**
-     * Instantiate a Builder to be able to create a {@link MessageTimerMonitor}.
+     * Instantiate a Builder to be able to create a {@code MessageTimerMonitor}.
      * <p>
      * The {@link Clock} is defaulted to a {@link Clock#defaultClock()} and the {@code reservoirFactory} defaults to
      * creating a {@link ExponentiallyDecayingReservoir}.
      *
-     * @return a Builder to be able to create a {@link MessageTimerMonitor}
+     * @return a Builder to be able to create a {@code MessageTimerMonitor}
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Instantiate a {@link MessageTimerMonitor} based on the fields contained in the {@link Builder}.
+     * Instantiate a {@code MessageTimerMonitor} based on the fields contained in the {@link Builder}.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link MessageTimerMonitor} instance
+     * @param builder the {@link Builder} used to instantiate a {@code MessageTimerMonitor} instance
      */
     protected MessageTimerMonitor(Builder builder) {
         builder.validate();
@@ -104,12 +105,12 @@ public class MessageTimerMonitor implements MessageMonitor<Message>, MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        Map<String, Metric> metrics = new HashMap<>();
-        metrics.put("allTimer", allTimer);
-        metrics.put("successTimer", successTimer);
-        metrics.put("failureTimer", failureTimer);
-        metrics.put("ignoredTimer", ignoredTimer);
+    public Map<MetricName, Metric> getMetrics() {
+        Map<MetricName, Metric> metrics = new HashMap<>();
+        metrics.put(MetricName.build("allTimer"), allTimer);
+        metrics.put(MetricName.build("successTimer"), successTimer);
+        metrics.put(MetricName.build("failureTimer"), failureTimer);
+        metrics.put(MetricName.build("ignoredTimer"), ignoredTimer);
         return metrics;
     }
 

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MetricsConfigurationEnhancer.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/MetricsConfigurationEnhancer.java
@@ -16,7 +16,8 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricRegistry;
 import jakarta.annotation.Nonnull;
 import org.axonframework.common.StringUtils;
 import org.axonframework.common.configuration.ComponentRegistry;
@@ -63,16 +64,16 @@ public class MetricsConfigurationEnhancer implements ConfigurationEnhancer {
     private final MetricRegistry registry;
 
     /**
-     * Initializes a new {@code MetricsConfigurationEnhancer} constructing {@link MessageMonitor MessageMonitors} that are
-     * registered with a new {@link MetricRegistry} with default settings.
+     * Initializes a new {@code MetricsConfigurationEnhancer} constructing {@link MessageMonitor MessageMonitors} that
+     * are registered with a new {@link MetricRegistry} with default settings.
      */
     public MetricsConfigurationEnhancer() {
         this(new MetricRegistry());
     }
 
     /**
-     * Initializes a new {@code MetricsConfigurationEnhancer} constructing {@link MessageMonitor MessageMonitors} that are
-     * registered with the given {@code registry}.
+     * Initializes a new {@code MetricsConfigurationEnhancer} constructing {@link MessageMonitor MessageMonitors} that
+     * are registered with the given {@code registry}.
      *
      * @param registry the {@link MetricRegistry} which will record the metrics
      */
@@ -143,9 +144,9 @@ public class MetricsConfigurationEnhancer implements ConfigurationEnhancer {
         MessageTimerMonitor timerMonitor = MessageTimerMonitor.builder().build();
 
         MetricRegistry eventSinkRegistry = new MetricRegistry();
-        eventSinkRegistry.register("messageCounter", countingMonitor);
-        eventSinkRegistry.register("messageTimer", timerMonitor);
-        registry.register(sinkName, eventSinkRegistry);
+        eventSinkRegistry.register(MetricName.build("messageCounter"), countingMonitor);
+        eventSinkRegistry.register(MetricName.build("messageTimer"), timerMonitor);
+        registry.register(MetricName.build(sinkName), eventSinkRegistry);
 
         return new MultiMessageMonitor<>(countingMonitor, timerMonitor);
     }
@@ -157,11 +158,11 @@ public class MetricsConfigurationEnhancer implements ConfigurationEnhancer {
         EventProcessorLatencyMonitor latencyMonitor = new EventProcessorLatencyMonitor();
 
         MetricRegistry eventProcessingRegistry = new MetricRegistry();
-        eventProcessingRegistry.register("messageCounter", countingMonitor);
-        eventProcessingRegistry.register("messageTimer", timerMonitor);
-        eventProcessingRegistry.register("capacity", capacityMonitor);
-        eventProcessingRegistry.register("latency", latencyMonitor);
-        registry.register(processorName, eventProcessingRegistry);
+        eventProcessingRegistry.register(MetricName.build("messageCounter"), countingMonitor);
+        eventProcessingRegistry.register(MetricName.build("messageTimer"), timerMonitor);
+        eventProcessingRegistry.register(MetricName.build("capacity"), capacityMonitor);
+        eventProcessingRegistry.register(MetricName.build("latency"), latencyMonitor);
+        registry.register(MetricName.build(processorName), eventProcessingRegistry);
 
         return new MultiMessageMonitor<>(countingMonitor, timerMonitor, capacityMonitor, latencyMonitor);
     }
@@ -172,10 +173,10 @@ public class MetricsConfigurationEnhancer implements ConfigurationEnhancer {
         CapacityMonitor capacityMonitor = new CapacityMonitor(1, TimeUnit.MINUTES);
 
         MetricRegistry handlerRegistry = new MetricRegistry();
-        handlerRegistry.register("messageCounter", countingMonitor);
-        handlerRegistry.register("messageTimer", timerMonitor);
-        handlerRegistry.register("capacity", capacityMonitor);
-        registry.register(name, handlerRegistry);
+        handlerRegistry.register(MetricName.build("messageCounter"), countingMonitor);
+        handlerRegistry.register(MetricName.build("messageTimer"), timerMonitor);
+        handlerRegistry.register(MetricName.build("capacity"), capacityMonitor);
+        registry.register(MetricName.build(name), handlerRegistry);
 
         return new MultiMessageMonitor<>(countingMonitor, timerMonitor, capacityMonitor);
     }

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/springboot/DropwizardMetricsAutoConfiguration.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/springboot/DropwizardMetricsAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extension.metrics.dropwizard.springboot;
 
-import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.metrics5.MetricRegistry;
 import jakarta.annotation.Nonnull;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.ConfigurationEnhancer;
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Bean;
 @AutoConfigureBefore(AxonAutoConfiguration.class)
 @ConditionalOnClass(name = {
         "org.axonframework.extension.springboot.autoconfig.AxonAutoConfiguration",
-        "com.codahale.metrics.MetricRegistry"
+        "io.dropwizard.metrics5.MetricRegistry"
 })
 @EnableConfigurationProperties(MetricsProperties.class)
 public class DropwizardMetricsAutoConfiguration {

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/CapacityMonitorTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/CapacityMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -31,9 +32,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("unchecked")
 class CapacityMonitorTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     void singleThreadedCapacity() {
         TestClock testClock = new TestClock();
@@ -42,11 +43,12 @@ class CapacityMonitorTest {
         testClock.increase(1000);
         monitorCallback.reportSuccess();
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
-        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get("capacity");
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
+        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get(MetricName.build("capacity"));
         assertEquals(1, capacityGauge.getValue(), 0);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void multithreadedCapacity() {
         TestClock testClock = new TestClock();
@@ -59,17 +61,18 @@ class CapacityMonitorTest {
         callbacks.get(foo).reportSuccess();
         callbacks.get(bar).reportFailure(null);
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
-        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get("capacity");
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
+        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get(MetricName.build("capacity"));
         assertEquals(2, capacityGauge.getValue(), 0);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void emptyCapacity() {
         TestClock testClock = new TestClock();
         CapacityMonitor testSubject = new CapacityMonitor(1, TimeUnit.SECONDS, testClock);
-        Map<String, Metric> metricSet = testSubject.getMetrics();
-        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get("capacity");
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
+        Gauge<Double> capacityGauge = (Gauge<Double>) metricSet.get(MetricName.build("capacity"));
         assertEquals(0, capacityGauge.getValue(), 0);
     }
 

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitorTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
@@ -38,7 +39,7 @@ class EventProcessorLatencyMonitorTest {
 
     private final EventProcessorLatencyMonitor testSubject = new EventProcessorLatencyMonitor();
 
-    private final Map<String, Metric> metricSet = testSubject.getMetrics();
+    private final Map<MetricName, Metric> metricSet = testSubject.getMetrics();
 
     @Test
     void messages() {
@@ -55,7 +56,7 @@ class EventProcessorLatencyMonitorTest {
         callbacks.get(firstEventMessage).reportSuccess();
 
         //noinspection unchecked
-        Gauge<Long> latency = (Gauge<Long>) metricSet.get("latency");
+        Gauge<Long> latency = (Gauge<Long>) metricSet.get(MetricName.build("latency"));
 
         assertTrue(latency.getValue() >= 1000);
     }
@@ -75,7 +76,7 @@ class EventProcessorLatencyMonitorTest {
         callbacks.get(firstEventMessage).reportFailure(null);
 
         //noinspection unchecked
-        Gauge<Long> latency = (Gauge<Long>) metricSet.get("latency");
+        Gauge<Long> latency = (Gauge<Long>) metricSet.get(MetricName.build("latency"));
 
         assertTrue(latency.getValue() >= 1000);
     }
@@ -85,7 +86,7 @@ class EventProcessorLatencyMonitorTest {
         testSubject.onMessageIngested(null).reportSuccess();
 
         //noinspection unchecked
-        Gauge<Long> latency = (Gauge<Long>) metricSet.get("latency");
+        Gauge<Long> latency = (Gauge<Long>) metricSet.get(MetricName.build("latency"));
 
         assertEquals(0, latency.getValue(), 0);
     }

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MessageCountingMonitorTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MessageCountingMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Metric;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
 
@@ -44,13 +45,13 @@ class MessageCountingMonitorTest {
         callbacks.get(bar).reportFailure(null);
         callbacks.get(baz).reportIgnored();
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
 
-        Counter ingestedCounter = (Counter) metricSet.get("ingestedCounter");
-        Counter processedCounter = (Counter) metricSet.get("processedCounter");
-        Counter successCounter = (Counter) metricSet.get("successCounter");
-        Counter failureCounter = (Counter) metricSet.get("failureCounter");
-        Counter ignoredCounter = (Counter) metricSet.get("ignoredCounter");
+        Counter ingestedCounter = (Counter) metricSet.get(MetricName.build("ingestedCounter"));
+        Counter processedCounter = (Counter) metricSet.get(MetricName.build("processedCounter"));
+        Counter successCounter = (Counter) metricSet.get(MetricName.build("successCounter"));
+        Counter failureCounter = (Counter) metricSet.get(MetricName.build("failureCounter"));
+        Counter ignoredCounter = (Counter) metricSet.get(MetricName.build("ignoredCounter"));
 
         assertEquals(3, ingestedCounter.getCount());
         assertEquals(2, processedCounter.getCount());

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MessageTimerMonitorTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MessageTimerMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.SlidingTimeWindowReservoir;
-import com.codahale.metrics.Timer;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.SlidingTimeWindowReservoir;
+import io.dropwizard.metrics5.Timer;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.monitoring.MessageMonitor;
 import org.junit.jupiter.api.*;
@@ -52,12 +53,12 @@ class MessageTimerMonitorTest {
         testClock.increase(1000);
         monitorCallback.reportSuccess();
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
 
-        Timer all = (Timer) metricSet.get("allTimer");
-        Timer successTimer = (Timer) metricSet.get("successTimer");
-        Timer failureTimer = (Timer) metricSet.get("failureTimer");
-        Timer ignoredTimer = (Timer) metricSet.get("ignoredTimer");
+        Timer all = (Timer) metricSet.get(MetricName.build("allTimer"));
+        Timer successTimer = (Timer) metricSet.get(MetricName.build("successTimer"));
+        Timer failureTimer = (Timer) metricSet.get(MetricName.build("failureTimer"));
+        Timer ignoredTimer = (Timer) metricSet.get(MetricName.build("ignoredTimer"));
 
         assertArrayEquals(new long[]{1000000}, all.getSnapshot().getValues());
         assertArrayEquals(new long[]{1000000}, successTimer.getSnapshot().getValues());
@@ -71,12 +72,12 @@ class MessageTimerMonitorTest {
         testClock.increase(1000);
         monitorCallback.reportFailure(null);
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
 
-        Timer all = (Timer) metricSet.get("allTimer");
-        Timer successTimer = (Timer) metricSet.get("successTimer");
-        Timer failureTimer = (Timer) metricSet.get("failureTimer");
-        Timer ignoredTimer = (Timer) metricSet.get("ignoredTimer");
+        Timer all = (Timer) metricSet.get(MetricName.build("allTimer"));
+        Timer successTimer = (Timer) metricSet.get(MetricName.build("successTimer"));
+        Timer failureTimer = (Timer) metricSet.get(MetricName.build("failureTimer"));
+        Timer ignoredTimer = (Timer) metricSet.get(MetricName.build("ignoredTimer"));
 
         assertArrayEquals(new long[]{1000000}, all.getSnapshot().getValues());
         assertArrayEquals(new long[]{}, successTimer.getSnapshot().getValues());
@@ -90,12 +91,12 @@ class MessageTimerMonitorTest {
         testClock.increase(1000);
         monitorCallback.reportIgnored();
 
-        Map<String, Metric> metricSet = testSubject.getMetrics();
+        Map<MetricName, Metric> metricSet = testSubject.getMetrics();
 
-        Timer all = (Timer) metricSet.get("allTimer");
-        Timer successTimer = (Timer) metricSet.get("successTimer");
-        Timer failureTimer = (Timer) metricSet.get("failureTimer");
-        Timer ignoredTimer = (Timer) metricSet.get("ignoredTimer");
+        Timer all = (Timer) metricSet.get(MetricName.build("allTimer"));
+        Timer successTimer = (Timer) metricSet.get(MetricName.build("successTimer"));
+        Timer failureTimer = (Timer) metricSet.get(MetricName.build("failureTimer"));
+        Timer ignoredTimer = (Timer) metricSet.get(MetricName.build("ignoredTimer"));
 
         assertArrayEquals(new long[]{1000000}, all.getSnapshot().getValues());
         assertArrayEquals(new long[]{}, successTimer.getSnapshot().getValues());
@@ -104,9 +105,9 @@ class MessageTimerMonitorTest {
     }
 
     /**
-     * A different {@link com.codahale.metrics.Reservoir} is used, which simply means the storage approach of the metric
-     * histogram is adjusted. Within the test space, this still renders the same results, hence the similar assertion as
-     * in {@link #testSuccessMessage()}.
+     * A different {@link io.dropwizard.metrics5.Reservoir} is used, which simply means the storage approach of the
+     * metric histogram is adjusted. Within the test space, this still renders the same results, hence the similar
+     * assertion as in {@link #successMessage()}.
      */
     @Test
     void customReservoir() {
@@ -120,11 +121,11 @@ class MessageTimerMonitorTest {
         testClock.increase(1000);
         result.reportSuccess();
 
-        Map<String, Metric> metrics = customReservoirTestSubject.getMetrics();
-        Timer all = (Timer) metrics.get("allTimer");
-        Timer successTimer = (Timer) metrics.get("successTimer");
-        Timer failureTimer = (Timer) metrics.get("failureTimer");
-        Timer ignoredTimer = (Timer) metrics.get("ignoredTimer");
+        Map<MetricName, Metric> metrics = customReservoirTestSubject.getMetrics();
+        Timer all = (Timer) metrics.get(MetricName.build("allTimer"));
+        Timer successTimer = (Timer) metrics.get(MetricName.build("successTimer"));
+        Timer failureTimer = (Timer) metrics.get(MetricName.build("failureTimer"));
+        Timer ignoredTimer = (Timer) metrics.get(MetricName.build("ignoredTimer"));
 
         assertArrayEquals(new long[]{1000000}, all.getSnapshot().getValues());
         assertArrayEquals(new long[]{1000000}, successTimer.getSnapshot().getValues());

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MetricsConfigurationEnhancerTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/MetricsConfigurationEnhancerTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.metrics5.MetricRegistry;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.DefaultComponentRegistry;
 import org.axonframework.common.util.StubLifecycleRegistry;
@@ -284,14 +284,14 @@ class MetricsConfigurationEnhancerTest {
                        .keySet()
                        .stream()
                        .findFirst()
-                       .map(metricName -> metricName.split("\\.", 3)[0]);
+                       .map(metricName -> metricName.getKey().split("\\.", 3)[0]);
     }
 
     private static List<String> retrieveUniqueMetricNames(MetricRegistry registry) {
         return registry.getMetrics()
                        .keySet()
                        .stream()
-                       .map(metricName -> metricName.split("\\.", 3)[1])
+                       .map(metricName -> metricName.getKey().split("\\.", 3)[1])
                        .distinct()
                        .toList();
     }

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/PayloadTypeMessageMonitorWrapperTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/PayloadTypeMessageMonitorWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
+import io.dropwizard.metrics5.Metric;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricSet;
+import org.axonframework.common.ReflectionUtils;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandMessage;
-import org.axonframework.common.ReflectionUtils;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.monitoring.MessageMonitor;
@@ -66,9 +67,9 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message> & M
         assertNotNull(messageMessageMonitor);
         assertTrue(expectedMonitorClass.isInstance(messageMessageMonitor));
 
-        Map<String, Metric> resultMetrics = testSubject.getMetrics();
+        Map<MetricName, Metric> resultMetrics = testSubject.getMetrics();
         assertEquals(1, resultMetrics.size());
-        assertNotNull(resultMetrics.get(expectedMonitorName));
+        assertNotNull(resultMetrics.get(MetricName.build(expectedMonitorName)));
     }
 
     @Test
@@ -94,10 +95,10 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message> & M
         assertNotNull(messageMessageMonitor);
         assertTrue(expectedMonitorClass.isInstance(messageMessageMonitor));
 
-        Map<String, Metric> resultMetrics = testSubject.getMetrics();
+        Map<MetricName, Metric> resultMetrics = testSubject.getMetrics();
         assertEquals(2, resultMetrics.size());
-        assertNotNull(resultMetrics.get(expectedStringMonitorName));
-        assertNotNull(resultMetrics.get(expectedStringMonitorName));
+        assertNotNull(resultMetrics.get(MetricName.build(expectedStringMonitorName)));
+        assertNotNull(resultMetrics.get(MetricName.build(expectedStringMonitorName)));
     }
 
     @Test
@@ -110,8 +111,8 @@ class PayloadTypeMessageMonitorWrapperTest<T extends MessageMonitor<Message> & M
 
         testSubject.onMessageIngested(STRING_MESSAGE);
 
-        Map<String, Metric> resultMetrics = testSubject.getMetrics();
+        Map<MetricName, Metric> resultMetrics = testSubject.getMetrics();
         assertEquals(1, resultMetrics.size());
-        assertNotNull(resultMetrics.get(expectedMonitorName));
+        assertNotNull(resultMetrics.get(MetricName.build(expectedMonitorName)));
     }
 }

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/TestClock.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/TestClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.axonframework.extension.metrics.dropwizard;
 
-import com.codahale.metrics.Clock;
+import io.dropwizard.metrics5.Clock;
 
 class TestClock extends Clock {
 

--- a/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/springboot/DropwizardMetricsAutoConfigurationTest.java
+++ b/extensions/metrics/metrics-dropwizard/src/test/java/org/axonframework/extension/metrics/dropwizard/springboot/DropwizardMetricsAutoConfigurationTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extension.metrics.dropwizard.springboot;
 
-import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.metrics5.MetricRegistry;
 import org.axonframework.extension.metrics.dropwizard.MetricsConfigurationEnhancer;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;


### PR DESCRIPTION
This pull request upgrades our Dropwizard dependency from 4 to 5.
This changes the `groupId` and thus a number of imports.
Arguably the "biggest" change is the fact a `MetricName` is used instead of a `String` to define the metrics, which has been pushed through in this PR as well.