### PR TITLE
Fix race-condition for `DistributedQueryBusSubscriptionQueryTest#replayBufferOverflow`

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.integrationtests.queryhandling;
 
+import org.axonframework.common.FutureUtils;
 import org.jspecify.annotations.NonNull;
 import org.assertj.core.util.Strings;
 import org.awaitility.Awaitility;
@@ -531,14 +532,17 @@ public abstract class AbstractSubscriptionQueryTestSuite extends AbstractQueryTe
         await().until(result::hasNextAvailable);
         Thread.sleep(500);
 
+        List<CompletableFuture<?>> updatesEmitted = new ArrayList<>();
         for (int i = 0; i <= 20; i++) {
             int number = i;
-            queryBus.emitUpdate(testFilter,
+            updatesEmitted.add(queryBus.emitUpdate(testFilter,
                                 () -> new GenericSubscriptionQueryUpdateMessage(TEST_UPDATE_PAYLOAD_TYPE,
                                                                                 "Update" + number),
-                                testContext);
+                                testContext));
         }
-        queryBus.completeSubscriptions(testFilter, testContext);
+        FutureUtils.joinAndUnwrap(CompletableFuture.allOf(updatesEmitted.toArray(new CompletableFuture[0])));
+
+        FutureUtils.joinAndUnwrap(queryBus.completeSubscriptions(testFilter, testContext));
 
         List<QueryResponseMessage> responses = Collections.synchronizedList(new ArrayList<>());
 


### PR DESCRIPTION
This PR fixes a race condition leading to the `DistributedQueryBusSubscriptionQueryTest#replayBufferOverflow` test failing eventually. 

Not waiting for all updates to be emitted will eventually have the result callback consume results while emitting updates. This empties the buffer before it reaches the limit (the desired buffering happening), which leads to more results than expected being recorded. The test assertion is: when stuffing 20 updates into a buffer of size 10, we expect 10 items to be present after all updates have been emitted. By waiting for all updates being emitted and joining the complete subscriptions we make sure the buffer is full and no more updates are emitted before consuming them from the callback.