### PR TITLE
Make Axon Server Connector dependency optional for Spring Boot Starter

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -37,6 +37,7 @@
             <groupId>org.axonframework</groupId>
             <artifactId>axon-server-connector</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR makes the `axon-server-connector` dependency optional. 
Although Axon Framework prefers use of Axon Server throughout, it's still a _choice_ at the end of the day. 
The Axon Spring Boot Starter should not pull in the dependency at all times for those scenarios when people are not using it. 
This predicament becomes especially apparent with the renewed @AxonSpringBootTest annotation.