### PR TITLE
Introduce conversion awareness to the `GenericMessage` (#3618)

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
@@ -16,12 +16,12 @@
 
 package org.axonframework.messaging.core;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.TypeReference;
 import org.axonframework.conversion.ConversionException;
 import org.axonframework.conversion.Converter;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -30,7 +30,8 @@ import java.util.Map;
  * Generic implementation of the {@link Message} interface containing the {@link #payload() payload} and
  * {@link #metadata() metadata} in deserialized form.
  * <p>
- * This {@code Message} implementation is "conversion aware," as it maintains <b>any</b> conversion results from
+ * This {@code Message} implementation is "conversion aware," as it is capable of maintaining a converter suitable for
+ * its payload set via {@link #withConverter(Converter)} and maintains <b>any</b> conversion results from
  * {@link #payloadAs(Type, Converter)} and {@link #withConvertedPayload(Type, Converter)} (either invoked with a
  * {@link Class}, {@link TypeReference}, or {@link Type}), together with the hash of the given {@link Converter}. In
  * doing so, this {@code Message} optimizes subsequent {@code payloadAs/withConvertedPayload} invocations for the same
@@ -46,13 +47,12 @@ public class GenericMessage extends AbstractMessage {
     private final @Nullable Object payload;
     private final Class<?> payloadType;
     private final Metadata metadata;
+    private final @Nullable Converter converter;
 
     private final ConversionCache convertedPayloads;
 
     /**
      * Constructs a {@code GenericMessage} for the given {@code type} and {@code payload}.
-     * <p>
-     * Uses the correlation data of the current Unit of Work, if present.
      *
      * @param type    The {@link MessageType type} for this {@link Message}.
      * @param payload The payload for this {@link Message}.
@@ -65,8 +65,7 @@ public class GenericMessage extends AbstractMessage {
     /**
      * Constructs a {@code GenericMessage} for the given {@code type}, {@code payload}, and {@code metadata}.
      * <p>
-     * The given {@code metadata} is merged with the {@link Metadata} from the correlation data of the current Unit of
-     * Work, if present. In case the {@code payload == null}, {@link Void} will be used as the {@code payloadType}.
+     * In case the {@code payload == null}, {@link Void} will be used as the {@code payloadType}.
      *
      * @param type     The {@link MessageType type} for this {@link Message}.
      * @param payload  The payload for this {@link Message}.
@@ -81,9 +80,6 @@ public class GenericMessage extends AbstractMessage {
     /**
      * Constructs a {@code GenericMessage} for the given {@code type}, {@code payload}, {@code declaredPayloadType}, and
      * {@code metadata}.
-     * <p>
-     * The given {@code metadata} is merged with the Metadata from the correlation data of the current Unit of Work, if
-     * present.
      *
      * @param <P>                 The generic type of the expected payload of the resulting object.
      * @param type                The {@link MessageType type} for this {@link Message}.
@@ -101,10 +97,6 @@ public class GenericMessage extends AbstractMessage {
     /**
      * Constructs a {@code GenericMessage} for the given {@code identifier}, {@code type}, {@code payload}, and
      * {@code metadata}, intended to reconstruct another {@link Message}.
-     * <p>
-     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
-     * of Work. If you in tend to construct a new {@code GenericMessage}, please use
-     * {@link #GenericMessage(MessageType, Object)} instead.
      *
      * @param identifier The identifier of this {@link Message}.
      * @param type       The {@link MessageType type} for this {@link Message}.
@@ -121,10 +113,6 @@ public class GenericMessage extends AbstractMessage {
     /**
      * Constructs a {@code GenericMessage} for the given {@code identifier}, {@code type}, {@code payload}, and
      * {@code metadata}, intended to reconstruct another {@link Message}.
-     * <p>
-     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
-     * of Work. If you in tend to construct a new {@code GenericMessage}, please use
-     * {@link #GenericMessage(MessageType, Object)} instead.
      *
      * @param <P>                 The generic type of the expected payload of the resulting object.
      * @param identifier          The identifier of this {@link Message}.
@@ -143,15 +131,17 @@ public class GenericMessage extends AbstractMessage {
         this.payloadType = declaredPayloadType;
         this.metadata = Metadata.from(metadata);
         this.convertedPayloads = new ConversionCache(payload);
+        this.converter = null;
     }
 
     private GenericMessage(GenericMessage original,
-                           Metadata metadata) {
+                           Metadata metadata, @Nullable Converter converter) {
         super(original.identifier(), original.type());
         this.payload = original.payload();
         this.payloadType = original.payloadType();
         this.metadata = metadata;
         this.convertedPayloads = new ConversionCache(payload);
+        this.converter = converter;
     }
 
     /**
@@ -182,6 +172,11 @@ public class GenericMessage extends AbstractMessage {
     }
 
     @Override
+    public @Nullable <T> T payloadAs(Class<T> type) {
+        return payloadAs(type, this.converter);
+    }
+
+    @Override
     @Nullable
     public <T> T payloadAs(Type type, @Nullable Converter converter) {
         //noinspection rawtypes,unchecked
@@ -208,7 +203,21 @@ public class GenericMessage extends AbstractMessage {
 
     @Override
     protected Message withMetadata(Metadata metadata) {
-        return new GenericMessage(this, metadata);
+        return new GenericMessage(this, metadata, this.converter);
+    }
+
+    /**
+     * Returns a new {@code GenericMessage} instance with the same payload and properties as this message and the given
+     * {@code converter} to be used for payload conversion.
+     * <p>
+     * Note: if called from a subtype, the message will lose subtype information because this method creates a new
+     * instance of {@code GenericMessage}.
+     *
+     * @param converter the converter for the new message
+     * @return a copy of this instance with the converter
+     */
+    public GenericMessage withConverter(@Nullable Converter converter) {
+        return new GenericMessage(this, this.metadata, converter);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageDecorator.java
@@ -64,6 +64,12 @@ public abstract class MessageDecorator implements Message {
 
     @Override
     @Nullable
+    public <T> T payloadAs(Class<T> type) {
+        return delegate.payloadAs(type);
+    }
+
+    @Override
+    @Nullable
     public <T> T payloadAs(Type type, @Nullable Converter converter) {
         return delegate.payloadAs(type, converter);
     }

--- a/messaging/src/test/java/org/axonframework/messaging/core/GenericMessageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/GenericMessageTest.java
@@ -16,23 +16,145 @@
 
 package org.axonframework.messaging.core;
 
-import org.jspecify.annotations.Nullable;
+import org.assertj.core.api.Assertions;
 import org.axonframework.common.ObjectUtils;
+import org.axonframework.common.TypeReference;
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.ConversionException;
+import org.axonframework.conversion.Converter;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test correct operations of the {@link GenericMessage} class.
  *
  * @author Rene de Waele
  */
-class GenericMessageTest extends MessageTestSuite<Message> {
+class GenericMessageTest extends MessageTestSuite<GenericMessage> {
+
+
+    @Nested
+    class WithConverter {
+
+        private Converter converter;
+        private String exStringPayload = "payload";
+        private byte[] exBytePayload = exStringPayload.getBytes(StandardCharsets.UTF_8);
+
+        @BeforeEach
+        void setUp() {
+            converter = spy(new ChainingContentTypeConverter());
+        }
+
+        @AfterEach
+        void tearDown() {
+            verifyNoMoreInteractions(converter);
+        }
+
+        @Test
+        void payloadAsClassReturnsPayloadWithoutConversionOnSameType() {
+            GenericMessage exMessage = buildMessage(exStringPayload)
+                    .withConverter(converter);
+
+            // test
+            String acPayload = exMessage.payloadAs(String.class);
+
+            assertThat(acPayload).isEqualTo(exStringPayload);
+        }
+
+        @Test
+        void payloadAsClassInvokesConverterOnDifferentType() {
+            GenericMessage exMessage = buildMessage(exBytePayload)
+                    .withConverter(converter);
+
+            // test
+            String acPayload = exMessage.payloadAs(String.class);
+
+            assertThat(acPayload).isEqualTo(exStringPayload);
+            verify(converter).convert(eq(exBytePayload), eq((Type) String.class));
+        }
+
+        @Test
+        void payloadAsClassFailsWithConversionExceptionWithoutConverter() {
+            GenericMessage exMessage = buildMessage(exBytePayload);
+
+            // test
+            Assertions.assertThatThrownBy(() -> exMessage.payloadAs(Integer.class))
+                      .isInstanceOf(ConversionException.class);
+        }
+
+        @Test
+        void payloadAsTypeRefInvokesConverter() {
+            GenericMessage exMessage = buildMessage(exBytePayload)
+                    .withConverter(converter);
+
+            // test
+            String acPayload = exMessage.payloadAs(new TypeReference<String>() {
+            });
+
+            assertThat(acPayload).isEqualTo(exStringPayload);
+            verify(converter).convert(eq(exBytePayload), eq((Type) String.class));
+        }
+
+        @Test
+        void payloadAsCachesConversion() {
+            GenericMessage exMessage = buildMessage(exBytePayload)
+                    .withConverter(converter);
+
+            // test
+            String acPayload = exMessage.payloadAs(String.class);
+            String acPayload2 = exMessage.payloadAs(String.class);
+
+            assertThat(acPayload).isEqualTo(exStringPayload);
+            assertThat(acPayload2).isEqualTo(exStringPayload);
+            verify(converter, times(1)).convert(eq(exBytePayload), eq((Type) String.class));
+        }
+
+        @Test
+        void withConverterReturnsNewInstanceOfSameConcreteType() {
+            // given
+            GenericMessage original = buildMessage(exBytePayload);
+
+            // when
+            GenericMessage result = original.withConverter(converter);
+
+            // then
+            assertThat(result).isInstanceOf(GenericMessage.class);
+            assertThat(result).isNotSameAs(original);
+        }
+
+        @Test
+        void withConverterPreservesMembers() {
+            // given
+            GenericMessage original = buildMessage(exBytePayload);
+
+            // when
+            GenericMessage result = original.withConverter(converter);
+
+            // then
+            assertThat(result).isInstanceOf(GenericMessage.class);
+            assertThat(result).isNotSameAs(original);
+            assertThat(result.identifier()).isEqualTo(original.identifier());
+            assertThat(result.type()).isEqualTo(original.type());
+            assertThat(result.payload()).isEqualTo(original.payload());
+            assertThat(result.payloadType()).isEqualTo(original.payloadType());
+            assertThat(result.metadata()).isEqualTo(original.metadata());
+        }
+    }
 
     @Override
-    protected Message buildDefaultMessage() {
+    protected GenericMessage buildDefaultMessage() {
         return new GenericMessage(TEST_IDENTIFIER, TEST_TYPE, TEST_PAYLOAD, TEST_PAYLOAD_TYPE, TEST_METADATA);
     }
 
     @Override
-    protected <P> Message buildMessage(@Nullable P payload) {
+    protected <P> GenericMessage buildMessage(@Nullable P payload) {
         return new GenericMessage(new MessageType(ObjectUtils.nullSafeTypeOf(payload)), payload);
     }
 }


### PR DESCRIPTION
As preparation to enable transparent last-minute we introduce conversion awareness to the `GenericMessage` by allowing it to hold a converter to be used for payload conversion.

This allows messages to be attached with the appropriate converter for payload conversion at the point where they are created and passed on for handling.

To avoid an additional wrapper class, we introduce the conversion capability to the GenericMessage implementation which also holds the conversion cache behaviour.

This will eventually also make the `SerializedMessage` from the Stash obsolete, once upcasting is covered. 

This PR provides the base functionality needed for resolving #3618 