### PR TITLE
ai-agents(skills): broaden `issue-from-notes trigger` to match direct issue creation requests

### DIFF
--- a/.claude/skills/issue-from-notes/SKILL.md
+++ b/.claude/skills/issue-from-notes/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: issue-from-notes
 description: >
-  Convert meeting notes, transcriptions, or informal descriptions into properly formatted GitHub issue
-  bodies following the project's issue templates. Use when the user says "create issue from notes",
-  "write up an issue", "turn these notes into an issue", "file a bug from meeting notes",
-  "create enhancement from discussion", provides meeting notes or transcription and asks for an issue,
-  or any variation of converting unstructured text into a structured GitHub issue.
+  Create well-structured GitHub issues from any source: meeting notes, transcriptions, conversation
+  context, informal descriptions, or direct requests. Use when the user says "create a github issue",
+  "create issue from notes", "write up an issue", "turn these notes into an issue", "file a bug",
+  "file a bug from meeting notes", "create enhancement from discussion", "make an issue for",
+  "open an issue about", "create a follow-up issue", or any variation of creating a structured
+  GitHub issue — whether the input comes from notes, conversation context, or a direct description.
 ---
 
 # Issue From Notes


### PR DESCRIPTION
The skill description only matched "notes/transcription"-oriented phrases, so requests like "create a github issue for X" did not auto-invoke it. Widened the trigger phrases to cover direct issue creation, follow-up issues, and conversation-context-based requests.