### PR TITLE
Fix axon server address resolution for AxonServerTestContainerConnectionDetailsFactory

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/service/connection/AxonServerTestContainerConnectionDetailsFactory.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/service/connection/AxonServerTestContainerConnectionDetailsFactory.java
@@ -51,7 +51,7 @@ public class AxonServerTestContainerConnectionDetailsFactory extends ContainerCo
 
         @Override
         public String routingServers() {
-            return getContainer().getAxonServerAddress() + ":" + getContainer().getGrpcPort();
+            return getContainer().getAxonServerAddress();
         }
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/connection/SpringBootTestContainerIntegrationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/connection/SpringBootTestContainerIntegrationTest.java
@@ -16,6 +16,12 @@
 
 package org.axonframework.extension.springboot.connection;
 
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+
+
 import io.axoniq.axonserver.connector.AxonServerConnection;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
@@ -27,11 +33,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.time.Duration;
-
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Testcontainers
@@ -54,7 +55,7 @@ class SpringBootTestContainerIntegrationTest {
     void verifyApplicationStartsNormallyWithAxonServerInstance() {
         assertTrue(axonServer.isRunning());
         assertNotNull(connectionDetails);
-        assertTrue(connectionDetails.routingServers().endsWith("" + axonServer.getGrpcPort()));
+        assertEquals(axonServer.getHost() + ":" + axonServer.getGrpcPort(), connectionDetails.routingServers());
         assertNotNull(axonServerConfiguration);
 
         assertNotEquals("localhost:8024", axonServerConfiguration.getServers());

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/connection/SpringBootTestContainerIntegrationWithAxonServerPropertiesFileIT.java
@@ -63,7 +63,7 @@ class SpringBootTestContainerIntegrationWithAxonServerPropertiesFileIT {
     void verifyApplicationStartsNormallyWithAxonServerInstance() {
         assertTrue(axonServer.isRunning());
         assertNotNull(connectionDetails);
-        assertTrue(connectionDetails.routingServers().endsWith("" + axonServer.getGrpcPort()));
+        assertEquals(axonServer.getHost() + ":" + axonServer.getGrpcPort(), connectionDetails.routingServers());
         assertNotNull(axonServerConfiguration);
 
         assertNotEquals("localhost:8024", axonServerConfiguration.getServers());


### PR DESCRIPTION
The `#routingServers` method seems to be duplicating the grpc port of the axon server address by using `#getAxonServerAddress()` of the `AxonServerContainer` (which already includes the grpc port) AND additionaly appending the grpc additionally