### PR TITLE
Add NPM package system for Axoniq Docs playbook dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,7 +57,7 @@ updates:
     - "Priority 1: Must"
   milestone: 119
   groups:
-    maven-dependencies:
+    antora-dependencies:
       update-types:
         - "patch"
         - "minor"


### PR DESCRIPTION
Add NPM package system for Axoniq Docs playbook dependencies. This ensures we're more up to date in this area. From time to time, we get a dependabot PR for vulnerabilities here. If we add it to our dependabot settings, we should be ahead of this.