### PR TITLE
fix(test): `AxonTestFixture` - records commands before serialization in `DistributedCommandBus`

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/course/StudentAxonTestFixtureAxonServerIntegrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/course/StudentAxonTestFixtureAxonServerIntegrationIT.java
@@ -108,4 +108,34 @@ class StudentAxonTestFixtureAxonServerIntegrationIT {
                .success()
                .events(new CourseCreated(courseId));
     }
+
+    @Test
+    void axonTestFixtureRecordsCommandWithNonSerializedPayload() {
+        var courseId = UUID.randomUUID().toString();
+        var command = new CreateCourse(courseId);
+
+        fixture.given()
+               .when()
+               .command(command)
+               .then()
+               .success()
+               .commands(command);
+    }
+
+    @Test
+    void axonTestFixtureRecordsCommandPayloadSatisfyingCustomAssertion() {
+        var courseId = UUID.randomUUID().toString();
+
+        fixture.given()
+               .when()
+               .command(new CreateCourse(courseId))
+               .then()
+               .success()
+               .commandsSatisfy(commands -> {
+                   Assertions.assertEquals(1, commands.size());
+                   var payload = commands.getFirst().payload();
+                   Assertions.assertInstanceOf(CreateCourse.class, payload);
+                   Assertions.assertEquals(courseId, ((CreateCourse) payload).courseId());
+               });
+    }
 }

--- a/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
+++ b/test/src/main/java/org/axonframework/test/fixture/MessagesRecordingConfigurationEnhancer.java
@@ -26,6 +26,8 @@ import org.axonframework.eventsourcing.eventstore.EventStore;
 
 import java.util.Objects;
 
+import static org.axonframework.messaging.commandhandling.distributed.DistributedCommandBusConfigurationEnhancer.DISTRIBUTED_COMMAND_BUS_ORDER;
+
 /**
  * ConfigurationEnhancer that registers {@link RecordingEventStore}, {@link RecordingEventSink} and
  * {@link RecordingCommandBus}. The recorded messages can then be used to assert expectations with test cases.
@@ -47,7 +49,14 @@ public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnha
     /**
      * Innermost position — recording sees the message after all other decorators (interceptors) have processed it.
      */
-    private static final int DECORATION_ORDER = Integer.MIN_VALUE;
+    private static final int EVENTS_RECORDER_DECORATION_ORDER = Integer.MIN_VALUE;
+
+    /**
+     * Decoration order for the command bus recorder. Placed just outside the
+     * {@link org.axonframework.messaging.commandhandling.distributed.DistributedCommandBus} so that commands are
+     * recorded with their original, non-serialized payloads before they reach the distributed bus.
+     */
+    private static final int COMMANDS_RECORDER_DECORATION_ORDER = DISTRIBUTED_COMMAND_BUS_ORDER + 1;
 
     @Override
     public void enhance(@Nonnull ComponentRegistry registry) {
@@ -57,7 +66,7 @@ public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnha
         registry.registerComponent(RecordingComponentsRegistry.class, config -> recordings);
 
         registry.registerDecorator(CommandBus.class,
-                                   DECORATION_ORDER,
+                                   COMMANDS_RECORDER_DECORATION_ORDER,
                                    (config, name, delegate) -> {
                                        var recording = new RecordingCommandBus(delegate);
                                        recordings.registerCommandBus(recording);
@@ -66,7 +75,7 @@ public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnha
 
         if (registry.hasComponent(EventStore.class)) {
             registry.registerDecorator(EventStore.class,
-                                       DECORATION_ORDER,
+                                       EVENTS_RECORDER_DECORATION_ORDER,
                                        (config, name, delegate) -> {
                                            var recording = new RecordingEventStore(delegate);
                                            recordings.registerEventSink(recording);
@@ -74,7 +83,7 @@ public class MessagesRecordingConfigurationEnhancer implements ConfigurationEnha
                                        });
         } else {
             registry.registerDecorator(EventBus.class,
-                                       DECORATION_ORDER,
+                                       EVENTS_RECORDER_DECORATION_ORDER,
                                        (config, name, delegate) -> {
                                            var recording = new RecordingEventBus(delegate);
                                            recordings.registerEventSink(recording);


### PR DESCRIPTION
Introduce COMMANDS_RECORDER_DECORATION_ORDER to ensure the command bus recorder is placed before the DistributedCommandBus in the decorator chain. This captures commands with their original,non-serialized payloads.