### PR TITLE
Make routing with `SequentialPolicy` consistent across JVM restarts (#4253)

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPolicy.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/async/SequentialPolicy.java
@@ -26,7 +26,13 @@ import javax.annotation.Nonnull;
  */
 public class SequentialPolicy implements SequencingPolicy<Object> {
 
-    private static final Object FULL_SEQUENTIAL_POLICY = new Object();
+    /**
+     * Object used to represent the full sequential policy.
+     * <p>
+     * Note: This uses a String constant to provide a consistent {@link Object#hashCode()} and
+     * {@link Object#equals(Object)} behaviour across JVM restarts.
+     */
+    public static final Object FULL_SEQUENTIAL_POLICY = "FULL_SEQUENTIAL_POLICY";
 
     @Override
     public Object getSequenceIdentifierFor(@Nonnull Object task) {


### PR DESCRIPTION
To make routing messages that relies on the SequencingPolicy#getSequenceIdentifierFor` consistent across JVM restarts when using the `SequentialPolicy`, instead of a `new Object()` we now use a String constant that provides consistent `#hashCode` and `#equals` behaviour across JVM restarts.