### PR TITLE
fix isolation for MonitoringPooledEventProcessingReportIT

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractAxonServerIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractAxonServerIT.java
@@ -40,11 +40,12 @@ public abstract class AbstractAxonServerIT {
 
     protected static final Logger logger = LoggerFactory.getLogger(AbstractAxonServerIT.class);
 
-    private static final AxonServerContainer container = new AxonServerContainer("docker.axoniq.io/axoniq/axonserver:2025.2.0")
-            .withAxonServerHostname("localhost")
-            .withDevMode(true)
-            .withReuse(true)
-            .withDcbContext(true);
+    private static final AxonServerContainer container =
+            new AxonServerContainer("docker.axoniq.io/axoniq/axonserver:2025.2.0")
+                    .withAxonServerHostname("localhost")
+                    .withDevMode(true)
+                    .withReuse(true)
+                    .withDcbContext(true);
 
     protected CommandGateway commandGateway;
     protected AxonConfiguration startedConfiguration;
@@ -71,6 +72,21 @@ public abstract class AbstractAxonServerIT {
                                                  ))
                                                  .start();
         commandGateway = startedConfiguration.getComponent(CommandGateway.class);
+    }
+
+    /**
+     * Purge all events from the Axon Server container
+     */
+    protected void purgeEvents() {
+        try {
+            logger.info("Purging events from Axon Server.");
+            AxonServerContainerUtils.purgeEventsFromAxonServer(container.getHost(),
+                                                               container.getHttpPort(),
+                                                               "default",
+                                                               AxonServerContainerUtils.DCB_CONTEXT);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MonitoringPooledEventProcessingReportIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MonitoringPooledEventProcessingReportIT.java
@@ -20,7 +20,6 @@ import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.QualifiedName;
-import org.axonframework.messaging.eventhandling.EventHandlingComponent;
 import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
 import org.axonframework.messaging.eventhandling.sequencing.SequentialPolicy;
@@ -106,6 +105,9 @@ public class MonitoringPooledEventProcessingReportIT extends AbstractStudentIT {
 
     @Override
     protected EventSourcingConfigurer testSuiteConfigurer(EventSourcingConfigurer configurer) {
+        // purge events to restart with an empty eventstore and avoid processing historic events
+        purgeEvents();
+
         // a noop setup that allows verification of ignored event
         configurer.messaging(mc -> mc
                 .registerMessageMonitor(c -> new RecordingMessageMonitor(reportedMessages))


### PR DESCRIPTION
The tests in MonitoringPooledEventProcessingReportIT were failing because the event processor setup in the test also processed historic events from previous test runs that persisted in axon server.

By introducing `org.axonframework.integrationtests.testsuite.AbstractAxonServerIT#purgeEvents` (which utilizes the existing `AxonServerContainerUtils`) and using it in the test-configuration callback before starting the application config, we can achieve a clean application state before running each test.