### PR TITLE
Autoconfigure after should use names i.o. classes in `JpaEventStoreAutoConfiguration`

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -53,6 +53,7 @@ import java.util.function.UnaryOperator;
  */
 @AutoConfiguration(afterName = {
         "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration",
+        "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration",
         "org.axonframework.extension.springboot.autoconfig.AxonServerAutoConfiguration",
         "org.axonframework.extension.springboot.autoconfig.JpaAutoConfiguration"
 })


### PR DESCRIPTION
This pull request adjusts the `JpaEventStoreAutoConfiguration` to use the FQCN instead of the `class` in the `@AutoConfiguration(after = {...})` attribute.
By doing so, we ensure users don't get a `ClassNotFoundException` when they don't have the both the old (SB3 and below) and new (SB4) `HibernateJpaAutoConfiguration`  on the class path.