### PR TITLE
Add documentation explaining application startup event

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/index.adoc
@@ -245,7 +245,7 @@ Axon Framework 5 has been restructured into more focused modules. This allows fo
 
 Users should update their dependency management (Maven/Gradle) to reflect these changes. Note that the modules in `extensions` have moved to a different group ID (`org.axonframework.extensions.*`) as well.
 
-=== Startup Event
+=== Startup event
 In Axon Framework 4, the internal AxonStartedEvent was used to ensure the application was fully loaded before processing began.
 In Axon Framework 5, this responsibility shifts to Spring: components are initialized at startup, and ApplicationStartedEvent is the signal that the application is ready
 


### PR DESCRIPTION
This PR adds docs that explain #4030 

While discussing in the team we realized that in AF5 there is no need to have a dedicated _AxonStartedEvent_ because all components are initialized at startup by Spring.