### PR TITLE
[#4253] Make routing with `SequentialPolicy` consistent across JVM restarts

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/sequencing/SequentialPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/sequencing/SequentialPolicy.java
@@ -38,9 +38,12 @@ public class SequentialPolicy implements SequencingPolicy<Message> {
 
     /**
      * Object used to represent the full sequential policy.
+     * <p>
+     * Note: This uses a String constant to provide a consistent {@link Object#hashCode()} and
+     * {@link Object#equals(Object)} behaviour across JVM restarts.
      */
     @Internal
-    public static final Object FULL_SEQUENTIAL_POLICY = new Object();
+    public static final Object FULL_SEQUENTIAL_POLICY = "FULL_SEQUENTIAL_POLICY";
 
     private SequentialPolicy() {
     }


### PR DESCRIPTION
To make routing messages that relies on the `SequencingPolicy#sequenceIdentifierFor` consistent across JVM restarts when using the `SequentialPolicy`, instead of a `new Object()` we now use a String constant that provides consistent `#hashCode` and `#equals` behaviour across JVM restarts.

This PR resolves #4253.