### PR TITLE
The DistributedCommandBus should not log error responses

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/distributed/DistributedCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/distributed/DistributedCommandBus.java
@@ -147,7 +147,7 @@ public class DistributedCommandBus implements CommandBus {
 
         private void handleError(CommandMessage commandMessage, CommandBusConnector.ResultCallback callback,
                                  Throwable e) {
-            logger.error("Error processing incoming command [{}]", commandMessage.type(), e);
+            logger.debug("Error processing incoming command [{}]", commandMessage.type(), e);
             callback.onError(e);
         }
 


### PR DESCRIPTION
When a command returns an error result, the DistributedCommandBus should not log that other than on debug level, since it already reports the error in the provided callbacks.