### PR TITLE
Add reference documentation for inline message payload conversion

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/conversion.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/conversion.adoc
@@ -92,6 +92,33 @@ This approach:
 * Enables different services to use different Java representations.
 * Simplifies integration with external systems that may expect different formats.
 
+[#converter_attachment_at_message_loading_time]
+=== Converter attachment at message loading time
+
+To make the automatic conversion above possible without requiring handler code to reference a converter, Axon attaches the appropriate `Converter` to every message at the moment it is loaded from a serialized state (received over the wire, loaded from a database, loaded from a store, etc.).
+The converter is attached to the message, so calling `payloadAs(SomeType.class)` in a handler converts the payload to the expected type without the need to explicitly reference a converter from that handler.
+
+For example, the following handler receives the raw event message and converts its payload without needing to know which converter is configured:
+
+[source,java]
+----
+@EventHandler
+public void on(EventMessage<?> event) {
+    // Works without passing a converter — Axon attached one when loading the event
+    UserRegisteredEvent payload = event.payloadAs(UserRegisteredEvent.class);
+    userRepository.save(new User(payload.getUserId(), payload.getEmail()));
+}
+----
+
+When building custom infrastructure that produces `Message` instances, call `withConverter(Converter)` before the message reaches any handler to enable the same behavior:
+
+[source,java]
+----
+GenericEventMessage messageWithConverter = rawMessage.withConverter(eventConverter);
+----
+
+This ensures all downstream code like command handlers, event processors, dead-letter queue processors and query handlers can convert the payload without requiring the converter to be passed explicitly.
+
 [#converter_types]
 == Converter types
 

--- a/docs/reference-guide/modules/messaging-concepts/pages/anatomy-message.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/anatomy-message.adoc
@@ -252,10 +252,20 @@ public void retrievePayload(Message message) {
 }
 ----
 
-The `payloadAs(Type)` method converts the payload to the required type at the moment you need it.
-In most cases, you don't need to pass a `Converter` explicitly - if the message has passed through converter-aware components (which is typical in Axon), the conversion happens automatically.
+The `payloadAs(Class<T>)` method attempts to convert the message payload into the required type as you access it.
 
-If you need explicit control over conversion, you can provide a converter:
+In cases where a message originates outside the JVM (Axon Server, Database, Store), Axon attaches an applicable xref:ROOT:conversion.adoc#converter_attachment_at_message_loading_time[converter] to the message before passing it on for handling. This applies for `CommandMessages`, `CommandResultMessages`, `EventMessages`, `QueryMessages` and `QueryResponseMessages` and makes those messages conversion aware, so handler code usually does not need to reference a converter directly when using a generic message type for handling:
+
+[source,java]
+----
+@EventHandler
+public void on(EventMessage event) {
+    // Converter is already attached — no need to pass it explicitly
+    OrderPlacedEvent order = event.payloadAs(OrderPlacedEvent.class);
+}
+----
+
+If you need explicit control over conversion or if you are working with a message that was not produced by Axon's infrastructure, you can still supply a converter directly:
 
 [source,java]
 ----
@@ -264,7 +274,12 @@ public void retrieveConvertedPayload(Message message, Converter converter) {
 }
 ----
 
-This is useful when you need the same message in different formats at different points in your processing logic.
+When building custom infrastructure that produces `Message` instances (for example `GenericMessage`, `GenericCommandMessage`, `GenericEventMessage`, `GenericQueryMessage`, etc.), you can call `withConverter(Converter)` to attach the converter so downstream handlers benefit from the same automatic conversion:
+
+[source,java]
+----
+GenericEventMessage messageWithConverter = rawMessage.withConverter(eventConverter);
+----
 
 === Converting message payloads
 


### PR DESCRIPTION
Update the documentation with information about the new conversion awareness of messages in relevant places

This PR is a successor to #4312, #4313, #4314 and #4315 and should be merged once those are resolved. 