### PR TITLE
Fix test isolation for the ReplayStatusChangedHandlerIT

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractAxonServerIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractAxonServerIT.java
@@ -17,9 +17,9 @@
 package org.axonframework.integrationtests.testsuite;
 
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.test.server.AxonServerContainer;
 import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
@@ -75,21 +75,6 @@ public abstract class AbstractAxonServerIT {
     }
 
     /**
-     * Purge all events from the Axon Server container
-     */
-    protected void purgeEvents() {
-        try {
-            logger.info("Purging events from Axon Server.");
-            AxonServerContainerUtils.purgeEventsFromAxonServer(container.getHost(),
-                                                               container.getHttpPort(),
-                                                               "default",
-                                                               AxonServerContainerUtils.DCB_CONTEXT);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Creates the {@link ApplicationConfigurer} defining the Axon Framework test context.
      *
      * @return The {@link ApplicationConfigurer} defining the Axon Framework test context.
@@ -108,6 +93,7 @@ public abstract class AbstractAxonServerIT {
      */
     protected void purgeEventStorage() {
         try {
+            logger.info("Purging events from Axon Server.");
             AxonServerContainerUtils.purgeEventsFromAxonServer(
                     container.getHost(),
                     container.getHttpPort(),

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MonitoringPooledEventProcessingReportIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/MonitoringPooledEventProcessingReportIT.java
@@ -107,7 +107,7 @@ public class MonitoringPooledEventProcessingReportIT extends AbstractStudentIT {
     @Override
     protected EventSourcingConfigurer testSuiteConfigurer(EventSourcingConfigurer configurer) {
         // purge events to restart with an empty eventstore and avoid processing historic events
-        purgeEvents();
+        purgeEventStorage();
 
         // a noop setup that allows verification of ignored event
         configurer.messaging(mc -> mc

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/ReplayStatusChangedHandlerIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/ReplayStatusChangedHandlerIT.java
@@ -70,6 +70,7 @@ class ReplayStatusChangedHandlerIT extends AbstractStudentIT {
         resetHandlerInvoked = new AtomicBoolean(false);
         replayStatusReference = new AtomicReference<>(null);
         statusChangedInvoked = new CountDownLatch(0);
+        purgeEventStorage();
     }
 
     @Test


### PR DESCRIPTION
If the testcontainer is reused or the test is flaky and getting retried, any other `StudentEnrolledEvent` preexisting in the eventstore will also be handled by the test event handler and count towards the `eventHandlerInvocations` that are expected to exactly be 4 for the `resettingPsepTriggersReplayStatusChangeHandlersWhenFinishingTheReplay`. The `org.axonframework.integrationtests.testsuite.AbstractAxonServerIT#purgeEventStorage` makes sure no other events leak into the test.

While at it also removed the duplicate purgeEvents method from org.axonframework.integrationtests.testsuite.AbstractAxonServerIT