### PR TITLE
Upgrade axonserver connector usage to 2026.0.0-SNAPSHOT

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
@@ -17,6 +17,7 @@
 package org.axonframework.axonserver.connector.event;
 
 import io.axoniq.axonserver.grpc.event.Confirmation;
+import io.axoniq.axonserver.grpc.event.ConfirmationWithConsistencyMarker;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.EventStoreGrpc;
 import io.axoniq.axonserver.grpc.event.EventWithToken;
@@ -86,7 +87,7 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
     }
 
     @Override
-    public StreamObserver<Event> appendEvent(StreamObserver<Confirmation> responseObserver) {
+    public StreamObserver<Event> appendEvent(StreamObserver<ConfirmationWithConsistencyMarker> responseObserver) {
         return new StreamObserver<>() {
 
             private final List<Event> eventsInTx = new LinkedList<>();
@@ -104,7 +105,7 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
             @Override
             public void onCompleted() {
                 events.addAll(eventsInTx);
-                responseObserver.onNext(Confirmation.newBuilder().setSuccess(true).build());
+                responseObserver.onNext(ConfirmationWithConsistencyMarker.newBuilder().setSuccess(true).build());
                 responseObserver.onCompleted();
             }
         };

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -47,7 +47,7 @@
         </mockito.agent.argLine>
 
         <!-- Axon Server -->
-        <axonserver-connector-java.version>2025.2.1</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2026.0.0-SNAPSHOT</axonserver-connector-java.version>
         <!-- Caching -->
         <ehcache.version>3.11.1</ehcache.version>
         <javax.cache-api.version>1.1.1</javax.cache-api.version>


### PR DESCRIPTION
Upgrades the `axonserver-connector-java` dependency to 2026.0.0-SNAPSHOT in the parent POM, required for development of other components depending on this version.

Additionally, update the `appendEvent` method signature to use `ConfirmationWithConsistencyMarker` instead of `Confirmation` to align with the new connector API. 

Relates: https://github.com/AxonIQ/axonserver-connector-java/pull/483