### PR TITLE
Doc typo - refer to Event schedulers instead of Deadlines

### DIFF
--- a/docs/reference-guide/modules/deadlines/pages/event-schedulers.adoc
+++ b/docs/reference-guide/modules/deadlines/pages/event-schedulers.adoc
@@ -2,7 +2,7 @@
 
 [WARNING]
 ====
-Deadlines do not have a replacement yet in Axon Framework 5.
+Event schedulers do not have a replacement yet in Axon Framework 5.
 Once the intended replacement is in place the documentation will be adjusted accordingly.
 ====
 


### PR DESCRIPTION
This PR resolves a typo in the documentation, stating the section is about deadlines, while it's about event scheduling.