### PR TITLE
Adjust Spring-Boot version support matrix

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/spring-boot-integration.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/spring-boot-integration.adoc
@@ -24,7 +24,7 @@ The following table shows which Spring Boot versions are supported by each Axon 
 |✓
 |✓
 
-|5.0+
+|5.0.3+
 |
 |✓
 |✓


### PR DESCRIPTION
As we did only introduce Spring Boot 4 support with #4219, Spring Boot 4 is just supported from 5.0.3 onwards. This PR adjusts the refguide version matrix