### PR TITLE
Improve Javadoc on QueryUpdateEmitter

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -16,24 +16,24 @@
 
 package org.axonframework.messaging.queryhandling;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.conversion.ConversionException;
 import org.axonframework.messaging.core.Context.ResourceKey;
+import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeNotResolvedException;
 import org.axonframework.messaging.core.MessageTypeResolver;
-import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandler;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
  * Query-specific component that interacts with
- * {@link QueryBus#subscriptionQuery(SubscriptionQueryMessage, ProcessingContext, int) subscription queries} about
+ * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} about
  * {@link #emit(Class, Predicate, Object) update}, {@link #completeExceptionally(Class, Predicate, Throwable) errors},
  * and when there are {@link #complete(Class, Predicate) no more update}.
  * <p>
@@ -77,18 +77,18 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits given {@code update} to subscription queries matching the given {@code queryType} and given
      * {@code filter}.
      *
-     * @param queryType The type of the {@link SubscriptionQueryMessage} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()}, converted to the given
-     *                  {@code queryType} to filter on.
+     * @param queryType The type of the {@link QueryMessage} to filter on.
+     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}.
      * @param update    The incremental update to emit for
-     *                  {@link QueryBus#subscriptionQuery(SubscriptionQueryMessage, ProcessingContext, int) subscription
+     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
      *                  queries} matching the given {@code filter}.
-     * @param <Q>       The type of the {@link SubscriptionQueryMessage} to filter on.
+     * @param <Q>       The type of the {@link QueryMessage} to filter on.
      * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
      *                                                             {@link MessageType}
      *                                                             equivalent required to filter the
-     *                                                             {@link SubscriptionQueryMessage#payload()}.
-     * @throws ConversionException If the {@link SubscriptionQueryMessage#payload()}
+     *                                                             {@link QueryMessage#payload()}.
+     * @throws ConversionException If the {@link QueryMessage#payload()}
      *                                                             could not be converted to the given {@code queryType}
      *                                                             to perform the given {@code filter}. Will only occur
      *                                                             if a {@link MessageType}
@@ -104,18 +104,18 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * <p>
      * The {@code updateSupplier} is only invoked whenever there are matching queries.
      *
-     * @param queryType      The type of the {@link SubscriptionQueryMessage} to filter on.
-     * @param filter         A predicate testing the {@link SubscriptionQueryMessage#payload()}, converted to the given
-     *                       {@code queryType} to filter on.
+     * @param queryType      The type of the {@link QueryMessage} to filter on.
+     * @param filter         A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                       converted to the given {@code queryType}
      * @param updateSupplier The update supplier to emit for
-     *                       {@link QueryBus#subscriptionQuery(SubscriptionQueryMessage, ProcessingContext, int)
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
      *                       subscription queries} matching the given {@code queryType} and {@code filter}.
-     * @param <Q>            The type of the {@link SubscriptionQueryMessage} to filter on.
+     * @param <Q>            The type of the {@link QueryMessage} to filter on.
      * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
      *                                                             {@link MessageType}
      *                                                             equivalent required to filter the
-     *                                                             {@link SubscriptionQueryMessage#payload()}.
-     * @throws ConversionException If the {@link SubscriptionQueryMessage#payload()}
+     *                                                             {@link QueryMessage#payload()}.
+     * @throws ConversionException If the {@link QueryMessage#payload()}
      *                                                             could not be converted to the given {@code queryType}
      *                                                             to perform the given {@code filter}. Will only occur
      *                                                             if a {@link MessageType}
@@ -129,11 +129,11 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits given {@code update} to subscription queries matching the given {@code queryName} and given
      * {@code filter}.
      *
-     * @param queryName The qualified name of the {@link SubscriptionQueryMessage#type()} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()} as is to the given
-     *                  {@code queryType} to filter on.
+     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
+     * @param filter    A predicate to filter matching subscription queries based on the raw
+     *                  {@link QueryMessage#payload()}.
      * @param update    The incremental update to emit for
-     *                  {@link QueryBus#subscriptionQuery(SubscriptionQueryMessage, ProcessingContext, int) subscription
+     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
      *                  queries} matching the given {@code filter}.
      */
     default void emit(QualifiedName queryName, Predicate<Object> filter, @Nullable Object update) {
@@ -146,11 +146,11 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * <p>
      * The {@code updateSupplier} is only invoked whenever there are matching queries.
      *
-     * @param queryName      The qualified name of the {@link SubscriptionQueryMessage#type()} to filter on.
-     * @param filter         A predicate testing the {@link SubscriptionQueryMessage#payload()} as is to the given
-     *                       {@code queryType} to filter on.
+     * @param queryName      The qualified name of the {@link QueryMessage#type()} to filter on.
+     * @param filter         A predicate to filter matching subscription queries based on the raw
+     *                       {@link QueryMessage#payload()}.
      * @param updateSupplier The update supplier to emit for
-     *                       {@link QueryBus#subscriptionQuery(SubscriptionQueryMessage, ProcessingContext, int)
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
      *                       subscription queries} matching the given {@code queryName} and {@code filter}.
      */
     void emit(QualifiedName queryName,
@@ -160,15 +160,15 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries matching the given {@code queryType} and {@code filter}.
      *
-     * @param queryType The type of the {@link SubscriptionQueryMessage} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()}, converted to the given
-     *                  {@code queryType} to filter on.
-     * @param <Q>       The type of the {@link SubscriptionQueryMessage} to filter on.
+     * @param queryType The type of the {@link QueryMessage} to filter on.
+     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}
+     * @param <Q>       The type of the {@link QueryMessage} to filter on.
      * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
      *                                                             {@link MessageType}
      *                                                             equivalent required to filter the
-     *                                                             {@link SubscriptionQueryMessage#payload()}.
-     * @throws ConversionException If the {@link SubscriptionQueryMessage#payload()}
+     *                                                             {@link QueryMessage#payload()}.
+     * @throws ConversionException If the {@link QueryMessage#payload()}
      *                                                             could not be converted to the given {@code queryType}
      *                                                             to perform the given {@code filter}. Will only occur
      *                                                             if a {@link MessageType}
@@ -179,25 +179,24 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries matching the given {@code queryName} and {@code filter}.
      *
-     * @param queryName The qualified name of the {@link SubscriptionQueryMessage#type()} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()} as is to the given
-     *                  {@code queryType} to filter on.
+     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
+     * @param filter    A predicate testing the raw {@link QueryMessage#payload()} as is.
      */
     void complete(QualifiedName queryName, Predicate<Object> filter);
 
     /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryType} and {@code filter}.
      *
-     * @param queryType The type of the {@link SubscriptionQueryMessage} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()}, converted to the given
-     *                  {@code queryType} to filter on.
+     * @param queryType The type of the {@link QueryMessage} to filter on.
+     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}
      * @param cause     The cause of an error leading to exceptionally complete subscription queries.
-     * @param <Q>       The type of the {@link SubscriptionQueryMessage} to filter on.
+     * @param <Q>       The type of the {@link QueryMessage} to filter on.
      * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
      *                                                             {@link MessageType}
      *                                                             equivalent required to filter the
-     *                                                             {@link SubscriptionQueryMessage#payload()}.
-     * @throws ConversionException If the {@link SubscriptionQueryMessage#payload()}
+     *                                                             {@link QueryMessage#payload()}.
+     * @throws ConversionException If the {@link QueryMessage#payload()}
      *                                                             could not be converted to the given {@code queryType}
      *                                                             to perform the given {@code filter}. Will only occur
      *                                                             if a {@link MessageType}
@@ -210,9 +209,9 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryName} and {@code filter}.
      *
-     * @param queryName The qualified name of the {@link SubscriptionQueryMessage#type()} to filter on.
-     * @param filter    A predicate testing the {@link SubscriptionQueryMessage#payload()} as is to the given
-     *                  {@code queryType} to filter on.
+     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
+     * @param filter    A predicate to filter matching subscription queries based on the raw
+     *                  {@link QueryMessage#payload()}.
      * @param cause     The cause of an error leading to exceptionally complete subscription queries.
      */
     void completeExceptionally(QualifiedName queryName,


### PR DESCRIPTION
* make it clear that the filter predicates on the method variants operating on QualifiedName receive the raw payload, not the converted one
* fix usage of references to `SubscriptionQueryMessage` (now `QueryMessage`)