### PR TITLE
Fix incorrect property names for query bus timeout configuration

### DIFF
--- a/docs/old-reference-guide/modules/messaging-concepts/pages/timeouts.adoc
+++ b/docs/old-reference-guide/modules/messaging-concepts/pages/timeouts.adoc
@@ -186,9 +186,9 @@ axon.timeout.transaction.command-bus.warning-interval-ms=1000
 
 
 # Timeout for the query bus
-axon.timeout.transaction.query.timeout-ms=20000
-axon.timeout.transaction.query.warning-threshold-ms=10000
-axon.timeout.transaction.query.warning-interval-ms=1000
+axon.timeout.transaction.query-bus.timeout-ms=20000
+axon.timeout.transaction.query-bus.warning-threshold-ms=10000
+axon.timeout.transaction.query-bus.warning-interval-ms=1000
 
 # Timeout for the deadline manager
 axon.timeout.transaction.deadline.timeout-ms=20000


### PR DESCRIPTION
The properties were using `query` instead of `query-bus` in the configuration examples, which would prevent the timeout settings from being applied correctly.
