### PR TITLE
Make the `EventGateway` a `DescribableComponent`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/DefaultEventGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/DefaultEventGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@ package org.axonframework.messaging.eventhandling.gateway;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.axonframework.common.FutureUtils;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventSink;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 /**
@@ -47,8 +47,8 @@ public class DefaultEventGateway implements EventGateway {
      * {@code messageTypeResolver} is used to resolve the type of the event if no {@link EventMessage} is provided but a
      * payload.
      *
-     * @param eventSink           The {@link EventSink} to publish events to.
-     * @param messageTypeResolver The {@link MessageTypeResolver} to resolve the type of the event.
+     * @param eventSink           the {@link EventSink} to publish events to
+     * @param messageTypeResolver the {@link MessageTypeResolver} to resolve the type of the event
      */
     public DefaultEventGateway(@Nonnull EventSink eventSink,
                                @Nonnull MessageTypeResolver messageTypeResolver) {
@@ -66,5 +66,11 @@ public class DefaultEventGateway implements EventGateway {
         return eventMessages.isEmpty()
                 ? FutureUtils.emptyCompletedFuture()
                 : eventSink.publish(context, eventMessages);
+    }
+
+    @Override
+    public void describeTo(@Nonnull ComponentDescriptor descriptor) {
+        descriptor.describeProperty("eventSink", eventSink);
+        descriptor.describeProperty("messageTypeResolver", messageTypeResolver);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2025. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.gateway;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventSink;
@@ -29,14 +30,14 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Interface towards the Event Handling components of an application.
  * <p>
- * This interface provides a friendlier API toward the {@link EventSink} and allows for
- * components to easily publish events.
+ * This interface provides a friendlier API toward the {@link EventSink} and allows for components to easily publish
+ * events.
  *
  * @author Bert Laverman
  * @see DefaultEventGateway
  * @since 4.1.0
  */
-public interface EventGateway {
+public interface EventGateway extends DescribableComponent {
 
     /**
      * Publishes the given {@code events} within the given {@code context}. When present, the {@code events} should be


### PR DESCRIPTION
This pull request makes the `EventGateway` interface a `DescribableComponent`.
As the `EventGateway` is an infrastructure component, it should be able to describe itself, for debugging purposes of the Axon configuration.