### PR TITLE
Upgrade Axon Server Connector for Java to 2026.0.0

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -47,7 +47,7 @@
         </mockito.agent.argLine>
 
         <!-- Axon Server -->
-        <axonserver-connector-java.version>2026.0.0-SNAPSHOT</axonserver-connector-java.version>
+        <axonserver-connector-java.version>2026.0.0</axonserver-connector-java.version>
         <!-- Caching -->
         <ehcache.version>3.11.1</ehcache.version>
         <javax.cache-api.version>1.1.1</javax.cache-api.version>


### PR DESCRIPTION
This pull request changes the Axon Server Connector for Java version from `2026.0.0-SNAPSHOT` to `2026.0.0`.